### PR TITLE
Expand container ranges

### DIFF
--- a/Real_Masters_all/a2twnshp.xml
+++ b/Real_Masters_all/a2twnshp.xml
@@ -606,7 +606,6 @@
         </scopecontent>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">3-16</container>
             <unittitle>
               <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
             </unittitle>
@@ -614,10 +613,160 @@
               <extent altrender="materialtype spaceoccupied">14 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">3</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">7</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">15</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">16</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">17-77</container>
             <unittitle>
               <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
             </unittitle>
@@ -625,10 +774,677 @@
               <extent>61 volumes/bundles</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">17</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">18</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">19</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">20</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">21</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">22</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">23</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">24</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">25</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">26</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">27</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">28</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">29</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">30</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">31</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">32</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">33</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">34</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">35</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">36</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">37</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">38</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">39</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">40</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">41</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">42</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">43</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">44</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">45</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">46</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">47</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">48</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">49</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">50</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">51</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">52</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">53</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">54</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">55</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">56</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">57</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">58</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">59</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">60</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">61</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">62</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">63</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">64</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">65</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">66</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">67</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">68</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">69</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">70</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">71</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">72</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">73</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">74</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">75</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">76</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">77</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">78-79</container>
             <unittitle>
               <unitdate type="inclusive" normal="1962">1962</unitdate>
             </unittitle>
@@ -636,6 +1452,25 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1962">1962</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">78</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1962">1962</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">79</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -671,7 +1506,6 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">84-85</container>
             <unittitle>
               <unitdate type="inclusive" normal="1972">1972</unitdate>
             </unittitle>
@@ -679,6 +1513,25 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1972">1972</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">84</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1972">1972</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">85</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -690,7 +1543,6 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">87-88</container>
             <unittitle>
               <unitdate type="inclusive" normal="1976">1976</unitdate>
             </unittitle>
@@ -698,10 +1550,28 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1976">1976</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">87</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1976">1976</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">88</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">89-90</container>
             <unittitle>
               <unitdate type="inclusive" normal="1978">1978</unitdate>
             </unittitle>
@@ -709,10 +1579,28 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1978">1978</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">89</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1978">1978</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">90</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">91-92</container>
             <unittitle>
               <unitdate type="inclusive" normal="1980">1980</unitdate>
             </unittitle>
@@ -720,6 +1608,25 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1980">1980</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">91</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1980">1980</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">92</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/aaphoto.xml
+++ b/Real_Masters_all/aaphoto.xml
@@ -629,12 +629,26 @@
             </c04>
             <c04 level="file">
               <did>
-                <container label="Folder" type="folder">58-59</container>
                 <unittitle>Huron</unittitle>
                 <physdesc>
                   <extent>2 envelopes</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Huron</unittitle>
+                  <container label="Folder" type="folder">58</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Huron</unittitle>
+                  <container label="Folder" type="folder">59</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/aapsch.xml
+++ b/Real_Masters_all/aapsch.xml
@@ -176,9 +176,95 @@ Ann Arbor Public Schools Records
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volumes">1-10</container>
             <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+              <container type="volume" label="Oversize Volumes">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+              <container type="volume" label="Oversize Volumes">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+              <container type="volume" label="Oversize Volumes">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+              <container type="volume" label="Oversize Volumes">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+              <container type="volume" label="Oversize Volumes">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+              <container type="volume" label="Oversize Volumes">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+              <container type="volume" label="Oversize Volumes">7</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+              <container type="volume" label="Oversize Volumes">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+              <container type="volume" label="Oversize Volumes">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+              <container type="volume" label="Oversize Volumes">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/alumasso.xml
+++ b/Real_Masters_all/alumasso.xml
@@ -956,9 +956,23 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">66-67</container>
             <unittitle>Harold Wilson Correspondence <unitdate type="inclusive" normal="1951/1956">1951-1956</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Harold Wilson Correspondence <unitdate type="inclusive" normal="1951/1956">1951-1956</unitdate></unittitle>
+              <container type="box" label="Box">66</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Harold Wilson Correspondence <unitdate type="inclusive" normal="1951/1956">1951-1956</unitdate></unittitle>
+              <container type="box" label="Box">67</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -3121,11 +3135,51 @@
           </did>
           <c03>
             <did>
-              <container type="box" label="Box">105-108</container>
               <unittitle>
                 <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate>
               </unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate>
+                </unittitle>
+                <container type="box" label="Box">105</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate>
+                </unittitle>
+                <container type="box" label="Box">106</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate>
+                </unittitle>
+                <container type="box" label="Box">107</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate>
+                </unittitle>
+                <container type="box" label="Box">108</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="file">
@@ -3134,12 +3188,26 @@
           </did>
           <c03>
             <did>
-              <container type="box" label="Box">109-110</container>
               <unittitle>Responses to Alumnae Council Questionnaires <unitdate type="inclusive" normal="1924">1924</unitdate></unittitle>
             </did>
             <odd>
               <p>[see separately bound index]</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Responses to Alumnae Council Questionnaires <unitdate type="inclusive" normal="1924">1924</unitdate></unittitle>
+                <container type="box" label="Box">109</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Responses to Alumnae Council Questionnaires <unitdate type="inclusive" normal="1924">1924</unitdate></unittitle>
+                <container type="box" label="Box">110</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -3381,7 +3449,6 @@
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">114-115</container>
               <unittitle>
                 <unitdate type="inclusive" normal="1931/1946">1931-1946</unitdate>
               </unittitle>
@@ -3389,6 +3456,25 @@
             <odd>
               <p>(including World War II letters)</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1931/1946">1931-1946</unitdate>
+                </unittitle>
+                <container type="box" label="Box">114</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1931/1946">1931-1946</unitdate>
+                </unittitle>
+                <container type="box" label="Box">115</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3772,9 +3858,23 @@
         </scopecontent>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">118-119</container>
             <unittitle>Class Officers Council Files <unitdate type="inclusive" normal="1932/1950">1932-1950</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Class Officers Council Files <unitdate type="inclusive" normal="1932/1950">1932-1950</unitdate></unittitle>
+              <container type="box" label="Box">118</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Class Officers Council Files <unitdate type="inclusive" normal="1932/1950">1932-1950</unitdate></unittitle>
+              <container type="box" label="Box">119</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/amorgan.xml
+++ b/Real_Masters_all/amorgan.xml
@@ -11369,7 +11369,6 @@
         </c02>
         <c02 level="file">
           <did>
-            <container label="Box" type="box">41-44</container>
             <unittitle>
               <title render="italic">Awful Rainbow</title>
             </unittitle>
@@ -11380,6 +11379,47 @@
           <odd>
             <p>(manuscripts and related material)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <title render="italic">Awful Rainbow</title>
+              </unittitle>
+              <container label="Box" type="box">41</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <title render="italic">Awful Rainbow</title>
+              </unittitle>
+              <container label="Box" type="box">42</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <title render="italic">Awful Rainbow</title>
+              </unittitle>
+              <container label="Box" type="box">43</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <title render="italic">Awful Rainbow</title>
+              </unittitle>
+              <container label="Box" type="box">44</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/arborum.xml
+++ b/Real_Masters_all/arborum.xml
@@ -1209,13 +1209,28 @@ Nichols Arboretum (University of Michigan), Bentley Historical Library, Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="map-case" label="Drawer">241</container>
-            <container type="folder" label="Folder">7-8</container>
             <unittitle>"The First Trail" by the Department of Landscape Architecture <unitdate type="inclusive" normal="1965">1965</unitdate></unittitle>
             <physdesc>
               <physfacet>mounted on six presentation boards)</physfacet>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>"The First Trail" by the Department of Landscape Architecture <unitdate type="inclusive" normal="1965">1965</unitdate></unittitle>
+              <container type="map-case" label="Drawer">241</container>
+              <container type="folder" label="Folder">7</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>"The First Trail" by the Department of Landscape Architecture <unitdate type="inclusive" normal="1965">1965</unitdate></unittitle>
+              <container type="map-case" label="Drawer">241</container>
+              <container type="folder" label="Folder">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/bandum.xml
+++ b/Real_Masters_all/bandum.xml
@@ -2082,9 +2082,23 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Scrapbook">21-22</container>
             <unittitle>[Vol. 21-22] <unitdate type="inclusive" normal="1964/1965">1964-1965</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>[Vol. 21-22] <unitdate type="inclusive" normal="1964/1965">1964-1965</unitdate></unittitle>
+              <container type="volume" label="Scrapbook">21</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>[Vol. 21-22] <unitdate type="inclusive" normal="1964/1965">1964-1965</unitdate></unittitle>
+              <container type="volume" label="Scrapbook">22</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -2100,9 +2114,23 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Scrapbook">25-26</container>
             <unittitle>[Vol. 25-26] <unitdate type="inclusive" normal="1965/1966">1965-1966</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>[Vol. 25-26] <unitdate type="inclusive" normal="1965/1966">1965-1966</unitdate></unittitle>
+              <container type="volume" label="Scrapbook">25</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>[Vol. 25-26] <unitdate type="inclusive" normal="1965/1966">1965-1966</unitdate></unittitle>
+              <container type="volume" label="Scrapbook">26</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -2130,9 +2158,23 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Scrapbook">31-32</container>
             <unittitle>[Vol. 31-32] <unitdate type="inclusive" normal="1969/1970">1969-1970</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>[Vol. 31-32] <unitdate type="inclusive" normal="1969/1970">1969-1970</unitdate></unittitle>
+              <container type="volume" label="Scrapbook">31</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>[Vol. 31-32] <unitdate type="inclusive" normal="1969/1970">1969-1970</unitdate></unittitle>
+              <container type="volume" label="Scrapbook">32</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/bemuehlg.xml
+++ b/Real_Masters_all/bemuehlg.xml
@@ -141,12 +141,35 @@ B. E. Muehlig’s Dry Goods Store (Ann Arbor, Mich.) records, Bentley Historical
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">10-12</container>
             <unittitle>Vol. nos. 10-12</unittitle>
           </did>
           <odd>
             <p>(volumes not received)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Vol. nos. 10-12</unittitle>
+              <container type="volume" label="Oversize Volume">10</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Vol. nos. 10-12</unittitle>
+              <container type="volume" label="Oversize Volume">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Vol. nos. 10-12</unittitle>
+              <container type="volume" label="Oversize Volume">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/bentleya.xml
+++ b/Real_Masters_all/bentleya.xml
@@ -6295,12 +6295,35 @@
           </c03>
           <c03 level="file">
             <did>
-              <container label="Box" type="box">48-50</container>
               <unittitle>Notebooks and published materials on Con-Con &amp; related topics</unittitle>
             </did>
             <odd>
               <p>(also includes additional newspaper clippings)</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Notebooks and published materials on Con-Con &amp; related topics</unittitle>
+                <container label="Box" type="box">48</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Notebooks and published materials on Con-Con &amp; related topics</unittitle>
+                <container label="Box" type="box">49</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Notebooks and published materials on Con-Con &amp; related topics</unittitle>
+                <container label="Box" type="box">50</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
       </c01>
@@ -12338,9 +12361,59 @@
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">97-102</container>
               <unittitle>Hearings and reports <unitdate type="inclusive" normal="1953/1960">1953-1960</unitdate></unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Hearings and reports <unitdate type="inclusive" normal="1953/1960">1953-1960</unitdate></unittitle>
+                <container type="box" label="Box">97</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Hearings and reports <unitdate type="inclusive" normal="1953/1960">1953-1960</unitdate></unittitle>
+                <container type="box" label="Box">98</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Hearings and reports <unitdate type="inclusive" normal="1953/1960">1953-1960</unitdate></unittitle>
+                <container type="box" label="Box">99</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Hearings and reports <unitdate type="inclusive" normal="1953/1960">1953-1960</unitdate></unittitle>
+                <container type="box" label="Box">100</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Hearings and reports <unitdate type="inclusive" normal="1953/1960">1953-1960</unitdate></unittitle>
+                <container type="box" label="Box">101</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Hearings and reports <unitdate type="inclusive" normal="1953/1960">1953-1960</unitdate></unittitle>
+                <container type="box" label="Box">102</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
       </c01>

--- a/Real_Masters_all/blanchjj.xml
+++ b/Real_Masters_all/blanchjj.xml
@@ -20104,21 +20104,49 @@
             </odd>
             <c04 level="file">
               <did>
-                <container type="volume" label="Oversize Volume">1-2</container>
                 <unittitle>Statewide issues survey <unitdate type="inclusive" normal="1981-07">July 1981</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 volumes</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Statewide issues survey <unitdate type="inclusive" normal="1981-07">July 1981</unitdate></unittitle>
+                  <container type="volume" label="Oversize Volume">1</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Statewide issues survey <unitdate type="inclusive" normal="1981-07">July 1981</unitdate></unittitle>
+                  <container type="volume" label="Oversize Volume">2</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container type="volume" label="Oversize Volume">3-4</container>
                 <unittitle>18th Congressional District issues survey <unitdate type="inclusive" normal="1981-07">July 1981</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 volumes</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>18th Congressional District issues survey <unitdate type="inclusive" normal="1981-07">July 1981</unitdate></unittitle>
+                  <container type="volume" label="Oversize Volume">3</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>18th Congressional District issues survey <unitdate type="inclusive" normal="1981-07">July 1981</unitdate></unittitle>
+                  <container type="volume" label="Oversize Volume">4</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -20785,9 +20813,23 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Boxes">318-319</container>
                 <unittitle>Topical and issues files</unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Topical and issues files</unittitle>
+                  <container type="box" label="Boxes">318</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Topical and issues files</unittitle>
+                  <container type="box" label="Boxes">319</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
           </c03>
           <c03 level="otherlevel" otherlevel="sub-subseries">
@@ -20808,15 +20850,61 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Boxes">320-322</container>
                 <unittitle>Lisa Grayson (Campaign Press Secretary) files</unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Lisa Grayson (Campaign Press Secretary) files</unittitle>
+                  <container type="box" label="Boxes">320</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Lisa Grayson (Campaign Press Secretary) files</unittitle>
+                  <container type="box" label="Boxes">321</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Lisa Grayson (Campaign Press Secretary) files</unittitle>
+                  <container type="box" label="Boxes">322</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Boxes">323-325</container>
                 <unittitle>Gary Bachula (Campaign Manager) files</unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Gary Bachula (Campaign Manager) files</unittitle>
+                  <container type="box" label="Boxes">323</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Gary Bachula (Campaign Manager) files</unittitle>
+                  <container type="box" label="Boxes">324</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Gary Bachula (Campaign Manager) files</unittitle>
+                  <container type="box" label="Boxes">325</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -20831,12 +20919,26 @@
             </did>
             <c04 level="file">
               <did>
-                <container type="box" label="Boxes">327-328</container>
                 <unittitle>Charles Kolbe files</unittitle>
               </did>
               <odd>
                 <p>(research on John Engler)</p>
               </odd>
+              <c05 level="file">
+                <did>
+                  <unittitle>Charles Kolbe files</unittitle>
+                  <container type="box" label="Boxes">327</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Charles Kolbe files</unittitle>
+                  <container type="box" label="Boxes">328</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -20864,9 +20966,23 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Boxes">267-268</container>
                 <unittitle>Unprocessed/unlisted</unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Unprocessed/unlisted</unittitle>
+                  <container type="box" label="Boxes">267</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Unprocessed/unlisted</unittitle>
+                  <container type="box" label="Boxes">268</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
           </c03>
         </c02>
@@ -20928,9 +21044,23 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Boxes">331-332</container>
                 <unittitle>Statements and proposed platform recommendations</unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Statements and proposed platform recommendations</unittitle>
+                  <container type="box" label="Boxes">331</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Statements and proposed platform recommendations</unittitle>
+                  <container type="box" label="Boxes">332</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -21105,9 +21235,23 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">275-276</container>
             <unittitle>Appointments to state boards and commissions</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Appointments to state boards and commissions</unittitle>
+              <container type="box" label="Boxes">275</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Appointments to state boards and commissions</unittitle>
+              <container type="box" label="Boxes">276</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">
@@ -21167,15 +21311,43 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">280-281</container>
             <unittitle>Ambassador to Canada</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Ambassador to Canada</unittitle>
+              <container type="box" label="Boxes">280</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ambassador to Canada</unittitle>
+              <container type="box" label="Boxes">281</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">338-339</container>
             <unittitle>Ambassador to Canada</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Ambassador to Canada</unittitle>
+              <container type="box" label="Boxes">338</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ambassador to Canada</unittitle>
+              <container type="box" label="Boxes">339</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -21213,9 +21385,23 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">285-286</container>
               <unittitle>Notebooks of clippings (issues and candidates)</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Notebooks of clippings (issues and candidates)</unittitle>
+                <container type="box" label="Boxes">285</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Notebooks of clippings (issues and candidates)</unittitle>
+                <container type="box" label="Boxes">286</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -21240,33 +21426,184 @@
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">288-289</container>
               <unittitle>Blanchard for Governor television spots <unitdate type="inclusive" normal="1982">1982</unitdate></unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Blanchard for Governor television spots <unitdate type="inclusive" normal="1982">1982</unitdate></unittitle>
+                <container type="box" label="Boxes">288</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Blanchard for Governor television spots <unitdate type="inclusive" normal="1982">1982</unitdate></unittitle>
+                <container type="box" label="Boxes">289</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">290-296</container>
               <unittitle>Gubernatorial speeches, appearances, and related</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Gubernatorial speeches, appearances, and related</unittitle>
+                <container type="box" label="Boxes">290</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Gubernatorial speeches, appearances, and related</unittitle>
+                <container type="box" label="Boxes">291</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Gubernatorial speeches, appearances, and related</unittitle>
+                <container type="box" label="Boxes">292</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Gubernatorial speeches, appearances, and related</unittitle>
+                <container type="box" label="Boxes">293</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Gubernatorial speeches, appearances, and related</unittitle>
+                <container type="box" label="Boxes">294</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Gubernatorial speeches, appearances, and related</unittitle>
+                <container type="box" label="Boxes">295</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Gubernatorial speeches, appearances, and related</unittitle>
+                <container type="box" label="Boxes">296</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">297-299</container>
               <unittitle><unitdate type="inclusive" normal="1990">1990</unitdate> gubernatorial campaign</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle><unitdate type="inclusive" normal="1990">1990</unitdate> gubernatorial campaign</unittitle>
+                <container type="box" label="Boxes">297</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle><unitdate type="inclusive" normal="1990">1990</unitdate> gubernatorial campaign</unittitle>
+                <container type="box" label="Boxes">298</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle><unitdate type="inclusive" normal="1990">1990</unitdate> gubernatorial campaign</unittitle>
+                <container type="box" label="Boxes">299</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">300-301</container>
               <unittitle>Post-gubernatorial activities (include period as ambassador to Canada)</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Post-gubernatorial activities (include period as ambassador to Canada)</unittitle>
+                <container type="box" label="Boxes">300</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Post-gubernatorial activities (include period as ambassador to Canada)</unittitle>
+                <container type="box" label="Boxes">301</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">302-306</container>
               <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> gubernatorial primary campaign</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> gubernatorial primary campaign</unittitle>
+                <container type="box" label="Boxes">302</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> gubernatorial primary campaign</unittitle>
+                <container type="box" label="Boxes">303</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> gubernatorial primary campaign</unittitle>
+                <container type="box" label="Boxes">304</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> gubernatorial primary campaign</unittitle>
+                <container type="box" label="Boxes">305</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> gubernatorial primary campaign</unittitle>
+                <container type="box" label="Boxes">306</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -21281,15 +21618,70 @@
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">307-309</container>
               <unittitle>Gubernatorial and post-gubernatorial photographs and albums</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Gubernatorial and post-gubernatorial photographs and albums</unittitle>
+                <container type="box" label="Boxes">307</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Gubernatorial and post-gubernatorial photographs and albums</unittitle>
+                <container type="box" label="Boxes">308</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Gubernatorial and post-gubernatorial photographs and albums</unittitle>
+                <container type="box" label="Boxes">309</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">341-344</container>
               <unittitle>Gubernatorial, political, and career as US Ambassador to Canada</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Gubernatorial, political, and career as US Ambassador to Canada</unittitle>
+                <container type="box" label="Boxes">341</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Gubernatorial, political, and career as US Ambassador to Canada</unittitle>
+                <container type="box" label="Boxes">342</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Gubernatorial, political, and career as US Ambassador to Canada</unittitle>
+                <container type="box" label="Boxes">343</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Gubernatorial, political, and career as US Ambassador to Canada</unittitle>
+                <container type="box" label="Boxes">344</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/bolcom.xml
+++ b/Real_Masters_all/bolcom.xml
@@ -397,12 +397,26 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">16-17</container>
             <unittitle>Financial <unitdate type="inclusive" normal="1998">1998</unitdate></unittitle>
           </did>
           <odd>
             <p>(prior to 1998 financial materials were interspersed with the Performance files)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Financial <unitdate type="inclusive" normal="1998">1998</unitdate></unittitle>
+              <container type="box" label="Box">16</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Financial <unitdate type="inclusive" normal="1998">1998</unitdate></unittitle>
+              <container type="box" label="Box">17</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -598,18 +612,91 @@
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">18-19</container>
               <unittitle>Manuscript and printed scores</unittitle>
             </did>
             <odd>
               <p>(includes some non-score material)</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Manuscript and printed scores</unittitle>
+                <container type="box" label="Box">18</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Manuscript and printed scores</unittitle>
+                <container type="box" label="Box">19</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="bundle" label="Bundles">1-7</container>
               <unittitle>Printed scores (outsize)</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Printed scores (outsize)</unittitle>
+                <container type="bundle" label="Bundles">1</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Printed scores (outsize)</unittitle>
+                <container type="bundle" label="Bundles">2</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Printed scores (outsize)</unittitle>
+                <container type="bundle" label="Bundles">3</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Printed scores (outsize)</unittitle>
+                <container type="bundle" label="Bundles">4</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Printed scores (outsize)</unittitle>
+                <container type="bundle" label="Bundles">5</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Printed scores (outsize)</unittitle>
+                <container type="bundle" label="Bundles">6</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Printed scores (outsize)</unittitle>
+                <container type="bundle" label="Bundles">7</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="file">
@@ -620,12 +707,26 @@
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">20-21</container>
               <unittitle>Manuscript and printed scores</unittitle>
             </did>
             <odd>
               <p>(includes audio cassette)</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Manuscript and printed scores</unittitle>
+                <container type="box" label="Box">20</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Manuscript and printed scores</unittitle>
+                <container type="box" label="Box">21</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -648,9 +749,32 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="bundle" label="Bundle">9-11</container>
               <unittitle>Printed scores (outsize)</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Printed scores (outsize)</unittitle>
+                <container type="bundle" label="Bundle">9</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Printed scores (outsize)</unittitle>
+                <container type="bundle" label="Bundle">10</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Printed scores (outsize)</unittitle>
+                <container type="bundle" label="Bundle">11</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="file">
@@ -697,12 +821,71 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="bundle" label="Bundle">12-18</container>
             <unittitle>Songs of Innocence and of Experience</unittitle>
             <physdesc>
               <extent>7 bundles</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Songs of Innocence and of Experience</unittitle>
+              <container type="bundle" label="Bundle">12</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Songs of Innocence and of Experience</unittitle>
+              <container type="bundle" label="Bundle">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Songs of Innocence and of Experience</unittitle>
+              <container type="bundle" label="Bundle">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Songs of Innocence and of Experience</unittitle>
+              <container type="bundle" label="Bundle">15</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Songs of Innocence and of Experience</unittitle>
+              <container type="bundle" label="Bundle">16</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Songs of Innocence and of Experience</unittitle>
+              <container type="bundle" label="Bundle">17</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Songs of Innocence and of Experience</unittitle>
+              <container type="bundle" label="Bundle">18</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -1207,9 +1390,41 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">33-36</container>
             <unittitle>A Wedding, Act II</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>A Wedding, Act II</unittitle>
+              <container type="box" label="Boxes">33</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>A Wedding, Act II</unittitle>
+              <container type="box" label="Boxes">34</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>A Wedding, Act II</unittitle>
+              <container type="box" label="Boxes">35</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>A Wedding, Act II</unittitle>
+              <container type="box" label="Boxes">36</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -1375,9 +1590,23 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">46-47</container>
             <unittitle>Canciones de Lorca <unitdate type="inclusive" normal="2006">2006</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Canciones de Lorca <unitdate type="inclusive" normal="2006">2006</unitdate></unittitle>
+              <container type="box" label="Boxes">46</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Canciones de Lorca <unitdate type="inclusive" normal="2006">2006</unitdate></unittitle>
+              <container type="box" label="Boxes">47</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/boyneusa.xml
+++ b/Real_Masters_all/boyneusa.xml
@@ -297,9 +297,23 @@ Boyne USA Resorts records, Bentley Historical Library, University of Michigan</p
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">3-4</container>
             <unittitle>Skiing and golfing magazines, most containing articles or advertisements from Boyne USA</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Skiing and golfing magazines, most containing articles or advertisements from Boyne USA</unittitle>
+              <container type="box" label="Boxes">3</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Skiing and golfing magazines, most containing articles or advertisements from Boyne USA</unittitle>
+              <container type="box" label="Boxes">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">
@@ -780,7 +794,6 @@ Boyne USA Resorts records, Bentley Historical Library, University of Michigan</p
           </c03>
           <c03 level="file">
             <did>
-              <container type="volume" label="Oversize Volume">17-18</container>
               <unittitle>Albums of snapshots of golfing events and golfing personalities <unitdate type="inclusive" normal="1980/1989" certainty="approximate">1980s</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 volumes</extent>
@@ -792,6 +805,21 @@ Boyne USA Resorts records, Bentley Historical Library, University of Michigan</p
             <odd>
               <p>(Oversize vols. No. 17-18)</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Albums of snapshots of golfing events and golfing personalities <unitdate type="inclusive" normal="1980/1989" certainty="approximate">1980s</unitdate></unittitle>
+                <container type="volume" label="Oversize Volume">17</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Albums of snapshots of golfing events and golfing personalities <unitdate type="inclusive" normal="1980/1989" certainty="approximate">1980s</unitdate></unittitle>
+                <container type="volume" label="Oversize Volume">18</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="series">
@@ -4640,12 +4668,35 @@ Boyne USA Resorts records, Bentley Historical Library, University of Michigan</p
         </scopecontent>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volumes">12-14</container>
             <unittitle>Storeroom inventory of alcohol: beer, wine, liquor <unitdate type="inclusive" normal="1981/1987">1981-1987</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Storeroom inventory of alcohol: beer, wine, liquor <unitdate type="inclusive" normal="1981/1987">1981-1987</unitdate></unittitle>
+              <container type="volume" label="Oversize Volumes">12</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Storeroom inventory of alcohol: beer, wine, liquor <unitdate type="inclusive" normal="1981/1987">1981-1987</unitdate></unittitle>
+              <container type="volume" label="Oversize Volumes">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Storeroom inventory of alcohol: beer, wine, liquor <unitdate type="inclusive" normal="1981/1987">1981-1987</unitdate></unittitle>
+              <container type="volume" label="Oversize Volumes">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/busadmin.xml
+++ b/Real_Masters_all/busadmin.xml
@@ -18011,9 +18011,41 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">96-99</container>
               <unittitle>[Boxes 96-99 were eliminated during <unitdate type="inclusive" normal="1994">1994</unitdate> reprocessing.]</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>[Boxes 96-99 were eliminated during <unitdate type="inclusive" normal="1994">1994</unitdate> reprocessing.]</unittitle>
+                <container type="box" label="Box">96</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Boxes 96-99 were eliminated during <unitdate type="inclusive" normal="1994">1994</unitdate> reprocessing.]</unittitle>
+                <container type="box" label="Box">97</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Boxes 96-99 were eliminated during <unitdate type="inclusive" normal="1994">1994</unitdate> reprocessing.]</unittitle>
+                <container type="box" label="Box">98</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Boxes 96-99 were eliminated during <unitdate type="inclusive" normal="1994">1994</unitdate> reprocessing.]</unittitle>
+                <container type="box" label="Box">99</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
       </c01>

--- a/Real_Masters_all/cacioppo.xml
+++ b/Real_Masters_all/cacioppo.xml
@@ -569,21 +569,49 @@ George Cacioppo papers, Bentley Historical Library, University of Michigan</p>
         </did>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">8-9</container>
             <unittitle>Sketchbooks</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">34 items</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Sketchbooks</unittitle>
+              <container type="box" label="Boxes">8</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Sketchbooks</unittitle>
+              <container type="box" label="Boxes">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">10-11</container>
             <unittitle>Individual unidentified sketches</unittitle>
             <physdesc>
               <extent>6 li. inches</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Individual unidentified sketches</unittitle>
+              <container type="box" label="Boxes">10</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Individual unidentified sketches</unittitle>
+              <container type="box" label="Boxes">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/classalb.xml
+++ b/Real_Masters_all/classalb.xml
@@ -28905,12 +28905,35 @@ University of Michigan Class Albums, Bentley Historical Library, University of M
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">35-37</container>
               <unittitle>Unidentified</unittitle>
             </did>
             <odd>
               <p>[1-25, 44, 45, 46]</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Unidentified</unittitle>
+                <container type="box" label="Box">35</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Unidentified</unittitle>
+                <container type="box" label="Box">36</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Unidentified</unittitle>
+                <container type="box" label="Box">37</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
       </c01>

--- a/Real_Masters_all/cranehh.xml
+++ b/Real_Masters_all/cranehh.xml
@@ -4776,9 +4776,32 @@
         </c02>
         <c02 level="file">
           <did>
-            <container label="Boxes" type="box">27-29</container>
             <unittitle>Sound recordings of sermons and other speeches</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Sound recordings of sermons and other speeches</unittitle>
+              <container label="Boxes" type="box">27</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Sound recordings of sermons and other speeches</unittitle>
+              <container label="Boxes" type="box">28</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Sound recordings of sermons and other speeches</unittitle>
+              <container label="Boxes" type="box">29</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/darmich.xml
+++ b/Real_Masters_all/darmich.xml
@@ -1161,9 +1161,23 @@ Daughters of the American Revolution of Michigan records, Bentley Historical Lib
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">18-19</container>
             <unittitle>Research and topical files of State Historian</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Research and topical files of State Historian</unittitle>
+              <container type="box" label="Boxes">18</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research and topical files of State Historian</unittitle>
+              <container type="box" label="Boxes">19</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/dpgmedp.xml
+++ b/Real_Masters_all/dpgmedp.xml
@@ -580,7 +580,6 @@ Department of Postgraduate Medicine and Health Professions Education (University
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">14-15</container>
             <unittitle>
               <unitdate type="inclusive" normal="1982">1982</unitdate>
             </unittitle>
@@ -588,10 +587,28 @@ Department of Postgraduate Medicine and Health Professions Education (University
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1982">1982</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">14</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1982">1982</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">15</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">16-17</container>
             <unittitle>
               <unitdate type="inclusive" normal="1983">1983</unitdate>
             </unittitle>
@@ -599,6 +616,25 @@ Department of Postgraduate Medicine and Health Professions Education (University
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1983">1983</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">16</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1983">1983</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">17</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -658,7 +694,6 @@ Department of Postgraduate Medicine and Health Professions Education (University
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">25-26</container>
             <unittitle>
               <unitdate type="inclusive" normal="1995">1995</unitdate>
             </unittitle>
@@ -666,6 +701,25 @@ Department of Postgraduate Medicine and Health Professions Education (University
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1995">1995</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">25</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1995">1995</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">26</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -677,7 +731,6 @@ Department of Postgraduate Medicine and Health Professions Education (University
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">28-29</container>
             <unittitle>
               <unitdate type="inclusive" normal="1997">1997</unitdate>
             </unittitle>
@@ -685,6 +738,25 @@ Department of Postgraduate Medicine and Health Professions Education (University
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1997">1997</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">28</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1997">1997</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">29</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/drda.xml
+++ b/Real_Masters_all/drda.xml
@@ -5078,12 +5078,53 @@ Division of Research Development and Administration (University of Michigan) Rec
         </scopecontent>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">26-30</container>
             <unittitle>Microfilm of grant files</unittitle>
           </did>
           <odd>
             <p>(326 reels of 16mm microfilm with index in Box 26)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Microfilm of grant files</unittitle>
+              <container type="box" label="Boxes">26</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Microfilm of grant files</unittitle>
+              <container type="box" label="Boxes">27</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Microfilm of grant files</unittitle>
+              <container type="box" label="Boxes">28</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Microfilm of grant files</unittitle>
+              <container type="box" label="Boxes">29</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Microfilm of grant files</unittitle>
+              <container type="box" label="Boxes">30</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/drewwalt.xml
+++ b/Real_Masters_all/drewwalt.xml
@@ -3974,12 +3974,332 @@
         </did>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">1-36</container>
             <unittitle>Originals of microfilmed papers</unittitle>
           </did>
           <accessrestrict>
             <p>[Boxes 1-35, staff use only, available on microfilm]</p>
           </accessrestrict>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">7</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">15</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">16</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">17</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">18</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">19</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">20</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">21</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">22</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">23</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">24</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">25</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">26</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">27</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">28</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">29</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">30</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">31</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">32</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">33</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">34</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">35</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">36</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/dsigmad.xml
+++ b/Real_Masters_all/dsigmad.xml
@@ -903,9 +903,23 @@ Delta Sigma Delta records, Bentley Historical Library, University of Michigan</p
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">7-8</container>
             <unittitle>Plaques <unitdate type="inclusive" normal="1954/1975">1954-1975</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Plaques <unitdate type="inclusive" normal="1954/1975">1954-1975</unitdate></unittitle>
+              <container type="box" label="Boxes">7</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Plaques <unitdate type="inclusive" normal="1954/1975">1954-1975</unitdate></unittitle>
+              <container type="box" label="Boxes">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/duncant.xml
+++ b/Real_Masters_all/duncant.xml
@@ -1019,12 +1019,26 @@ Todd Duncan papers, Bentley Historical Library, University of Michigan</p>
       </c01>
       <c01 level="series">
         <did>
-          <container type="box" label="Box">11-12</container>
           <unittitle>Oversize Material</unittitle>
         </did>
         <odd>
           <p>(Items are listed above)</p>
         </odd>
+        <c02 level="file">
+          <did>
+            <unittitle>Oversize Material</unittitle>
+            <container type="box" label="Box">11</container>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Oversize Material</unittitle>
+            <container type="box" label="Box">12</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
       </c01>
     </dsc>
   </archdesc>

--- a/Real_Masters_all/episwest.xml
+++ b/Real_Masters_all/episwest.xml
@@ -346,12 +346,53 @@
           </scopecontent>
           <c03 level="file">
             <did>
-              <container type="volume" label="Oversize Volume">1-5</container>
               <unittitle>Record Books <unitdate type="inclusive" normal="1875/1908">1875-1908</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 volumes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Record Books <unitdate type="inclusive" normal="1875/1908">1875-1908</unitdate></unittitle>
+                <container type="volume" label="Oversize Volume">1</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Record Books <unitdate type="inclusive" normal="1875/1908">1875-1908</unitdate></unittitle>
+                <container type="volume" label="Oversize Volume">2</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Record Books <unitdate type="inclusive" normal="1875/1908">1875-1908</unitdate></unittitle>
+                <container type="volume" label="Oversize Volume">3</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Record Books <unitdate type="inclusive" normal="1875/1908">1875-1908</unitdate></unittitle>
+                <container type="volume" label="Oversize Volume">4</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Record Books <unitdate type="inclusive" normal="1875/1908">1875-1908</unitdate></unittitle>
+                <container type="volume" label="Oversize Volume">5</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -12267,12 +12308,26 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">17-18</container>
             <unittitle>Diocesan Scrapbooks <unitdate type="inclusive" normal="1969/1987">1969-1987</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Diocesan Scrapbooks <unitdate type="inclusive" normal="1969/1987">1969-1987</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">17</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Diocesan Scrapbooks <unitdate type="inclusive" normal="1969/1987">1969-1987</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">18</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/esgeorge.xml
+++ b/Real_Masters_all/esgeorge.xml
@@ -3991,13 +3991,38 @@ Edwin S. George Reserve (Mich.) records, Bentley Historical Library, University 
           </c03>
           <c03 level="file">
             <did>
-              <container type="map-case" label="Drawer">308</container>
-              <container type="folder" label="Folders">5-7</container>
               <unittitle>USDA Aerial Photographs <unitdate type="inclusive" normal="1940/1970">1940-1970</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>USDA Aerial Photographs <unitdate type="inclusive" normal="1940/1970">1940-1970</unitdate></unittitle>
+                <container type="map-case" label="Drawer">308</container>
+                <container type="folder" label="Folders">5</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>USDA Aerial Photographs <unitdate type="inclusive" normal="1940/1970">1940-1970</unitdate></unittitle>
+                <container type="map-case" label="Drawer">308</container>
+                <container type="folder" label="Folders">6</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>USDA Aerial Photographs <unitdate type="inclusive" normal="1940/1970">1940-1970</unitdate></unittitle>
+                <container type="map-case" label="Drawer">308</container>
+                <container type="folder" label="Folders">7</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/esmwartr.xml
+++ b/Real_Masters_all/esmwartr.xml
@@ -110,15 +110,61 @@ Engineering Science and Management War Training Program (University of Michigan)
         </did>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">2-3</container>
             <unittitle>Engineering Training Program <unitdate type="inclusive" normal="1940/1941">1940-1941</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Engineering Training Program <unitdate type="inclusive" normal="1940/1941">1940-1941</unitdate></unittitle>
+              <container type="box" label="Boxes">2</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Engineering Training Program <unitdate type="inclusive" normal="1940/1941">1940-1941</unitdate></unittitle>
+              <container type="box" label="Boxes">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">4-7</container>
             <unittitle>Engineering Science and Management Defense Training Program <unitdate type="inclusive" normal="1941/1942">1941-1942</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Engineering Science and Management Defense Training Program <unitdate type="inclusive" normal="1941/1942">1941-1942</unitdate></unittitle>
+              <container type="box" label="Boxes">4</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Engineering Science and Management Defense Training Program <unitdate type="inclusive" normal="1941/1942">1941-1942</unitdate></unittitle>
+              <container type="box" label="Boxes">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Engineering Science and Management Defense Training Program <unitdate type="inclusive" normal="1941/1942">1941-1942</unitdate></unittitle>
+              <container type="box" label="Boxes">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Engineering Science and Management Defense Training Program <unitdate type="inclusive" normal="1941/1942">1941-1942</unitdate></unittitle>
+              <container type="box" label="Boxes">7</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -126,27 +172,158 @@ Engineering Science and Management War Training Program (University of Michigan)
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">8-13</container>
               <unittitle>
                 <unitdate type="inclusive" normal="1942/1943">1942-1943</unitdate>
               </unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1942/1943">1942-1943</unitdate>
+                </unittitle>
+                <container type="box" label="Boxes">8</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1942/1943">1942-1943</unitdate>
+                </unittitle>
+                <container type="box" label="Boxes">9</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1942/1943">1942-1943</unitdate>
+                </unittitle>
+                <container type="box" label="Boxes">10</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1942/1943">1942-1943</unitdate>
+                </unittitle>
+                <container type="box" label="Boxes">11</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1942/1943">1942-1943</unitdate>
+                </unittitle>
+                <container type="box" label="Boxes">12</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1942/1943">1942-1943</unitdate>
+                </unittitle>
+                <container type="box" label="Boxes">13</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">14-17</container>
               <unittitle>
                 <unitdate type="inclusive" normal="1943/1944">1943-1944</unitdate>
               </unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1943/1944">1943-1944</unitdate>
+                </unittitle>
+                <container type="box" label="Boxes">14</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1943/1944">1943-1944</unitdate>
+                </unittitle>
+                <container type="box" label="Boxes">15</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1943/1944">1943-1944</unitdate>
+                </unittitle>
+                <container type="box" label="Boxes">16</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1943/1944">1943-1944</unitdate>
+                </unittitle>
+                <container type="box" label="Boxes">17</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">18-20</container>
               <unittitle>
                 <unitdate type="inclusive" normal="1944/1945">1944-1945</unitdate>
               </unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1944/1945">1944-1945</unitdate>
+                </unittitle>
+                <container type="box" label="Boxes">18</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1944/1945">1944-1945</unitdate>
+                </unittitle>
+                <container type="box" label="Boxes">19</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1944/1945">1944-1945</unitdate>
+                </unittitle>
+                <container type="box" label="Boxes">20</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/extserv.xml
+++ b/Real_Masters_all/extserv.xml
@@ -6446,12 +6446,44 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">46-49</container>
             <unittitle>Personnel Files</unittitle>
           </did>
           <accessrestrict>
             <p>[CLOSED EXCEPT WITH WRITTEN PERMISSION OF DONOR]</p>
           </accessrestrict>
+          <c03 level="file">
+            <did>
+              <unittitle>Personnel Files</unittitle>
+              <container type="box" label="Box">46</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Personnel Files</unittitle>
+              <container type="box" label="Box">47</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Personnel Files</unittitle>
+              <container type="box" label="Box">48</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Personnel Files</unittitle>
+              <container type="box" label="Box">49</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/fineresr.xml
+++ b/Real_Masters_all/fineresr.xml
@@ -178,18 +178,109 @@ Sidney Fine collected research materials, Bentley Historical Library, University
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">3-6</container>
             <unittitle>Collected materials used in his research on the Detroit Riot of 1967</unittitle>
           </did>
           <odd>
             <p>(interviews with Nathan Caplan included in box 5)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Collected materials used in his research on the Detroit Riot of 1967</unittitle>
+              <container type="box" label="Boxes">3</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Collected materials used in his research on the Detroit Riot of 1967</unittitle>
+              <container type="box" label="Boxes">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Collected materials used in his research on the Detroit Riot of 1967</unittitle>
+              <container type="box" label="Boxes">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Collected materials used in his research on the Detroit Riot of 1967</unittitle>
+              <container type="box" label="Boxes">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">7-13</container>
             <unittitle>Collected material relating to his research on Walter Drew</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Collected material relating to his research on Walter Drew</unittitle>
+              <container type="box" label="Boxes">7</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Collected material relating to his research on Walter Drew</unittitle>
+              <container type="box" label="Boxes">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Collected material relating to his research on Walter Drew</unittitle>
+              <container type="box" label="Boxes">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Collected material relating to his research on Walter Drew</unittitle>
+              <container type="box" label="Boxes">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Collected material relating to his research on Walter Drew</unittitle>
+              <container type="box" label="Boxes">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Collected material relating to his research on Walter Drew</unittitle>
+              <container type="box" label="Boxes">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Collected material relating to his research on Walter Drew</unittitle>
+              <container type="box" label="Boxes">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/finopum.xml
+++ b/Real_Masters_all/finopum.xml
@@ -332,12 +332,26 @@ Financial Operations (University of Michigan) records, Bentley Historical Librar
             </did>
             <c04 level="file">
               <did>
-                <container type="volume" label="Oversize Volume">17-18</container>
                 <unittitle>Journals <unitdate type="inclusive" normal="1890/1912">1890-1912</unitdate></unittitle>
               </did>
               <odd>
                 <p>[Nos. 17-18]</p>
               </odd>
+              <c05 level="file">
+                <did>
+                  <unittitle>Journals <unitdate type="inclusive" normal="1890/1912">1890-1912</unitdate></unittitle>
+                  <container type="volume" label="Oversize Volume">17</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Journals <unitdate type="inclusive" normal="1890/1912">1890-1912</unitdate></unittitle>
+                  <container type="volume" label="Oversize Volume">18</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -762,39 +776,185 @@ Financial Operations (University of Michigan) records, Bentley Historical Librar
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">28-34</container>
             <unittitle>Ledgers <unitdate type="inclusive" normal="1920/1945" certainty="approximate">circa 1920-1945</unitdate></unittitle>
           </did>
           <odd>
             <p>[Nos. 28-34]</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers <unitdate type="inclusive" normal="1920/1945" certainty="approximate">circa 1920-1945</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">28</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers <unitdate type="inclusive" normal="1920/1945" certainty="approximate">circa 1920-1945</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">29</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers <unitdate type="inclusive" normal="1920/1945" certainty="approximate">circa 1920-1945</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">30</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers <unitdate type="inclusive" normal="1920/1945" certainty="approximate">circa 1920-1945</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">31</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers <unitdate type="inclusive" normal="1920/1945" certainty="approximate">circa 1920-1945</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">32</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers <unitdate type="inclusive" normal="1920/1945" certainty="approximate">circa 1920-1945</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">33</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers <unitdate type="inclusive" normal="1920/1945" certainty="approximate">circa 1920-1945</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">34</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">35-38</container>
             <unittitle>Securities Records <unitdate type="inclusive" normal="1920/1950" certainty="approximate">circa 1920-1950</unitdate></unittitle>
           </did>
           <odd>
             <p>[Nos. 35-38]</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Securities Records <unitdate type="inclusive" normal="1920/1950" certainty="approximate">circa 1920-1950</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">35</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Securities Records <unitdate type="inclusive" normal="1920/1950" certainty="approximate">circa 1920-1950</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">36</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Securities Records <unitdate type="inclusive" normal="1920/1950" certainty="approximate">circa 1920-1950</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">37</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Securities Records <unitdate type="inclusive" normal="1920/1950" certainty="approximate">circa 1920-1950</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">38</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">39-42</container>
             <unittitle>Receipt Registers <unitdate type="inclusive" normal="1932/1948">1932-1948</unitdate></unittitle>
           </did>
           <odd>
             <p>[Nos. 39-42]</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Receipt Registers <unitdate type="inclusive" normal="1932/1948">1932-1948</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">39</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Receipt Registers <unitdate type="inclusive" normal="1932/1948">1932-1948</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">40</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Receipt Registers <unitdate type="inclusive" normal="1932/1948">1932-1948</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">41</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Receipt Registers <unitdate type="inclusive" normal="1932/1948">1932-1948</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">42</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">43-45</container>
             <unittitle>Journals <unitdate type="inclusive" normal="1923/1946">1923-1946</unitdate></unittitle>
           </did>
           <odd>
             <p>[Nos. 43-45]</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Journals <unitdate type="inclusive" normal="1923/1946">1923-1946</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">43</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Journals <unitdate type="inclusive" normal="1923/1946">1923-1946</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">44</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Journals <unitdate type="inclusive" normal="1923/1946">1923-1946</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">45</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -1525,12 +1685,26 @@ Financial Operations (University of Michigan) records, Bentley Historical Librar
           </did>
           <c03 level="file">
             <did>
-              <container type="volume" label="Oversize Volume">20-21</container>
               <unittitle>Journals <unitdate type="inclusive" normal="1926/1947">1926-1947</unitdate></unittitle>
             </did>
             <odd>
               <p>[Nos. 20-21]</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Journals <unitdate type="inclusive" normal="1926/1947">1926-1947</unitdate></unittitle>
+                <container type="volume" label="Oversize Volume">20</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Journals <unitdate type="inclusive" normal="1926/1947">1926-1947</unitdate></unittitle>
+                <container type="volume" label="Oversize Volume">21</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/fordwd.xml
+++ b/Real_Masters_all/fordwd.xml
@@ -11238,7 +11238,6 @@
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">151-152</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1973/1974">1973-1974</unitdate>
                 </unittitle>
@@ -11249,14 +11248,51 @@
               <odd>
                 <p>(files relate to H.R. 69, The Elementary and Secondary Education Amendments of 1973)</p>
               </odd>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1973/1974">1973-1974</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">151</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1973/1974">1973-1974</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">152</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">95-96</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1975/1976">1975-1976</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1975/1976">1975-1976</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">95</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1975/1976">1975-1976</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">96</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/fprespon.xml
+++ b/Real_Masters_all/fprespon.xml
@@ -408,12 +408,134 @@ First Presbyterian Church (Pontiac, Mich.) records, Bentley Historical Library, 
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volumes">2-15</container>
             <unittitle>Ledgers with contributions of members</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">14 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">2</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">7</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">15</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/gjelsnrh.xml
+++ b/Real_Masters_all/gjelsnrh.xml
@@ -121,8 +121,6 @@ Rudolph H. Gjelsness papers, Bentley Historical Library, University of Michigan<
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">1</container>
-              <container type="folder" label="Folders">1-4</container>
               <unittitle>
                 <unitdate type="inclusive">Undated</unitdate>
               </unittitle>
@@ -130,6 +128,51 @@ Rudolph H. Gjelsness papers, Bentley Historical Library, University of Michigan<
                 <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive">Undated</unitdate>
+                </unittitle>
+                <container type="box" label="Box">1</container>
+                <container type="folder" label="Folders">1</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive">Undated</unitdate>
+                </unittitle>
+                <container type="box" label="Box">1</container>
+                <container type="folder" label="Folders">2</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive">Undated</unitdate>
+                </unittitle>
+                <container type="box" label="Box">1</container>
+                <container type="folder" label="Folders">3</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive">Undated</unitdate>
+                </unittitle>
+                <container type="box" label="Box">1</container>
+                <container type="folder" label="Folders">4</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -429,12 +472,31 @@ Rudolph H. Gjelsness papers, Bentley Historical Library, University of Michigan<
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">1</container>
-              <container type="folder" label="Folders">37-38</container>
               <unittitle>
                 <unitdate type="inclusive" normal="1916">1916</unitdate>
               </unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1916">1916</unitdate>
+                </unittitle>
+                <container type="box" label="Box">1</container>
+                <container type="folder" label="Folders">37</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1916">1916</unitdate>
+                </unittitle>
+                <container type="box" label="Box">1</container>
+                <container type="folder" label="Folders">38</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -462,16 +524,29 @@ Rudolph H. Gjelsness papers, Bentley Historical Library, University of Michigan<
         </did>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">2</container>
-            <container type="folder" label="Folder">1-2</container>
             <unittitle>Biographical data</unittitle>
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">2</container>
-              <container type="folder" label="Folder">3</container>
               <unittitle>Memorial statements</unittitle>
             </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Biographical data</unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Biographical data</unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
           </c03>
         </c02>
         <c02 level="file">
@@ -530,13 +605,38 @@ Rudolph H. Gjelsness papers, Bentley Historical Library, University of Michigan<
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">2</container>
-              <container type="folder" label="Folder">9-11</container>
               <unittitle>Miscellaneous papers</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous papers</unittitle>
+                <container type="box" label="Box">2</container>
+                <container type="folder" label="Folder">9</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous papers</unittitle>
+                <container type="box" label="Box">2</container>
+                <container type="folder" label="Folder">10</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous papers</unittitle>
+                <container type="box" label="Box">2</container>
+                <container type="folder" label="Folder">11</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="file">
@@ -1513,10 +1613,25 @@ Rudolph H. Gjelsness papers, Bentley Historical Library, University of Michigan<
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">4</container>
-            <container type="folder" label="Folders">46-47</container>
             <unittitle>Societies and Institutions</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Societies and Institutions</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folders">46</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Societies and Institutions</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folders">47</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -1534,10 +1649,35 @@ Rudolph H. Gjelsness papers, Bentley Historical Library, University of Michigan<
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">4</container>
-            <container type="folder" label="Folders">50-52</container>
             <unittitle>Transliteration</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Transliteration</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folders">50</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Transliteration</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folders">51</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Transliteration</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folders">52</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -1557,12 +1697,43 @@ Rudolph H. Gjelsness papers, Bentley Historical Library, University of Michigan<
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">5</container>
-              <container type="folder" label="Folder">1-3</container>
               <unittitle>
                 <unitdate type="inclusive">Undated</unitdate>
               </unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive">Undated</unitdate>
+                </unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">1</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive">Undated</unitdate>
+                </unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">2</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive">Undated</unitdate>
+                </unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">3</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2230,17 +2401,57 @@ Rudolph H. Gjelsness papers, Bentley Historical Library, University of Michigan<
         </did>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">6</container>
-            <container type="folder" label="Folder">34-36</container>
             <unittitle>Manuscripts, unpublished</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Manuscripts, unpublished</unittitle>
+              <container type="box" label="Box">6</container>
+              <container type="folder" label="Folder">34</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Manuscripts, unpublished</unittitle>
+              <container type="box" label="Box">6</container>
+              <container type="folder" label="Folder">35</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Manuscripts, unpublished</unittitle>
+              <container type="box" label="Box">6</container>
+              <container type="folder" label="Folder">36</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">6</container>
-            <container type="folder" label="Folder">37-38</container>
             <unittitle>Publications</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Publications</unittitle>
+              <container type="box" label="Box">6</container>
+              <container type="folder" label="Folder">37</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Publications</unittitle>
+              <container type="box" label="Box">6</container>
+              <container type="folder" label="Folder">38</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -2248,37 +2459,71 @@ Rudolph H. Gjelsness papers, Bentley Historical Library, University of Michigan<
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">6</container>
-              <container type="folder" label="Folder">39-40</container>
               <unittitle>Björnsterne Björnson</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Björnsterne Björnson</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">39</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Björnsterne Björnson</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">40</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">6</container>
-              <container type="folder" label="Folder">41-43</container>
               <unittitle>Johann Falkberget</unittitle>
             </did>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">6</container>
-                <container type="folder" label="Folder">44</container>
                 <unittitle>Biographical</unittitle>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">6</container>
-                <container type="folder" label="Folder">45</container>
                 <unittitle>Correspondence</unittitle>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">6</container>
-                <container type="folder" label="Folder">46</container>
                 <unittitle><title render="italic">Lisbeth of Jarnfjeld</title>, Reviews of Gjelsness translation</unittitle>
               </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Johann Falkberget</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">41</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Johann Falkberget</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">42</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Johann Falkberget</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">43</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
             </c04>
           </c03>
           <c03 level="file">
@@ -2310,20 +2555,120 @@ Rudolph H. Gjelsness papers, Bentley Historical Library, University of Michigan<
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">7</container>
-            <container type="folder" label="Folder">3-8</container>
             <unittitle>Comments</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Comments</unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">3</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Comments</unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Comments</unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Comments</unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Comments</unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">7</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Comments</unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">7</container>
-            <container type="folder" label="Folder">9-13</container>
             <unittitle>Proceedings of the Institute on Catalog Code Revision, Montreal <unitdate type="inclusive" normal="1960">1960</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">5 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Proceedings of the Institute on Catalog Code Revision, Montreal <unitdate type="inclusive" normal="1960">1960</unitdate></unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">9</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Proceedings of the Institute on Catalog Code Revision, Montreal <unitdate type="inclusive" normal="1960">1960</unitdate></unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Proceedings of the Institute on Catalog Code Revision, Montreal <unitdate type="inclusive" normal="1960">1960</unitdate></unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Proceedings of the Institute on Catalog Code Revision, Montreal <unitdate type="inclusive" normal="1960">1960</unitdate></unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Proceedings of the Institute on Catalog Code Revision, Montreal <unitdate type="inclusive" normal="1960">1960</unitdate></unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/gmwill.xml
+++ b/Real_Masters_all/gmwill.xml
@@ -32545,9 +32545,59 @@
                     </c08>
                     <c08 level="file">
                       <did>
-                        <container label="Box" type="box">355-360</container>
                         <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
                       </did>
+                      <c09 level="file">
+                        <did>
+                          <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
+                          <container label="Box" type="box">355</container>
+                        </did>
+                      </c09>
+                      <c09 level="file">
+                        <did>
+                          <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
+                          <container label="Box" type="box">356</container>
+                        </did>
+                        <odd>
+                          <p>(continued)</p>
+                        </odd>
+                      </c09>
+                      <c09 level="file">
+                        <did>
+                          <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
+                          <container label="Box" type="box">357</container>
+                        </did>
+                        <odd>
+                          <p>(continued)</p>
+                        </odd>
+                      </c09>
+                      <c09 level="file">
+                        <did>
+                          <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
+                          <container label="Box" type="box">358</container>
+                        </did>
+                        <odd>
+                          <p>(continued)</p>
+                        </odd>
+                      </c09>
+                      <c09 level="file">
+                        <did>
+                          <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
+                          <container label="Box" type="box">359</container>
+                        </did>
+                        <odd>
+                          <p>(continued)</p>
+                        </odd>
+                      </c09>
+                      <c09 level="file">
+                        <did>
+                          <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
+                          <container label="Box" type="box">360</container>
+                        </did>
+                        <odd>
+                          <p>(continued)</p>
+                        </odd>
+                      </c09>
                     </c08>
                     <c08 level="file">
                       <did>
@@ -35583,9 +35633,32 @@
                 </c06>
                 <c06 level="file">
                   <did>
-                    <container label="Box" type="box">369-371</container>
                     <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
                   </did>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
+                      <container label="Box" type="box">369</container>
+                    </did>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
+                      <container label="Box" type="box">370</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
+                      <container label="Box" type="box">371</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
                 </c06>
                 <c06 level="file">
                   <did>
@@ -35789,12 +35862,26 @@
               </did>
               <c05 level="file">
                 <did>
-                  <container label="Box" type="box">389-390</container>
                   <unittitle>re Civil Defense</unittitle>
                 </did>
                 <odd>
                   <p>(Plans and Surveys)</p>
                 </odd>
+                <c06 level="file">
+                  <did>
+                    <unittitle>re Civil Defense</unittitle>
+                    <container label="Box" type="box">389</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>re Civil Defense</unittitle>
+                    <container label="Box" type="box">390</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
             </c04>
             <c04 level="otherlevel" otherlevel="sub-subseries">
@@ -38746,11 +38833,29 @@
               </did>
               <c05 level="file">
                 <did>
-                  <container label="Box" type="box">420-421</container>
                   <unittitle>
                     <unitdate type="inclusive" normal="1960-11/1961-01">November 1960-January 1961</unitdate>
                   </unittitle>
                 </did>
+                <c06 level="file">
+                  <did>
+                    <unittitle>
+                      <unitdate type="inclusive" normal="1960-11/1961-01">November 1960-January 1961</unitdate>
+                    </unittitle>
+                    <container label="Box" type="box">420</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>
+                      <unitdate type="inclusive" normal="1960-11/1961-01">November 1960-January 1961</unitdate>
+                    </unittitle>
+                    <container label="Box" type="box">421</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
             </c04>
             <c04 level="otherlevel" otherlevel="sub-subseries">
@@ -41367,11 +41472,40 @@
             </scopecontent>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">505-507</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1951/1961">1951-1961</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1951/1961">1951-1961</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">505</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1951/1961">1951-1961</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">506</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1951/1961">1951-1961</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">507</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
           </c03>
           <c03 level="subseries">
@@ -42584,43 +42718,287 @@
             </scopecontent>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">558-561</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1949/1950">1949-1950</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1949/1950">1949-1950</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">558</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1949/1950">1949-1950</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">559</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1949/1950">1949-1950</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">560</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1949/1950">1949-1950</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">561</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">561-565</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1951/1952">1951-1952</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1951/1952">1951-1952</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">561</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1951/1952">1951-1952</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">562</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1951/1952">1951-1952</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">563</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1951/1952">1951-1952</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">564</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1951/1952">1951-1952</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">565</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">566-570</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1953/1954">1953-1954</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1953/1954">1953-1954</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">566</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1953/1954">1953-1954</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">567</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1953/1954">1953-1954</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">568</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1953/1954">1953-1954</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">569</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1953/1954">1953-1954</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">570</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">570-574</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1955/1956">1955-1956</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1955/1956">1955-1956</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">570</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1955/1956">1955-1956</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">571</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1955/1956">1955-1956</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">572</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1955/1956">1955-1956</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">573</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1955/1956">1955-1956</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">574</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">574-578</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1957/1958">1957-1958</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1957/1958">1957-1958</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">574</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1957/1958">1957-1958</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">575</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1957/1958">1957-1958</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">576</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1957/1958">1957-1958</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">577</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1957/1958">1957-1958</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">578</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -42719,35 +43097,107 @@
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">587-588</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1955">1955</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1955">1955</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">587</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1955">1955</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">588</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">588-589</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1956">1956</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1956">1956</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">588</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1956">1956</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">589</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">590-591</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1957">1957</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1957">1957</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">590</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1957">1957</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">591</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">592-593</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1958">1958</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1958">1958</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">592</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1958">1958</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">593</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -42897,12 +43347,62 @@
             </scopecontent>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">610-615</container>
                 <unittitle>Papers</unittitle>
               </did>
               <odd>
                 <p>[include family and social correspondence, clippings, and memorabilia]</p>
               </odd>
+              <c05 level="file">
+                <did>
+                  <unittitle>Papers</unittitle>
+                  <container label="Box" type="box">610</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Papers</unittitle>
+                  <container label="Box" type="box">611</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Papers</unittitle>
+                  <container label="Box" type="box">612</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Papers</unittitle>
+                  <container label="Box" type="box">613</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Papers</unittitle>
+                  <container label="Box" type="box">614</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Papers</unittitle>
+                  <container label="Box" type="box">615</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
           </c03>
           <c03 level="subseries">
@@ -42914,12 +43414,80 @@
             </scopecontent>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">616-623</container>
                 <unittitle>Programs</unittitle>
               </did>
               <odd>
                 <p>(events which GMW attended, or to which he was invited)</p>
               </odd>
+              <c05 level="file">
+                <did>
+                  <unittitle>Programs</unittitle>
+                  <container label="Box" type="box">616</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Programs</unittitle>
+                  <container label="Box" type="box">617</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Programs</unittitle>
+                  <container label="Box" type="box">618</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Programs</unittitle>
+                  <container label="Box" type="box">619</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Programs</unittitle>
+                  <container label="Box" type="box">620</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Programs</unittitle>
+                  <container label="Box" type="box">621</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Programs</unittitle>
+                  <container label="Box" type="box">622</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Programs</unittitle>
+                  <container label="Box" type="box">623</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
           </c03>
           <c03 level="subseries">
@@ -42931,13 +43499,35 @@
             </scopecontent>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">624-626</container>
                 <unittitle>Executive Office Financial Records</unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Executive Office Financial Records</unittitle>
+                  <container label="Box" type="box">624</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Executive Office Financial Records</unittitle>
+                  <container label="Box" type="box">625</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Executive Office Financial Records</unittitle>
+                  <container label="Box" type="box">626</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">627-633</container>
                 <unittitle>Personal Financial Records</unittitle>
               </did>
               <odd>
@@ -42946,6 +43536,66 @@
               <odd>
                 <p>(unarranged)</p>
               </odd>
+              <c05 level="file">
+                <did>
+                  <unittitle>Personal Financial Records</unittitle>
+                  <container label="Box" type="box">627</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Personal Financial Records</unittitle>
+                  <container label="Box" type="box">628</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Personal Financial Records</unittitle>
+                  <container label="Box" type="box">629</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Personal Financial Records</unittitle>
+                  <container label="Box" type="box">630</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Personal Financial Records</unittitle>
+                  <container label="Box" type="box">631</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Personal Financial Records</unittitle>
+                  <container label="Box" type="box">632</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Personal Financial Records</unittitle>
+                  <container label="Box" type="box">633</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
           </c03>
           <c03 level="subseries">
@@ -42957,111 +43607,764 @@
             </scopecontent>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">634-635</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1949">1949</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1949">1949</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">634</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1949">1949</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">635</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">636-637</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1950">1950</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1950">1950</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">636</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1950">1950</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">637</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">638-641</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1951">1951</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1951">1951</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">638</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1951">1951</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">639</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1951">1951</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">640</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1951">1951</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">641</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">642-646</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1952">1952</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1952">1952</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">642</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1952">1952</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">643</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1952">1952</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">644</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1952">1952</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">645</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1952">1952</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">646</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">647-649</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1953">1953</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1953">1953</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">647</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1953">1953</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">648</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1953">1953</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">649</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">650-654</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1954">1954</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1954">1954</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">650</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1954">1954</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">651</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1954">1954</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">652</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1954">1954</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">653</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1954">1954</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">654</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">655-658</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1955">1955</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1955">1955</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">655</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1955">1955</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">656</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1955">1955</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">657</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1955">1955</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">658</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">659-663</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1956">1956</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1956">1956</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">659</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1956">1956</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">660</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1956">1956</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">661</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1956">1956</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">662</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1956">1956</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">663</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">664-668</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1957">1957</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1957">1957</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">664</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1957">1957</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">665</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1957">1957</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">666</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1957">1957</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">667</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1957">1957</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">668</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">669-675</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1958">1958</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1958">1958</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">669</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1958">1958</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">670</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1958">1958</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">671</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1958">1958</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">672</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1958">1958</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">673</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1958">1958</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">674</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1958">1958</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">675</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">676-680</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1959">1959</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1959">1959</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">676</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1959">1959</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">677</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1959">1959</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">678</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1959">1959</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">679</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1959">1959</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">680</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">681-688</container>
                 <unittitle>[Box Nos. eliminated]</unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>[Box Nos. eliminated]</unittitle>
+                  <container label="Box" type="box">681</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>[Box Nos. eliminated]</unittitle>
+                  <container label="Box" type="box">682</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>[Box Nos. eliminated]</unittitle>
+                  <container label="Box" type="box">683</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>[Box Nos. eliminated]</unittitle>
+                  <container label="Box" type="box">684</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>[Box Nos. eliminated]</unittitle>
+                  <container label="Box" type="box">685</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>[Box Nos. eliminated]</unittitle>
+                  <container label="Box" type="box">686</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>[Box Nos. eliminated]</unittitle>
+                  <container label="Box" type="box">687</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>[Box Nos. eliminated]</unittitle>
+                  <container label="Box" type="box">688</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">689-694</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1960">1960</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1960">1960</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">689</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1960">1960</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">690</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1960">1960</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">691</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1960">1960</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">692</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1960">1960</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">693</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1960">1960</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">694</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">695-700</container>
                 <unittitle>[Box Nos. eliminated]</unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>[Box Nos. eliminated]</unittitle>
+                  <container label="Box" type="box">695</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>[Box Nos. eliminated]</unittitle>
+                  <container label="Box" type="box">696</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>[Box Nos. eliminated]</unittitle>
+                  <container label="Box" type="box">697</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>[Box Nos. eliminated]</unittitle>
+                  <container label="Box" type="box">698</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>[Box Nos. eliminated]</unittitle>
+                  <container label="Box" type="box">699</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>[Box Nos. eliminated]</unittitle>
+                  <container label="Box" type="box">700</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/granholm.xml
+++ b/Real_Masters_all/granholm.xml
@@ -81396,9 +81396,23 @@ Jennifer Granholm papers, Bentley Historical Library, University of Michigan</p>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">224-225</container>
             <unittitle>Awards, certificates, and gifts from constituents related to First Gentleman Mulhern’s achievements and public activities</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Awards, certificates, and gifts from constituents related to First Gentleman Mulhern’s achievements and public activities</unittitle>
+              <container type="box" label="Box">224</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Awards, certificates, and gifts from constituents related to First Gentleman Mulhern’s achievements and public activities</unittitle>
+              <container type="box" label="Box">225</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -81414,9 +81428,68 @@ Jennifer Granholm papers, Bentley Historical Library, University of Michigan</p>
         </c02>
         <c02 level="file">
           <did>
-            <container type="object" label="Framed Citations">1-7</container>
             <unittitle>4 framed awards and certificates of Daniel Mulhern and 3 framed awards and certificates of Governor Granholm</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>4 framed awards and certificates of Daniel Mulhern and 3 framed awards and certificates of Governor Granholm</unittitle>
+              <container type="object" label="Framed Citations">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>4 framed awards and certificates of Daniel Mulhern and 3 framed awards and certificates of Governor Granholm</unittitle>
+              <container type="object" label="Framed Citations">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>4 framed awards and certificates of Daniel Mulhern and 3 framed awards and certificates of Governor Granholm</unittitle>
+              <container type="object" label="Framed Citations">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>4 framed awards and certificates of Daniel Mulhern and 3 framed awards and certificates of Governor Granholm</unittitle>
+              <container type="object" label="Framed Citations">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>4 framed awards and certificates of Daniel Mulhern and 3 framed awards and certificates of Governor Granholm</unittitle>
+              <container type="object" label="Framed Citations">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>4 framed awards and certificates of Daniel Mulhern and 3 framed awards and certificates of Governor Granholm</unittitle>
+              <container type="object" label="Framed Citations">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>4 framed awards and certificates of Daniel Mulhern and 3 framed awards and certificates of Governor Granholm</unittitle>
+              <container type="object" label="Framed Citations">7</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/harrisgb.xml
+++ b/Real_Masters_all/harrisgb.xml
@@ -795,7 +795,6 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="reel" label="MF Reels">1-18</container>
             <physloc>mf cab.</physloc>
             <unittitle>Research material</unittitle>
             <physdesc>
@@ -805,6 +804,165 @@
           <odd>
             <p>(including copies of works of Elizabethan literature)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">7</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">15</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">16</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">17</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">18</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/hartphil.xml
+++ b/Real_Masters_all/hartphil.xml
@@ -7787,11 +7787,29 @@
           </c03>
           <c03 level="file">
             <did>
-              <container label="Box" type="box">111-112</container>
               <unittitle>
                 <unitdate>Undated</unitdate>
               </unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate>Undated</unitdate>
+                </unittitle>
+                <container label="Box" type="box">111</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate>Undated</unitdate>
+                </unittitle>
+                <container label="Box" type="box">112</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -34676,7 +34694,6 @@
         </scopecontent>
         <c02 level="file">
           <did>
-            <container label="Boxes" type="box">231-232</container>
             <unittitle>
               <unitdate type="inclusive" normal="1958/1959">1958-1959</unitdate>
             </unittitle>
@@ -34684,6 +34701,25 @@
           <odd>
             <p>(mainly 1959) (arranged by topic or legislative subject)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1958/1959">1958-1959</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">231</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1958/1959">1958-1959</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">232</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -34703,19 +34739,66 @@
         </c02>
         <c02 level="file">
           <did>
-            <container label="Boxes" type="box">234-236</container>
             <unittitle>
               <unitdate type="inclusive" normal="1961">1961</unitdate>
             </unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1961">1961</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">234</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1961">1961</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">235</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1961">1961</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">236</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container label="Boxes" type="box">237-238</container>
             <unittitle>
               <unitdate type="inclusive" normal="1962">1962</unitdate>
             </unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1962">1962</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">237</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1962">1962</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">238</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -34727,7 +34810,6 @@
         </c02>
         <c02 level="file">
           <did>
-            <container label="Boxes" type="box">238-241</container>
             <unittitle>
               <unitdate type="inclusive" normal="1964">1964</unitdate>
             </unittitle>
@@ -34735,14 +34817,84 @@
           <odd>
             <p>(includes .5 linear feet re Civil Rights Act)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1964">1964</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">238</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1964">1964</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">239</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1964">1964</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">240</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1964">1964</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">241</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container label="Boxes" type="box">241-243</container>
             <unittitle>
               <unitdate type="inclusive" normal="1965">1965</unitdate>
             </unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1965">1965</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">241</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1965">1965</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">242</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1965">1965</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">243</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -35103,9 +35255,41 @@
         </c02>
         <c02 level="file">
           <did>
-            <container label="Boxes" type="box">260-263</container>
             <unittitle><unitdate type="inclusive" normal="1970">1970</unitdate> campaign</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle><unitdate type="inclusive" normal="1970">1970</unitdate> campaign</unittitle>
+              <container label="Boxes" type="box">260</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle><unitdate type="inclusive" normal="1970">1970</unitdate> campaign</unittitle>
+              <container label="Boxes" type="box">261</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle><unitdate type="inclusive" normal="1970">1970</unitdate> campaign</unittitle>
+              <container label="Boxes" type="box">262</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle><unitdate type="inclusive" normal="1970">1970</unitdate> campaign</unittitle>
+              <container label="Boxes" type="box">263</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -35132,9 +35316,23 @@
         </c02>
         <c02 level="file">
           <did>
-            <container label="Boxes" type="box">265-266</container>
             <unittitle>Microfiche of selective portions of the Hart papers</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Microfiche of selective portions of the Hart papers</unittitle>
+              <container label="Boxes" type="box">265</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Microfiche of selective portions of the Hart papers</unittitle>
+              <container label="Boxes" type="box">266</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/hrecsurv.xml
+++ b/Real_Masters_all/hrecsurv.xml
@@ -8236,9 +8236,23 @@ s offices (as well as having some of its own work done by WPA workers), the Bent
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">1-2</container>
             <unittitle>Alpena County <unitdate type="inclusive" normal="1871/1919">1871-1919</unitdate>, <unitdate type="inclusive" normal="1937">1937</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Alpena County <unitdate type="inclusive" normal="1871/1919">1871-1919</unitdate>, <unitdate type="inclusive" normal="1937">1937</unitdate></unittitle>
+              <container type="box" label="Boxes">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Alpena County <unitdate type="inclusive" normal="1871/1919">1871-1919</unitdate>, <unitdate type="inclusive" normal="1937">1937</unitdate></unittitle>
+              <container type="box" label="Boxes">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -8301,7 +8315,6 @@ s offices (as well as having some of its own work done by WPA workers), the Bent
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">2-3</container>
             <unittitle>Benzie County <unitdate type="inclusive" normal="1869/1920">1869-1920</unitdate></unittitle>
           </did>
           <c03 level="file">
@@ -8319,12 +8332,50 @@ s offices (as well as having some of its own work done by WPA workers), the Bent
               <unittitle>Laws Concerning Keeping of Records (arranged by government department)</unittitle>
             </did>
           </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Benzie County <unitdate type="inclusive" normal="1869/1920">1869-1920</unitdate></unittitle>
+              <container type="box" label="Boxes">2</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Benzie County <unitdate type="inclusive" normal="1869/1920">1869-1920</unitdate></unittitle>
+              <container type="box" label="Boxes">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">3-5</container>
             <unittitle>Berrien County <unitdate type="inclusive" normal="1832/1941">1832-1941</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Berrien County <unitdate type="inclusive" normal="1832/1941">1832-1941</unitdate></unittitle>
+              <container type="box" label="Boxes">3</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Berrien County <unitdate type="inclusive" normal="1832/1941">1832-1941</unitdate></unittitle>
+              <container type="box" label="Boxes">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Berrien County <unitdate type="inclusive" normal="1832/1941">1832-1941</unitdate></unittitle>
+              <container type="box" label="Boxes">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -8374,9 +8425,23 @@ s offices (as well as having some of its own work done by WPA workers), the Bent
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">5-6</container>
             <unittitle>Clare County <unitdate type="inclusive" normal="1871/1925">1871-1925</unitdate>, <unitdate type="inclusive" normal="1940">1940</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Clare County <unitdate type="inclusive" normal="1871/1925">1871-1925</unitdate>, <unitdate type="inclusive" normal="1940">1940</unitdate></unittitle>
+              <container type="box" label="Boxes">5</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Clare County <unitdate type="inclusive" normal="1871/1925">1871-1925</unitdate>, <unitdate type="inclusive" normal="1940">1940</unitdate></unittitle>
+              <container type="box" label="Boxes">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -8531,13 +8596,26 @@ s offices (as well as having some of its own work done by WPA workers), the Bent
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">8-9</container>
             <unittitle>Genesee County <unitdate type="inclusive" normal="1836/1895">1836-1895</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Genesee County <unitdate type="inclusive" normal="1836/1895">1836-1895</unitdate></unittitle>
+              <container type="box" label="Boxes">8</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Genesee County <unitdate type="inclusive" normal="1836/1895">1836-1895</unitdate></unittitle>
+              <container type="box" label="Boxes">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">8-10</container>
             <unittitle>Gladwin County</unittitle>
           </did>
           <c03 level="file">
@@ -8560,6 +8638,30 @@ s offices (as well as having some of its own work done by WPA workers), the Bent
                 <unitdate type="inclusive" normal="1940">1940</unitdate>
               </unittitle>
             </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Gladwin County</unittitle>
+              <container type="box" label="Boxes">8</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Gladwin County</unittitle>
+              <container type="box" label="Boxes">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Gladwin County</unittitle>
+              <container type="box" label="Boxes">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
           </c03>
         </c02>
         <c02 level="file">
@@ -8759,9 +8861,23 @@ s offices (as well as having some of its own work done by WPA workers), the Bent
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">11-12</container>
             <unittitle>Jackson County <unitdate type="inclusive" normal="1837/1885">1837-1885</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Jackson County <unitdate type="inclusive" normal="1837/1885">1837-1885</unitdate></unittitle>
+              <container type="box" label="Boxes">11</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Jackson County <unitdate type="inclusive" normal="1837/1885">1837-1885</unitdate></unittitle>
+              <container type="box" label="Boxes">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -8802,9 +8918,23 @@ s offices (as well as having some of its own work done by WPA workers), the Bent
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">13-14</container>
             <unittitle>Kent County <unitdate type="inclusive" normal="1845/1888">1845-1888</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Kent County <unitdate type="inclusive" normal="1845/1888">1845-1888</unitdate></unittitle>
+              <container type="box" label="Boxes">13</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Kent County <unitdate type="inclusive" normal="1845/1888">1845-1888</unitdate></unittitle>
+              <container type="box" label="Boxes">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -9426,9 +9556,32 @@ s offices (as well as having some of its own work done by WPA workers), the Bent
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">22-24</container>
             <unittitle>Grand Rapids <unitdate type="inclusive" normal="1838/1873">1838-1873</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Grand Rapids <unitdate type="inclusive" normal="1838/1873">1838-1873</unitdate></unittitle>
+              <container type="box" label="Boxes">22</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Grand Rapids <unitdate type="inclusive" normal="1838/1873">1838-1873</unitdate></unittitle>
+              <container type="box" label="Boxes">23</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Grand Rapids <unitdate type="inclusive" normal="1838/1873">1838-1873</unitdate></unittitle>
+              <container type="box" label="Boxes">24</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/hubbardl.xml
+++ b/Real_Masters_all/hubbardl.xml
@@ -193,8 +193,6 @@ Lucius L. Hubbard Papers
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">3</container>
-            <container type="folder" label="Folders">1-11</container>
             <unittitle>
               <unitdate type="inclusive" normal="1929/1935">1929-1935</unitdate>
               <unitdate type="inclusive">undated</unitdate>
@@ -203,6 +201,146 @@ Lucius L. Hubbard Papers
               <extent altrender="materialtype spaceoccupied">11 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1929/1935">1929-1935</unitdate>
+                <unitdate type="inclusive">undated</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folders">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1929/1935">1929-1935</unitdate>
+                <unitdate type="inclusive">undated</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folders">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1929/1935">1929-1935</unitdate>
+                <unitdate type="inclusive">undated</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folders">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1929/1935">1929-1935</unitdate>
+                <unitdate type="inclusive">undated</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folders">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1929/1935">1929-1935</unitdate>
+                <unitdate type="inclusive">undated</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folders">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1929/1935">1929-1935</unitdate>
+                <unitdate type="inclusive">undated</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folders">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1929/1935">1929-1935</unitdate>
+                <unitdate type="inclusive">undated</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folders">7</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1929/1935">1929-1935</unitdate>
+                <unitdate type="inclusive">undated</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folders">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1929/1935">1929-1935</unitdate>
+                <unitdate type="inclusive">undated</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folders">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1929/1935">1929-1935</unitdate>
+                <unitdate type="inclusive">undated</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folders">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1929/1935">1929-1935</unitdate>
+                <unitdate type="inclusive">undated</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folders">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -714,10 +852,55 @@ Lucius L. Hubbard Papers
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">3</container>
-            <container type="folder" label="Folders">41-45</container>
             <unittitle>Progress reports of Longyear and Hodge, Mining Engineers <unitdate type="inclusive" normal="1909-09/1911-01">September 1909-January 1911</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Progress reports of Longyear and Hodge, Mining Engineers <unitdate type="inclusive" normal="1909-09/1911-01">September 1909-January 1911</unitdate></unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folders">41</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Progress reports of Longyear and Hodge, Mining Engineers <unitdate type="inclusive" normal="1909-09/1911-01">September 1909-January 1911</unitdate></unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folders">42</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Progress reports of Longyear and Hodge, Mining Engineers <unitdate type="inclusive" normal="1909-09/1911-01">September 1909-January 1911</unitdate></unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folders">43</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Progress reports of Longyear and Hodge, Mining Engineers <unitdate type="inclusive" normal="1909-09/1911-01">September 1909-January 1911</unitdate></unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folders">44</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Progress reports of Longyear and Hodge, Mining Engineers <unitdate type="inclusive" normal="1909-09/1911-01">September 1909-January 1911</unitdate></unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folders">45</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -777,13 +960,28 @@ Lucius L. Hubbard Papers
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">3</container>
-              <container type="folder" label="Folders">50-51</container>
               <unittitle>Maps of the State of Maine</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Maps of the State of Maine</unittitle>
+                <container type="box" label="Box">3</container>
+                <container type="folder" label="Folders">50</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Maps of the State of Maine</unittitle>
+                <container type="box" label="Box">3</container>
+                <container type="folder" label="Folders">51</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="item">
             <did>
@@ -794,13 +992,58 @@ Lucius L. Hubbard Papers
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">3</container>
-              <container type="folder" label="Folders">53-57</container>
               <unittitle>Miscellaneous manuscript maps, often not identified</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous manuscript maps, often not identified</unittitle>
+                <container type="box" label="Box">3</container>
+                <container type="folder" label="Folders">53</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous manuscript maps, often not identified</unittitle>
+                <container type="box" label="Box">3</container>
+                <container type="folder" label="Folders">54</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous manuscript maps, often not identified</unittitle>
+                <container type="box" label="Box">3</container>
+                <container type="folder" label="Folders">55</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous manuscript maps, often not identified</unittitle>
+                <container type="box" label="Box">3</container>
+                <container type="folder" label="Folders">56</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous manuscript maps, often not identified</unittitle>
+                <container type="box" label="Box">3</container>
+                <container type="folder" label="Folders">57</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="item">
             <did>
@@ -826,13 +1069,28 @@ Lucius L. Hubbard Papers
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">4</container>
-            <container type="folder" label="Folders">61-62</container>
             <unittitle>Reports and notes of the Seneca Copper Corporation <unitdate type="inclusive" normal="1920/1921">1920-1921</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Reports and notes of the Seneca Copper Corporation <unitdate type="inclusive" normal="1920/1921">1920-1921</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folders">61</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Reports and notes of the Seneca Copper Corporation <unitdate type="inclusive" normal="1920/1921">1920-1921</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folders">62</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -846,30 +1104,115 @@ Lucius L. Hubbard Papers
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">4</container>
-            <container type="folder" label="Folder">64-66</container>
             <unittitle>Reports and notes of the Houghton Copper Company <unitdate type="inclusive" normal="1910/1913">1910-1913</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Reports and notes of the Houghton Copper Company <unitdate type="inclusive" normal="1910/1913">1910-1913</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">64</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Reports and notes of the Houghton Copper Company <unitdate type="inclusive" normal="1910/1913">1910-1913</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">65</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Reports and notes of the Houghton Copper Company <unitdate type="inclusive" normal="1910/1913">1910-1913</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">66</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">4</container>
-            <container type="folder" label="Folders">67-71</container>
             <unittitle>Reports and notes of the Champion Copper Company <unitdate type="inclusive" normal="1900/1905">1900-1905</unitdate>, <unitdate type="inclusive" normal="1923" certainty="approximate">1923 undated</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">5 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Reports and notes of the Champion Copper Company <unitdate type="inclusive" normal="1900/1905">1900-1905</unitdate>, <unitdate type="inclusive" normal="1923" certainty="approximate">1923 undated</unitdate></unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folders">67</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Reports and notes of the Champion Copper Company <unitdate type="inclusive" normal="1900/1905">1900-1905</unitdate>, <unitdate type="inclusive" normal="1923" certainty="approximate">1923 undated</unitdate></unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folders">68</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Reports and notes of the Champion Copper Company <unitdate type="inclusive" normal="1900/1905">1900-1905</unitdate>, <unitdate type="inclusive" normal="1923" certainty="approximate">1923 undated</unitdate></unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folders">69</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Reports and notes of the Champion Copper Company <unitdate type="inclusive" normal="1900/1905">1900-1905</unitdate>, <unitdate type="inclusive" normal="1923" certainty="approximate">1923 undated</unitdate></unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folders">70</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Reports and notes of the Champion Copper Company <unitdate type="inclusive" normal="1900/1905">1900-1905</unitdate>, <unitdate type="inclusive" normal="1923" certainty="approximate">1923 undated</unitdate></unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folders">71</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">4</container>
-            <container type="folder" label="Folders">72-73</container>
             <unittitle>General reports of the Copper Range Co. <unitdate type="inclusive" normal="1899/1903">1899-1903</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>General reports of the Copper Range Co. <unitdate type="inclusive" normal="1899/1903">1899-1903</unitdate></unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folders">72</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>General reports of the Copper Range Co. <unitdate type="inclusive" normal="1899/1903">1899-1903</unitdate></unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folders">73</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="item">
           <did>

--- a/Real_Masters_all/interloc.xml
+++ b/Real_Masters_all/interloc.xml
@@ -25376,12 +25376,10 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
         </scopecontent>
         <c02 level="subseries">
           <did>
-            <container type="box" label="Box">76-77</container>
             <unittitle>Community and School Bands</unittitle>
           </did>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>Broadcast school band from control room at University of Michigan (two nuns in background)</unittitle>
             </did>
             <odd>
@@ -25390,7 +25388,6 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>Detroit All City Elementary Band, Fowler Smith conductor, in Cass High School Auditorium <unitdate type="inclusive" normal="1925">1925</unitdate></unittitle>
             </did>
             <odd>
@@ -25399,7 +25396,6 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>Dewitt, Michigan, band playing by school</unittitle>
             </did>
             <odd>
@@ -25408,7 +25404,6 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>Flint, Michigan, Post Office Band in front of municipal building with Elmer Duhlstrom, conductor</unittitle>
             </did>
             <odd>
@@ -25417,7 +25412,6 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>Flushing, Michigan, High School Band (integrated) playing outside</unittitle>
             </did>
             <odd>
@@ -25426,7 +25420,6 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>Harp ensemble with Pasquale Montani, possibly Richmond, Indiana, in <unitdate type="inclusive" normal="1923">1923</unitdate></unittitle>
             </did>
             <odd>
@@ -25435,7 +25428,6 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>Illinois All State High School Orchestra with Ray Dvorak conductor <unitdate type="inclusive" normal="1930">1930</unitdate></unittitle>
             </did>
             <odd>
@@ -25444,7 +25436,6 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>Los Angeles Elementary Schools, Orchestra Department, in stadium seats</unittitle>
             </did>
             <odd>
@@ -25453,7 +25444,6 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>McBain, Michigan, band on steps of school</unittitle>
             </did>
             <odd>
@@ -25462,7 +25452,6 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>(Michigan ?) band in school room</unittitle>
             </did>
             <odd>
@@ -25471,7 +25460,6 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>(Michigan?) orchestra on steps of school</unittitle>
             </did>
             <odd>
@@ -25480,7 +25468,6 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>Minneapolis Working Boys' Band outside public building</unittitle>
             </did>
             <odd>
@@ -25489,7 +25476,6 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>Nicholas Senn High School Championship Band</unittitle>
             </did>
             <odd>
@@ -25498,7 +25484,6 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>San Francisco Municipal Railway Band and Baseball Team outdoors</unittitle>
             </did>
             <odd>
@@ -25507,7 +25492,6 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>Sheridan County (Wyoming?) band in Native American attire</unittitle>
             </did>
             <odd>
@@ -25516,7 +25500,6 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>St. Thomas (Ann Arbor?) band in gymnasium</unittitle>
             </did>
             <odd>
@@ -25525,7 +25508,6 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>Sterling, Michigan, band on steps of school</unittitle>
             </did>
             <odd>
@@ -25534,7 +25516,6 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>University of Illinois band on football field in formation</unittitle>
             </did>
             <odd>
@@ -25543,11 +25524,25 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
           </c03>
           <c03 level="item">
             <did>
-              <container type="box" label="Box">76-77</container>
               <unittitle>University of Michigan band on steps of (Angell Hall?)</unittitle>
             </did>
             <odd>
               <p>(183</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Community and School Bands</unittitle>
+              <container type="box" label="Box">76</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Community and School Bands</unittitle>
+              <container type="box" label="Box">77</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
             </odd>
           </c03>
         </c02>

--- a/Real_Masters_all/iogeront.xml
+++ b/Real_Masters_all/iogeront.xml
@@ -4152,12 +4152,26 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">23-24</container>
             <unittitle>Institute of Gerontology collection of speeches, conferences, training sessions</unittitle>
             <physdesc>
               <extent>approx. 100 cassettes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Institute of Gerontology collection of speeches, conferences, training sessions</unittitle>
+              <container type="box" label="Box">23</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Institute of Gerontology collection of speeches, conferences, training sessions</unittitle>
+              <container type="box" label="Box">24</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/iogt.xml
+++ b/Real_Masters_all/iogt.xml
@@ -540,12 +540,26 @@ International Organization of Good Templars records, Bentley Historical Library,
         </did>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">18-19</container>
             <unittitle>Temperance books and pamphlets <unitdate type="inclusive" normal="1865/1963">1865-1963</unitdate></unittitle>
           </did>
           <odd>
             <p>(in Swedish and Norwegian)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Temperance books and pamphlets <unitdate type="inclusive" normal="1865/1963">1865-1963</unitdate></unittitle>
+              <container type="box" label="Box">18</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Temperance books and pamphlets <unitdate type="inclusive" normal="1865/1963">1865-1963</unitdate></unittitle>
+              <container type="box" label="Box">19</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/ismrrd.xml
+++ b/Real_Masters_all/ismrrd.xml
@@ -1756,9 +1756,23 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">9-10</container>
             <unittitle>Developmental Disabilities Office (DDO)</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Developmental Disabilities Office (DDO)</unittitle>
+              <container type="box" label="Box">9</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Developmental Disabilities Office (DDO)</unittitle>
+              <container type="box" label="Box">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -1768,9 +1782,23 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">10-11</container>
             <unittitle>Early Intervention</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Early Intervention</unittitle>
+              <container type="box" label="Box">10</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Early Intervention</unittitle>
+              <container type="box" label="Box">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -1888,9 +1916,32 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">12-14</container>
             <unittitle>Maternal and Child Health</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Maternal and Child Health</unittitle>
+              <container type="box" label="Box">12</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Maternal and Child Health</unittitle>
+              <container type="box" label="Box">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Maternal and Child Health</unittitle>
+              <container type="box" label="Box">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -2130,19 +2181,55 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">20-21</container>
             <unittitle>
               <unitdate type="inclusive" normal="1972/1973">1972/73</unitdate>
             </unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1972/1973">1972/73</unitdate>
+              </unittitle>
+              <container type="box" label="Box">20</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1972/1973">1972/73</unitdate>
+              </unittitle>
+              <container type="box" label="Box">21</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">21-22</container>
             <unittitle>
               <unitdate type="inclusive" normal="1973">1973</unitdate>
             </unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1973">1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">21</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1973">1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">22</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -2154,19 +2241,66 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">23-24</container>
             <unittitle>
               <unitdate type="inclusive" normal="1974">1974</unitdate>
             </unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1974">1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">23</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1974">1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">24</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">24-26</container>
             <unittitle>
               <unitdate type="inclusive" normal="1974/1975">1974/75</unitdate>
             </unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1974/1975">1974/75</unitdate>
+              </unittitle>
+              <container type="box" label="Box">24</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1974/1975">1974/75</unitdate>
+              </unittitle>
+              <container type="box" label="Box">25</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1974/1975">1974/75</unitdate>
+              </unittitle>
+              <container type="box" label="Box">26</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -2178,19 +2312,55 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">26-27</container>
             <unittitle>
               <unitdate type="inclusive" normal="1975/1976">1975/76</unitdate>
             </unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1975/1976">1975/76</unitdate>
+              </unittitle>
+              <container type="box" label="Box">26</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1975/1976">1975/76</unitdate>
+              </unittitle>
+              <container type="box" label="Box">27</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">27-28</container>
             <unittitle>
               <unitdate type="inclusive" normal="1976">1976</unitdate>
             </unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1976">1976</unitdate>
+              </unittitle>
+              <container type="box" label="Box">27</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1976">1976</unitdate>
+              </unittitle>
+              <container type="box" label="Box">28</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -2202,35 +2372,140 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">28-31</container>
             <unittitle>
               <unitdate type="inclusive" normal="1977">1977</unitdate>
             </unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1977">1977</unitdate>
+              </unittitle>
+              <container type="box" label="Box">28</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1977">1977</unitdate>
+              </unittitle>
+              <container type="box" label="Box">29</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1977">1977</unitdate>
+              </unittitle>
+              <container type="box" label="Box">30</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1977">1977</unitdate>
+              </unittitle>
+              <container type="box" label="Box">31</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">31-32</container>
             <unittitle>
               <unitdate type="inclusive" normal="1977/1978">1977/78</unitdate>
             </unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1977/1978">1977/78</unitdate>
+              </unittitle>
+              <container type="box" label="Box">31</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1977/1978">1977/78</unitdate>
+              </unittitle>
+              <container type="box" label="Box">32</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">32-33</container>
             <unittitle>
               <unitdate type="inclusive" normal="1978">1978</unitdate>
             </unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1978">1978</unitdate>
+              </unittitle>
+              <container type="box" label="Box">32</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1978">1978</unitdate>
+              </unittitle>
+              <container type="box" label="Box">33</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">33-35</container>
             <unittitle>
               <unitdate type="inclusive" normal="1978/1979">1978/79</unitdate>
             </unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1978/1979">1978/79</unitdate>
+              </unittitle>
+              <container type="box" label="Box">33</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1978/1979">1978/79</unitdate>
+              </unittitle>
+              <container type="box" label="Box">34</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1978/1979">1978/79</unitdate>
+              </unittitle>
+              <container type="box" label="Box">35</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -2250,11 +2525,51 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">36-39</container>
             <unittitle>
               <unitdate type="inclusive" normal="1980">1980</unitdate>
             </unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1980">1980</unitdate>
+              </unittitle>
+              <container type="box" label="Box">36</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1980">1980</unitdate>
+              </unittitle>
+              <container type="box" label="Box">37</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1980">1980</unitdate>
+              </unittitle>
+              <container type="box" label="Box">38</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1980">1980</unitdate>
+              </unittitle>
+              <container type="box" label="Box">39</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -2266,11 +2581,29 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">40-41</container>
             <unittitle>
               <unitdate type="inclusive" normal="1981">1981</unitdate>
             </unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1981">1981</unitdate>
+              </unittitle>
+              <container type="box" label="Box">40</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1981">1981</unitdate>
+              </unittitle>
+              <container type="box" label="Box">41</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -2282,19 +2615,77 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">41-44</container>
             <unittitle>
               <unitdate type="inclusive" normal="1982">1982</unitdate>
             </unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1982">1982</unitdate>
+              </unittitle>
+              <container type="box" label="Box">41</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1982">1982</unitdate>
+              </unittitle>
+              <container type="box" label="Box">42</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1982">1982</unitdate>
+              </unittitle>
+              <container type="box" label="Box">43</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1982">1982</unitdate>
+              </unittitle>
+              <container type="box" label="Box">44</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">44-45</container>
             <unittitle>
               <unitdate type="inclusive" normal="1982/1983">1982/83</unitdate>
             </unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1982/1983">1982/83</unitdate>
+              </unittitle>
+              <container type="box" label="Box">44</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1982/1983">1982/83</unitdate>
+              </unittitle>
+              <container type="box" label="Box">45</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -2346,9 +2737,23 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">47-48</container>
             <unittitle>Publications</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Publications</unittitle>
+              <container type="box" label="Box">47</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Publications</unittitle>
+              <container type="box" label="Box">48</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/kahnalb.xml
+++ b/Real_Masters_all/kahnalb.xml
@@ -6217,7 +6217,6 @@
           </did>
           <c03 level="file">
             <did>
-              <container label="Volume" type="volume">12-13</container>
               <unittitle>Furniture (Books I &amp; II)</unittitle>
               <physdesc>
                 <physfacet>catalogue photographs and prints of furniture drawings</physfacet>
@@ -6226,6 +6225,21 @@
             <odd>
               <p>[vols. 12 &amp; 13]</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Furniture (Books I &amp; II)</unittitle>
+                <container label="Volume" type="volume">12</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Furniture (Books I &amp; II)</unittitle>
+                <container label="Volume" type="volume">13</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="file">
@@ -6234,7 +6248,6 @@
           </did>
           <c03 level="file">
             <did>
-              <container label="Volume" type="volume">10-11</container>
               <unittitle>Furniture and Draperies by W. &amp; J. Sloane, New York (Books I &amp; II)</unittitle>
               <physdesc>
                 <physfacet>catalogue photographs, blueprints of furniture drawings, and fabric swatches</physfacet>
@@ -6243,6 +6256,21 @@
             <odd>
               <p>[vols. 10 &amp; 11]</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Furniture and Draperies by W. &amp; J. Sloane, New York (Books I &amp; II)</unittitle>
+                <container label="Volume" type="volume">10</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Furniture and Draperies by W. &amp; J. Sloane, New York (Books I &amp; II)</unittitle>
+                <container label="Volume" type="volume">11</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/kelseymu.xml
+++ b/Real_Masters_all/kelseymu.xml
@@ -734,10 +734,25 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">3</container>
-              <container label="Folder" type="folder">11-12</container>
               <unittitle>Photos of fragments</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Photos of fragments</unittitle>
+                <container type="box" label="Box">3</container>
+                <container label="Folder" type="folder">11</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Photos of fragments</unittitle>
+                <container type="box" label="Box">3</container>
+                <container label="Folder" type="folder">12</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3687,13 +3702,28 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">3</container>
-              <container type="folder" label="Folder">10-11</container>
               <unittitle>Karanis. Near East Research. Kelsey, etc. papyri <unitdate type="inclusive" normal="1925/1926">1925-1926</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Karanis. Near East Research. Kelsey, etc. papyri <unitdate type="inclusive" normal="1925/1926">1925-1926</unitdate></unittitle>
+                <container type="box" label="Box">3</container>
+                <container type="folder" label="Folder">10</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Karanis. Near East Research. Kelsey, etc. papyri <unitdate type="inclusive" normal="1925/1926">1925-1926</unitdate></unittitle>
+                <container type="box" label="Box">3</container>
+                <container type="folder" label="Folder">11</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -5618,17 +5648,47 @@
                 </c06>
                 <c06 level="file">
                   <did>
-                    <container type="box" label="Box">11</container>
-                    <container label="Folder" type="folder">5-6</container>
                     <unittitle>Notes taken in reading for "Roman Morals."</unittitle>
                   </did>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Notes taken in reading for "Roman Morals."</unittitle>
+                      <container type="box" label="Box">11</container>
+                      <container label="Folder" type="folder">5</container>
+                    </did>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Notes taken in reading for "Roman Morals."</unittitle>
+                      <container type="box" label="Box">11</container>
+                      <container label="Folder" type="folder">6</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
                 </c06>
                 <c06 level="file">
                   <did>
-                    <container type="box" label="Box">11</container>
-                    <container label="Folder" type="folder">7-8</container>
                     <unittitle>Misc. reading references.</unittitle>
                   </did>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Misc. reading references.</unittitle>
+                      <container type="box" label="Box">11</container>
+                      <container label="Folder" type="folder">7</container>
+                    </did>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Misc. reading references.</unittitle>
+                      <container type="box" label="Box">11</container>
+                      <container label="Folder" type="folder">8</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
                 </c06>
                 <c06 level="file">
                   <did>
@@ -5639,10 +5699,75 @@
                 </c06>
                 <c06 level="file">
                   <did>
-                    <container type="box" label="Box">11</container>
-                    <container label="Folder" type="folder">10-16</container>
                     <unittitle>Misc. notes. Reading for "Roman Morals."</unittitle>
                   </did>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Misc. notes. Reading for "Roman Morals."</unittitle>
+                      <container type="box" label="Box">11</container>
+                      <container label="Folder" type="folder">10</container>
+                    </did>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Misc. notes. Reading for "Roman Morals."</unittitle>
+                      <container type="box" label="Box">11</container>
+                      <container label="Folder" type="folder">11</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Misc. notes. Reading for "Roman Morals."</unittitle>
+                      <container type="box" label="Box">11</container>
+                      <container label="Folder" type="folder">12</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Misc. notes. Reading for "Roman Morals."</unittitle>
+                      <container type="box" label="Box">11</container>
+                      <container label="Folder" type="folder">13</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Misc. notes. Reading for "Roman Morals."</unittitle>
+                      <container type="box" label="Box">11</container>
+                      <container label="Folder" type="folder">14</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Misc. notes. Reading for "Roman Morals."</unittitle>
+                      <container type="box" label="Box">11</container>
+                      <container label="Folder" type="folder">15</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Misc. notes. Reading for "Roman Morals."</unittitle>
+                      <container type="box" label="Box">11</container>
+                      <container label="Folder" type="folder">16</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
                 </c06>
                 <c06 level="file">
                   <did>
@@ -5709,10 +5834,25 @@
                 </c06>
                 <c06 level="file">
                   <did>
-                    <container type="box" label="Box">12</container>
-                    <container label="Folder" type="folder">1-2</container>
                     <unittitle>Notes taken in reading for "Roman Morals."</unittitle>
                   </did>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Notes taken in reading for "Roman Morals."</unittitle>
+                      <container type="box" label="Box">12</container>
+                      <container label="Folder" type="folder">1</container>
+                    </did>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Notes taken in reading for "Roman Morals."</unittitle>
+                      <container type="box" label="Box">12</container>
+                      <container label="Folder" type="folder">2</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
                 </c06>
                 <c06 level="file">
                   <did>
@@ -6094,13 +6234,28 @@
                 </c06>
                 <c06 level="file">
                   <did>
-                    <container type="box" label="Box">15</container>
-                    <container label="Folder" type="folder">3-4</container>
                     <unittitle>Emotions.</unittitle>
                   </did>
                   <odd>
                     <p>(Notes)</p>
                   </odd>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Emotions.</unittitle>
+                      <container type="box" label="Box">15</container>
+                      <container label="Folder" type="folder">3</container>
+                    </did>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Emotions.</unittitle>
+                      <container type="box" label="Box">15</container>
+                      <container label="Folder" type="folder">4</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
                 </c06>
                 <c06 level="file">
                   <did>
@@ -11606,13 +11761,108 @@
               </did>
               <c05 level="file">
                 <did>
-                  <container type="box" label="Box">48</container>
-                  <container type="folder" label="Folder">1-10</container>
                   <unittitle>A.I.A. Bulletins <unitdate type="inclusive" normal="1913">1913</unitdate>, <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">10 folders</extent>
                   </physdesc>
                 </did>
+                <c06 level="file">
+                  <did>
+                    <unittitle>A.I.A. Bulletins <unitdate type="inclusive" normal="1913">1913</unitdate>, <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate></unittitle>
+                    <container type="box" label="Box">48</container>
+                    <container type="folder" label="Folder">1</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>A.I.A. Bulletins <unitdate type="inclusive" normal="1913">1913</unitdate>, <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate></unittitle>
+                    <container type="box" label="Box">48</container>
+                    <container type="folder" label="Folder">2</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>A.I.A. Bulletins <unitdate type="inclusive" normal="1913">1913</unitdate>, <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate></unittitle>
+                    <container type="box" label="Box">48</container>
+                    <container type="folder" label="Folder">3</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>A.I.A. Bulletins <unitdate type="inclusive" normal="1913">1913</unitdate>, <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate></unittitle>
+                    <container type="box" label="Box">48</container>
+                    <container type="folder" label="Folder">4</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>A.I.A. Bulletins <unitdate type="inclusive" normal="1913">1913</unitdate>, <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate></unittitle>
+                    <container type="box" label="Box">48</container>
+                    <container type="folder" label="Folder">5</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>A.I.A. Bulletins <unitdate type="inclusive" normal="1913">1913</unitdate>, <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate></unittitle>
+                    <container type="box" label="Box">48</container>
+                    <container type="folder" label="Folder">6</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>A.I.A. Bulletins <unitdate type="inclusive" normal="1913">1913</unitdate>, <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate></unittitle>
+                    <container type="box" label="Box">48</container>
+                    <container type="folder" label="Folder">7</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>A.I.A. Bulletins <unitdate type="inclusive" normal="1913">1913</unitdate>, <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate></unittitle>
+                    <container type="box" label="Box">48</container>
+                    <container type="folder" label="Folder">8</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>A.I.A. Bulletins <unitdate type="inclusive" normal="1913">1913</unitdate>, <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate></unittitle>
+                    <container type="box" label="Box">48</container>
+                    <container type="folder" label="Folder">9</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>A.I.A. Bulletins <unitdate type="inclusive" normal="1913">1913</unitdate>, <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate></unittitle>
+                    <container type="box" label="Box">48</container>
+                    <container type="folder" label="Folder">10</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
               <c05 level="file">
                 <did>
@@ -12496,13 +12746,28 @@
               </c05>
               <c05 level="file">
                 <did>
-                  <container type="box" label="Box">57</container>
-                  <container type="folder" label="Folder">7-8</container>
                   <unittitle>Questionnaires <unitdate type="inclusive" normal="1922">1922</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Questionnaires <unitdate type="inclusive" normal="1922">1922</unitdate></unittitle>
+                    <container type="box" label="Box">57</container>
+                    <container type="folder" label="Folder">7</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Questionnaires <unitdate type="inclusive" normal="1922">1922</unitdate></unittitle>
+                    <container type="box" label="Box">57</container>
+                    <container type="folder" label="Folder">8</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
               <c05 level="file">
                 <did>
@@ -12580,13 +12845,28 @@
               </c05>
               <c05 level="file">
                 <did>
-                  <container type="box" label="Box">59</container>
-                  <container type="folder" label="Folder">6-7</container>
                   <unittitle>U/M Financial Report <unitdate type="inclusive" normal="1917/1918">1917-1918</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
+                <c06 level="file">
+                  <did>
+                    <unittitle>U/M Financial Report <unitdate type="inclusive" normal="1917/1918">1917-1918</unitdate></unittitle>
+                    <container type="box" label="Box">59</container>
+                    <container type="folder" label="Folder">6</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>U/M Financial Report <unitdate type="inclusive" normal="1917/1918">1917-1918</unitdate></unittitle>
+                    <container type="box" label="Box">59</container>
+                    <container type="folder" label="Folder">7</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
               <c05 level="file">
                 <did>
@@ -12998,13 +13278,58 @@
               </c05>
               <c05 level="file">
                 <did>
-                  <container type="box" label="Box">64</container>
-                  <container type="folder" label="Folder">4-8</container>
                   <unittitle>Burton, Marion L. <unitdate type="inclusive" normal="1920/1925">1920-1925</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">5 folders</extent>
                   </physdesc>
                 </did>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Burton, Marion L. <unitdate type="inclusive" normal="1920/1925">1920-1925</unitdate></unittitle>
+                    <container type="box" label="Box">64</container>
+                    <container type="folder" label="Folder">4</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Burton, Marion L. <unitdate type="inclusive" normal="1920/1925">1920-1925</unitdate></unittitle>
+                    <container type="box" label="Box">64</container>
+                    <container type="folder" label="Folder">5</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Burton, Marion L. <unitdate type="inclusive" normal="1920/1925">1920-1925</unitdate></unittitle>
+                    <container type="box" label="Box">64</container>
+                    <container type="folder" label="Folder">6</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Burton, Marion L. <unitdate type="inclusive" normal="1920/1925">1920-1925</unitdate></unittitle>
+                    <container type="box" label="Box">64</container>
+                    <container type="folder" label="Folder">7</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Burton, Marion L. <unitdate type="inclusive" normal="1920/1925">1920-1925</unitdate></unittitle>
+                    <container type="box" label="Box">64</container>
+                    <container type="folder" label="Folder">8</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
               <c05 level="file">
                 <did>
@@ -13045,12 +13370,31 @@
                 </c06>
                 <c06 level="file">
                   <did>
-                    <container type="box" label="Box">65</container>
-                    <container type="folder" label="Folder">2-3</container>
                     <unittitle>
                       <unitdate type="inclusive" normal="1916/1917">1916-1917</unitdate>
                     </unittitle>
                   </did>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1916/1917">1916-1917</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">65</container>
+                      <container type="folder" label="Folder">2</container>
+                    </did>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1916/1917">1916-1917</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">65</container>
+                      <container type="folder" label="Folder">3</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
                 </c06>
                 <c06 level="file">
                   <did>
@@ -13315,8 +13659,6 @@
                 </did>
                 <c06 level="file">
                   <did>
-                    <container type="box" label="Box">67</container>
-                    <container type="folder" label="Folder">1-8</container>
                     <unittitle>
                       <unitdate type="inclusive" normal="1907/1913">1907-1913</unitdate>
                     </unittitle>
@@ -13324,11 +13666,102 @@
                       <extent altrender="materialtype spaceoccupied">8 folders</extent>
                     </physdesc>
                   </did>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1907/1913">1907-1913</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">67</container>
+                      <container type="folder" label="Folder">1</container>
+                    </did>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1907/1913">1907-1913</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">67</container>
+                      <container type="folder" label="Folder">2</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1907/1913">1907-1913</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">67</container>
+                      <container type="folder" label="Folder">3</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1907/1913">1907-1913</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">67</container>
+                      <container type="folder" label="Folder">4</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1907/1913">1907-1913</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">67</container>
+                      <container type="folder" label="Folder">5</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1907/1913">1907-1913</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">67</container>
+                      <container type="folder" label="Folder">6</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1907/1913">1907-1913</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">67</container>
+                      <container type="folder" label="Folder">7</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1907/1913">1907-1913</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">67</container>
+                      <container type="folder" label="Folder">8</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
                 </c06>
                 <c06 level="file">
                   <did>
-                    <container type="box" label="Box">68</container>
-                    <container type="folder" label="Folder">1-9</container>
                     <unittitle>
                       <unitdate type="inclusive" normal="1914/1919">1914-1919</unitdate>
                     </unittitle>
@@ -13336,6 +13769,111 @@
                       <extent altrender="materialtype spaceoccupied">9 folders</extent>
                     </physdesc>
                   </did>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1914/1919">1914-1919</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">68</container>
+                      <container type="folder" label="Folder">1</container>
+                    </did>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1914/1919">1914-1919</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">68</container>
+                      <container type="folder" label="Folder">2</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1914/1919">1914-1919</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">68</container>
+                      <container type="folder" label="Folder">3</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1914/1919">1914-1919</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">68</container>
+                      <container type="folder" label="Folder">4</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1914/1919">1914-1919</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">68</container>
+                      <container type="folder" label="Folder">5</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1914/1919">1914-1919</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">68</container>
+                      <container type="folder" label="Folder">6</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1914/1919">1914-1919</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">68</container>
+                      <container type="folder" label="Folder">7</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1914/1919">1914-1919</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">68</container>
+                      <container type="folder" label="Folder">8</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1914/1919">1914-1919</unitdate>
+                      </unittitle>
+                      <container type="box" label="Box">68</container>
+                      <container type="folder" label="Folder">9</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
                 </c06>
                 <c06 level="file">
                   <did>
@@ -13793,13 +14331,38 @@
                 </c06>
                 <c06 level="file">
                   <did>
-                    <container type="box" label="Box">72</container>
-                    <container type="folder" label="Folder">4-6</container>
                     <unittitle>Photographs <unitdate>undated</unitdate></unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">3 folders</extent>
                     </physdesc>
                   </did>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Photographs <unitdate>undated</unitdate></unittitle>
+                      <container type="box" label="Box">72</container>
+                      <container type="folder" label="Folder">4</container>
+                    </did>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Photographs <unitdate>undated</unitdate></unittitle>
+                      <container type="box" label="Box">72</container>
+                      <container type="folder" label="Folder">5</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Photographs <unitdate>undated</unitdate></unittitle>
+                      <container type="box" label="Box">72</container>
+                      <container type="folder" label="Folder">6</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
                 </c06>
                 <c06 level="file">
                   <did>
@@ -14136,8 +14699,6 @@
               </c05>
               <c05 level="file">
                 <did>
-                  <container type="box" label="Box">81</container>
-                  <container type="folder" label="Folder">2-4</container>
                   <unittitle>
                     <unitdate type="inclusive" normal="1921/1927">1921-1927</unitdate>
                   </unittitle>
@@ -14145,6 +14706,39 @@
                     <extent altrender="materialtype spaceoccupied">3 folders</extent>
                   </physdesc>
                 </did>
+                <c06 level="file">
+                  <did>
+                    <unittitle>
+                      <unitdate type="inclusive" normal="1921/1927">1921-1927</unitdate>
+                    </unittitle>
+                    <container type="box" label="Box">81</container>
+                    <container type="folder" label="Folder">2</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>
+                      <unitdate type="inclusive" normal="1921/1927">1921-1927</unitdate>
+                    </unittitle>
+                    <container type="box" label="Box">81</container>
+                    <container type="folder" label="Folder">3</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>
+                      <unitdate type="inclusive" normal="1921/1927">1921-1927</unitdate>
+                    </unittitle>
+                    <container type="box" label="Box">81</container>
+                    <container type="folder" label="Folder">4</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
               <c05 level="file">
                 <did>
@@ -15071,13 +15665,48 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">91</container>
-              <container type="folder" label="Folder">2-5</container>
               <unittitle>Marsh, Edward C. <unitdate type="inclusive" normal="1913/1919">1913-1919</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Marsh, Edward C. <unitdate type="inclusive" normal="1913/1919">1913-1919</unitdate></unittitle>
+                <container type="box" label="Box">91</container>
+                <container type="folder" label="Folder">2</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Marsh, Edward C. <unitdate type="inclusive" normal="1913/1919">1913-1919</unitdate></unittitle>
+                <container type="box" label="Box">91</container>
+                <container type="folder" label="Folder">3</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Marsh, Edward C. <unitdate type="inclusive" normal="1913/1919">1913-1919</unitdate></unittitle>
+                <container type="box" label="Box">91</container>
+                <container type="folder" label="Folder">4</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Marsh, Edward C. <unitdate type="inclusive" normal="1913/1919">1913-1919</unitdate></unittitle>
+                <container type="box" label="Box">91</container>
+                <container type="folder" label="Folder">5</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -15211,13 +15840,28 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">92</container>
-                <container type="folder" label="Folder">11-12</container>
                 <unittitle>Loose plates and photos <unitdate>undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose plates and photos <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">92</container>
+                  <container type="folder" label="Folder">11</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose plates and photos <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">92</container>
+                  <container type="folder" label="Folder">12</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -15254,13 +15898,188 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">93</container>
-                <container type="folder" label="Folder">3-20</container>
                 <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">18 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">93</container>
+                  <container type="folder" label="Folder">3</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">93</container>
+                  <container type="folder" label="Folder">4</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">93</container>
+                  <container type="folder" label="Folder">5</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">93</container>
+                  <container type="folder" label="Folder">6</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">93</container>
+                  <container type="folder" label="Folder">7</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">93</container>
+                  <container type="folder" label="Folder">8</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">93</container>
+                  <container type="folder" label="Folder">9</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">93</container>
+                  <container type="folder" label="Folder">10</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">93</container>
+                  <container type="folder" label="Folder">11</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">93</container>
+                  <container type="folder" label="Folder">12</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">93</container>
+                  <container type="folder" label="Folder">13</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">93</container>
+                  <container type="folder" label="Folder">14</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">93</container>
+                  <container type="folder" label="Folder">15</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">93</container>
+                  <container type="folder" label="Folder">16</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">93</container>
+                  <container type="folder" label="Folder">17</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">93</container>
+                  <container type="folder" label="Folder">18</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">93</container>
+                  <container type="folder" label="Folder">19</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Book II: Chapters 2-19 <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">93</container>
+                  <container type="folder" label="Folder">20</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -15418,10 +16237,25 @@
             </did>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">96</container>
-                <container type="folder" label="Folder">1-2</container>
                 <unittitle>Loose, miscellaneous items <unitdate>undated</unitdate></unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose, miscellaneous items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">96</container>
+                  <container type="folder" label="Folder">1</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose, miscellaneous items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">96</container>
+                  <container type="folder" label="Folder">2</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
           </c03>
           <c03 level="file">
@@ -15552,13 +16386,88 @@
               </c05>
               <c05 level="file">
                 <did>
-                  <container type="box" label="Box">98</container>
-                  <container type="folder" label="Folder">2-9</container>
                   <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">8 folders</extent>
                   </physdesc>
                 </did>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">2</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">3</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">4</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">5</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">6</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">7</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">8</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">9</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
             </c04>
             <c04 level="file">
@@ -15574,23 +16483,223 @@
               </c05>
               <c05 level="file">
                 <did>
-                  <container type="box" label="Box">98</container>
-                  <container type="folder" label="Folder">11-22</container>
                   <unittitle>Post cards in books <unitdate>undated</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">12 folders</extent>
                   </physdesc>
                 </did>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Post cards in books <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">11</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Post cards in books <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">12</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Post cards in books <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">13</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Post cards in books <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">14</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Post cards in books <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">15</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Post cards in books <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">16</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Post cards in books <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">17</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Post cards in books <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">18</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Post cards in books <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">19</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Post cards in books <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">20</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Post cards in books <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">21</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Post cards in books <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">22</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
               <c05 level="file">
                 <did>
-                  <container type="box" label="Box">98</container>
-                  <container type="folder" label="Folder">23-31</container>
                   <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">10 folders</extent>
                   </physdesc>
                 </did>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">23</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">24</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">25</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">26</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">27</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">28</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">29</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">30</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Printed matter <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">98</container>
+                    <container type="folder" label="Folder">31</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
             </c04>
             <c04 level="file">
@@ -15803,13 +16912,28 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">103</container>
-                <container type="folder" label="Folder">2-3</container>
                 <unittitle>Miscellaneous pamphlets <unitdate>undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Miscellaneous pamphlets <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">103</container>
+                  <container type="folder" label="Folder">2</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Miscellaneous pamphlets <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">103</container>
+                  <container type="folder" label="Folder">3</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -15839,13 +16963,178 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">104</container>
-                <container type="folder" label="Folder">3-19</container>
                 <unittitle>Loose items <unitdate>undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">17 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">104</container>
+                  <container type="folder" label="Folder">3</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">104</container>
+                  <container type="folder" label="Folder">4</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">104</container>
+                  <container type="folder" label="Folder">5</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">104</container>
+                  <container type="folder" label="Folder">6</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">104</container>
+                  <container type="folder" label="Folder">7</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">104</container>
+                  <container type="folder" label="Folder">8</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">104</container>
+                  <container type="folder" label="Folder">9</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">104</container>
+                  <container type="folder" label="Folder">10</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">104</container>
+                  <container type="folder" label="Folder">11</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">104</container>
+                  <container type="folder" label="Folder">12</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">104</container>
+                  <container type="folder" label="Folder">13</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">104</container>
+                  <container type="folder" label="Folder">14</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">104</container>
+                  <container type="folder" label="Folder">15</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">104</container>
+                  <container type="folder" label="Folder">16</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">104</container>
+                  <container type="folder" label="Folder">17</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">104</container>
+                  <container type="folder" label="Folder">18</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Loose items <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">104</container>
+                  <container type="folder" label="Folder">19</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -15882,13 +17171,38 @@
             </did>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">105</container>
-                <container type="folder" label="Folder">5-7</container>
                 <unittitle>Tomb of Tut-Ankh-Amen News items <unitdate type="inclusive" normal="1923">1923</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Tomb of Tut-Ankh-Amen News items <unitdate type="inclusive" normal="1923">1923</unitdate></unittitle>
+                  <container type="box" label="Box">105</container>
+                  <container type="folder" label="Folder">5</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Tomb of Tut-Ankh-Amen News items <unitdate type="inclusive" normal="1923">1923</unitdate></unittitle>
+                  <container type="box" label="Box">105</container>
+                  <container type="folder" label="Folder">6</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Tomb of Tut-Ankh-Amen News items <unitdate type="inclusive" normal="1923">1923</unitdate></unittitle>
+                  <container type="box" label="Box">105</container>
+                  <container type="folder" label="Folder">7</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
           </c03>
           <c03 level="file">
@@ -15918,13 +17232,28 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">106</container>
-                <container type="folder" label="Folder">4-5</container>
                 <unittitle>Miscellaneous material <unitdate>undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Miscellaneous material <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">106</container>
+                  <container type="folder" label="Folder">4</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Miscellaneous material <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">106</container>
+                  <container type="folder" label="Folder">5</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -15934,13 +17263,38 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">108</container>
-                <container type="folder" label="Folder">1-3</container>
                 <unittitle>Courses of study <unitdate>undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Courses of study <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">108</container>
+                  <container type="folder" label="Folder">1</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Courses of study <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">108</container>
+                  <container type="folder" label="Folder">2</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Courses of study <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">108</container>
+                  <container type="folder" label="Folder">3</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -16148,13 +17502,48 @@
             </did>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">111</container>
-                <container type="folder" label="Folder">1-4</container>
                 <unittitle>Articles by George Swain <unitdate type="inclusive" normal="1925/1926">1925-1926</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">4 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Articles by George Swain <unitdate type="inclusive" normal="1925/1926">1925-1926</unitdate></unittitle>
+                  <container type="box" label="Box">111</container>
+                  <container type="folder" label="Folder">1</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Articles by George Swain <unitdate type="inclusive" normal="1925/1926">1925-1926</unitdate></unittitle>
+                  <container type="box" label="Box">111</container>
+                  <container type="folder" label="Folder">2</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Articles by George Swain <unitdate type="inclusive" normal="1925/1926">1925-1926</unitdate></unittitle>
+                  <container type="box" label="Box">111</container>
+                  <container type="folder" label="Folder">3</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Articles by George Swain <unitdate type="inclusive" normal="1925/1926">1925-1926</unitdate></unittitle>
+                  <container type="box" label="Box">111</container>
+                  <container type="folder" label="Folder">4</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
           </c03>
           <c03 level="file">
@@ -16196,10 +17585,25 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">112</container>
-                <container type="folder" label="Folder">2-3</container>
                 <unittitle>Miscellaneous material <unitdate>undated</unitdate></unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Miscellaneous material <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">112</container>
+                  <container type="folder" label="Folder">2</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Miscellaneous material <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">112</container>
+                  <container type="folder" label="Folder">3</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -16710,13 +18114,88 @@
               </did>
               <c05 level="file">
                 <did>
-                  <container type="box" label="Box">128</container>
-                  <container type="folder" label="Folder">1-8</container>
                   <unittitle>I-LXIX <unitdate>undated</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">8 folders</extent>
                   </physdesc>
                 </did>
+                <c06 level="file">
+                  <did>
+                    <unittitle>I-LXIX <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">128</container>
+                    <container type="folder" label="Folder">1</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>I-LXIX <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">128</container>
+                    <container type="folder" label="Folder">2</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>I-LXIX <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">128</container>
+                    <container type="folder" label="Folder">3</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>I-LXIX <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">128</container>
+                    <container type="folder" label="Folder">4</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>I-LXIX <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">128</container>
+                    <container type="folder" label="Folder">5</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>I-LXIX <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">128</container>
+                    <container type="folder" label="Folder">6</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>I-LXIX <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">128</container>
+                    <container type="folder" label="Folder">7</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>I-LXIX <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">128</container>
+                    <container type="folder" label="Folder">8</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
               <c05 level="file">
                 <did>
@@ -16925,13 +18404,28 @@
               </did>
               <c05 level="file">
                 <did>
-                  <container type="box" label="Box">132</container>
-                  <container type="folder" label="Folder">5-6</container>
                   <unittitle>Italy Campagna Rome <unitdate>undated</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Italy Campagna Rome <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">132</container>
+                    <container type="folder" label="Folder">5</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Italy Campagna Rome <unitdate>undated</unitdate></unittitle>
+                    <container type="box" label="Box">132</container>
+                    <container type="folder" label="Folder">6</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
               <c05 level="file">
                 <did>
@@ -16974,23 +18468,53 @@
             </did>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">134</container>
-                <container label="Folder" type="folder">3-4</container>
                 <unittitle>I-II <unitdate>undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>I-II <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">134</container>
+                  <container label="Folder" type="folder">3</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>I-II <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">134</container>
+                  <container label="Folder" type="folder">4</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">135</container>
-                <container type="folder" label="Folder">1-2</container>
                 <unittitle>III-IV <unitdate>undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>III-IV <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">135</container>
+                  <container type="folder" label="Folder">1</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>III-IV <unitdate>undated</unitdate></unittitle>
+                  <container type="box" label="Box">135</container>
+                  <container type="folder" label="Folder">2</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -18148,13 +19672,28 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">156</container>
-              <container type="folder" label="Folder">6-7</container>
               <unittitle>Two receipt books from American Express <unitdate>undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Two receipt books from American Express <unitdate>undated</unitdate></unittitle>
+                <container type="box" label="Box">156</container>
+                <container type="folder" label="Folder">6</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Two receipt books from American Express <unitdate>undated</unitdate></unittitle>
+                <container type="box" label="Box">156</container>
+                <container type="folder" label="Folder">7</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="series">
@@ -19409,10 +20948,35 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">4</container>
-              <container type="folder" label="Folder">2-4</container>
               <unittitle>List of Objects</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>List of Objects</unittitle>
+                <container type="box" label="Box">4</container>
+                <container type="folder" label="Folder">2</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>List of Objects</unittitle>
+                <container type="box" label="Box">4</container>
+                <container type="folder" label="Folder">3</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>List of Objects</unittitle>
+                <container type="box" label="Box">4</container>
+                <container type="folder" label="Folder">4</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -20131,10 +21695,25 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">1</container>
-                <container type="folder" label="Folder">18-19</container>
                 <unittitle>Metropolitan Museum --loan</unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Metropolitan Museum --loan</unittitle>
+                  <container type="box" label="Box">1</container>
+                  <container type="folder" label="Folder">18</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Metropolitan Museum --loan</unittitle>
+                  <container type="box" label="Box">1</container>
+                  <container type="folder" label="Folder">19</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -20382,10 +21961,45 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">3</container>
-                <container type="folder" label="Folder">1-4</container>
                 <unittitle>Vouchers and receipts: I; II; III; IV <unitdate type="inclusive" normal="1973">1973</unitdate></unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Vouchers and receipts: I; II; III; IV <unitdate type="inclusive" normal="1973">1973</unitdate></unittitle>
+                  <container type="box" label="Box">3</container>
+                  <container type="folder" label="Folder">1</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Vouchers and receipts: I; II; III; IV <unitdate type="inclusive" normal="1973">1973</unitdate></unittitle>
+                  <container type="box" label="Box">3</container>
+                  <container type="folder" label="Folder">2</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Vouchers and receipts: I; II; III; IV <unitdate type="inclusive" normal="1973">1973</unitdate></unittitle>
+                  <container type="box" label="Box">3</container>
+                  <container type="folder" label="Folder">3</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Vouchers and receipts: I; II; III; IV <unitdate type="inclusive" normal="1973">1973</unitdate></unittitle>
+                  <container type="box" label="Box">3</container>
+                  <container type="folder" label="Folder">4</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
           </c03>
         </c02>

--- a/Real_Masters_all/lacyaj.xml
+++ b/Real_Masters_all/lacyaj.xml
@@ -303,28 +303,206 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">1</container>
-            <container type="folder" label="Folder">2-16</container>
             <unittitle>Letters written from Northern Indiana Normal School <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1894-09/1896-05">September 1894-May 1896</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">15 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from Northern Indiana Normal School <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1894-09/1896-05">September 1894-May 1896</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">2</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from Northern Indiana Normal School <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1894-09/1896-05">September 1894-May 1896</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from Northern Indiana Normal School <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1894-09/1896-05">September 1894-May 1896</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from Northern Indiana Normal School <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1894-09/1896-05">September 1894-May 1896</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from Northern Indiana Normal School <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1894-09/1896-05">September 1894-May 1896</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from Northern Indiana Normal School <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1894-09/1896-05">September 1894-May 1896</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">7</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from Northern Indiana Normal School <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1894-09/1896-05">September 1894-May 1896</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from Northern Indiana Normal School <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1894-09/1896-05">September 1894-May 1896</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from Northern Indiana Normal School <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1894-09/1896-05">September 1894-May 1896</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from Northern Indiana Normal School <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1894-09/1896-05">September 1894-May 1896</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from Northern Indiana Normal School <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1894-09/1896-05">September 1894-May 1896</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from Northern Indiana Normal School <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1894-09/1896-05">September 1894-May 1896</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from Northern Indiana Normal School <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1894-09/1896-05">September 1894-May 1896</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from Northern Indiana Normal School <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1894-09/1896-05">September 1894-May 1896</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">15</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from Northern Indiana Normal School <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1894-09/1896-05">September 1894-May 1896</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">16</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">1</container>
-            <container type="folder" label="Folder">17-20</container>
             <unittitle>Letters written from the University of Michigan <unitdate type="inclusive" normal="1896-12/1898-05">December 1896-May 1898</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from the University of Michigan <unitdate type="inclusive" normal="1896-12/1898-05">December 1896-May 1898</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">17</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from the University of Michigan <unitdate type="inclusive" normal="1896-12/1898-05">December 1896-May 1898</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">18</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from the University of Michigan <unitdate type="inclusive" normal="1896-12/1898-05">December 1896-May 1898</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">19</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters written from the University of Michigan <unitdate type="inclusive" normal="1896-12/1898-05">December 1896-May 1898</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">20</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">1</container>
-            <container type="folder" label="Folder">21-33</container>
             <unittitle>Courtship letters between Arthur Lacy and Beth Garwick <unitdate type="inclusive" normal="1896-08/1898-12">August 1896-December 1898</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">13 folders</extent>
@@ -333,6 +511,133 @@
           <odd>
             <p>(include reminiscences of Lacy's marriage proposal to Beth Garwick, November 1897 in folder 28)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Courtship letters between Arthur Lacy and Beth Garwick <unitdate type="inclusive" normal="1896-08/1898-12">August 1896-December 1898</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">21</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Courtship letters between Arthur Lacy and Beth Garwick <unitdate type="inclusive" normal="1896-08/1898-12">August 1896-December 1898</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">22</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Courtship letters between Arthur Lacy and Beth Garwick <unitdate type="inclusive" normal="1896-08/1898-12">August 1896-December 1898</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">23</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Courtship letters between Arthur Lacy and Beth Garwick <unitdate type="inclusive" normal="1896-08/1898-12">August 1896-December 1898</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">24</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Courtship letters between Arthur Lacy and Beth Garwick <unitdate type="inclusive" normal="1896-08/1898-12">August 1896-December 1898</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">25</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Courtship letters between Arthur Lacy and Beth Garwick <unitdate type="inclusive" normal="1896-08/1898-12">August 1896-December 1898</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">26</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Courtship letters between Arthur Lacy and Beth Garwick <unitdate type="inclusive" normal="1896-08/1898-12">August 1896-December 1898</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">27</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Courtship letters between Arthur Lacy and Beth Garwick <unitdate type="inclusive" normal="1896-08/1898-12">August 1896-December 1898</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">28</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Courtship letters between Arthur Lacy and Beth Garwick <unitdate type="inclusive" normal="1896-08/1898-12">August 1896-December 1898</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">29</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Courtship letters between Arthur Lacy and Beth Garwick <unitdate type="inclusive" normal="1896-08/1898-12">August 1896-December 1898</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">30</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Courtship letters between Arthur Lacy and Beth Garwick <unitdate type="inclusive" normal="1896-08/1898-12">August 1896-December 1898</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">31</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Courtship letters between Arthur Lacy and Beth Garwick <unitdate type="inclusive" normal="1896-08/1898-12">August 1896-December 1898</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">32</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Courtship letters between Arthur Lacy and Beth Garwick <unitdate type="inclusive" normal="1896-08/1898-12">August 1896-December 1898</unitdate></unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">33</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">
@@ -341,8 +646,6 @@
         </did>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">1</container>
-            <container type="folder" label="Folder">34-47</container>
             <unittitle>
               <unitdate type="inclusive" normal="1895/1914">1895-1914</unitdate>
             </unittitle>
@@ -350,6 +653,171 @@
               <extent altrender="materialtype spaceoccupied">14 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1895/1914">1895-1914</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">34</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1895/1914">1895-1914</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">35</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1895/1914">1895-1914</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">36</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1895/1914">1895-1914</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">37</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1895/1914">1895-1914</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">38</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1895/1914">1895-1914</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">39</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1895/1914">1895-1914</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">40</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1895/1914">1895-1914</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">41</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1895/1914">1895-1914</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">42</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1895/1914">1895-1914</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">43</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1895/1914">1895-1914</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">44</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1895/1914">1895-1914</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">45</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1895/1914">1895-1914</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">46</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1895/1914">1895-1914</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">47</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -360,8 +828,6 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">1</container>
-            <container type="folder" label="Folder">49-53</container>
             <unittitle>
               <unitdate type="inclusive" normal="1915/1919">1915-1919</unitdate>
             </unittitle>
@@ -369,11 +835,66 @@
               <extent altrender="materialtype spaceoccupied">5 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1915/1919">1915-1919</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">49</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1915/1919">1915-1919</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">50</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1915/1919">1915-1919</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">51</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1915/1919">1915-1919</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">52</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1915/1919">1915-1919</unitdate>
+              </unittitle>
+              <container type="box" label="Box">1</container>
+              <container type="folder" label="Folder">53</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">2</container>
-            <container type="folder" label="Folder">54-58</container>
             <unittitle>
               <unitdate type="inclusive" normal="1920/1924">1920-1924</unitdate>
             </unittitle>
@@ -381,6 +902,63 @@
               <extent altrender="materialtype spaceoccupied">5 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1920/1924">1920-1924</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">54</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1920/1924">1920-1924</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">55</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1920/1924">1920-1924</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">56</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1920/1924">1920-1924</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">57</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1920/1924">1920-1924</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">58</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -391,8 +969,6 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">2</container>
-            <container type="folder" label="Folder">60-100</container>
             <unittitle>
               <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
             </unittitle>
@@ -400,6 +976,495 @@
               <extent altrender="materialtype spaceoccupied">41 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">60</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">61</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">62</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">63</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">64</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">65</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">66</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">67</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">68</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">69</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">70</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">71</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">72</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">73</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">74</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">75</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">76</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">77</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">78</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">79</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">80</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">81</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">82</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">83</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">84</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">85</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">86</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">87</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">88</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">89</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">90</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">91</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">92</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">93</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">94</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">95</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">96</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">97</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">98</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">99</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1925/1934-05">1925-May 1934</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">100</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -410,13 +1475,68 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">2</container>
-            <container type="folder" label="Folder">102-107</container>
             <unittitle>Letters urging Lacy to run for Governor, <unitdate type="inclusive" normal="1934">May-September 1934</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">6 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters urging Lacy to run for Governor, <unitdate type="inclusive" normal="1934">May-September 1934</unitdate></unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">102</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters urging Lacy to run for Governor, <unitdate type="inclusive" normal="1934">May-September 1934</unitdate></unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">103</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters urging Lacy to run for Governor, <unitdate type="inclusive" normal="1934">May-September 1934</unitdate></unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">104</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters urging Lacy to run for Governor, <unitdate type="inclusive" normal="1934">May-September 1934</unitdate></unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">105</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters urging Lacy to run for Governor, <unitdate type="inclusive" normal="1934">May-September 1934</unitdate></unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">106</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters urging Lacy to run for Governor, <unitdate type="inclusive" normal="1934">May-September 1934</unitdate></unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">107</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -427,8 +1547,6 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">2</container>
-            <container type="folder" label="Folder">109-120</container>
             <unittitle>
               <unitdate type="inclusive" normal="1934-07/1940-12">July 1934-December 1940</unitdate>
             </unittitle>
@@ -436,11 +1554,150 @@
               <extent altrender="materialtype spaceoccupied">12 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1934-07/1940-12">July 1934-December 1940</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">109</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1934-07/1940-12">July 1934-December 1940</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">110</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1934-07/1940-12">July 1934-December 1940</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">111</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1934-07/1940-12">July 1934-December 1940</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">112</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1934-07/1940-12">July 1934-December 1940</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">113</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1934-07/1940-12">July 1934-December 1940</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">114</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1934-07/1940-12">July 1934-December 1940</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">115</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1934-07/1940-12">July 1934-December 1940</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">116</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1934-07/1940-12">July 1934-December 1940</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">117</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1934-07/1940-12">July 1934-December 1940</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">118</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1934-07/1940-12">July 1934-December 1940</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">119</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1934-07/1940-12">July 1934-December 1940</unitdate>
+              </unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">120</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">3</container>
-            <container type="folder" label="Folder">121-131</container>
             <unittitle>
               <unitdate type="inclusive" normal="1941/1947">1941-1947</unitdate>
             </unittitle>
@@ -448,21 +1705,193 @@
               <extent altrender="materialtype spaceoccupied">11 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1941/1947">1941-1947</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">121</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1941/1947">1941-1947</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">122</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1941/1947">1941-1947</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">123</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1941/1947">1941-1947</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">124</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1941/1947">1941-1947</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">125</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1941/1947">1941-1947</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">126</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1941/1947">1941-1947</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">127</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1941/1947">1941-1947</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">128</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1941/1947">1941-1947</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">129</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1941/1947">1941-1947</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">130</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1941/1947">1941-1947</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">131</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">3</container>
-            <container type="folder" label="Folder">132-136</container>
             <unittitle>Mary A. Rackham estate income tax liability case <unitdate type="inclusive" normal="1948-11/1951">November 1948-1951</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">5 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Mary A. Rackham estate income tax liability case <unitdate type="inclusive" normal="1948-11/1951">November 1948-1951</unitdate></unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">132</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Mary A. Rackham estate income tax liability case <unitdate type="inclusive" normal="1948-11/1951">November 1948-1951</unitdate></unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">133</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Mary A. Rackham estate income tax liability case <unitdate type="inclusive" normal="1948-11/1951">November 1948-1951</unitdate></unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">134</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Mary A. Rackham estate income tax liability case <unitdate type="inclusive" normal="1948-11/1951">November 1948-1951</unitdate></unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">135</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Mary A. Rackham estate income tax liability case <unitdate type="inclusive" normal="1948-11/1951">November 1948-1951</unitdate></unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">136</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">3</container>
-            <container type="folder" label="Folder">137-164</container>
             <unittitle>
               <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
             </unittitle>
@@ -470,6 +1899,339 @@
               <extent altrender="materialtype spaceoccupied">28 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">137</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">138</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">139</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">140</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">141</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">142</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">143</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">144</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">145</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">146</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">147</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">148</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">149</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">150</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">151</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">152</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">153</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">154</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">155</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">156</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">157</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">158</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">159</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">160</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">161</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">162</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">163</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1948/1974">1948-1974</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">164</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">
@@ -494,8 +2256,6 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">3</container>
-            <container type="folder" label="Folder">167-168</container>
             <unittitle>
               <unitdate type="inclusive" normal="1876/1905">1876-1905</unitdate>
             </unittitle>
@@ -503,21 +2263,75 @@
               <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1876/1905">1876-1905</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">167</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1876/1905">1876-1905</unitdate>
+              </unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">168</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">3</container>
-            <container type="folder" label="Folder">168-171</container>
             <unittitle>Letters of Arthur Lacy to Beth Lacy <unitdate type="inclusive" normal="1901-11/1901-12">November-December 1901</unitdate>, <unitdate type="inclusive" normal="1904-09">September 1904</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters of Arthur Lacy to Beth Lacy <unitdate type="inclusive" normal="1901-11/1901-12">November-December 1901</unitdate>, <unitdate type="inclusive" normal="1904-09">September 1904</unitdate></unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">168</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters of Arthur Lacy to Beth Lacy <unitdate type="inclusive" normal="1901-11/1901-12">November-December 1901</unitdate>, <unitdate type="inclusive" normal="1904-09">September 1904</unitdate></unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">169</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters of Arthur Lacy to Beth Lacy <unitdate type="inclusive" normal="1901-11/1901-12">November-December 1901</unitdate>, <unitdate type="inclusive" normal="1904-09">September 1904</unitdate></unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">170</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Letters of Arthur Lacy to Beth Lacy <unitdate type="inclusive" normal="1901-11/1901-12">November-December 1901</unitdate>, <unitdate type="inclusive" normal="1904-09">September 1904</unitdate></unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">171</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">4</container>
-            <container type="folder" label="Folder">172-175</container>
             <unittitle>
               <unitdate type="inclusive" normal="1906-04/1906-12">April 1906-December 1906</unitdate>
             </unittitle>
@@ -525,6 +2339,51 @@
               <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1906-04/1906-12">April 1906-December 1906</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">172</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1906-04/1906-12">April 1906-December 1906</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">173</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1906-04/1906-12">April 1906-December 1906</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">174</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1906-04/1906-12">April 1906-December 1906</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">175</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -535,8 +2394,6 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">4</container>
-            <container type="folder" label="Folder">177-209</container>
             <unittitle>
               <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
             </unittitle>
@@ -544,6 +2401,399 @@
               <extent altrender="materialtype spaceoccupied">33 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">177</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">178</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">179</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">180</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">181</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">182</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">183</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">184</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">185</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">186</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">187</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">188</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">189</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">190</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">191</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">192</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">193</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">194</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">195</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">196</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">197</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">198</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">199</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">200</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">201</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">202</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">203</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">204</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">205</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">206</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">207</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">208</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1907/1973">1907-1973</unitdate>
+              </unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">209</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -629,8 +2879,6 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">5</container>
-            <container type="folder" label="Folder">217-226</container>
             <unittitle>
               <unitdate type="inclusive" normal="1901/1956">1901-1956 (scattered dates)</unitdate>
             </unittitle>
@@ -638,6 +2886,123 @@
               <extent altrender="materialtype spaceoccupied">10 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1901/1956">1901-1956 (scattered dates)</unitdate>
+              </unittitle>
+              <container type="box" label="Box">5</container>
+              <container type="folder" label="Folder">217</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1901/1956">1901-1956 (scattered dates)</unitdate>
+              </unittitle>
+              <container type="box" label="Box">5</container>
+              <container type="folder" label="Folder">218</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1901/1956">1901-1956 (scattered dates)</unitdate>
+              </unittitle>
+              <container type="box" label="Box">5</container>
+              <container type="folder" label="Folder">219</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1901/1956">1901-1956 (scattered dates)</unitdate>
+              </unittitle>
+              <container type="box" label="Box">5</container>
+              <container type="folder" label="Folder">220</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1901/1956">1901-1956 (scattered dates)</unitdate>
+              </unittitle>
+              <container type="box" label="Box">5</container>
+              <container type="folder" label="Folder">221</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1901/1956">1901-1956 (scattered dates)</unitdate>
+              </unittitle>
+              <container type="box" label="Box">5</container>
+              <container type="folder" label="Folder">222</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1901/1956">1901-1956 (scattered dates)</unitdate>
+              </unittitle>
+              <container type="box" label="Box">5</container>
+              <container type="folder" label="Folder">223</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1901/1956">1901-1956 (scattered dates)</unitdate>
+              </unittitle>
+              <container type="box" label="Box">5</container>
+              <container type="folder" label="Folder">224</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1901/1956">1901-1956 (scattered dates)</unitdate>
+              </unittitle>
+              <container type="box" label="Box">5</container>
+              <container type="folder" label="Folder">225</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1901/1956">1901-1956 (scattered dates)</unitdate>
+              </unittitle>
+              <container type="box" label="Box">5</container>
+              <container type="folder" label="Folder">226</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">
@@ -742,13 +3107,78 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">5</container>
-            <container type="folder" label="Folder">239-245</container>
             <unittitle>Essays <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1895/1957">1895-1957 (scattered dates)</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">7 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Essays <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1895/1957">1895-1957 (scattered dates)</unitdate></unittitle>
+              <container type="box" label="Box">5</container>
+              <container type="folder" label="Folder">239</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Essays <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1895/1957">1895-1957 (scattered dates)</unitdate></unittitle>
+              <container type="box" label="Box">5</container>
+              <container type="folder" label="Folder">240</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Essays <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1895/1957">1895-1957 (scattered dates)</unitdate></unittitle>
+              <container type="box" label="Box">5</container>
+              <container type="folder" label="Folder">241</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Essays <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1895/1957">1895-1957 (scattered dates)</unitdate></unittitle>
+              <container type="box" label="Box">5</container>
+              <container type="folder" label="Folder">242</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Essays <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1895/1957">1895-1957 (scattered dates)</unitdate></unittitle>
+              <container type="box" label="Box">5</container>
+              <container type="folder" label="Folder">243</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Essays <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1895/1957">1895-1957 (scattered dates)</unitdate></unittitle>
+              <container type="box" label="Box">5</container>
+              <container type="folder" label="Folder">244</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Essays <unitdate>undated</unitdate>, <unitdate type="inclusive" normal="1895/1957">1895-1957 (scattered dates)</unitdate></unittitle>
+              <container type="box" label="Box">5</container>
+              <container type="folder" label="Folder">245</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -822,23 +3252,253 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">6</container>
-            <container type="folder" label="Folder">249-260</container>
             <unittitle>Notes <unitdate type="inclusive" normal="1942/1950">1942-1950</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">12 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1942/1950">1942-1950</unitdate></unittitle>
+              <container type="box" label="Box">6</container>
+              <container type="folder" label="Folder">249</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1942/1950">1942-1950</unitdate></unittitle>
+              <container type="box" label="Box">6</container>
+              <container type="folder" label="Folder">250</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1942/1950">1942-1950</unitdate></unittitle>
+              <container type="box" label="Box">6</container>
+              <container type="folder" label="Folder">251</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1942/1950">1942-1950</unitdate></unittitle>
+              <container type="box" label="Box">6</container>
+              <container type="folder" label="Folder">252</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1942/1950">1942-1950</unitdate></unittitle>
+              <container type="box" label="Box">6</container>
+              <container type="folder" label="Folder">253</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1942/1950">1942-1950</unitdate></unittitle>
+              <container type="box" label="Box">6</container>
+              <container type="folder" label="Folder">254</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1942/1950">1942-1950</unitdate></unittitle>
+              <container type="box" label="Box">6</container>
+              <container type="folder" label="Folder">255</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1942/1950">1942-1950</unitdate></unittitle>
+              <container type="box" label="Box">6</container>
+              <container type="folder" label="Folder">256</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1942/1950">1942-1950</unitdate></unittitle>
+              <container type="box" label="Box">6</container>
+              <container type="folder" label="Folder">257</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1942/1950">1942-1950</unitdate></unittitle>
+              <container type="box" label="Box">6</container>
+              <container type="folder" label="Folder">258</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1942/1950">1942-1950</unitdate></unittitle>
+              <container type="box" label="Box">6</container>
+              <container type="folder" label="Folder">259</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1942/1950">1942-1950</unitdate></unittitle>
+              <container type="box" label="Box">6</container>
+              <container type="folder" label="Folder">260</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">7</container>
-            <container type="folder" label="Folder">261-272</container>
             <unittitle>Notes <unitdate type="inclusive" normal="1951/1958">1951-1958</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">12 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1951/1958">1951-1958</unitdate></unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">261</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1951/1958">1951-1958</unitdate></unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">262</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1951/1958">1951-1958</unitdate></unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">263</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1951/1958">1951-1958</unitdate></unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">264</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1951/1958">1951-1958</unitdate></unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">265</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1951/1958">1951-1958</unitdate></unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">266</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1951/1958">1951-1958</unitdate></unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">267</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1951/1958">1951-1958</unitdate></unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">268</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1951/1958">1951-1958</unitdate></unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">269</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1951/1958">1951-1958</unitdate></unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">270</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1951/1958">1951-1958</unitdate></unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">271</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes <unitdate type="inclusive" normal="1951/1958">1951-1958</unitdate></unittitle>
+              <container type="box" label="Box">7</container>
+              <container type="folder" label="Folder">272</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">
@@ -957,8 +3617,6 @@
         </did>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">8</container>
-            <container type="folder" label="Folder">295-307</container>
             <unittitle>
               <unitdate>Undated</unitdate>
               <unitdate type="inclusive" normal="1892/1930">1892-1930</unitdate>
@@ -967,11 +3625,175 @@
               <extent altrender="materialtype spaceoccupied">12 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate>Undated</unitdate>
+                <unitdate type="inclusive" normal="1892/1930">1892-1930</unitdate>
+              </unittitle>
+              <container type="box" label="Box">8</container>
+              <container type="folder" label="Folder">295</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate>Undated</unitdate>
+                <unitdate type="inclusive" normal="1892/1930">1892-1930</unitdate>
+              </unittitle>
+              <container type="box" label="Box">8</container>
+              <container type="folder" label="Folder">296</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate>Undated</unitdate>
+                <unitdate type="inclusive" normal="1892/1930">1892-1930</unitdate>
+              </unittitle>
+              <container type="box" label="Box">8</container>
+              <container type="folder" label="Folder">297</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate>Undated</unitdate>
+                <unitdate type="inclusive" normal="1892/1930">1892-1930</unitdate>
+              </unittitle>
+              <container type="box" label="Box">8</container>
+              <container type="folder" label="Folder">298</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate>Undated</unitdate>
+                <unitdate type="inclusive" normal="1892/1930">1892-1930</unitdate>
+              </unittitle>
+              <container type="box" label="Box">8</container>
+              <container type="folder" label="Folder">299</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate>Undated</unitdate>
+                <unitdate type="inclusive" normal="1892/1930">1892-1930</unitdate>
+              </unittitle>
+              <container type="box" label="Box">8</container>
+              <container type="folder" label="Folder">300</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate>Undated</unitdate>
+                <unitdate type="inclusive" normal="1892/1930">1892-1930</unitdate>
+              </unittitle>
+              <container type="box" label="Box">8</container>
+              <container type="folder" label="Folder">301</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate>Undated</unitdate>
+                <unitdate type="inclusive" normal="1892/1930">1892-1930</unitdate>
+              </unittitle>
+              <container type="box" label="Box">8</container>
+              <container type="folder" label="Folder">302</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate>Undated</unitdate>
+                <unitdate type="inclusive" normal="1892/1930">1892-1930</unitdate>
+              </unittitle>
+              <container type="box" label="Box">8</container>
+              <container type="folder" label="Folder">303</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate>Undated</unitdate>
+                <unitdate type="inclusive" normal="1892/1930">1892-1930</unitdate>
+              </unittitle>
+              <container type="box" label="Box">8</container>
+              <container type="folder" label="Folder">304</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate>Undated</unitdate>
+                <unitdate type="inclusive" normal="1892/1930">1892-1930</unitdate>
+              </unittitle>
+              <container type="box" label="Box">8</container>
+              <container type="folder" label="Folder">305</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate>Undated</unitdate>
+                <unitdate type="inclusive" normal="1892/1930">1892-1930</unitdate>
+              </unittitle>
+              <container type="box" label="Box">8</container>
+              <container type="folder" label="Folder">306</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate>Undated</unitdate>
+                <unitdate type="inclusive" normal="1892/1930">1892-1930</unitdate>
+              </unittitle>
+              <container type="box" label="Box">8</container>
+              <container type="folder" label="Folder">307</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">9</container>
-            <container type="folder" label="Folder">308-313</container>
             <unittitle>
               <unitdate type="inclusive" normal="1931/1970">1931-1970</unitdate>
             </unittitle>
@@ -979,6 +3801,75 @@
               <extent altrender="materialtype spaceoccupied">6 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1931/1970">1931-1970</unitdate>
+              </unittitle>
+              <container type="box" label="Box">9</container>
+              <container type="folder" label="Folder">308</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1931/1970">1931-1970</unitdate>
+              </unittitle>
+              <container type="box" label="Box">9</container>
+              <container type="folder" label="Folder">309</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1931/1970">1931-1970</unitdate>
+              </unittitle>
+              <container type="box" label="Box">9</container>
+              <container type="folder" label="Folder">310</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1931/1970">1931-1970</unitdate>
+              </unittitle>
+              <container type="box" label="Box">9</container>
+              <container type="folder" label="Folder">311</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1931/1970">1931-1970</unitdate>
+              </unittitle>
+              <container type="box" label="Box">9</container>
+              <container type="folder" label="Folder">312</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1931/1970">1931-1970</unitdate>
+              </unittitle>
+              <container type="box" label="Box">9</container>
+              <container type="folder" label="Folder">313</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/likertr.xml
+++ b/Real_Masters_all/likertr.xml
@@ -2750,20 +2750,140 @@ Rensis Likert Papers, Bentley Historical Library, University of Michigan</p>
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">4</container>
-                <container type="folder" label="Folder">3-9</container>
                 <unittitle>Attitudes of Rural People Toward Radio Service. Study 123. Background files <unitdate type="inclusive" normal="1945-11">11/1945</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">7 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Attitudes of Rural People Toward Radio Service. Study 123. Background files <unitdate type="inclusive" normal="1945-11">11/1945</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">3</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Attitudes of Rural People Toward Radio Service. Study 123. Background files <unitdate type="inclusive" normal="1945-11">11/1945</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">4</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Attitudes of Rural People Toward Radio Service. Study 123. Background files <unitdate type="inclusive" normal="1945-11">11/1945</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">5</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Attitudes of Rural People Toward Radio Service. Study 123. Background files <unitdate type="inclusive" normal="1945-11">11/1945</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">6</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Attitudes of Rural People Toward Radio Service. Study 123. Background files <unitdate type="inclusive" normal="1945-11">11/1945</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">7</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Attitudes of Rural People Toward Radio Service. Study 123. Background files <unitdate type="inclusive" normal="1945-11">11/1945</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">8</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Attitudes of Rural People Toward Radio Service. Study 123. Background files <unitdate type="inclusive" normal="1945-11">11/1945</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">9</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">4</container>
-                <container type="folder" label="Folder">10-15</container>
                 <unittitle>Attitudes of Rural People Toward Radio Service. Study 123. Background files. Proceeding before F.C.C <unitdate type="inclusive" normal="1946-01">January 1946</unitdate></unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Attitudes of Rural People Toward Radio Service. Study 123. Background files. Proceeding before F.C.C <unitdate type="inclusive" normal="1946-01">January 1946</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">10</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Attitudes of Rural People Toward Radio Service. Study 123. Background files. Proceeding before F.C.C <unitdate type="inclusive" normal="1946-01">January 1946</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">11</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Attitudes of Rural People Toward Radio Service. Study 123. Background files. Proceeding before F.C.C <unitdate type="inclusive" normal="1946-01">January 1946</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">12</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Attitudes of Rural People Toward Radio Service. Study 123. Background files. Proceeding before F.C.C <unitdate type="inclusive" normal="1946-01">January 1946</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">13</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Attitudes of Rural People Toward Radio Service. Study 123. Background files. Proceeding before F.C.C <unitdate type="inclusive" normal="1946-01">January 1946</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">14</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Attitudes of Rural People Toward Radio Service. Study 123. Background files. Proceeding before F.C.C <unitdate type="inclusive" normal="1946-01">January 1946</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">15</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -2795,17 +2915,47 @@ Rensis Likert Papers, Bentley Historical Library, University of Michigan</p>
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">4</container>
-                <container type="folder" label="Folder">19-20</container>
                 <unittitle>Attitudes Toward FSA Tenant Purchase Program. Study 122 <unitdate type="inclusive" normal="1946-01">1/1946</unitdate></unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Attitudes Toward FSA Tenant Purchase Program. Study 122 <unitdate type="inclusive" normal="1946-01">1/1946</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">19</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Attitudes Toward FSA Tenant Purchase Program. Study 122 <unitdate type="inclusive" normal="1946-01">1/1946</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">20</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">4</container>
-                <container type="folder" label="Folder">21-22</container>
                 <unittitle>Attitudes Toward FSA Tenant Purchase Program. Study 122. Background files <unitdate type="inclusive" normal="1946-01">1/1946</unitdate></unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Attitudes Toward FSA Tenant Purchase Program. Study 122. Background files <unitdate type="inclusive" normal="1946-01">1/1946</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">21</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Attitudes Toward FSA Tenant Purchase Program. Study 122. Background files <unitdate type="inclusive" normal="1946-01">1/1946</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">22</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -2816,10 +2966,25 @@ Rensis Likert Papers, Bentley Historical Library, University of Michigan</p>
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">4</container>
-                <container type="folder" label="Folder">24-25</container>
                 <unittitle>Home Gardens and Home Preserving in 1945. Study 127. Background file <unitdate type="inclusive" normal="1946-01">1/1946</unitdate></unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Home Gardens and Home Preserving in 1945. Study 127. Background file <unitdate type="inclusive" normal="1946-01">1/1946</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">24</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Home Gardens and Home Preserving in 1945. Study 127. Background file <unitdate type="inclusive" normal="1946-01">1/1946</unitdate></unittitle>
+                  <container type="box" label="Box">4</container>
+                  <container type="folder" label="Folder">25</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -2935,10 +3100,55 @@ Rensis Likert Papers, Bentley Historical Library, University of Michigan</p>
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">5</container>
-                <container type="folder" label="Folder">2-6</container>
                 <unittitle>National Survey of Liquid Asset Holdings, Spending and Saving. Study 132. Background files <unitdate type="inclusive" normal="1946-05">5/1946</unitdate></unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>National Survey of Liquid Asset Holdings, Spending and Saving. Study 132. Background files <unitdate type="inclusive" normal="1946-05">5/1946</unitdate></unittitle>
+                  <container type="box" label="Box">5</container>
+                  <container type="folder" label="Folder">2</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>National Survey of Liquid Asset Holdings, Spending and Saving. Study 132. Background files <unitdate type="inclusive" normal="1946-05">5/1946</unitdate></unittitle>
+                  <container type="box" label="Box">5</container>
+                  <container type="folder" label="Folder">3</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>National Survey of Liquid Asset Holdings, Spending and Saving. Study 132. Background files <unitdate type="inclusive" normal="1946-05">5/1946</unitdate></unittitle>
+                  <container type="box" label="Box">5</container>
+                  <container type="folder" label="Folder">4</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>National Survey of Liquid Asset Holdings, Spending and Saving. Study 132. Background files <unitdate type="inclusive" normal="1946-05">5/1946</unitdate></unittitle>
+                  <container type="box" label="Box">5</container>
+                  <container type="folder" label="Folder">5</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>National Survey of Liquid Asset Holdings, Spending and Saving. Study 132. Background files <unitdate type="inclusive" normal="1946-05">5/1946</unitdate></unittitle>
+                  <container type="box" label="Box">5</container>
+                  <container type="folder" label="Folder">6</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -3022,13 +3232,38 @@ Rensis Likert Papers, Bentley Historical Library, University of Michigan</p>
             </did>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">5</container>
-                <container type="folder" label="Folder">15-17</container>
                 <unittitle>Study 15</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Study 15</unittitle>
+                  <container type="box" label="Box">5</container>
+                  <container type="folder" label="Folder">15</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Study 15</unittitle>
+                  <container type="box" label="Box">5</container>
+                  <container type="folder" label="Folder">16</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Study 15</unittitle>
+                  <container type="box" label="Box">5</container>
+                  <container type="folder" label="Folder">17</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -3075,13 +3310,28 @@ Rensis Likert Papers, Bentley Historical Library, University of Michigan</p>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">5</container>
-              <container type="folder" label="Folder">24-25</container>
               <unittitle>An Exploration of Factors Affecting Farmers' Decisions Regarding Hogs. Study 135.</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>An Exploration of Factors Affecting Farmers' Decisions Regarding Hogs. Study 135.</unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">24</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>An Exploration of Factors Affecting Farmers' Decisions Regarding Hogs. Study 135.</unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">25</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3099,10 +3349,25 @@ Rensis Likert Papers, Bentley Historical Library, University of Michigan</p>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">5</container>
-              <container type="folder" label="Folder">28-29</container>
               <unittitle>Wages and Wage Rates of Hired Farm Workers</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Wages and Wage Rates of Hired Farm Workers</unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">28</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Wages and Wage Rates of Hired Farm Workers</unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">29</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3113,10 +3378,25 @@ Rensis Likert Papers, Bentley Historical Library, University of Michigan</p>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">5</container>
-              <container type="folder" label="Folder">31-32</container>
               <unittitle>Food shortage and its Effect on West Coast Morale. Study 64</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Food shortage and its Effect on West Coast Morale. Study 64</unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">31</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Food shortage and its Effect on West Coast Morale. Study 64</unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">32</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3155,10 +3435,85 @@ Rensis Likert Papers, Bentley Historical Library, University of Michigan</p>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">5</container>
-              <container type="folder" label="Folder">38-45</container>
               <unittitle>Miscellaneous</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous</unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">38</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous</unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">39</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous</unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">40</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous</unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">41</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous</unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">42</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous</unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">43</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous</unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">44</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous</unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">45</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3169,43 +3524,353 @@ Rensis Likert Papers, Bentley Historical Library, University of Michigan</p>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">6</container>
-              <container type="folder" label="Folder">1-23</container>
               <unittitle>Questionnaires, forms, memoranda</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">23 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">1</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">2</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">3</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">4</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">5</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">6</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">7</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">8</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">9</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">10</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">11</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">12</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">13</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">14</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">15</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">16</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">17</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">18</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">19</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">20</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">21</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">22</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Questionnaires, forms, memoranda</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">23</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">6</container>
-              <container type="folder" label="Folder">24-27</container>
               <unittitle>Notebooks containing questionnaires, forms, memoranda (4 v.)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Notebooks containing questionnaires, forms, memoranda (4 v.)</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">24</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Notebooks containing questionnaires, forms, memoranda (4 v.)</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">25</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Notebooks containing questionnaires, forms, memoranda (4 v.)</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">26</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Notebooks containing questionnaires, forms, memoranda (4 v.)</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">27</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">7</container>
-              <container type="folder" label="Folder">1-4</container>
               <unittitle>Notebooks containing questionnaires, forms, memoranda (4 v.)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Notebooks containing questionnaires, forms, memoranda (4 v.)</unittitle>
+                <container type="box" label="Box">7</container>
+                <container type="folder" label="Folder">1</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Notebooks containing questionnaires, forms, memoranda (4 v.)</unittitle>
+                <container type="box" label="Box">7</container>
+                <container type="folder" label="Folder">2</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Notebooks containing questionnaires, forms, memoranda (4 v.)</unittitle>
+                <container type="box" label="Box">7</container>
+                <container type="folder" label="Folder">3</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Notebooks containing questionnaires, forms, memoranda (4 v.)</unittitle>
+                <container type="box" label="Box">7</container>
+                <container type="folder" label="Folder">4</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">7</container>
-              <container type="folder" label="Folder">5-6</container>
               <unittitle>Papers concerning Agricultural Quiz Corner and other exhibit material</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Papers concerning Agricultural Quiz Corner and other exhibit material</unittitle>
+                <container type="box" label="Box">7</container>
+                <container type="folder" label="Folder">5</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Papers concerning Agricultural Quiz Corner and other exhibit material</unittitle>
+                <container type="box" label="Box">7</container>
+                <container type="folder" label="Folder">6</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -4024,13 +4689,88 @@ Rensis Likert Papers, Bentley Historical Library, University of Michigan</p>
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">9</container>
-                <container type="folder" label="Folder">39-46</container>
                 <unittitle>Detroit People in Perspective: A Survey of Group Attitudes and Aspirations <unitdate type="inclusive" normal="1943-10-28">10/28/1943</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">7 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Detroit People in Perspective: A Survey of Group Attitudes and Aspirations <unitdate type="inclusive" normal="1943-10-28">10/28/1943</unitdate></unittitle>
+                  <container type="box" label="Box">9</container>
+                  <container type="folder" label="Folder">39</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Detroit People in Perspective: A Survey of Group Attitudes and Aspirations <unitdate type="inclusive" normal="1943-10-28">10/28/1943</unitdate></unittitle>
+                  <container type="box" label="Box">9</container>
+                  <container type="folder" label="Folder">40</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Detroit People in Perspective: A Survey of Group Attitudes and Aspirations <unitdate type="inclusive" normal="1943-10-28">10/28/1943</unitdate></unittitle>
+                  <container type="box" label="Box">9</container>
+                  <container type="folder" label="Folder">41</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Detroit People in Perspective: A Survey of Group Attitudes and Aspirations <unitdate type="inclusive" normal="1943-10-28">10/28/1943</unitdate></unittitle>
+                  <container type="box" label="Box">9</container>
+                  <container type="folder" label="Folder">42</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Detroit People in Perspective: A Survey of Group Attitudes and Aspirations <unitdate type="inclusive" normal="1943-10-28">10/28/1943</unitdate></unittitle>
+                  <container type="box" label="Box">9</container>
+                  <container type="folder" label="Folder">43</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Detroit People in Perspective: A Survey of Group Attitudes and Aspirations <unitdate type="inclusive" normal="1943-10-28">10/28/1943</unitdate></unittitle>
+                  <container type="box" label="Box">9</container>
+                  <container type="folder" label="Folder">44</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Detroit People in Perspective: A Survey of Group Attitudes and Aspirations <unitdate type="inclusive" normal="1943-10-28">10/28/1943</unitdate></unittitle>
+                  <container type="box" label="Box">9</container>
+                  <container type="folder" label="Folder">45</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Detroit People in Perspective: A Survey of Group Attitudes and Aspirations <unitdate type="inclusive" normal="1943-10-28">10/28/1943</unitdate></unittitle>
+                  <container type="box" label="Box">9</container>
+                  <container type="folder" label="Folder">46</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -4908,13 +5648,48 @@ Rensis Likert Papers, Bentley Historical Library, University of Michigan</p>
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">11</container>
-              <container type="folder" label="Folder">1-4</container>
               <unittitle>Publications</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Publications</unittitle>
+                <container type="box" label="Box">11</container>
+                <container type="folder" label="Folder">1</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Publications</unittitle>
+                <container type="box" label="Box">11</container>
+                <container type="folder" label="Folder">2</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Publications</unittitle>
+                <container type="box" label="Box">11</container>
+                <container type="folder" label="Folder">3</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Publications</unittitle>
+                <container type="box" label="Box">11</container>
+                <container type="folder" label="Folder">4</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/mershon.xml
+++ b/Real_Masters_all/mershon.xml
@@ -555,10 +555,45 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">27</container>
-              <container label="Folder" type="folder">4-7</container>
               <unittitle>Personal correspondence, undated</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Personal correspondence, undated</unittitle>
+                <container type="box" label="Box">27</container>
+                <container label="Folder" type="folder">4</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Personal correspondence, undated</unittitle>
+                <container type="box" label="Box">27</container>
+                <container label="Folder" type="folder">5</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Personal correspondence, undated</unittitle>
+                <container type="box" label="Box">27</container>
+                <container label="Folder" type="folder">6</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Personal correspondence, undated</unittitle>
+                <container type="box" label="Box">27</container>
+                <container label="Folder" type="folder">7</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -576,10 +611,25 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">27</container>
-              <container label="Folder" type="folder">10-11</container>
               <unittitle>Saginaw &amp; Manistee Lumber Company records</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Saginaw &amp; Manistee Lumber Company records</unittitle>
+                <container type="box" label="Box">27</container>
+                <container label="Folder" type="folder">10</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Saginaw &amp; Manistee Lumber Company records</unittitle>
+                <container type="box" label="Box">27</container>
+                <container label="Folder" type="folder">11</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -590,10 +640,25 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">27</container>
-              <container label="Folder" type="folder">12-13</container>
               <unittitle>Materials on fish habits, etc.</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Materials on fish habits, etc.</unittitle>
+                <container type="box" label="Box">27</container>
+                <container label="Folder" type="folder">12</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Materials on fish habits, etc.</unittitle>
+                <container type="box" label="Box">27</container>
+                <container label="Folder" type="folder">13</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/mgleecl.xml
+++ b/Real_Masters_all/mgleecl.xml
@@ -520,9 +520,23 @@
         </did>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">5-6</container>
             <unittitle>Photos</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Photos</unittitle>
+              <container type="box" label="Box">5</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Photos</unittitle>
+              <container type="box" label="Box">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/michbell.xml
+++ b/Real_Masters_all/michbell.xml
@@ -434,23 +434,73 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">1</container>
-              <container type="folder" label="Folder">2-5</container>
               <unittitle>Accounting personnel</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Accounting personnel</unittitle>
+                <container type="box" label="Box">1</container>
+                <container type="folder" label="Folder">2</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Accounting personnel</unittitle>
+                <container type="box" label="Box">1</container>
+                <container type="folder" label="Folder">3</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Accounting personnel</unittitle>
+                <container type="box" label="Box">1</container>
+                <container type="folder" label="Folder">4</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Accounting personnel</unittitle>
+                <container type="box" label="Box">1</container>
+                <container type="folder" label="Folder">5</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">1</container>
-              <container type="folder" label="Folder">6-7</container>
               <unittitle>Activities-Employees</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Activities-Employees</unittitle>
+                <container type="box" label="Box">1</container>
+                <container type="folder" label="Folder">6</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Activities-Employees</unittitle>
+                <container type="box" label="Box">1</container>
+                <container type="folder" label="Folder">7</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -615,13 +665,38 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">1</container>
-              <container type="folder" label="Folder">31-33</container>
               <unittitle>Awards</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Awards</unittitle>
+                <container type="box" label="Box">1</container>
+                <container type="folder" label="Folder">31</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Awards</unittitle>
+                <container type="box" label="Box">1</container>
+                <container type="folder" label="Folder">32</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Awards</unittitle>
+                <container type="box" label="Box">1</container>
+                <container type="folder" label="Folder">33</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -781,13 +856,68 @@
                 </c06>
                 <c06 level="file">
                   <did>
-                    <container type="box" label="Box">2</container>
-                    <container type="folder" label="Folder">53-58</container>
                     <unittitle>Construction views, etc.</unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">6 folders</extent>
                     </physdesc>
                   </did>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Construction views, etc.</unittitle>
+                      <container type="box" label="Box">2</container>
+                      <container type="folder" label="Folder">53</container>
+                    </did>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Construction views, etc.</unittitle>
+                      <container type="box" label="Box">2</container>
+                      <container type="folder" label="Folder">54</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Construction views, etc.</unittitle>
+                      <container type="box" label="Box">2</container>
+                      <container type="folder" label="Folder">55</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Construction views, etc.</unittitle>
+                      <container type="box" label="Box">2</container>
+                      <container type="folder" label="Folder">56</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Construction views, etc.</unittitle>
+                      <container type="box" label="Box">2</container>
+                      <container type="folder" label="Folder">57</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Construction views, etc.</unittitle>
+                      <container type="box" label="Box">2</container>
+                      <container type="folder" label="Folder">58</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
                 </c06>
                 <c06 level="file">
                   <did>
@@ -812,13 +942,28 @@
                 </c06>
                 <c06 level="file">
                   <did>
-                    <container type="box" label="Box">2</container>
-                    <container type="folder" label="Folder">62-63</container>
                     <unittitle>Sculpture-Alexander Calder stabile</unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">2 folders</extent>
                     </physdesc>
                   </did>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Sculpture-Alexander Calder stabile</unittitle>
+                      <container type="box" label="Box">2</container>
+                      <container type="folder" label="Folder">62</container>
+                    </did>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>Sculpture-Alexander Calder stabile</unittitle>
+                      <container type="box" label="Box">2</container>
+                      <container type="folder" label="Folder">63</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
                 </c06>
               </c05>
               <c05 level="file">
@@ -883,13 +1028,28 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">2</container>
-                <container type="folder" label="Folder">71-72</container>
                 <unittitle>Buried</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Buried</unittitle>
+                  <container type="box" label="Box">2</container>
+                  <container type="folder" label="Folder">71</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Buried</unittitle>
+                  <container type="box" label="Box">2</container>
+                  <container type="folder" label="Folder">72</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -1065,13 +1225,58 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">3</container>
-              <container type="folder" label="Folder">97-101</container>
               <unittitle>Christmas parties and charitable activities <unitdate type="inclusive" normal="1947/1975">1947-1975</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Christmas parties and charitable activities <unitdate type="inclusive" normal="1947/1975">1947-1975</unitdate></unittitle>
+                <container type="box" label="Box">3</container>
+                <container type="folder" label="Folder">97</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Christmas parties and charitable activities <unitdate type="inclusive" normal="1947/1975">1947-1975</unitdate></unittitle>
+                <container type="box" label="Box">3</container>
+                <container type="folder" label="Folder">98</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Christmas parties and charitable activities <unitdate type="inclusive" normal="1947/1975">1947-1975</unitdate></unittitle>
+                <container type="box" label="Box">3</container>
+                <container type="folder" label="Folder">99</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Christmas parties and charitable activities <unitdate type="inclusive" normal="1947/1975">1947-1975</unitdate></unittitle>
+                <container type="box" label="Box">3</container>
+                <container type="folder" label="Folder">100</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Christmas parties and charitable activities <unitdate type="inclusive" normal="1947/1975">1947-1975</unitdate></unittitle>
+                <container type="box" label="Box">3</container>
+                <container type="folder" label="Folder">101</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -1593,13 +1798,48 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">4</container>
-              <container type="folder" label="Folder">171-174</container>
               <unittitle>Demonstrations (equipment, training sessions, etc.)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Demonstrations (equipment, training sessions, etc.)</unittitle>
+                <container type="box" label="Box">4</container>
+                <container type="folder" label="Folder">171</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Demonstrations (equipment, training sessions, etc.)</unittitle>
+                <container type="box" label="Box">4</container>
+                <container type="folder" label="Folder">172</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Demonstrations (equipment, training sessions, etc.)</unittitle>
+                <container type="box" label="Box">4</container>
+                <container type="folder" label="Folder">173</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Demonstrations (equipment, training sessions, etc.)</unittitle>
+                <container type="box" label="Box">4</container>
+                <container type="folder" label="Folder">174</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -1678,13 +1918,28 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">5</container>
-              <container type="folder" label="Folder">185-186</container>
               <unittitle>Directories</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Directories</unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">185</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Directories</unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">186</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -1788,13 +2043,68 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">5</container>
-                <container type="folder" label="Folder">200-205</container>
                 <unittitle>Miscellaneous</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">6 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Miscellaneous</unittitle>
+                  <container type="box" label="Box">5</container>
+                  <container type="folder" label="Folder">200</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Miscellaneous</unittitle>
+                  <container type="box" label="Box">5</container>
+                  <container type="folder" label="Folder">201</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Miscellaneous</unittitle>
+                  <container type="box" label="Box">5</container>
+                  <container type="folder" label="Folder">202</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Miscellaneous</unittitle>
+                  <container type="box" label="Box">5</container>
+                  <container type="folder" label="Folder">203</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Miscellaneous</unittitle>
+                  <container type="box" label="Box">5</container>
+                  <container type="folder" label="Folder">204</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Miscellaneous</unittitle>
+                  <container type="box" label="Box">5</container>
+                  <container type="folder" label="Folder">205</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -1849,13 +2159,68 @@
               </did>
               <c05 level="file">
                 <did>
-                  <container type="box" label="Box">6</container>
-                  <container type="folder" label="Folder">212-217</container>
                   <unittitle>Bell addition</unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">6 folders</extent>
                   </physdesc>
                 </did>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Bell addition</unittitle>
+                    <container type="box" label="Box">6</container>
+                    <container type="folder" label="Folder">212</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Bell addition</unittitle>
+                    <container type="box" label="Box">6</container>
+                    <container type="folder" label="Folder">213</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Bell addition</unittitle>
+                    <container type="box" label="Box">6</container>
+                    <container type="folder" label="Folder">214</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Bell addition</unittitle>
+                    <container type="box" label="Box">6</container>
+                    <container type="folder" label="Folder">215</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Bell addition</unittitle>
+                    <container type="box" label="Box">6</container>
+                    <container type="folder" label="Folder">216</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Bell addition</unittitle>
+                    <container type="box" label="Box">6</container>
+                    <container type="folder" label="Folder">217</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
               <c05 level="file">
                 <did>
@@ -1945,13 +2310,28 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">6</container>
-              <container type="folder" label="Folder">230-231</container>
               <unittitle>Employee activities (non-work, charitable) <unitdate type="inclusive" normal="1955/1958">1955-1958</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Employee activities (non-work, charitable) <unitdate type="inclusive" normal="1955/1958">1955-1958</unitdate></unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">230</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Employee activities (non-work, charitable) <unitdate type="inclusive" normal="1955/1958">1955-1958</unitdate></unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">231</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -1976,13 +2356,28 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">6</container>
-              <container type="folder" label="Folder">235-236</container>
               <unittitle>Employees and employees at work</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Employees and employees at work</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">235</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Employees and employees at work</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">236</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -1993,13 +2388,48 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">6</container>
-              <container type="folder" label="Folder">238-241</container>
               <unittitle>Employees-Skilled/craft</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Employees-Skilled/craft</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">238</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Employees-Skilled/craft</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">239</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Employees-Skilled/craft</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">240</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Employees-Skilled/craft</unittitle>
+                <container type="box" label="Box">6</container>
+                <container type="folder" label="Folder">241</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2047,13 +2477,28 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">7</container>
-                <container type="folder" label="Folder">247-248</container>
                 <unittitle>High school</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>High school</unittitle>
+                  <container type="box" label="Box">7</container>
+                  <container type="folder" label="Folder">247</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>High school</unittitle>
+                  <container type="box" label="Box">7</container>
+                  <container type="folder" label="Folder">248</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
           </c03>
           <c03 level="file">
@@ -2211,13 +2656,98 @@
               </c05>
               <c05 level="file">
                 <did>
-                  <container type="box" label="Box">7</container>
-                  <container type="folder" label="Folder">269-277</container>
                   <unittitle>Miscellaneous</unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">9 folders</extent>
                   </physdesc>
                 </did>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Miscellaneous</unittitle>
+                    <container type="box" label="Box">7</container>
+                    <container type="folder" label="Folder">269</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Miscellaneous</unittitle>
+                    <container type="box" label="Box">7</container>
+                    <container type="folder" label="Folder">270</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Miscellaneous</unittitle>
+                    <container type="box" label="Box">7</container>
+                    <container type="folder" label="Folder">271</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Miscellaneous</unittitle>
+                    <container type="box" label="Box">7</container>
+                    <container type="folder" label="Folder">272</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Miscellaneous</unittitle>
+                    <container type="box" label="Box">7</container>
+                    <container type="folder" label="Folder">273</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Miscellaneous</unittitle>
+                    <container type="box" label="Box">7</container>
+                    <container type="folder" label="Folder">274</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Miscellaneous</unittitle>
+                    <container type="box" label="Box">7</container>
+                    <container type="folder" label="Folder">275</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Miscellaneous</unittitle>
+                    <container type="box" label="Box">7</container>
+                    <container type="folder" label="Folder">276</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Miscellaneous</unittitle>
+                    <container type="box" label="Box">7</container>
+                    <container type="folder" label="Folder">277</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
               <c05 level="file">
                 <did>
@@ -2394,13 +2924,58 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">8</container>
-              <container type="folder" label="Folder">302-306</container>
               <unittitle>Frames-C.O. frames</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Frames-C.O. frames</unittitle>
+                <container type="box" label="Box">8</container>
+                <container type="folder" label="Folder">302</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Frames-C.O. frames</unittitle>
+                <container type="box" label="Box">8</container>
+                <container type="folder" label="Folder">303</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Frames-C.O. frames</unittitle>
+                <container type="box" label="Box">8</container>
+                <container type="folder" label="Folder">304</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Frames-C.O. frames</unittitle>
+                <container type="box" label="Box">8</container>
+                <container type="folder" label="Folder">305</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Frames-C.O. frames</unittitle>
+                <container type="box" label="Box">8</container>
+                <container type="folder" label="Folder">306</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2472,13 +3047,28 @@
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">9</container>
-              <container type="folder" label="Folder">316-317</container>
               <unittitle>Hobbies</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Hobbies</unittitle>
+                <container type="box" label="Box">9</container>
+                <container type="folder" label="Folder">316</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Hobbies</unittitle>
+                <container type="box" label="Box">9</container>
+                <container type="folder" label="Folder">317</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2557,13 +3147,68 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">9</container>
-              <container type="folder" label="Folder">328-333</container>
               <unittitle>Installers</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">6 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Installers</unittitle>
+                <container type="box" label="Box">9</container>
+                <container type="folder" label="Folder">328</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Installers</unittitle>
+                <container type="box" label="Box">9</container>
+                <container type="folder" label="Folder">329</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Installers</unittitle>
+                <container type="box" label="Box">9</container>
+                <container type="folder" label="Folder">330</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Installers</unittitle>
+                <container type="box" label="Box">9</container>
+                <container type="folder" label="Folder">331</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Installers</unittitle>
+                <container type="box" label="Box">9</container>
+                <container type="folder" label="Folder">332</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Installers</unittitle>
+                <container type="box" label="Box">9</container>
+                <container type="folder" label="Folder">333</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2607,13 +3252,48 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">9</container>
-              <container type="folder" label="Folder">339-342</container>
               <unittitle>Junior Achievement</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Junior Achievement</unittitle>
+                <container type="box" label="Box">9</container>
+                <container type="folder" label="Folder">339</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Junior Achievement</unittitle>
+                <container type="box" label="Box">9</container>
+                <container type="folder" label="Folder">340</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Junior Achievement</unittitle>
+                <container type="box" label="Box">9</container>
+                <container type="folder" label="Folder">341</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Junior Achievement</unittitle>
+                <container type="box" label="Box">9</container>
+                <container type="folder" label="Folder">342</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2666,8 +3346,6 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">10</container>
-              <container type="folder" label="Folder">350-352</container>
               <unittitle>Linemen</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
@@ -2676,6 +3354,33 @@
                 <physfacet>include color transparencies, 1957</physfacet>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Linemen</unittitle>
+                <container type="box" label="Box">10</container>
+                <container type="folder" label="Folder">350</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Linemen</unittitle>
+                <container type="box" label="Box">10</container>
+                <container type="folder" label="Folder">351</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Linemen</unittitle>
+                <container type="box" label="Box">10</container>
+                <container type="folder" label="Folder">352</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2714,13 +3419,38 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">10</container>
-              <container type="folder" label="Folder">358-360</container>
               <unittitle>Management</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Management</unittitle>
+                <container type="box" label="Box">10</container>
+                <container type="folder" label="Folder">358</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Management</unittitle>
+                <container type="box" label="Box">10</container>
+                <container type="folder" label="Folder">359</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Management</unittitle>
+                <container type="box" label="Box">10</container>
+                <container type="folder" label="Folder">360</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2738,13 +3468,58 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">10</container>
-              <container type="folder" label="Folder">363-367</container>
               <unittitle>Marketing Department</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Marketing Department</unittitle>
+                <container type="box" label="Box">10</container>
+                <container type="folder" label="Folder">363</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Marketing Department</unittitle>
+                <container type="box" label="Box">10</container>
+                <container type="folder" label="Folder">364</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Marketing Department</unittitle>
+                <container type="box" label="Box">10</container>
+                <container type="folder" label="Folder">365</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Marketing Department</unittitle>
+                <container type="box" label="Box">10</container>
+                <container type="folder" label="Folder">366</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Marketing Department</unittitle>
+                <container type="box" label="Box">10</container>
+                <container type="folder" label="Folder">367</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2762,13 +3537,28 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">10</container>
-              <container type="folder" label="Folder">370-371</container>
               <unittitle>Medical Group</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Medical Group</unittitle>
+                <container type="box" label="Box">10</container>
+                <container type="folder" label="Folder">370</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Medical Group</unittitle>
+                <container type="box" label="Box">10</container>
+                <container type="folder" label="Folder">371</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2793,13 +3583,38 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">11</container>
-              <container type="folder" label="Folder">375-377</container>
               <unittitle>Microwave towers</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Microwave towers</unittitle>
+                <container type="box" label="Box">11</container>
+                <container type="folder" label="Folder">375</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Microwave towers</unittitle>
+                <container type="box" label="Box">11</container>
+                <container type="folder" label="Folder">376</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Microwave towers</unittitle>
+                <container type="box" label="Box">11</container>
+                <container type="folder" label="Folder">377</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2838,13 +3653,48 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">11</container>
-              <container type="folder" label="Folder">383-386</container>
               <unittitle>Mobile radio telephone</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Mobile radio telephone</unittitle>
+                <container type="box" label="Box">11</container>
+                <container type="folder" label="Folder">383</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Mobile radio telephone</unittitle>
+                <container type="box" label="Box">11</container>
+                <container type="folder" label="Folder">384</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Mobile radio telephone</unittitle>
+                <container type="box" label="Box">11</container>
+                <container type="folder" label="Folder">385</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Mobile radio telephone</unittitle>
+                <container type="box" label="Box">11</container>
+                <container type="folder" label="Folder">386</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2880,13 +3730,28 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">11</container>
-                <container type="folder" label="Folder">391-392</container>
                 <unittitle>Company trucks</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Company trucks</unittitle>
+                  <container type="box" label="Box">11</container>
+                  <container type="folder" label="Folder">391</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Company trucks</unittitle>
+                  <container type="box" label="Box">11</container>
+                  <container type="folder" label="Folder">392</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -3104,23 +3969,173 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">12</container>
-              <container type="folder" label="Folder">422-434</container>
               <unittitle>Operators</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">13 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Operators</unittitle>
+                <container type="box" label="Box">12</container>
+                <container type="folder" label="Folder">422</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Operators</unittitle>
+                <container type="box" label="Box">12</container>
+                <container type="folder" label="Folder">423</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Operators</unittitle>
+                <container type="box" label="Box">12</container>
+                <container type="folder" label="Folder">424</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Operators</unittitle>
+                <container type="box" label="Box">12</container>
+                <container type="folder" label="Folder">425</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Operators</unittitle>
+                <container type="box" label="Box">12</container>
+                <container type="folder" label="Folder">426</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Operators</unittitle>
+                <container type="box" label="Box">12</container>
+                <container type="folder" label="Folder">427</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Operators</unittitle>
+                <container type="box" label="Box">12</container>
+                <container type="folder" label="Folder">428</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Operators</unittitle>
+                <container type="box" label="Box">12</container>
+                <container type="folder" label="Folder">429</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Operators</unittitle>
+                <container type="box" label="Box">12</container>
+                <container type="folder" label="Folder">430</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Operators</unittitle>
+                <container type="box" label="Box">12</container>
+                <container type="folder" label="Folder">431</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Operators</unittitle>
+                <container type="box" label="Box">12</container>
+                <container type="folder" label="Folder">432</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Operators</unittitle>
+                <container type="box" label="Box">12</container>
+                <container type="folder" label="Folder">433</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Operators</unittitle>
+                <container type="box" label="Box">12</container>
+                <container type="folder" label="Folder">434</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">12</container>
-              <container type="folder" label="Folder">435-437</container>
               <unittitle>Outside companies (photos of other firms)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Outside companies (photos of other firms)</unittitle>
+                <container type="box" label="Box">12</container>
+                <container type="folder" label="Folder">435</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Outside companies (photos of other firms)</unittitle>
+                <container type="box" label="Box">12</container>
+                <container type="folder" label="Folder">436</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Outside companies (photos of other firms)</unittitle>
+                <container type="box" label="Box">12</container>
+                <container type="folder" label="Folder">437</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3128,8 +4143,6 @@
             </did>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">13</container>
-                <container type="folder" label="Folder">438-460</container>
                 <unittitle>Robert Thom Michigan history series</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">23 folders</extent>
@@ -3138,6 +4151,233 @@
               <odd>
                 <p>(arranged alphabetically by title of painting; each folder contains color transparencies, negatives, and color print)</p>
               </odd>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">438</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">439</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">440</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">441</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">442</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">443</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">444</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">445</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">446</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">447</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">448</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">449</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">450</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">451</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">452</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">453</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">454</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">455</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">456</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">457</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">458</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">459</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Robert Thom Michigan history series</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">460</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -3167,13 +4407,98 @@
             </did>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">13</container>
-                <container type="folder" label="Folder">464-472</container>
                 <unittitle>General</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">9 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>General</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">464</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>General</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">465</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>General</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">466</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>General</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">467</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>General</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">468</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>General</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">469</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>General</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">470</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>General</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">471</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>General</unittitle>
+                  <container type="box" label="Box">13</container>
+                  <container type="folder" label="Folder">472</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -3185,23 +4510,93 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">14</container>
-              <container type="folder" label="Folder">474-475</container>
               <unittitle>People (various business and personal activities)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>People (various business and personal activities)</unittitle>
+                <container type="box" label="Box">14</container>
+                <container type="folder" label="Folder">474</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>People (various business and personal activities)</unittitle>
+                <container type="box" label="Box">14</container>
+                <container type="folder" label="Folder">475</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">14</container>
-              <container type="folder" label="Folder">476-481</container>
               <unittitle>Personalities (employee activities and hobbies)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">6 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Personalities (employee activities and hobbies)</unittitle>
+                <container type="box" label="Box">14</container>
+                <container type="folder" label="Folder">476</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Personalities (employee activities and hobbies)</unittitle>
+                <container type="box" label="Box">14</container>
+                <container type="folder" label="Folder">477</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Personalities (employee activities and hobbies)</unittitle>
+                <container type="box" label="Box">14</container>
+                <container type="folder" label="Folder">478</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Personalities (employee activities and hobbies)</unittitle>
+                <container type="box" label="Box">14</container>
+                <container type="folder" label="Folder">479</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Personalities (employee activities and hobbies)</unittitle>
+                <container type="box" label="Box">14</container>
+                <container type="folder" label="Folder">480</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Personalities (employee activities and hobbies)</unittitle>
+                <container type="box" label="Box">14</container>
+                <container type="folder" label="Folder">481</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3226,13 +4621,38 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">14</container>
-              <container type="folder" label="Folder">485-487</container>
               <unittitle>Plant training (lab set ups for plant school)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Plant training (lab set ups for plant school)</unittitle>
+                <container type="box" label="Box">14</container>
+                <container type="folder" label="Folder">485</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Plant training (lab set ups for plant school)</unittitle>
+                <container type="box" label="Box">14</container>
+                <container type="folder" label="Folder">486</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Plant training (lab set ups for plant school)</unittitle>
+                <container type="box" label="Box">14</container>
+                <container type="folder" label="Folder">487</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3299,53 +4719,178 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">15</container>
-              <container type="folder" label="Folder">497-499</container>
               <unittitle>PBX (operators, equipment, staff activities)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>PBX (operators, equipment, staff activities)</unittitle>
+                <container type="box" label="Box">15</container>
+                <container type="folder" label="Folder">497</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>PBX (operators, equipment, staff activities)</unittitle>
+                <container type="box" label="Box">15</container>
+                <container type="folder" label="Folder">498</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>PBX (operators, equipment, staff activities)</unittitle>
+                <container type="box" label="Box">15</container>
+                <container type="folder" label="Folder">499</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">15</container>
-              <container type="folder" label="Folder">500-501</container>
               <unittitle>PBX (use by other companies; include work operations of various firms</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>PBX (use by other companies; include work operations of various firms</unittitle>
+                <container type="box" label="Box">15</container>
+                <container type="folder" label="Folder">500</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>PBX (use by other companies; include work operations of various firms</unittitle>
+                <container type="box" label="Box">15</container>
+                <container type="folder" label="Folder">501</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">15</container>
-              <container type="folder" label="Folder">502-503</container>
               <unittitle>Posters</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Posters</unittitle>
+                <container type="box" label="Box">15</container>
+                <container type="folder" label="Folder">502</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Posters</unittitle>
+                <container type="box" label="Box">15</container>
+                <container type="folder" label="Folder">503</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">15</container>
-              <container type="folder" label="Folder">504-505</container>
               <unittitle>Princess Phones</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Princess Phones</unittitle>
+                <container type="box" label="Box">15</container>
+                <container type="folder" label="Folder">504</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Princess Phones</unittitle>
+                <container type="box" label="Box">15</container>
+                <container type="folder" label="Folder">505</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">15</container>
-              <container type="folder" label="Folder">506-511</container>
               <unittitle>Public offices (commercial offices and employees)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">6 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Public offices (commercial offices and employees)</unittitle>
+                <container type="box" label="Box">15</container>
+                <container type="folder" label="Folder">506</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Public offices (commercial offices and employees)</unittitle>
+                <container type="box" label="Box">15</container>
+                <container type="folder" label="Folder">507</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Public offices (commercial offices and employees)</unittitle>
+                <container type="box" label="Box">15</container>
+                <container type="folder" label="Folder">508</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Public offices (commercial offices and employees)</unittitle>
+                <container type="box" label="Box">15</container>
+                <container type="folder" label="Folder">509</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Public offices (commercial offices and employees)</unittitle>
+                <container type="box" label="Box">15</container>
+                <container type="folder" label="Folder">510</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Public offices (commercial offices and employees)</unittitle>
+                <container type="box" label="Box">15</container>
+                <container type="folder" label="Folder">511</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3445,13 +4990,28 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">16</container>
-              <container type="folder" label="Folder">525-526</container>
               <unittitle>Retired people</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Retired people</unittitle>
+                <container type="box" label="Box">16</container>
+                <container type="folder" label="Folder">525</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Retired people</unittitle>
+                <container type="box" label="Box">16</container>
+                <container type="folder" label="Folder">526</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3469,13 +5029,38 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">16</container>
-              <container type="folder" label="Folder">529-531</container>
               <unittitle>Rural</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Rural</unittitle>
+                <container type="box" label="Box">16</container>
+                <container type="folder" label="Folder">529</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Rural</unittitle>
+                <container type="box" label="Box">16</container>
+                <container type="folder" label="Folder">530</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Rural</unittitle>
+                <container type="box" label="Box">16</container>
+                <container type="folder" label="Folder">531</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3483,13 +5068,38 @@
             </did>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">16</container>
-                <container type="folder" label="Folder">532-534</container>
                 <unittitle>General</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>General</unittitle>
+                  <container type="box" label="Box">16</container>
+                  <container type="folder" label="Folder">532</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>General</unittitle>
+                  <container type="box" label="Box">16</container>
+                  <container type="folder" label="Folder">533</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>General</unittitle>
+                  <container type="box" label="Box">16</container>
+                  <container type="folder" label="Folder">534</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -3575,13 +5185,28 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">16</container>
-                <container type="folder" label="Folder">546-547</container>
                 <unittitle>Michigan</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Michigan</unittitle>
+                  <container type="box" label="Box">16</container>
+                  <container type="folder" label="Folder">546</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Michigan</unittitle>
+                  <container type="box" label="Box">16</container>
+                  <container type="folder" label="Folder">547</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -3661,13 +5286,28 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">17</container>
-              <container type="folder" label="Folder">558-559</container>
               <unittitle>Service representatives</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Service representatives</unittitle>
+                <container type="box" label="Box">17</container>
+                <container type="folder" label="Folder">558</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Service representatives</unittitle>
+                <container type="box" label="Box">17</container>
+                <container type="folder" label="Folder">559</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3685,13 +5325,28 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">17</container>
-              <container type="folder" label="Folder">562-563</container>
               <unittitle>Signs</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Signs</unittitle>
+                <container type="box" label="Box">17</container>
+                <container type="folder" label="Folder">562</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Signs</unittitle>
+                <container type="box" label="Box">17</container>
+                <container type="folder" label="Folder">563</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3907,13 +5562,38 @@
             </did>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">18</container>
-                <container type="folder" label="Folder">593-595</container>
                 <unittitle>Baseball</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Baseball</unittitle>
+                  <container type="box" label="Box">18</container>
+                  <container type="folder" label="Folder">593</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Baseball</unittitle>
+                  <container type="box" label="Box">18</container>
+                  <container type="folder" label="Folder">594</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Baseball</unittitle>
+                  <container type="box" label="Box">18</container>
+                  <container type="folder" label="Folder">595</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -4044,13 +5724,28 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">18</container>
-              <container type="folder" label="Folder">614-615</container>
               <unittitle>Stocks and bonds</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Stocks and bonds</unittitle>
+                <container type="box" label="Box">18</container>
+                <container type="folder" label="Folder">614</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Stocks and bonds</unittitle>
+                <container type="box" label="Box">18</container>
+                <container type="folder" label="Folder">615</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -4152,13 +5847,48 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">19</container>
-              <container type="folder" label="Folder">627-630</container>
               <unittitle>Suggestion (employee) plan and winners</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Suggestion (employee) plan and winners</unittitle>
+                <container type="box" label="Box">19</container>
+                <container type="folder" label="Folder">627</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Suggestion (employee) plan and winners</unittitle>
+                <container type="box" label="Box">19</container>
+                <container type="folder" label="Folder">628</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Suggestion (employee) plan and winners</unittitle>
+                <container type="box" label="Box">19</container>
+                <container type="folder" label="Folder">629</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Suggestion (employee) plan and winners</unittitle>
+                <container type="box" label="Box">19</container>
+                <container type="folder" label="Folder">630</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -4244,13 +5974,28 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">19</container>
-              <container type="folder" label="Folder">642-643</container>
               <unittitle>Telephone Hour</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Telephone Hour</unittitle>
+                <container type="box" label="Box">19</container>
+                <container type="folder" label="Folder">642</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Telephone Hour</unittitle>
+                <container type="box" label="Box">19</container>
+                <container type="folder" label="Folder">643</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -4279,13 +6024,28 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">19</container>
-                <container type="folder" label="Folder">647-648</container>
                 <unittitle>Bedrooms</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Bedrooms</unittitle>
+                  <container type="box" label="Box">19</container>
+                  <container type="folder" label="Folder">647</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Bedrooms</unittitle>
+                  <container type="box" label="Box">19</container>
+                  <container type="folder" label="Folder">648</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -4310,13 +6070,28 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">20</container>
-                <container type="folder" label="Folder">652-653</container>
                 <unittitle>Kitchens</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Kitchens</unittitle>
+                  <container type="box" label="Box">20</container>
+                  <container type="folder" label="Folder">652</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Kitchens</unittitle>
+                  <container type="box" label="Box">20</container>
+                  <container type="folder" label="Folder">653</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -4349,13 +6124,38 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">20</container>
-              <container type="folder" label="Folder">658-660</container>
               <unittitle>Teletypewriters</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Teletypewriters</unittitle>
+                <container type="box" label="Box">20</container>
+                <container type="folder" label="Folder">658</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Teletypewriters</unittitle>
+                <container type="box" label="Box">20</container>
+                <container type="folder" label="Folder">659</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Teletypewriters</unittitle>
+                <container type="box" label="Box">20</container>
+                <container type="folder" label="Folder">660</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -4363,23 +6163,53 @@
             </did>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">20</container>
-                <container type="folder" label="Folder">661-662</container>
                 <unittitle>General</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>General</unittitle>
+                  <container type="box" label="Box">20</container>
+                  <container type="folder" label="Folder">661</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>General</unittitle>
+                  <container type="box" label="Box">20</container>
+                  <container type="folder" label="Folder">662</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">20</container>
-                <container type="folder" label="Folder">663-664</container>
                 <unittitle>Antennas</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Antennas</unittitle>
+                  <container type="box" label="Box">20</container>
+                  <container type="folder" label="Folder">663</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Antennas</unittitle>
+                  <container type="box" label="Box">20</container>
+                  <container type="folder" label="Folder">664</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -4458,8 +6288,6 @@
             </did>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">20</container>
-                <container type="folder" label="Folder">675-676</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1976">1976</unitdate>
                 </unittitle>
@@ -4467,6 +6295,27 @@
                   <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1976">1976</unitdate>
+                  </unittitle>
+                  <container type="box" label="Box">20</container>
+                  <container type="folder" label="Folder">675</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1976">1976</unitdate>
+                  </unittitle>
+                  <container type="box" label="Box">20</container>
+                  <container type="folder" label="Folder">676</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -4479,13 +6328,28 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">20</container>
-                <container type="folder" label="Folder">678-679</container>
                 <unittitle>Miscellaneous</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Miscellaneous</unittitle>
+                  <container type="box" label="Box">20</container>
+                  <container type="folder" label="Folder">678</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Miscellaneous</unittitle>
+                  <container type="box" label="Box">20</container>
+                  <container type="folder" label="Folder">679</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
           </c03>
           <c03 level="file">
@@ -4597,13 +6461,38 @@
             </did>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">21</container>
-                <container type="folder" label="Folder">694-696</container>
                 <unittitle>General</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 folders</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>General</unittitle>
+                  <container type="box" label="Box">21</container>
+                  <container type="folder" label="Folder">694</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>General</unittitle>
+                  <container type="box" label="Box">21</container>
+                  <container type="folder" label="Folder">695</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>General</unittitle>
+                  <container type="box" label="Box">21</container>
+                  <container type="folder" label="Folder">696</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -4664,13 +6553,28 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">21</container>
-              <container type="folder" label="Folder">705-706</container>
               <unittitle>Trimline</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Trimline</unittitle>
+                <container type="box" label="Box">21</container>
+                <container type="folder" label="Folder">705</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Trimline</unittitle>
+                <container type="box" label="Box">21</container>
+                <container type="folder" label="Folder">706</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -4702,23 +6606,53 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">21</container>
-              <container type="folder" label="Folder">711-712</container>
               <unittitle>United Foundations</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>United Foundations</unittitle>
+                <container type="box" label="Box">21</container>
+                <container type="folder" label="Folder">711</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>United Foundations</unittitle>
+                <container type="box" label="Box">21</container>
+                <container type="folder" label="Folder">712</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">21</container>
-              <container type="folder" label="Folder">713-714</container>
               <unittitle>Upbeat</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Upbeat</unittitle>
+                <container type="box" label="Box">21</container>
+                <container type="folder" label="Folder">713</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Upbeat</unittitle>
+                <container type="box" label="Box">21</container>
+                <container type="folder" label="Folder">714</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -4736,13 +6670,48 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">22</container>
-              <container type="folder" label="Folder">717-720</container>
               <unittitle>Vail Medal</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Vail Medal</unittitle>
+                <container type="box" label="Box">22</container>
+                <container type="folder" label="Folder">717</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Vail Medal</unittitle>
+                <container type="box" label="Box">22</container>
+                <container type="folder" label="Folder">718</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Vail Medal</unittitle>
+                <container type="box" label="Box">22</container>
+                <container type="folder" label="Folder">719</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Vail Medal</unittitle>
+                <container type="box" label="Box">22</container>
+                <container type="folder" label="Folder">720</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -4781,13 +6750,38 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">22</container>
-              <container type="folder" label="Folder">726-728</container>
               <unittitle>Western Electric</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Western Electric</unittitle>
+                <container type="box" label="Box">22</container>
+                <container type="folder" label="Folder">726</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Western Electric</unittitle>
+                <container type="box" label="Box">22</container>
+                <container type="folder" label="Folder">727</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Western Electric</unittitle>
+                <container type="box" label="Box">22</container>
+                <container type="folder" label="Folder">728</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -4805,13 +6799,28 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">22</container>
-              <container type="folder" label="Folder">731-732</container>
               <unittitle>Women's Club</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Women's Club</unittitle>
+                <container type="box" label="Box">22</container>
+                <container type="folder" label="Folder">731</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Women's Club</unittitle>
+                <container type="box" label="Box">22</container>
+                <container type="folder" label="Folder">732</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/milliken.xml
+++ b/Real_Masters_all/milliken.xml
@@ -17589,9 +17589,1382 @@
           </scopecontent>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">1619-1771</container>
               <unittitle>ROBO Letters</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1619</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1620</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1621</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1622</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1623</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1624</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1625</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1626</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1627</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1628</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1629</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1630</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1631</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1632</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1633</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1634</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1635</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1636</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1637</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1638</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1639</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1640</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1641</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1642</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1643</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1644</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1645</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1646</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1647</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1648</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1649</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1650</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1651</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1652</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1653</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1654</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1655</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1656</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1657</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1658</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1659</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1660</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1661</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1662</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1663</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1664</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1665</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1666</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1667</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1668</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1669</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1670</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1671</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1672</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1673</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1674</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1675</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1676</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1677</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1678</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1679</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1680</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1681</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1682</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1683</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1684</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1685</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1686</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1687</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1688</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1689</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1690</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1691</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1692</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1693</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1694</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1695</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1696</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1697</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1698</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1699</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1700</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1701</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1702</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1703</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1704</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1705</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1706</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1707</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1708</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1709</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1710</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1711</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1712</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1713</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1714</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1715</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1716</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1717</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1718</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1719</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1720</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1721</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1722</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1723</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1724</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1725</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1726</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1727</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1728</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1729</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1730</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1731</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1732</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1733</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1734</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1735</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1736</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1737</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1738</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1739</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1740</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1741</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1742</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1743</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1744</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1745</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1746</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1747</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1748</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1749</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1750</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1751</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1752</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1753</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1754</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1755</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1756</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1757</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1758</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1759</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1760</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1761</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1762</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1763</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1764</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1765</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1766</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1767</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1768</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1769</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1770</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>ROBO Letters</unittitle>
+                <container type="box" label="Box">1771</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
       </c01>

--- a/Real_Masters_all/murphyf.xml
+++ b/Real_Masters_all/murphyf.xml
@@ -7021,9 +7021,32 @@
         </c02>
         <c02 level="file">
           <did>
-            <container label="Box" type="box">87-89</container>
             <unittitle>Memorandum to Attorney General Frank Murphy from the Federal Bureau of Investigation <unitdate type="inclusive" normal="1939">1939</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Memorandum to Attorney General Frank Murphy from the Federal Bureau of Investigation <unitdate type="inclusive" normal="1939">1939</unitdate></unittitle>
+              <container label="Box" type="box">87</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Memorandum to Attorney General Frank Murphy from the Federal Bureau of Investigation <unitdate type="inclusive" normal="1939">1939</unitdate></unittitle>
+              <container label="Box" type="box">88</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Memorandum to Attorney General Frank Murphy from the Federal Bureau of Investigation <unitdate type="inclusive" normal="1939">1939</unitdate></unittitle>
+              <container label="Box" type="box">89</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/nursing.xml
+++ b/Real_Masters_all/nursing.xml
@@ -16768,12 +16768,35 @@
           </scopecontent>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">69-71</container>
               <unittitle>[Unprocessed files]</unittitle>
             </did>
             <accessrestrict>
               <p>[ER RESTRICTED until <date type="restriction" normal="2024-07-01">July 1, 2024</date>]</p>
             </accessrestrict>
+            <c04 level="file">
+              <did>
+                <unittitle>[Unprocessed files]</unittitle>
+                <container type="box" label="Box">69</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Unprocessed files]</unittitle>
+                <container type="box" label="Box">70</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Unprocessed files]</unittitle>
+                <container type="box" label="Box">71</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
       </c01>

--- a/Real_Masters_all/oharajas.xml
+++ b/Real_Masters_all/oharajas.xml
@@ -4809,9 +4809,32 @@
           </c03>
           <c03 level="file">
             <did>
-              <container label="Boxes" type="box">41-43</container>
               <unittitle>Newspaper Clippings</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Newspaper Clippings</unittitle>
+                <container label="Boxes" type="box">41</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Newspaper Clippings</unittitle>
+                <container label="Boxes" type="box">42</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Newspaper Clippings</unittitle>
+                <container label="Boxes" type="box">43</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="series">

--- a/Real_Masters_all/parsonsj.xml
+++ b/Real_Masters_all/parsonsj.xml
@@ -20643,7 +20643,6 @@ Jeffrey R. Parsons papers, Bentley Historical Library, University of Michigan</p
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">26-27</container>
                 <unittitle>Rolls 51-55</unittitle>
                 <dao href="MTE-11" show="new" actuate="onrequest">
                   <daodesc>
@@ -20651,6 +20650,21 @@ Jeffrey R. Parsons papers, Bentley Historical Library, University of Michigan</p
                   </daodesc>
                 </dao>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Rolls 51-55</unittitle>
+                  <container type="box" label="Box">26</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Rolls 51-55</unittitle>
+                  <container type="box" label="Box">27</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/penncent.xml
+++ b/Real_Masters_all/penncent.xml
@@ -9303,11 +9303,29 @@
                 </c06>
                 <c06 level="file">
                   <did>
-                    <container type="volume" label="Oversize Volume">45-46</container>
                     <unittitle>
                       <unitdate type="inclusive" normal="1882">1882</unitdate>
                     </unittitle>
                   </did>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1882">1882</unitdate>
+                      </unittitle>
+                      <container type="volume" label="Oversize Volume">45</container>
+                    </did>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <unittitle>
+                        <unitdate type="inclusive" normal="1882">1882</unitdate>
+                      </unittitle>
+                      <container type="volume" label="Oversize Volume">46</container>
+                    </did>
+                    <odd>
+                      <p>(continued)</p>
+                    </odd>
+                  </c07>
                 </c06>
                 <c06 level="file">
                   <did>

--- a/Real_Masters_all/pharmacy.xml
+++ b/Real_Masters_all/pharmacy.xml
@@ -7267,7 +7267,6 @@
         </scopecontent>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">35-37</container>
             <unittitle>
               <unitdate type="inclusive" normal="1989/1994">1989-1994</unitdate>
             </unittitle>
@@ -7275,6 +7274,36 @@
           <accessrestrict>
             <p>[PR RESTRICTED until July 1 <date type="restriction" normal="2034-07-01">2034</date>]</p>
           </accessrestrict>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1989/1994">1989-1994</unitdate>
+              </unittitle>
+              <container type="box" label="Box">35</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1989/1994">1989-1994</unitdate>
+              </unittitle>
+              <container type="box" label="Box">36</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1989/1994">1989-1994</unitdate>
+              </unittitle>
+              <container type="box" label="Box">37</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/plantext.xml
+++ b/Real_Masters_all/plantext.xml
@@ -148,12 +148,35 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="tube" label="Tubes">1-3</container>
             <unittitle>Detroit Observatory <unitdate type="inclusive" normal="1907/1909">1907-1909</unitdate></unittitle>
             <physdesc>
               <physfacet>oversize tubes</physfacet>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Detroit Observatory <unitdate type="inclusive" normal="1907/1909">1907-1909</unitdate></unittitle>
+              <container type="tube" label="Tubes">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Detroit Observatory <unitdate type="inclusive" normal="1907/1909">1907-1909</unitdate></unittitle>
+              <container type="tube" label="Tubes">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Detroit Observatory <unitdate type="inclusive" normal="1907/1909">1907-1909</unitdate></unittitle>
+              <container type="tube" label="Tubes">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -382,21 +405,58 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="tube" label="Tube">10-11</container>
             <unittitle>Michigan Union <unitdate type="inclusive" normal="1917">1917</unitdate></unittitle>
             <physdesc>
               <physfacet>oversize tubes</physfacet>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Michigan Union <unitdate type="inclusive" normal="1917">1917</unitdate></unittitle>
+              <container type="tube" label="Tube">10</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Michigan Union <unitdate type="inclusive" normal="1917">1917</unitdate></unittitle>
+              <container type="tube" label="Tube">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="tube" label="Tubes">12-14</container>
             <unittitle>Natural Science Building <unitdate type="inclusive" normal="1914">1914</unitdate></unittitle>
             <physdesc>
               <physfacet>oversize tubes</physfacet>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Natural Science Building <unitdate type="inclusive" normal="1914">1914</unitdate></unittitle>
+              <container type="tube" label="Tubes">12</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Natural Science Building <unitdate type="inclusive" normal="1914">1914</unitdate></unittitle>
+              <container type="tube" label="Tubes">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Natural Science Building <unitdate type="inclusive" normal="1914">1914</unitdate></unittitle>
+              <container type="tube" label="Tubes">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -430,10 +490,24 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="tube" label="Tubes">15-16</container>
             <unittitle>Planting Diagrams <unitdate type="inclusive" normal="1910/1938">1910-1938</unitdate></unittitle>
             <physdesc>oversize tubes</physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Planting Diagrams <unitdate type="inclusive" normal="1910/1938">1910-1938</unitdate></unittitle>
+              <container type="tube" label="Tubes">15</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Planting Diagrams <unitdate type="inclusive" normal="1910/1938">1910-1938</unitdate></unittitle>
+              <container type="tube" label="Tubes">16</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/powereb.xml
+++ b/Real_Masters_all/powereb.xml
@@ -5281,13 +5281,88 @@ Eugene B. Power papers, Bentley Historical Library, University of Michigan</p>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">145</container>
-            <container type="reel" label="Roll">12-19</container>
             <unittitle>Miscellaneous EBP speeches, correspondence, and UMI reports</unittitle>
             <physdesc>
               <extent>8 reels</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous EBP speeches, correspondence, and UMI reports</unittitle>
+              <container type="box" label="Box">145</container>
+              <container type="reel" label="Roll">12</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous EBP speeches, correspondence, and UMI reports</unittitle>
+              <container type="box" label="Box">145</container>
+              <container type="reel" label="Roll">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous EBP speeches, correspondence, and UMI reports</unittitle>
+              <container type="box" label="Box">145</container>
+              <container type="reel" label="Roll">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous EBP speeches, correspondence, and UMI reports</unittitle>
+              <container type="box" label="Box">145</container>
+              <container type="reel" label="Roll">15</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous EBP speeches, correspondence, and UMI reports</unittitle>
+              <container type="box" label="Box">145</container>
+              <container type="reel" label="Roll">16</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous EBP speeches, correspondence, and UMI reports</unittitle>
+              <container type="box" label="Box">145</container>
+              <container type="reel" label="Roll">17</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous EBP speeches, correspondence, and UMI reports</unittitle>
+              <container type="box" label="Box">145</container>
+              <container type="reel" label="Roll">18</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous EBP speeches, correspondence, and UMI reports</unittitle>
+              <container type="box" label="Box">145</container>
+              <container type="reel" label="Roll">19</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/rackhamg.xml
+++ b/Real_Masters_all/rackhamg.xml
@@ -2027,9 +2027,32 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">76-78</container>
               <unittitle>Topical File (A-Z)</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Topical File (A-Z)</unittitle>
+                <container type="box" label="Box">76</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Topical File (A-Z)</unittitle>
+                <container type="box" label="Box">77</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Topical File (A-Z)</unittitle>
+                <container type="box" label="Box">78</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="subseries">

--- a/Real_Masters_all/romneyg.xml
+++ b/Real_Masters_all/romneyg.xml
@@ -24071,9 +24071,23 @@
             </c04>
             <c04 level="file">
               <did>
-                <container label="Boxes" type="box">302-303</container>
                 <unittitle>Invitations to Lenore Romney</unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Invitations to Lenore Romney</unittitle>
+                  <container label="Boxes" type="box">302</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Invitations to Lenore Romney</unittitle>
+                  <container label="Boxes" type="box">303</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
           </c03>
           <c03 level="subseries">
@@ -24085,43 +24099,133 @@
             </scopecontent>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">304-305</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1963">1963</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1963">1963</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">304</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1963">1963</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">305</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Boxes" type="box">306-307</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1964">1964</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1964">1964</unitdate>
+                  </unittitle>
+                  <container label="Boxes" type="box">306</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1964">1964</unitdate>
+                  </unittitle>
+                  <container label="Boxes" type="box">307</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Boxes" type="box">308-309</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1965">1965</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1965">1965</unitdate>
+                  </unittitle>
+                  <container label="Boxes" type="box">308</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1965">1965</unitdate>
+                  </unittitle>
+                  <container label="Boxes" type="box">309</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Boxes" type="box">309-310</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1966">1966</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1966">1966</unitdate>
+                  </unittitle>
+                  <container label="Boxes" type="box">309</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1966">1966</unitdate>
+                  </unittitle>
+                  <container label="Boxes" type="box">310</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Boxes" type="box">310-311</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1967">1967</unitdate>
                 </unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1967">1967</unitdate>
+                  </unittitle>
+                  <container label="Boxes" type="box">310</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1967">1967</unitdate>
+                  </unittitle>
+                  <container label="Boxes" type="box">311</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -31367,9 +31471,167 @@
               </did>
               <c05 level="file">
                 <did>
-                  <container label="Box" type="box">379-396</container>
                   <unittitle>Name files</unittitle>
                 </did>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Name files</unittitle>
+                    <container label="Box" type="box">379</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Name files</unittitle>
+                    <container label="Box" type="box">380</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Name files</unittitle>
+                    <container label="Box" type="box">381</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Name files</unittitle>
+                    <container label="Box" type="box">382</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Name files</unittitle>
+                    <container label="Box" type="box">383</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Name files</unittitle>
+                    <container label="Box" type="box">384</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Name files</unittitle>
+                    <container label="Box" type="box">385</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Name files</unittitle>
+                    <container label="Box" type="box">386</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Name files</unittitle>
+                    <container label="Box" type="box">387</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Name files</unittitle>
+                    <container label="Box" type="box">388</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Name files</unittitle>
+                    <container label="Box" type="box">389</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Name files</unittitle>
+                    <container label="Box" type="box">390</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Name files</unittitle>
+                    <container label="Box" type="box">391</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Name files</unittitle>
+                    <container label="Box" type="box">392</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Name files</unittitle>
+                    <container label="Box" type="box">393</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Name files</unittitle>
+                    <container label="Box" type="box">394</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Name files</unittitle>
+                    <container label="Box" type="box">395</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Name files</unittitle>
+                    <container label="Box" type="box">396</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
             </c04>
             <c04 level="otherlevel" otherlevel="sub-subseries">
@@ -31378,9 +31640,23 @@
               </did>
               <c05 level="file">
                 <did>
-                  <container label="Box" type="box">397-398</container>
                   <unittitle>Case files</unittitle>
                 </did>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Case files</unittitle>
+                    <container label="Box" type="box">397</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Case files</unittitle>
+                    <container label="Box" type="box">398</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
             </c04>
             <c04 level="otherlevel" otherlevel="sub-subseries">

--- a/Real_Masters_all/ruthvena.xml
+++ b/Real_Masters_all/ruthvena.xml
@@ -15911,9 +15911,23 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">60-61</container>
               <unittitle>Speeches as president (various topics) <unitdate type="inclusive" normal="1929/1951">1929-1951</unitdate></unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Speeches as president (various topics) <unitdate type="inclusive" normal="1929/1951">1929-1951</unitdate></unittitle>
+                <container type="box" label="Box">60</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Speeches as president (various topics) <unitdate type="inclusive" normal="1929/1951">1929-1951</unitdate></unittitle>
+                <container type="box" label="Box">61</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/saxj.xml
+++ b/Real_Masters_all/saxj.xml
@@ -1530,9 +1530,32 @@ Joseph L. Sax papers, Bentley Historical Library, University of Michigan</p>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">13-15</container>
               <unittitle>Pigeon River Case (West Michigan Environmental Action Council v. Natural Resources Commission)</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Pigeon River Case (West Michigan Environmental Action Council v. Natural Resources Commission)</unittitle>
+                <container type="box" label="Box">13</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Pigeon River Case (West Michigan Environmental Action Council v. Natural Resources Commission)</unittitle>
+                <container type="box" label="Box">14</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Pigeon River Case (West Michigan Environmental Action Council v. Natural Resources Commission)</unittitle>
+                <container type="box" label="Box">15</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/sibleyjb.xml
+++ b/Real_Masters_all/sibleyjb.xml
@@ -135,12 +135,26 @@
         </did>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">1-2</container>
             <unittitle>Helmet, shell casing trench art (75 mm), 37 mm shell, VFW Post 436 cap, and uniform insignia</unittitle>
           </did>
           <odd>
             <p>Artifacts have not been digitized</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Helmet, shell casing trench art (75 mm), 37 mm shell, VFW Post 436 cap, and uniform insignia</unittitle>
+              <container type="box" label="Box">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Helmet, shell casing trench art (75 mm), 37 mm shell, VFW Post 436 cap, and uniform insignia</unittitle>
+              <container type="box" label="Box">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/sincljl.xml
+++ b/Real_Masters_all/sincljl.xml
@@ -7712,12 +7712,35 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">33-35</container>
               <unittitle>Underground and White Panther publications</unittitle>
             </did>
             <odd>
               <p>See inventory in Appendix I</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Underground and White Panther publications</unittitle>
+                <container type="box" label="Box">33</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Underground and White Panther publications</unittitle>
+                <container type="box" label="Box">34</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Underground and White Panther publications</unittitle>
+                <container type="box" label="Box">35</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/snre.xml
+++ b/Real_Masters_all/snre.xml
@@ -8515,9 +8515,23 @@
         </scopecontent>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">42-43</container>
             <unittitle>Course Files</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Course Files</unittitle>
+              <container type="box" label="Box">42</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Course Files</unittitle>
+              <container type="box" label="Box">43</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/taubmana.xml
+++ b/Real_Masters_all/taubmana.xml
@@ -14340,9 +14340,41 @@ A. Alfred Taubman papers, Bentley Historical Library, University of Michigan</p>
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Boxes">150-153</container>
                 <unittitle>[With additional processing and consolidation these box numbers were eliminated.]</unittitle>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>[With additional processing and consolidation these box numbers were eliminated.]</unittitle>
+                  <container type="box" label="Boxes">150</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>[With additional processing and consolidation these box numbers were eliminated.]</unittitle>
+                  <container type="box" label="Boxes">151</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>[With additional processing and consolidation these box numbers were eliminated.]</unittitle>
+                  <container type="box" label="Boxes">152</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>[With additional processing and consolidation these box numbers were eliminated.]</unittitle>
+                  <container type="box" label="Boxes">153</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
           </c03>
           <c03 level="otherlevel" otherlevel="sub-subseries">
@@ -24036,7 +24068,6 @@ A. Alfred Taubman papers, Bentley Historical Library, University of Michigan</p>
         </did>
         <c02 level="file">
           <did>
-            <container type="object" label="Display Panels">1-12</container>
             <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
             <physdesc>
               <extent>12 panels</extent>
@@ -24045,6 +24076,111 @@ A. Alfred Taubman papers, Bentley Historical Library, University of Michigan</p>
           <odd>
             <p>(The panels include photographs together with a time-line of significant events in Taubman's career)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">7</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02>
           <did>

--- a/Real_Masters_all/umhosp.xml
+++ b/Real_Masters_all/umhosp.xml
@@ -9813,7 +9813,6 @@ Hospitals (University of Michigan) records, Bentley Historical Library, Universi
           </c03>
           <c03 level="file">
             <did>
-              <container type="volume" label="Oversize volumes">2-33</container>
               <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
             </did>
             <odd>
@@ -9822,6 +9821,291 @@ Hospitals (University of Michigan) records, Bentley Historical Library, Universi
             <accessrestrict>
               <p>Closed to research</p>
             </accessrestrict>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">2</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">3</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">4</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">5</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">6</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">7</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">8</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">9</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">10</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">11</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">12</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">13</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">14</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">15</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">16</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">17</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">18</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">19</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">20</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">21</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">22</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">23</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">24</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">25</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">26</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">27</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">28</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">29</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">30</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">31</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">32</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">33</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
       </c01>
@@ -9838,12 +10122,89 @@ Hospitals (University of Michigan) records, Bentley Historical Library, Universi
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">40-48</container>
               <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
             </did>
             <accessrestrict>
               <p>Closed to research</p>
             </accessrestrict>
+            <c04 level="file">
+              <did>
+                <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
+                <container type="box" label="Box">40</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
+                <container type="box" label="Box">41</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
+                <container type="box" label="Box">42</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
+                <container type="box" label="Box">43</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
+                <container type="box" label="Box">44</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
+                <container type="box" label="Box">45</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
+                <container type="box" label="Box">46</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
+                <container type="box" label="Box">47</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
+                <container type="box" label="Box">48</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/umpresid.xml
+++ b/Real_Masters_all/umpresid.xml
@@ -65671,7 +65671,6 @@
               </c05>
               <c05 level="file">
                 <did>
-                  <container type="box" label="Box">229-230</container>
                   <unittitle>Faculty and Staff Case Materials (1970s-1980s bulk 1980s)</unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">19 folders</extent>
@@ -65680,6 +65679,21 @@
                 <accessrestrict>
                   <p>[PR RESTRICTED until 30 years from date of creation]</p>
                 </accessrestrict>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Faculty and Staff Case Materials (1970s-1980s bulk 1980s)</unittitle>
+                    <container type="box" label="Box">229</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Faculty and Staff Case Materials (1970s-1980s bulk 1980s)</unittitle>
+                    <container type="box" label="Box">230</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
               <c05 level="file">
                 <did>

--- a/Real_Masters_all/umpubs.xml
+++ b/Real_Masters_all/umpubs.xml
@@ -764,12 +764,26 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">15-16</container>
               <unittitle>Center for Great Lakes and Aquatic Sciences</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Center for Great Lakes and Aquatic Sciences</unittitle>
+                <container type="box" label="Box">15</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Center for Great Lakes and Aquatic Sciences</unittitle>
+                <container type="box" label="Box">16</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -829,12 +843,35 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">19-21</container>
               <unittitle>Center for Research on Economic Development (CRED)</unittitle>
               <physdesc>
                 <extent>3 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Center for Research on Economic Development (CRED)</unittitle>
+                <container type="box" label="Box">19</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Center for Research on Economic Development (CRED)</unittitle>
+                <container type="box" label="Box">20</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Center for Research on Economic Development (CRED)</unittitle>
+                <container type="box" label="Box">21</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -964,12 +1001,53 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">26-30</container>
               <unittitle>College of Engineering</unittitle>
               <physdesc>
                 <extent>4 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>College of Engineering</unittitle>
+                <container type="box" label="Box">26</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>College of Engineering</unittitle>
+                <container type="box" label="Box">27</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>College of Engineering</unittitle>
+                <container type="box" label="Box">28</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>College of Engineering</unittitle>
+                <container type="box" label="Box">29</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>College of Engineering</unittitle>
+                <container type="box" label="Box">30</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -1685,21 +1763,58 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">70-72</container>
               <unittitle>Executive Vice President and Chief Financial Officer</unittitle>
               <physdesc>
                 <extent>3 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Executive Vice President and Chief Financial Officer</unittitle>
+                <container type="box" label="Box">70</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Executive Vice President and Chief Financial Officer</unittitle>
+                <container type="box" label="Box">71</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Executive Vice President and Chief Financial Officer</unittitle>
+                <container type="box" label="Box">72</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">73-74</container>
               <unittitle>Extension Service</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Extension Service</unittitle>
+                <container type="box" label="Box">73</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Extension Service</unittitle>
+                <container type="box" label="Box">74</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2038,12 +2153,26 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">88-89</container>
               <unittitle>Horace H. Rackham School of Graduate Studies</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Horace H. Rackham School of Graduate Studies</unittitle>
+                <container type="box" label="Box">88</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Horace H. Rackham School of Graduate Studies</unittitle>
+                <container type="box" label="Box">89</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2106,12 +2235,26 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">92-93</container>
               <unittitle>Information Technology Division/Information Technology Central Services</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Information Technology Division/Information Technology Central Services</unittitle>
+                <container type="box" label="Box">92</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Information Technology Division/Information Technology Central Services</unittitle>
+                <container type="box" label="Box">93</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2156,12 +2299,26 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">95-96</container>
               <unittitle>Institute for Social Research -- Monitoring the Future</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Institute for Social Research -- Monitoring the Future</unittitle>
+                <container type="box" label="Box">95</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Institute for Social Research -- Monitoring the Future</unittitle>
+                <container type="box" label="Box">96</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2195,12 +2352,44 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">99-102</container>
               <unittitle>Institute of Gerontology</unittitle>
               <physdesc>
                 <extent>4 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Institute of Gerontology</unittitle>
+                <container type="box" label="Box">99</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Institute of Gerontology</unittitle>
+                <container type="box" label="Box">100</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Institute of Gerontology</unittitle>
+                <container type="box" label="Box">101</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Institute of Gerontology</unittitle>
+                <container type="box" label="Box">102</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2255,9 +2444,23 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">109-110</container>
               <unittitle>International Institute</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>International Institute</unittitle>
+                <container type="box" label="Box">109</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>International Institute</unittitle>
+                <container type="box" label="Box">110</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2498,12 +2701,26 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">117-118</container>
               <unittitle>M-Care</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>M-Care</unittitle>
+                <container type="box" label="Box">117</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>M-Care</unittitle>
+                <container type="box" label="Box">118</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2606,12 +2823,44 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">121-124</container>
               <unittitle>Medical School</unittitle>
               <physdesc>
                 <extent>4 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Medical School</unittitle>
+                <container type="box" label="Box">121</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Medical School</unittitle>
+                <container type="box" label="Box">122</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Medical School</unittitle>
+                <container type="box" label="Box">123</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Medical School</unittitle>
+                <container type="box" label="Box">124</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2901,12 +3150,26 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">139-140</container>
               <unittitle>News and Information Services</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>News and Information Services</unittitle>
+                <container type="box" label="Box">139</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>News and Information Services</unittitle>
+                <container type="box" label="Box">140</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3062,12 +3325,35 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">149-151</container>
               <unittitle>Office of Orientation</unittitle>
               <physdesc>
                 <extent>3 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Office of Orientation</unittitle>
+                <container type="box" label="Box">149</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Office of Orientation</unittitle>
+                <container type="box" label="Box">150</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Office of Orientation</unittitle>
+                <container type="box" label="Box">151</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3729,30 +4015,81 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">174-175</container>
               <unittitle>School of Business Administration</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>School of Business Administration</unittitle>
+                <container type="box" label="Box">174</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>School of Business Administration</unittitle>
+                <container type="box" label="Box">175</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">176-177</container>
               <unittitle>School of Dentistry</unittitle>
               <physdesc>
                 <extent/>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>School of Dentistry</unittitle>
+                <container type="box" label="Box">176</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>School of Dentistry</unittitle>
+                <container type="box" label="Box">177</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">178-180</container>
               <unittitle>School of Education</unittitle>
               <physdesc>
                 <extent>3 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>School of Education</unittitle>
+                <container type="box" label="Box">178</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>School of Education</unittitle>
+                <container type="box" label="Box">179</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>School of Education</unittitle>
+                <container type="box" label="Box">180</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3881,12 +4218,26 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">190-191</container>
               <unittitle>Solar Car Project</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Solar Car Project</unittitle>
+                <container type="box" label="Box">190</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Solar Car Project</unittitle>
+                <container type="box" label="Box">191</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -4467,12 +4818,26 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">211-212</container>
               <unittitle>University of Michigan Library</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>University of Michigan Library</unittitle>
+                <container type="box" label="Box">211</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>University of Michigan Library</unittitle>
+                <container type="box" label="Box">212</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -4565,30 +4930,72 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">220-221</container>
               <unittitle>Vice President for Academic Affairs</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Vice President for Academic Affairs</unittitle>
+                <container type="box" label="Box">220</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Vice President for Academic Affairs</unittitle>
+                <container type="box" label="Box">221</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">222-223</container>
               <unittitle>Vice President for Development</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Vice President for Development</unittitle>
+                <container type="box" label="Box">222</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Vice President for Development</unittitle>
+                <container type="box" label="Box">223</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">224-225</container>
               <unittitle>Vice President for State and Community Relations/Vice President for State and Government Relations</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Vice President for State and Community Relations/Vice President for State and Government Relations</unittitle>
+                <container type="box" label="Box">224</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Vice President for State and Community Relations/Vice President for State and Government Relations</unittitle>
+                <container type="box" label="Box">225</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/umussoc.xml
+++ b/Real_Masters_all/umussoc.xml
@@ -4753,7 +4753,6 @@ University Musical Society (University of Michigan) Records, Bentley Historical 
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">124-127</container>
             <unittitle>
               <unitdate type="inclusive" normal="1986/2005">1986/87-2004/05</unitdate>
             </unittitle>
@@ -4761,6 +4760,47 @@ University Musical Society (University of Michigan) Records, Bentley Historical 
           <accessrestrict>
             <p>[Closed for Research, Records Center Storage]</p>
           </accessrestrict>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1986/2005">1986/87-2004/05</unitdate>
+              </unittitle>
+              <container type="box" label="Boxes">124</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1986/2005">1986/87-2004/05</unitdate>
+              </unittitle>
+              <container type="box" label="Boxes">125</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1986/2005">1986/87-2004/05</unitdate>
+              </unittitle>
+              <container type="box" label="Boxes">126</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1986/2005">1986/87-2004/05</unitdate>
+              </unittitle>
+              <container type="box" label="Boxes">127</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/vpcfo.xml
+++ b/Real_Masters_all/vpcfo.xml
@@ -4285,9 +4285,77 @@ Vice President and Chief Financial Officer (University of Michigan) Records, Ben
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">26-33</container>
               <unittitle>[Eliminated During Reprocessing]</unittitle>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>[Eliminated During Reprocessing]</unittitle>
+                <container type="box" label="Box">26</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Eliminated During Reprocessing]</unittitle>
+                <container type="box" label="Box">27</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Eliminated During Reprocessing]</unittitle>
+                <container type="box" label="Box">28</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Eliminated During Reprocessing]</unittitle>
+                <container type="box" label="Box">29</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Eliminated During Reprocessing]</unittitle>
+                <container type="box" label="Box">30</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Eliminated During Reprocessing]</unittitle>
+                <container type="box" label="Box">31</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Eliminated During Reprocessing]</unittitle>
+                <container type="box" label="Box">32</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Eliminated During Reprocessing]</unittitle>
+                <container type="box" label="Box">33</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="subseries">

--- a/Real_Masters_all/wallm60m.xml
+++ b/Real_Masters_all/wallm60m.xml
@@ -24526,9 +24526,23 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">147-148</container>
             <unittitle>Biographies and clippings about MW <unitdate type="inclusive" normal="1990/1999" certainty="approximate">1990s</unitdate></unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Biographies and clippings about MW <unitdate type="inclusive" normal="1990/1999" certainty="approximate">1990s</unitdate></unittitle>
+              <container type="box" label="Box">147</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Biographies and clippings about MW <unitdate type="inclusive" normal="1990/1999" certainty="approximate">1990s</unitdate></unittitle>
+              <container type="box" label="Box">148</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -25894,21 +25908,76 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
         </accessrestrict>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">98-99</container>
             <unittitle>Anthony Herbert law suit</unittitle>
           </did>
           <accessrestrict>
             <p>[Closed until <date normal="2030-12-01" type="restriction">December 1, 2030</date>]</p>
           </accessrestrict>
+          <c03 level="file">
+            <did>
+              <unittitle>Anthony Herbert law suit</unittitle>
+              <container type="box" label="Box">98</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Anthony Herbert law suit</unittitle>
+              <container type="box" label="Box">99</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">100-104</container>
             <unittitle>William Westmoreland law suit</unittitle>
           </did>
           <accessrestrict>
             <p>[Closed until <date normal="2030-12-01" type="restriction">December 1, 2030</date>]</p>
           </accessrestrict>
+          <c03 level="file">
+            <did>
+              <unittitle>William Westmoreland law suit</unittitle>
+              <container type="box" label="Box">100</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>William Westmoreland law suit</unittitle>
+              <container type="box" label="Box">101</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>William Westmoreland law suit</unittitle>
+              <container type="box" label="Box">102</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>William Westmoreland law suit</unittitle>
+              <container type="box" label="Box">103</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>William Westmoreland law suit</unittitle>
+              <container type="box" label="Box">104</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/weillou.xml
+++ b/Real_Masters_all/weillou.xml
@@ -359,7 +359,6 @@ Louis A. Weil papers, Bentley Historical Library, University of Michigan</p>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Sound Discs">1-3</container>
             <unittitle><genreform normal="Phonograph records">Phonograph records</genreform> of broadcast featuring Supreme Court Justice Eugene Black in which he exposes "Michigan Gang" <unitdate type="inclusive" normal="1948-05-27">May 27, 1948</unitdate></unittitle>
             <physdesc>
               <extent>3 phonograph records</extent>
@@ -368,6 +367,30 @@ Louis A. Weil papers, Bentley Historical Library, University of Michigan</p>
               <physfacet>78 rpm</physfacet>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle><genreform normal="Phonograph records">Phonograph records</genreform> of broadcast featuring Supreme Court Justice Eugene Black in which he exposes "Michigan Gang" <unitdate type="inclusive" normal="1948-05-27">May 27, 1948</unitdate></unittitle>
+              <container type="box" label="Sound Discs">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle><genreform normal="Phonograph records">Phonograph records</genreform> of broadcast featuring Supreme Court Justice Eugene Black in which he exposes "Michigan Gang" <unitdate type="inclusive" normal="1948-05-27">May 27, 1948</unitdate></unittitle>
+              <container type="box" label="Sound Discs">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle><genreform normal="Phonograph records">Phonograph records</genreform> of broadcast featuring Supreme Court Justice Eugene Black in which he exposes "Michigan Gang" <unitdate type="inclusive" normal="1948-05-27">May 27, 1948</unitdate></unittitle>
+              <container type="box" label="Sound Discs">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/wenleyrm.xml
+++ b/Real_Masters_all/wenleyrm.xml
@@ -579,13 +579,28 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">2</container>
-              <container type="folder" label="Folder">45-46</container>
               <unittitle>Printed testimonials favoring Wenley's appointment to academic positions in Scotland</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Printed testimonials favoring Wenley's appointment to academic positions in Scotland</unittitle>
+                <container type="box" label="Box">2</container>
+                <container type="folder" label="Folder">45</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Printed testimonials favoring Wenley's appointment to academic positions in Scotland</unittitle>
+                <container type="box" label="Box">2</container>
+                <container type="folder" label="Folder">46</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
       </c01>
@@ -616,13 +631,38 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">2</container>
-            <container type="folder" label="Folder">50-52</container>
             <unittitle>"Recollections, reflections and impressions of a vagrant Scot: an essay in informal autobiography" <unitdate type="inclusive" normal="1916">1916</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>"Recollections, reflections and impressions of a vagrant Scot: an essay in informal autobiography" <unitdate type="inclusive" normal="1916">1916</unitdate></unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">50</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>"Recollections, reflections and impressions of a vagrant Scot: an essay in informal autobiography" <unitdate type="inclusive" normal="1916">1916</unitdate></unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">51</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>"Recollections, reflections and impressions of a vagrant Scot: an essay in informal autobiography" <unitdate type="inclusive" normal="1916">1916</unitdate></unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">52</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -644,23 +684,93 @@
         </did>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">2</container>
-            <container type="folder" label="Folder">60-64</container>
             <unittitle>"Philosophy of Religion"</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">5 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>"Philosophy of Religion"</unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">60</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>"Philosophy of Religion"</unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">61</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>"Philosophy of Religion"</unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">62</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>"Philosophy of Religion"</unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">63</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>"Philosophy of Religion"</unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">64</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">2</container>
-            <container type="folder" label="Folder">65-67</container>
             <unittitle>"Early Greek philosophy"</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>"Early Greek philosophy"</unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">65</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>"Early Greek philosophy"</unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">66</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>"Early Greek philosophy"</unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">67</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -673,13 +783,38 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">2</container>
-            <container type="folder" label="Folder">71-73</container>
             <unittitle>Shakespeare</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Shakespeare</unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">71</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Shakespeare</unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">72</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Shakespeare</unittitle>
+              <container type="box" label="Box">2</container>
+              <container type="folder" label="Folder">73</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -697,13 +832,28 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">3</container>
-            <container type="folder" label="Folder">76-77</container>
             <unittitle>Cause, skepticism, system, etc.</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Cause, skepticism, system, etc.</unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">76</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cause, skepticism, system, etc.</unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">77</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -917,13 +1067,28 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">3</container>
-            <container type="folder" label="Folder">113-114</container>
             <unittitle>Politics</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Politics</unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">113</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Politics</unittitle>
+              <container type="box" label="Box">3</container>
+              <container type="folder" label="Folder">114</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -953,63 +1118,503 @@
         </did>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">4</container>
-            <container type="folder" label="Folder">114-135</container>
             <unittitle>Miscellaneous speeches and papers</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">21 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">114</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">115</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">116</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">117</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">118</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">119</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">120</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">121</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">122</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">123</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">124</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">125</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">126</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">127</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">128</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">129</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">130</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">131</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">132</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">133</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">134</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous speeches and papers</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">135</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">4</container>
-            <container type="folder" label="Folder">136-145</container>
             <unittitle>Papers and addresses regarding education</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">10 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Papers and addresses regarding education</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">136</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Papers and addresses regarding education</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">137</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Papers and addresses regarding education</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">138</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Papers and addresses regarding education</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">139</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Papers and addresses regarding education</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">140</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Papers and addresses regarding education</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">141</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Papers and addresses regarding education</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">142</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Papers and addresses regarding education</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">143</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Papers and addresses regarding education</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">144</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Papers and addresses regarding education</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">145</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">4</container>
-            <container type="folder" label="Folder">146-148</container>
             <unittitle>Notes and addresses concerning literature</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes and addresses concerning literature</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">146</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes and addresses concerning literature</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">147</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes and addresses concerning literature</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">148</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">4</container>
-            <container type="folder" label="Folder">151-154</container>
             <unittitle>Notes and addresses</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes and addresses</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">151</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes and addresses</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">152</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes and addresses</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">153</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes and addresses</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">154</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">4</container>
-            <container type="folder" label="Folder">155-158</container>
             <unittitle>Philosophy papers and addresses</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Philosophy papers and addresses</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">155</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Philosophy papers and addresses</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">156</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Philosophy papers and addresses</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">157</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Philosophy papers and addresses</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">158</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">4</container>
-            <container type="folder" label="Folder">159-162</container>
             <unittitle>Addresses concerning religious issues</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Addresses concerning religious issues</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">159</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Addresses concerning religious issues</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">160</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Addresses concerning religious issues</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">161</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Addresses concerning religious issues</unittitle>
+              <container type="box" label="Box">4</container>
+              <container type="folder" label="Folder">162</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/willekel.xml
+++ b/Real_Masters_all/willekel.xml
@@ -1968,8 +1968,6 @@ Leonard Bernard Willeke papers, Bentley Historical Library, University of Michig
               </odd>
               <c05 level="file">
                 <did>
-                  <container type="map-case" label="Drawer">8</container>
-                  <container type="folder" label="Folders">50-54</container>
                   <unittitle>Architectural Drawings <unitdate type="inclusive">undated</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">5 folders</extent>
@@ -1978,6 +1976,53 @@ Leonard Bernard Willeke papers, Bentley Historical Library, University of Michig
                 <odd>
                   <p>(original pencil drawings, blueprints, and mounted renderings)</p>
                 </odd>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Architectural Drawings <unitdate type="inclusive">undated</unitdate></unittitle>
+                    <container type="map-case" label="Drawer">8</container>
+                    <container type="folder" label="Folders">50</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Architectural Drawings <unitdate type="inclusive">undated</unitdate></unittitle>
+                    <container type="map-case" label="Drawer">8</container>
+                    <container type="folder" label="Folders">51</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Architectural Drawings <unitdate type="inclusive">undated</unitdate></unittitle>
+                    <container type="map-case" label="Drawer">8</container>
+                    <container type="folder" label="Folders">52</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Architectural Drawings <unitdate type="inclusive">undated</unitdate></unittitle>
+                    <container type="map-case" label="Drawer">8</container>
+                    <container type="folder" label="Folders">53</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Architectural Drawings <unitdate type="inclusive">undated</unitdate></unittitle>
+                    <container type="map-case" label="Drawer">8</container>
+                    <container type="folder" label="Folders">54</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
               <c05 level="file">
                 <did>

--- a/Real_Masters_all/willrunl.xml
+++ b/Real_Masters_all/willrunl.xml
@@ -137,12 +137,35 @@ Willow Run Public School Library records, Bentley Historical Library, University
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volumes">1-3</container>
             <unittitle><genreform normal="Scrapbooks">Scrapbooks</genreform> relating to Willow Run, <unitdate type="inclusive" normal="1942/1944">1942-1944</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle><genreform normal="Scrapbooks">Scrapbooks</genreform> relating to Willow Run, <unitdate type="inclusive" normal="1942/1944">1942-1944</unitdate></unittitle>
+              <container type="volume" label="Oversize Volumes">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle><genreform normal="Scrapbooks">Scrapbooks</genreform> relating to Willow Run, <unitdate type="inclusive" normal="1942/1944">1942-1944</unitdate></unittitle>
+              <container type="volume" label="Oversize Volumes">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle><genreform normal="Scrapbooks">Scrapbooks</genreform> relating to Willow Run, <unitdate type="inclusive" normal="1942/1944">1942-1944</unitdate></unittitle>
+              <container type="volume" label="Oversize Volumes">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/winesher.xml
+++ b/Real_Masters_all/winesher.xml
@@ -4450,12 +4450,98 @@ Sherwin T. Wine papers, Bentley Historical Library, University of Michigan</p>
         </scopecontent>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">29-38</container>
             <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
           </did>
           <odd>
             <p>(unarranged)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">29</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">30</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">31</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">32</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">33</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">34</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">35</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">36</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">37</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">38</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/wislanlu.xml
+++ b/Real_Masters_all/wislanlu.xml
@@ -636,21 +636,135 @@ Wisconsin Land &amp; Lumber Company records, Bentley Historical Library, Univers
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">13-14</container>
             <unittitle>Order Books</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Order Books</unittitle>
+              <container type="box" label="Boxes">13</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Order Books</unittitle>
+              <container type="box" label="Boxes">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">32-37</container>
             <unittitle>Inventory books</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Inventory books</unittitle>
+              <container type="box" label="Boxes">32</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Inventory books</unittitle>
+              <container type="box" label="Boxes">33</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Inventory books</unittitle>
+              <container type="box" label="Boxes">34</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Inventory books</unittitle>
+              <container type="box" label="Boxes">35</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Inventory books</unittitle>
+              <container type="box" label="Boxes">36</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Inventory books</unittitle>
+              <container type="box" label="Boxes">37</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">40-45</container>
             <unittitle>Miscellaneous volumes (unlisted)</unittitle>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous volumes (unlisted)</unittitle>
+              <container type="box" label="Boxes">40</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous volumes (unlisted)</unittitle>
+              <container type="box" label="Boxes">41</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous volumes (unlisted)</unittitle>
+              <container type="box" label="Boxes">42</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous volumes (unlisted)</unittitle>
+              <container type="box" label="Boxes">43</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous volumes (unlisted)</unittitle>
+              <container type="box" label="Boxes">44</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous volumes (unlisted)</unittitle>
+              <container type="box" label="Boxes">45</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/ymcadet.xml
+++ b/Real_Masters_all/ymcadet.xml
@@ -1702,7 +1702,6 @@
         </scopecontent>
         <c02 level="file">
           <did>
-            <container type="volume" label="Volumes">1-2</container>
             <unittitle>
               <unitdate type="inclusive" normal="1936">1936</unitdate>
             </unittitle>
@@ -1710,10 +1709,28 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1936">1936</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1936">1936</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Volumes">3-4</container>
             <unittitle>
               <unitdate type="inclusive" normal="1937">1937</unitdate>
             </unittitle>
@@ -1721,10 +1738,28 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1937">1937</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">3</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1937">1937</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Volumes">5-6</container>
             <unittitle>
               <unitdate type="inclusive" normal="1938">1938</unitdate>
             </unittitle>
@@ -1732,10 +1767,28 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1938">1938</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">5</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1938">1938</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Volumes">7-8</container>
             <unittitle>
               <unitdate type="inclusive" normal="1939">1939</unitdate>
             </unittitle>
@@ -1743,10 +1796,28 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1939">1939</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">7</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1939">1939</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Volumes">9-10</container>
             <unittitle>
               <unitdate type="inclusive" normal="1940">1940</unitdate>
             </unittitle>
@@ -1754,10 +1825,28 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1940">1940</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">9</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1940">1940</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Volumes">11-12</container>
             <unittitle>
               <unitdate type="inclusive" normal="1941">1941</unitdate>
             </unittitle>
@@ -1765,6 +1854,25 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1941">1941</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">11</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1941">1941</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/youtie.xml
+++ b/Real_Masters_all/youtie.xml
@@ -2279,13 +2279,28 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">5</container>
-              <container type="folder" label="Folder">12-13</container>
               <unittitle>John Chrysostom</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>John Chrysostom</unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">12</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>John Chrysostom</unittitle>
+                <container type="box" label="Box">5</container>
+                <container type="folder" label="Folder">13</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/ztgergan.xml
+++ b/Real_Masters_all/ztgergan.xml
@@ -215,7 +215,6 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
           </c03>
           <c03 level="file">
             <did>
-              <container type="folder" label="Folders">3-4</container>
               <unittitle>Dearborn. St. Clement Orthodox Church <unitdate type="inclusive" normal="1964">1964</unitdate> (Job No. 921)</unittitle>
               <physdesc>
                 <extent>50 drawings</extent>
@@ -230,6 +229,21 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
             <odd>
               <p>(specification in Box 1)</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Dearborn. St. Clement Orthodox Church <unitdate type="inclusive" normal="1964">1964</unitdate> (Job No. 921)</unittitle>
+                <container type="folder" label="Folders">3</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Dearborn. St. Clement Orthodox Church <unitdate type="inclusive" normal="1964">1964</unitdate> (Job No. 921)</unittitle>
+                <container type="folder" label="Folders">4</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -759,7 +773,6 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
           </did>
           <c03 level="file">
             <did>
-              <container type="folder" label="Folders">14-15</container>
               <unittitle>Ann Arbor. Washtenaw County Building, Huron and Main Street <unitdate type="inclusive" normal="1946">1946</unitdate> (Job No. 592)</unittitle>
               <physdesc>
                 <extent>58 drawings</extent>
@@ -774,6 +787,21 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
             <odd>
               <p>(specifications in Box 1)</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Ann Arbor. Washtenaw County Building, Huron and Main Street <unitdate type="inclusive" normal="1946">1946</unitdate> (Job No. 592)</unittitle>
+                <container type="folder" label="Folders">14</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Ann Arbor. Washtenaw County Building, Huron and Main Street <unitdate type="inclusive" normal="1946">1946</unitdate> (Job No. 592)</unittitle>
+                <container type="folder" label="Folders">15</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -969,7 +997,6 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
           </c03>
           <c03 level="file">
             <did>
-              <container type="folder" label="Folders">25-27</container>
               <unittitle>Miscellaneous (single family residences) (No Job No.)</unittitle>
               <physdesc>
                 <extent>ca. 50 drawings</extent>
@@ -981,6 +1008,30 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
             <odd>
               <p>(Renderings)</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous (single family residences) (No Job No.)</unittitle>
+                <container type="folder" label="Folders">25</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous (single family residences) (No Job No.)</unittitle>
+                <container type="folder" label="Folders">26</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous (single family residences) (No Job No.)</unittitle>
+                <container type="folder" label="Folders">27</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
       </c01>


### PR DESCRIPTION
Expanded all container ranges. Wherever a qualifying range was found, the original c0x element was deleted and replaced with a new c0x element to house the expanded items, containing all of the data of the original non-expanded c0x node except for its container tags. Children were then inserted into that element for each item in the original container range, each containing only the unittitle of the original along with a new container number (one new child for each container in the original container range). An `<odd>` tag with the text "(continued)" was inserted into every new child past the first.

Occasionally there were two container tags in the original unexpanded node, one being a range and the other the static container that houses the items in the range (eg "box 1" for one container and "folders 5-10" for the second). In those cases the static container was copied verbatim into each expanded element along with the new un-ranged container element.

Code used for the change, including tests and the original range locations, can be found [here](https://github.com/walkerdb/bentley_code/tree/master/one-off%20scripts/expand_container_ranges)
