### PR TITLE
Expand container ranges, take 2

### DIFF
--- a/Real_Masters_all/a2twnshp.xml
+++ b/Real_Masters_all/a2twnshp.xml
@@ -606,7 +606,6 @@
         </scopecontent>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">3-16</container>
             <unittitle>
               <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
             </unittitle>
@@ -614,10 +613,160 @@
               <extent altrender="materialtype spaceoccupied">14 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">3</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">7</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">15</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1872/1887">1872-1887</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">16</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">17-77</container>
             <unittitle>
               <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
             </unittitle>
@@ -625,10 +774,677 @@
               <extent>61 volumes/bundles</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">17</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">18</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">19</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">20</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">21</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">22</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">23</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">24</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">25</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">26</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">27</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">28</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">29</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">30</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">31</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">32</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">33</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">34</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">35</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">36</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">37</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">38</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">39</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">40</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">41</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">42</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">43</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">44</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">45</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">46</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">47</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">48</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">49</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">50</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">51</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">52</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">53</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">54</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">55</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">56</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">57</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">58</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">59</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">60</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">61</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">62</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">63</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">64</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">65</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">66</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">67</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">68</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">69</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">70</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">71</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">72</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">73</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">74</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">75</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">76</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1900/1960">1900-1960</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">77</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">78-79</container>
             <unittitle>
               <unitdate type="inclusive" normal="1962">1962</unitdate>
             </unittitle>
@@ -636,6 +1452,25 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1962">1962</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">78</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1962">1962</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">79</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -671,7 +1506,6 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">84-85</container>
             <unittitle>
               <unitdate type="inclusive" normal="1972">1972</unitdate>
             </unittitle>
@@ -679,6 +1513,25 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1972">1972</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">84</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1972">1972</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">85</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -690,7 +1543,6 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">87-88</container>
             <unittitle>
               <unitdate type="inclusive" normal="1976">1976</unitdate>
             </unittitle>
@@ -698,10 +1550,28 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1976">1976</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">87</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1976">1976</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">88</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">89-90</container>
             <unittitle>
               <unitdate type="inclusive" normal="1978">1978</unitdate>
             </unittitle>
@@ -709,10 +1579,28 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1978">1978</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">89</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1978">1978</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">90</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">91-92</container>
             <unittitle>
               <unitdate type="inclusive" normal="1980">1980</unitdate>
             </unittitle>
@@ -720,6 +1608,25 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1980">1980</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">91</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1980">1980</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">92</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/aaphoto.xml
+++ b/Real_Masters_all/aaphoto.xml
@@ -629,12 +629,26 @@
             </c04>
             <c04 level="file">
               <did>
-                <container label="Folder" type="folder">58-59</container>
                 <unittitle>Huron</unittitle>
                 <physdesc>
                   <extent>2 envelopes</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Huron</unittitle>
+                  <container label="Folder" type="folder">58</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Huron</unittitle>
+                  <container label="Folder" type="folder">59</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/aapsch.xml
+++ b/Real_Masters_all/aapsch.xml
@@ -176,9 +176,90 @@ Ann Arbor Public Schools Records
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volumes">1-10</container>
             <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+            <container type="volume" label="Oversize Volumes">1</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+            <container type="volume" label="Oversize Volumes">2</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+            <container type="volume" label="Oversize Volumes">3</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+            <container type="volume" label="Oversize Volumes">4</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+            <container type="volume" label="Oversize Volumes">5</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+            <container type="volume" label="Oversize Volumes">6</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+            <container type="volume" label="Oversize Volumes">7</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+            <container type="volume" label="Oversize Volumes">8</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+            <container type="volume" label="Oversize Volumes">9</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Minutes <unitdate type="inclusive" normal="1857/1949">1857-1949</unitdate> (10 outsize volumes)</unittitle>
+            <container type="volume" label="Oversize Volumes">10</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/alumasso.xml
+++ b/Real_Masters_all/alumasso.xml
@@ -956,9 +956,18 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">66-67</container>
             <unittitle>Harold Wilson Correspondence <unitdate type="inclusive" normal="1951/1956">1951-1956</unitdate></unittitle>
+            <container type="box" label="Box">66</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Harold Wilson Correspondence <unitdate type="inclusive" normal="1951/1956">1951-1956</unitdate></unittitle>
+            <container type="box" label="Box">67</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -3119,13 +3128,46 @@
           <did>
             <unittitle>Michigan League Building Fund Campaign File <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate></unittitle>
           </did>
-          <c03>
+          <c03 level="file">
             <did>
-              <container type="box" label="Box">105-108</container>
               <unittitle>
                 <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate>
               </unittitle>
+              <container type="box" label="Box">105</container>
             </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate>
+              </unittitle>
+              <container type="box" label="Box">106</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate>
+              </unittitle>
+              <container type="box" label="Box">107</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1921/1926">1921-1926</unitdate>
+              </unittitle>
+              <container type="box" label="Box">108</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
           </c03>
         </c02>
         <c02 level="file">
@@ -3134,12 +3176,26 @@
           </did>
           <c03>
             <did>
-              <container type="box" label="Box">109-110</container>
               <unittitle>Responses to Alumnae Council Questionnaires <unitdate type="inclusive" normal="1924">1924</unitdate></unittitle>
             </did>
             <odd>
               <p>[see separately bound index]</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Responses to Alumnae Council Questionnaires <unitdate type="inclusive" normal="1924">1924</unitdate></unittitle>
+                <container type="box" label="Box">109</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Responses to Alumnae Council Questionnaires <unitdate type="inclusive" normal="1924">1924</unitdate></unittitle>
+                <container type="box" label="Box">110</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -3381,7 +3437,6 @@
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">114-115</container>
               <unittitle>
                 <unitdate type="inclusive" normal="1931/1946">1931-1946</unitdate>
               </unittitle>
@@ -3389,6 +3444,25 @@
             <odd>
               <p>(including World War II letters)</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1931/1946">1931-1946</unitdate>
+                </unittitle>
+                <container type="box" label="Box">114</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1931/1946">1931-1946</unitdate>
+                </unittitle>
+                <container type="box" label="Box">115</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3772,9 +3846,18 @@
         </scopecontent>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">118-119</container>
             <unittitle>Class Officers Council Files <unitdate type="inclusive" normal="1932/1950">1932-1950</unitdate></unittitle>
+            <container type="box" label="Box">118</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Class Officers Council Files <unitdate type="inclusive" normal="1932/1950">1932-1950</unitdate></unittitle>
+            <container type="box" label="Box">119</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/amorgan.xml
+++ b/Real_Masters_all/amorgan.xml
@@ -11369,7 +11369,6 @@
         </c02>
         <c02 level="file">
           <did>
-            <container label="Box" type="box">41-44</container>
             <unittitle>
               <title render="italic">Awful Rainbow</title>
             </unittitle>
@@ -11380,6 +11379,47 @@
           <odd>
             <p>(manuscripts and related material)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <title render="italic">Awful Rainbow</title>
+              </unittitle>
+              <container label="Box" type="box">41</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <title render="italic">Awful Rainbow</title>
+              </unittitle>
+              <container label="Box" type="box">42</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <title render="italic">Awful Rainbow</title>
+              </unittitle>
+              <container label="Box" type="box">43</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <title render="italic">Awful Rainbow</title>
+              </unittitle>
+              <container label="Box" type="box">44</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/arborum.xml
+++ b/Real_Masters_all/arborum.xml
@@ -1209,13 +1209,28 @@ Nichols Arboretum (University of Michigan), Bentley Historical Library, Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="map-case" label="Drawer">241</container>
-            <container type="folder" label="Folder">7-8</container>
             <unittitle>"The First Trail" by the Department of Landscape Architecture <unitdate type="inclusive" normal="1965">1965</unitdate></unittitle>
             <physdesc>
               <physfacet>mounted on six presentation boards)</physfacet>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>"The First Trail" by the Department of Landscape Architecture <unitdate type="inclusive" normal="1965">1965</unitdate></unittitle>
+              <container type="map-case" label="Drawer">241</container>
+              <container type="folder" label="Folder">7</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>"The First Trail" by the Department of Landscape Architecture <unitdate type="inclusive" normal="1965">1965</unitdate></unittitle>
+              <container type="map-case" label="Drawer">241</container>
+              <container type="folder" label="Folder">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/bandum.xml
+++ b/Real_Masters_all/bandum.xml
@@ -2082,9 +2082,18 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Scrapbook">21-22</container>
             <unittitle>[Vol. 21-22] <unitdate type="inclusive" normal="1964/1965">1964-1965</unitdate></unittitle>
+            <container type="volume" label="Scrapbook">21</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>[Vol. 21-22] <unitdate type="inclusive" normal="1964/1965">1964-1965</unitdate></unittitle>
+            <container type="volume" label="Scrapbook">22</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -2100,9 +2109,18 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Scrapbook">25-26</container>
             <unittitle>[Vol. 25-26] <unitdate type="inclusive" normal="1965/1966">1965-1966</unitdate></unittitle>
+            <container type="volume" label="Scrapbook">25</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>[Vol. 25-26] <unitdate type="inclusive" normal="1965/1966">1965-1966</unitdate></unittitle>
+            <container type="volume" label="Scrapbook">26</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -2130,9 +2148,18 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Scrapbook">31-32</container>
             <unittitle>[Vol. 31-32] <unitdate type="inclusive" normal="1969/1970">1969-1970</unitdate></unittitle>
+            <container type="volume" label="Scrapbook">31</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>[Vol. 31-32] <unitdate type="inclusive" normal="1969/1970">1969-1970</unitdate></unittitle>
+            <container type="volume" label="Scrapbook">32</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/bemuehlg.xml
+++ b/Real_Masters_all/bemuehlg.xml
@@ -141,12 +141,35 @@ B. E. Muehlig’s Dry Goods Store (Ann Arbor, Mich.) records, Bentley Historical
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">10-12</container>
             <unittitle>Vol. nos. 10-12</unittitle>
           </did>
           <odd>
             <p>(volumes not received)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Vol. nos. 10-12</unittitle>
+              <container type="volume" label="Oversize Volume">10</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Vol. nos. 10-12</unittitle>
+              <container type="volume" label="Oversize Volume">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Vol. nos. 10-12</unittitle>
+              <container type="volume" label="Oversize Volume">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/bentleya.xml
+++ b/Real_Masters_all/bentleya.xml
@@ -6295,12 +6295,35 @@
           </c03>
           <c03 level="file">
             <did>
-              <container label="Box" type="box">48-50</container>
               <unittitle>Notebooks and published materials on Con-Con &amp; related topics</unittitle>
             </did>
             <odd>
               <p>(also includes additional newspaper clippings)</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Notebooks and published materials on Con-Con &amp; related topics</unittitle>
+                <container label="Box" type="box">48</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Notebooks and published materials on Con-Con &amp; related topics</unittitle>
+                <container label="Box" type="box">49</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Notebooks and published materials on Con-Con &amp; related topics</unittitle>
+                <container label="Box" type="box">50</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
       </c01>
@@ -12338,9 +12361,54 @@
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">97-102</container>
               <unittitle>Hearings and reports <unitdate type="inclusive" normal="1953/1960">1953-1960</unitdate></unittitle>
+              <container type="box" label="Box">97</container>
             </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Hearings and reports <unitdate type="inclusive" normal="1953/1960">1953-1960</unitdate></unittitle>
+              <container type="box" label="Box">98</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Hearings and reports <unitdate type="inclusive" normal="1953/1960">1953-1960</unitdate></unittitle>
+              <container type="box" label="Box">99</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Hearings and reports <unitdate type="inclusive" normal="1953/1960">1953-1960</unitdate></unittitle>
+              <container type="box" label="Box">100</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Hearings and reports <unitdate type="inclusive" normal="1953/1960">1953-1960</unitdate></unittitle>
+              <container type="box" label="Box">101</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Hearings and reports <unitdate type="inclusive" normal="1953/1960">1953-1960</unitdate></unittitle>
+              <container type="box" label="Box">102</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
           </c03>
         </c02>
       </c01>

--- a/Real_Masters_all/blanchjj.xml
+++ b/Real_Masters_all/blanchjj.xml
@@ -20104,21 +20104,49 @@
             </odd>
             <c04 level="file">
               <did>
-                <container type="volume" label="Oversize Volume">1-2</container>
                 <unittitle>Statewide issues survey <unitdate type="inclusive" normal="1981-07">July 1981</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 volumes</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Statewide issues survey <unitdate type="inclusive" normal="1981-07">July 1981</unitdate></unittitle>
+                  <container type="volume" label="Oversize Volume">1</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Statewide issues survey <unitdate type="inclusive" normal="1981-07">July 1981</unitdate></unittitle>
+                  <container type="volume" label="Oversize Volume">2</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container type="volume" label="Oversize Volume">3-4</container>
                 <unittitle>18th Congressional District issues survey <unitdate type="inclusive" normal="1981-07">July 1981</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 volumes</extent>
                 </physdesc>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>18th Congressional District issues survey <unitdate type="inclusive" normal="1981-07">July 1981</unitdate></unittitle>
+                  <container type="volume" label="Oversize Volume">3</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>18th Congressional District issues survey <unitdate type="inclusive" normal="1981-07">July 1981</unitdate></unittitle>
+                  <container type="volume" label="Oversize Volume">4</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -20785,9 +20813,18 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Boxes">318-319</container>
                 <unittitle>Topical and issues files</unittitle>
+                <container type="box" label="Boxes">318</container>
               </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Topical and issues files</unittitle>
+                <container type="box" label="Boxes">319</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
             </c04>
           </c03>
           <c03 level="otherlevel" otherlevel="sub-subseries">
@@ -20808,15 +20845,51 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Boxes">320-322</container>
                 <unittitle>Lisa Grayson (Campaign Press Secretary) files</unittitle>
+                <container type="box" label="Boxes">320</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Boxes">323-325</container>
-                <unittitle>Gary Bachula (Campaign Manager) files</unittitle>
+                <unittitle>Lisa Grayson (Campaign Press Secretary) files</unittitle>
+                <container type="box" label="Boxes">321</container>
               </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Lisa Grayson (Campaign Press Secretary) files</unittitle>
+                <container type="box" label="Boxes">322</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Gary Bachula (Campaign Manager) files</unittitle>
+                <container type="box" label="Boxes">323</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Gary Bachula (Campaign Manager) files</unittitle>
+                <container type="box" label="Boxes">324</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Gary Bachula (Campaign Manager) files</unittitle>
+                <container type="box" label="Boxes">325</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>
@@ -20831,12 +20904,26 @@
             </did>
             <c04 level="file">
               <did>
-                <container type="box" label="Boxes">327-328</container>
                 <unittitle>Charles Kolbe files</unittitle>
               </did>
               <odd>
                 <p>(research on John Engler)</p>
               </odd>
+              <c05 level="file">
+                <did>
+                  <unittitle>Charles Kolbe files</unittitle>
+                  <container type="box" label="Boxes">327</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Charles Kolbe files</unittitle>
+                  <container type="box" label="Boxes">328</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -20864,9 +20951,18 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Boxes">267-268</container>
                 <unittitle>Unprocessed/unlisted</unittitle>
+                <container type="box" label="Boxes">267</container>
               </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Unprocessed/unlisted</unittitle>
+                <container type="box" label="Boxes">268</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
             </c04>
           </c03>
         </c02>
@@ -20928,9 +21024,18 @@
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Boxes">331-332</container>
                 <unittitle>Statements and proposed platform recommendations</unittitle>
+                <container type="box" label="Boxes">331</container>
               </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Statements and proposed platform recommendations</unittitle>
+                <container type="box" label="Boxes">332</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>
@@ -21105,9 +21210,18 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">275-276</container>
             <unittitle>Appointments to state boards and commissions</unittitle>
+            <container type="box" label="Boxes">275</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Appointments to state boards and commissions</unittitle>
+            <container type="box" label="Boxes">276</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
       </c01>
       <c01 level="series">
@@ -21167,15 +21281,33 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">280-281</container>
             <unittitle>Ambassador to Canada</unittitle>
+            <container type="box" label="Boxes">280</container>
           </did>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">338-339</container>
             <unittitle>Ambassador to Canada</unittitle>
+            <container type="box" label="Boxes">281</container>
           </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Ambassador to Canada</unittitle>
+            <container type="box" label="Boxes">338</container>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Ambassador to Canada</unittitle>
+            <container type="box" label="Boxes">339</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -21213,9 +21345,18 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">285-286</container>
               <unittitle>Notebooks of clippings (issues and candidates)</unittitle>
+              <container type="box" label="Boxes">285</container>
             </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notebooks of clippings (issues and candidates)</unittitle>
+              <container type="box" label="Boxes">286</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
@@ -21240,33 +21381,159 @@
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">288-289</container>
               <unittitle>Blanchard for Governor television spots <unitdate type="inclusive" normal="1982">1982</unitdate></unittitle>
+              <container type="box" label="Boxes">288</container>
             </did>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">290-296</container>
+              <unittitle>Blanchard for Governor television spots <unitdate type="inclusive" normal="1982">1982</unitdate></unittitle>
+              <container type="box" label="Boxes">289</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
               <unittitle>Gubernatorial speeches, appearances, and related</unittitle>
+              <container type="box" label="Boxes">290</container>
             </did>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">297-299</container>
+              <unittitle>Gubernatorial speeches, appearances, and related</unittitle>
+              <container type="box" label="Boxes">291</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Gubernatorial speeches, appearances, and related</unittitle>
+              <container type="box" label="Boxes">292</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Gubernatorial speeches, appearances, and related</unittitle>
+              <container type="box" label="Boxes">293</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Gubernatorial speeches, appearances, and related</unittitle>
+              <container type="box" label="Boxes">294</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Gubernatorial speeches, appearances, and related</unittitle>
+              <container type="box" label="Boxes">295</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Gubernatorial speeches, appearances, and related</unittitle>
+              <container type="box" label="Boxes">296</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
               <unittitle><unitdate type="inclusive" normal="1990">1990</unitdate> gubernatorial campaign</unittitle>
+              <container type="box" label="Boxes">297</container>
             </did>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">300-301</container>
+              <unittitle><unitdate type="inclusive" normal="1990">1990</unitdate> gubernatorial campaign</unittitle>
+              <container type="box" label="Boxes">298</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle><unitdate type="inclusive" normal="1990">1990</unitdate> gubernatorial campaign</unittitle>
+              <container type="box" label="Boxes">299</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
               <unittitle>Post-gubernatorial activities (include period as ambassador to Canada)</unittitle>
+              <container type="box" label="Boxes">300</container>
             </did>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">302-306</container>
-              <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> gubernatorial primary campaign</unittitle>
+              <unittitle>Post-gubernatorial activities (include period as ambassador to Canada)</unittitle>
+              <container type="box" label="Boxes">301</container>
             </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> gubernatorial primary campaign</unittitle>
+              <container type="box" label="Boxes">302</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> gubernatorial primary campaign</unittitle>
+              <container type="box" label="Boxes">303</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> gubernatorial primary campaign</unittitle>
+              <container type="box" label="Boxes">304</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> gubernatorial primary campaign</unittitle>
+              <container type="box" label="Boxes">305</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> gubernatorial primary campaign</unittitle>
+              <container type="box" label="Boxes">306</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
@@ -21281,15 +21548,60 @@
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">307-309</container>
               <unittitle>Gubernatorial and post-gubernatorial photographs and albums</unittitle>
+              <container type="box" label="Boxes">307</container>
             </did>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">341-344</container>
-              <unittitle>Gubernatorial, political, and career as US Ambassador to Canada</unittitle>
+              <unittitle>Gubernatorial and post-gubernatorial photographs and albums</unittitle>
+              <container type="box" label="Boxes">308</container>
             </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Gubernatorial and post-gubernatorial photographs and albums</unittitle>
+              <container type="box" label="Boxes">309</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Gubernatorial, political, and career as US Ambassador to Canada</unittitle>
+              <container type="box" label="Boxes">341</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Gubernatorial, political, and career as US Ambassador to Canada</unittitle>
+              <container type="box" label="Boxes">342</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Gubernatorial, political, and career as US Ambassador to Canada</unittitle>
+              <container type="box" label="Boxes">343</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Gubernatorial, political, and career as US Ambassador to Canada</unittitle>
+              <container type="box" label="Boxes">344</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/bolcom.xml
+++ b/Real_Masters_all/bolcom.xml
@@ -397,12 +397,26 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">16-17</container>
             <unittitle>Financial <unitdate type="inclusive" normal="1998">1998</unitdate></unittitle>
           </did>
           <odd>
             <p>(prior to 1998 financial materials were interspersed with the Performance files)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Financial <unitdate type="inclusive" normal="1998">1998</unitdate></unittitle>
+              <container type="box" label="Box">16</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Financial <unitdate type="inclusive" normal="1998">1998</unitdate></unittitle>
+              <container type="box" label="Box">17</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -598,18 +612,86 @@
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">18-19</container>
               <unittitle>Manuscript and printed scores</unittitle>
             </did>
             <odd>
               <p>(includes some non-score material)</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Manuscript and printed scores</unittitle>
+                <container type="box" label="Box">18</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Manuscript and printed scores</unittitle>
+                <container type="box" label="Box">19</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="bundle" label="Bundles">1-7</container>
               <unittitle>Printed scores (outsize)</unittitle>
+              <container type="bundle" label="Bundles">1</container>
             </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Printed scores (outsize)</unittitle>
+              <container type="bundle" label="Bundles">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Printed scores (outsize)</unittitle>
+              <container type="bundle" label="Bundles">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Printed scores (outsize)</unittitle>
+              <container type="bundle" label="Bundles">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Printed scores (outsize)</unittitle>
+              <container type="bundle" label="Bundles">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Printed scores (outsize)</unittitle>
+              <container type="bundle" label="Bundles">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Printed scores (outsize)</unittitle>
+              <container type="bundle" label="Bundles">7</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
           </c03>
         </c02>
         <c02 level="file">
@@ -620,12 +702,26 @@
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">20-21</container>
               <unittitle>Manuscript and printed scores</unittitle>
             </did>
             <odd>
               <p>(includes audio cassette)</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Manuscript and printed scores</unittitle>
+                <container type="box" label="Box">20</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Manuscript and printed scores</unittitle>
+                <container type="box" label="Box">21</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -648,9 +744,27 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="bundle" label="Bundle">9-11</container>
               <unittitle>Printed scores (outsize)</unittitle>
+              <container type="bundle" label="Bundle">9</container>
             </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Printed scores (outsize)</unittitle>
+              <container type="bundle" label="Bundle">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Printed scores (outsize)</unittitle>
+              <container type="bundle" label="Bundle">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
           </c03>
         </c02>
         <c02 level="file">
@@ -697,12 +811,71 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="bundle" label="Bundle">12-18</container>
             <unittitle>Songs of Innocence and of Experience</unittitle>
             <physdesc>
               <extent>7 bundles</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Songs of Innocence and of Experience</unittitle>
+              <container type="bundle" label="Bundle">12</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Songs of Innocence and of Experience</unittitle>
+              <container type="bundle" label="Bundle">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Songs of Innocence and of Experience</unittitle>
+              <container type="bundle" label="Bundle">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Songs of Innocence and of Experience</unittitle>
+              <container type="bundle" label="Bundle">15</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Songs of Innocence and of Experience</unittitle>
+              <container type="bundle" label="Bundle">16</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Songs of Innocence and of Experience</unittitle>
+              <container type="bundle" label="Bundle">17</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Songs of Innocence and of Experience</unittitle>
+              <container type="bundle" label="Bundle">18</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -1207,9 +1380,36 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">33-36</container>
             <unittitle>A Wedding, Act II</unittitle>
+            <container type="box" label="Boxes">33</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>A Wedding, Act II</unittitle>
+            <container type="box" label="Boxes">34</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>A Wedding, Act II</unittitle>
+            <container type="box" label="Boxes">35</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>A Wedding, Act II</unittitle>
+            <container type="box" label="Boxes">36</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -1375,9 +1575,18 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">46-47</container>
             <unittitle>Canciones de Lorca <unitdate type="inclusive" normal="2006">2006</unitdate></unittitle>
+            <container type="box" label="Boxes">46</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Canciones de Lorca <unitdate type="inclusive" normal="2006">2006</unitdate></unittitle>
+            <container type="box" label="Boxes">47</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/boyneusa.xml
+++ b/Real_Masters_all/boyneusa.xml
@@ -297,9 +297,18 @@ Boyne USA Resorts records, Bentley Historical Library, University of Michigan</p
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">3-4</container>
             <unittitle>Skiing and golfing magazines, most containing articles or advertisements from Boyne USA</unittitle>
+            <container type="box" label="Boxes">3</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Skiing and golfing magazines, most containing articles or advertisements from Boyne USA</unittitle>
+            <container type="box" label="Boxes">4</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
       </c01>
       <c01 level="series">
@@ -780,7 +789,6 @@ Boyne USA Resorts records, Bentley Historical Library, University of Michigan</p
           </c03>
           <c03 level="file">
             <did>
-              <container type="volume" label="Oversize Volume">17-18</container>
               <unittitle>Albums of snapshots of golfing events and golfing personalities <unitdate type="inclusive" normal="1980/1989" certainty="approximate">1980s</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 volumes</extent>
@@ -792,6 +800,21 @@ Boyne USA Resorts records, Bentley Historical Library, University of Michigan</p
             <odd>
               <p>(Oversize vols. No. 17-18)</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Albums of snapshots of golfing events and golfing personalities <unitdate type="inclusive" normal="1980/1989" certainty="approximate">1980s</unitdate></unittitle>
+                <container type="volume" label="Oversize Volume">17</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Albums of snapshots of golfing events and golfing personalities <unitdate type="inclusive" normal="1980/1989" certainty="approximate">1980s</unitdate></unittitle>
+                <container type="volume" label="Oversize Volume">18</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="series">
@@ -4640,12 +4663,35 @@ Boyne USA Resorts records, Bentley Historical Library, University of Michigan</p
         </scopecontent>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volumes">12-14</container>
             <unittitle>Storeroom inventory of alcohol: beer, wine, liquor <unitdate type="inclusive" normal="1981/1987">1981-1987</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Storeroom inventory of alcohol: beer, wine, liquor <unitdate type="inclusive" normal="1981/1987">1981-1987</unitdate></unittitle>
+              <container type="volume" label="Oversize Volumes">12</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Storeroom inventory of alcohol: beer, wine, liquor <unitdate type="inclusive" normal="1981/1987">1981-1987</unitdate></unittitle>
+              <container type="volume" label="Oversize Volumes">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Storeroom inventory of alcohol: beer, wine, liquor <unitdate type="inclusive" normal="1981/1987">1981-1987</unitdate></unittitle>
+              <container type="volume" label="Oversize Volumes">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/busadmin.xml
+++ b/Real_Masters_all/busadmin.xml
@@ -18011,9 +18011,36 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">96-99</container>
               <unittitle>[Boxes 96-99 were eliminated during <unitdate type="inclusive" normal="1994">1994</unitdate> reprocessing.]</unittitle>
+              <container type="box" label="Box">96</container>
             </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>[Boxes 96-99 were eliminated during <unitdate type="inclusive" normal="1994">1994</unitdate> reprocessing.]</unittitle>
+              <container type="box" label="Box">97</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>[Boxes 96-99 were eliminated during <unitdate type="inclusive" normal="1994">1994</unitdate> reprocessing.]</unittitle>
+              <container type="box" label="Box">98</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>[Boxes 96-99 were eliminated during <unitdate type="inclusive" normal="1994">1994</unitdate> reprocessing.]</unittitle>
+              <container type="box" label="Box">99</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
           </c03>
         </c02>
       </c01>

--- a/Real_Masters_all/cacioppo.xml
+++ b/Real_Masters_all/cacioppo.xml
@@ -569,21 +569,49 @@ George Cacioppo papers, Bentley Historical Library, University of Michigan</p>
         </did>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">8-9</container>
             <unittitle>Sketchbooks</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">34 items</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Sketchbooks</unittitle>
+              <container type="box" label="Boxes">8</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Sketchbooks</unittitle>
+              <container type="box" label="Boxes">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">10-11</container>
             <unittitle>Individual unidentified sketches</unittitle>
             <physdesc>
               <extent>6 li. inches</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Individual unidentified sketches</unittitle>
+              <container type="box" label="Boxes">10</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Individual unidentified sketches</unittitle>
+              <container type="box" label="Boxes">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/classalb.xml
+++ b/Real_Masters_all/classalb.xml
@@ -28905,12 +28905,35 @@ University of Michigan Class Albums, Bentley Historical Library, University of M
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">35-37</container>
               <unittitle>Unidentified</unittitle>
             </did>
             <odd>
               <p>[1-25, 44, 45, 46]</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Unidentified</unittitle>
+                <container type="box" label="Box">35</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Unidentified</unittitle>
+                <container type="box" label="Box">36</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Unidentified</unittitle>
+                <container type="box" label="Box">37</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
       </c01>

--- a/Real_Masters_all/cranehh.xml
+++ b/Real_Masters_all/cranehh.xml
@@ -4776,9 +4776,27 @@
         </c02>
         <c02 level="file">
           <did>
-            <container label="Boxes" type="box">27-29</container>
             <unittitle>Sound recordings of sermons and other speeches</unittitle>
+            <container label="Boxes" type="box">27</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Sound recordings of sermons and other speeches</unittitle>
+            <container label="Boxes" type="box">28</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Sound recordings of sermons and other speeches</unittitle>
+            <container label="Boxes" type="box">29</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/darmich.xml
+++ b/Real_Masters_all/darmich.xml
@@ -1161,9 +1161,18 @@ Daughters of the American Revolution of Michigan records, Bentley Historical Lib
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">18-19</container>
             <unittitle>Research and topical files of State Historian</unittitle>
+            <container type="box" label="Boxes">18</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Research and topical files of State Historian</unittitle>
+            <container type="box" label="Boxes">19</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/dpgmedp.xml
+++ b/Real_Masters_all/dpgmedp.xml
@@ -580,7 +580,6 @@ Department of Postgraduate Medicine and Health Professions Education (University
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">14-15</container>
             <unittitle>
               <unitdate type="inclusive" normal="1982">1982</unitdate>
             </unittitle>
@@ -588,10 +587,28 @@ Department of Postgraduate Medicine and Health Professions Education (University
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1982">1982</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">14</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1982">1982</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">15</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">16-17</container>
             <unittitle>
               <unitdate type="inclusive" normal="1983">1983</unitdate>
             </unittitle>
@@ -599,6 +616,25 @@ Department of Postgraduate Medicine and Health Professions Education (University
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1983">1983</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">16</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1983">1983</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">17</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -658,7 +694,6 @@ Department of Postgraduate Medicine and Health Professions Education (University
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">25-26</container>
             <unittitle>
               <unitdate type="inclusive" normal="1995">1995</unitdate>
             </unittitle>
@@ -666,6 +701,25 @@ Department of Postgraduate Medicine and Health Professions Education (University
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1995">1995</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">25</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1995">1995</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">26</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -677,7 +731,6 @@ Department of Postgraduate Medicine and Health Professions Education (University
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">28-29</container>
             <unittitle>
               <unitdate type="inclusive" normal="1997">1997</unitdate>
             </unittitle>
@@ -685,6 +738,25 @@ Department of Postgraduate Medicine and Health Professions Education (University
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1997">1997</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">28</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1997">1997</unitdate>
+              </unittitle>
+              <container type="volume" label="Oversize Volume">29</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/drda.xml
+++ b/Real_Masters_all/drda.xml
@@ -5078,12 +5078,53 @@ Division of Research Development and Administration (University of Michigan) Rec
         </scopecontent>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">26-30</container>
             <unittitle>Microfilm of grant files</unittitle>
           </did>
           <odd>
             <p>(326 reels of 16mm microfilm with index in Box 26)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Microfilm of grant files</unittitle>
+              <container type="box" label="Boxes">26</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Microfilm of grant files</unittitle>
+              <container type="box" label="Boxes">27</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Microfilm of grant files</unittitle>
+              <container type="box" label="Boxes">28</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Microfilm of grant files</unittitle>
+              <container type="box" label="Boxes">29</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Microfilm of grant files</unittitle>
+              <container type="box" label="Boxes">30</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/drewwalt.xml
+++ b/Real_Masters_all/drewwalt.xml
@@ -3974,12 +3974,332 @@
         </did>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">1-36</container>
             <unittitle>Originals of microfilmed papers</unittitle>
           </did>
           <accessrestrict>
             <p>[Boxes 1-35, staff use only, available on microfilm]</p>
           </accessrestrict>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">7</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">15</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">16</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">17</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">18</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">19</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">20</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">21</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">22</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">23</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">24</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">25</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">26</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">27</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">28</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">29</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">30</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">31</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">32</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">33</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">34</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">35</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Originals of microfilmed papers</unittitle>
+              <container type="box" label="Boxes">36</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/dsigmad.xml
+++ b/Real_Masters_all/dsigmad.xml
@@ -903,9 +903,18 @@ Delta Sigma Delta records, Bentley Historical Library, University of Michigan</p
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">7-8</container>
             <unittitle>Plaques <unitdate type="inclusive" normal="1954/1975">1954-1975</unitdate></unittitle>
+            <container type="box" label="Boxes">7</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Plaques <unitdate type="inclusive" normal="1954/1975">1954-1975</unitdate></unittitle>
+            <container type="box" label="Boxes">8</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/duncant.xml
+++ b/Real_Masters_all/duncant.xml
@@ -1019,12 +1019,26 @@ Todd Duncan papers, Bentley Historical Library, University of Michigan</p>
       </c01>
       <c01 level="series">
         <did>
-          <container type="box" label="Box">11-12</container>
           <unittitle>Oversize Material</unittitle>
         </did>
         <odd>
           <p>(Items are listed above)</p>
         </odd>
+        <c02 level="file">
+          <did>
+            <unittitle>Oversize Material</unittitle>
+            <container type="box" label="Box">11</container>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Oversize Material</unittitle>
+            <container type="box" label="Box">12</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
       </c01>
     </dsc>
   </archdesc>

--- a/Real_Masters_all/episwest.xml
+++ b/Real_Masters_all/episwest.xml
@@ -346,12 +346,53 @@
           </scopecontent>
           <c03 level="file">
             <did>
-              <container type="volume" label="Oversize Volume">1-5</container>
               <unittitle>Record Books <unitdate type="inclusive" normal="1875/1908">1875-1908</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 volumes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Record Books <unitdate type="inclusive" normal="1875/1908">1875-1908</unitdate></unittitle>
+                <container type="volume" label="Oversize Volume">1</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Record Books <unitdate type="inclusive" normal="1875/1908">1875-1908</unitdate></unittitle>
+                <container type="volume" label="Oversize Volume">2</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Record Books <unitdate type="inclusive" normal="1875/1908">1875-1908</unitdate></unittitle>
+                <container type="volume" label="Oversize Volume">3</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Record Books <unitdate type="inclusive" normal="1875/1908">1875-1908</unitdate></unittitle>
+                <container type="volume" label="Oversize Volume">4</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Record Books <unitdate type="inclusive" normal="1875/1908">1875-1908</unitdate></unittitle>
+                <container type="volume" label="Oversize Volume">5</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -12267,12 +12308,26 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">17-18</container>
             <unittitle>Diocesan Scrapbooks <unitdate type="inclusive" normal="1969/1987">1969-1987</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Diocesan Scrapbooks <unitdate type="inclusive" normal="1969/1987">1969-1987</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">17</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Diocesan Scrapbooks <unitdate type="inclusive" normal="1969/1987">1969-1987</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">18</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/esgeorge.xml
+++ b/Real_Masters_all/esgeorge.xml
@@ -3991,13 +3991,38 @@ Edwin S. George Reserve (Mich.) records, Bentley Historical Library, University 
           </c03>
           <c03 level="file">
             <did>
-              <container type="map-case" label="Drawer">308</container>
-              <container type="folder" label="Folders">5-7</container>
               <unittitle>USDA Aerial Photographs <unitdate type="inclusive" normal="1940/1970">1940-1970</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>USDA Aerial Photographs <unitdate type="inclusive" normal="1940/1970">1940-1970</unitdate></unittitle>
+                <container type="map-case" label="Drawer">308</container>
+                <container type="folder" label="Folders">5</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>USDA Aerial Photographs <unitdate type="inclusive" normal="1940/1970">1940-1970</unitdate></unittitle>
+                <container type="map-case" label="Drawer">308</container>
+                <container type="folder" label="Folders">6</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>USDA Aerial Photographs <unitdate type="inclusive" normal="1940/1970">1940-1970</unitdate></unittitle>
+                <container type="map-case" label="Drawer">308</container>
+                <container type="folder" label="Folders">7</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/esmwartr.xml
+++ b/Real_Masters_all/esmwartr.xml
@@ -110,15 +110,51 @@ Engineering Science and Management War Training Program (University of Michigan)
         </did>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">2-3</container>
             <unittitle>Engineering Training Program <unitdate type="inclusive" normal="1940/1941">1940-1941</unitdate></unittitle>
+            <container type="box" label="Boxes">2</container>
           </did>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">4-7</container>
-            <unittitle>Engineering Science and Management Defense Training Program <unitdate type="inclusive" normal="1941/1942">1941-1942</unitdate></unittitle>
+            <unittitle>Engineering Training Program <unitdate type="inclusive" normal="1940/1941">1940-1941</unitdate></unittitle>
+            <container type="box" label="Boxes">3</container>
           </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Engineering Science and Management Defense Training Program <unitdate type="inclusive" normal="1941/1942">1941-1942</unitdate></unittitle>
+            <container type="box" label="Boxes">4</container>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Engineering Science and Management Defense Training Program <unitdate type="inclusive" normal="1941/1942">1941-1942</unitdate></unittitle>
+            <container type="box" label="Boxes">5</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Engineering Science and Management Defense Training Program <unitdate type="inclusive" normal="1941/1942">1941-1942</unitdate></unittitle>
+            <container type="box" label="Boxes">6</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Engineering Science and Management Defense Training Program <unitdate type="inclusive" normal="1941/1942">1941-1942</unitdate></unittitle>
+            <container type="box" label="Boxes">7</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -126,27 +162,137 @@ Engineering Science and Management War Training Program (University of Michigan)
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">8-13</container>
               <unittitle>
                 <unitdate type="inclusive" normal="1942/1943">1942-1943</unitdate>
               </unittitle>
+              <container type="box" label="Boxes">8</container>
             </did>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">14-17</container>
+              <unittitle>
+                <unitdate type="inclusive" normal="1942/1943">1942-1943</unitdate>
+              </unittitle>
+              <container type="box" label="Boxes">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1942/1943">1942-1943</unitdate>
+              </unittitle>
+              <container type="box" label="Boxes">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1942/1943">1942-1943</unitdate>
+              </unittitle>
+              <container type="box" label="Boxes">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1942/1943">1942-1943</unitdate>
+              </unittitle>
+              <container type="box" label="Boxes">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1942/1943">1942-1943</unitdate>
+              </unittitle>
+              <container type="box" label="Boxes">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
               <unittitle>
                 <unitdate type="inclusive" normal="1943/1944">1943-1944</unitdate>
               </unittitle>
+              <container type="box" label="Boxes">14</container>
             </did>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Boxes">18-20</container>
+              <unittitle>
+                <unitdate type="inclusive" normal="1943/1944">1943-1944</unitdate>
+              </unittitle>
+              <container type="box" label="Boxes">15</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1943/1944">1943-1944</unitdate>
+              </unittitle>
+              <container type="box" label="Boxes">16</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1943/1944">1943-1944</unitdate>
+              </unittitle>
+              <container type="box" label="Boxes">17</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
               <unittitle>
                 <unitdate type="inclusive" normal="1944/1945">1944-1945</unitdate>
               </unittitle>
+              <container type="box" label="Boxes">18</container>
             </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1944/1945">1944-1945</unitdate>
+              </unittitle>
+              <container type="box" label="Boxes">19</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1944/1945">1944-1945</unitdate>
+              </unittitle>
+              <container type="box" label="Boxes">20</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/extserv.xml
+++ b/Real_Masters_all/extserv.xml
@@ -6446,12 +6446,44 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">46-49</container>
             <unittitle>Personnel Files</unittitle>
           </did>
           <accessrestrict>
             <p>[CLOSED EXCEPT WITH WRITTEN PERMISSION OF DONOR]</p>
           </accessrestrict>
+          <c03 level="file">
+            <did>
+              <unittitle>Personnel Files</unittitle>
+              <container type="box" label="Box">46</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Personnel Files</unittitle>
+              <container type="box" label="Box">47</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Personnel Files</unittitle>
+              <container type="box" label="Box">48</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Personnel Files</unittitle>
+              <container type="box" label="Box">49</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/fineresr.xml
+++ b/Real_Masters_all/fineresr.xml
@@ -178,18 +178,104 @@ Sidney Fine collected research materials, Bentley Historical Library, University
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">3-6</container>
             <unittitle>Collected materials used in his research on the Detroit Riot of 1967</unittitle>
           </did>
           <odd>
             <p>(interviews with Nathan Caplan included in box 5)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Collected materials used in his research on the Detroit Riot of 1967</unittitle>
+              <container type="box" label="Boxes">3</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Collected materials used in his research on the Detroit Riot of 1967</unittitle>
+              <container type="box" label="Boxes">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Collected materials used in his research on the Detroit Riot of 1967</unittitle>
+              <container type="box" label="Boxes">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Collected materials used in his research on the Detroit Riot of 1967</unittitle>
+              <container type="box" label="Boxes">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">7-13</container>
             <unittitle>Collected material relating to his research on Walter Drew</unittitle>
+            <container type="box" label="Boxes">7</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Collected material relating to his research on Walter Drew</unittitle>
+            <container type="box" label="Boxes">8</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Collected material relating to his research on Walter Drew</unittitle>
+            <container type="box" label="Boxes">9</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Collected material relating to his research on Walter Drew</unittitle>
+            <container type="box" label="Boxes">10</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Collected material relating to his research on Walter Drew</unittitle>
+            <container type="box" label="Boxes">11</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Collected material relating to his research on Walter Drew</unittitle>
+            <container type="box" label="Boxes">12</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Collected material relating to his research on Walter Drew</unittitle>
+            <container type="box" label="Boxes">13</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/finopum.xml
+++ b/Real_Masters_all/finopum.xml
@@ -332,12 +332,26 @@ Financial Operations (University of Michigan) records, Bentley Historical Librar
             </did>
             <c04 level="file">
               <did>
-                <container type="volume" label="Oversize Volume">17-18</container>
                 <unittitle>Journals <unitdate type="inclusive" normal="1890/1912">1890-1912</unitdate></unittitle>
               </did>
               <odd>
                 <p>[Nos. 17-18]</p>
               </odd>
+              <c05 level="file">
+                <did>
+                  <unittitle>Journals <unitdate type="inclusive" normal="1890/1912">1890-1912</unitdate></unittitle>
+                  <container type="volume" label="Oversize Volume">17</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Journals <unitdate type="inclusive" normal="1890/1912">1890-1912</unitdate></unittitle>
+                  <container type="volume" label="Oversize Volume">18</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
@@ -762,39 +776,185 @@ Financial Operations (University of Michigan) records, Bentley Historical Librar
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">28-34</container>
             <unittitle>Ledgers <unitdate type="inclusive" normal="1920/1945" certainty="approximate">circa 1920-1945</unitdate></unittitle>
           </did>
           <odd>
             <p>[Nos. 28-34]</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers <unitdate type="inclusive" normal="1920/1945" certainty="approximate">circa 1920-1945</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">28</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers <unitdate type="inclusive" normal="1920/1945" certainty="approximate">circa 1920-1945</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">29</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers <unitdate type="inclusive" normal="1920/1945" certainty="approximate">circa 1920-1945</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">30</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers <unitdate type="inclusive" normal="1920/1945" certainty="approximate">circa 1920-1945</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">31</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers <unitdate type="inclusive" normal="1920/1945" certainty="approximate">circa 1920-1945</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">32</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers <unitdate type="inclusive" normal="1920/1945" certainty="approximate">circa 1920-1945</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">33</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers <unitdate type="inclusive" normal="1920/1945" certainty="approximate">circa 1920-1945</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">34</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">35-38</container>
             <unittitle>Securities Records <unitdate type="inclusive" normal="1920/1950" certainty="approximate">circa 1920-1950</unitdate></unittitle>
           </did>
           <odd>
             <p>[Nos. 35-38]</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Securities Records <unitdate type="inclusive" normal="1920/1950" certainty="approximate">circa 1920-1950</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">35</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Securities Records <unitdate type="inclusive" normal="1920/1950" certainty="approximate">circa 1920-1950</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">36</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Securities Records <unitdate type="inclusive" normal="1920/1950" certainty="approximate">circa 1920-1950</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">37</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Securities Records <unitdate type="inclusive" normal="1920/1950" certainty="approximate">circa 1920-1950</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">38</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">39-42</container>
             <unittitle>Receipt Registers <unitdate type="inclusive" normal="1932/1948">1932-1948</unitdate></unittitle>
           </did>
           <odd>
             <p>[Nos. 39-42]</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Receipt Registers <unitdate type="inclusive" normal="1932/1948">1932-1948</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">39</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Receipt Registers <unitdate type="inclusive" normal="1932/1948">1932-1948</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">40</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Receipt Registers <unitdate type="inclusive" normal="1932/1948">1932-1948</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">41</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Receipt Registers <unitdate type="inclusive" normal="1932/1948">1932-1948</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">42</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volume">43-45</container>
             <unittitle>Journals <unitdate type="inclusive" normal="1923/1946">1923-1946</unitdate></unittitle>
           </did>
           <odd>
             <p>[Nos. 43-45]</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Journals <unitdate type="inclusive" normal="1923/1946">1923-1946</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">43</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Journals <unitdate type="inclusive" normal="1923/1946">1923-1946</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">44</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Journals <unitdate type="inclusive" normal="1923/1946">1923-1946</unitdate></unittitle>
+              <container type="volume" label="Oversize Volume">45</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -1525,12 +1685,26 @@ Financial Operations (University of Michigan) records, Bentley Historical Librar
           </did>
           <c03 level="file">
             <did>
-              <container type="volume" label="Oversize Volume">20-21</container>
               <unittitle>Journals <unitdate type="inclusive" normal="1926/1947">1926-1947</unitdate></unittitle>
             </did>
             <odd>
               <p>[Nos. 20-21]</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Journals <unitdate type="inclusive" normal="1926/1947">1926-1947</unitdate></unittitle>
+                <container type="volume" label="Oversize Volume">20</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Journals <unitdate type="inclusive" normal="1926/1947">1926-1947</unitdate></unittitle>
+                <container type="volume" label="Oversize Volume">21</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/fordwd.xml
+++ b/Real_Masters_all/fordwd.xml
@@ -11238,7 +11238,6 @@
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">151-152</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1973/1974">1973-1974</unitdate>
                 </unittitle>
@@ -11249,14 +11248,44 @@
               <odd>
                 <p>(files relate to H.R. 69, The Elementary and Secondary Education Amendments of 1973)</p>
               </odd>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1973/1974">1973-1974</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">151</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1973/1974">1973-1974</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">152</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">95-96</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1975/1976">1975-1976</unitdate>
                 </unittitle>
+                <container label="Box" type="box">95</container>
               </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1975/1976">1975-1976</unitdate>
+                </unittitle>
+                <container label="Box" type="box">96</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/fprespon.xml
+++ b/Real_Masters_all/fprespon.xml
@@ -408,12 +408,134 @@ First Presbyterian Church (Pontiac, Mich.) records, Bentley Historical Library, 
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volumes">2-15</container>
             <unittitle>Ledgers with contributions of members</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">14 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">2</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">7</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ledgers with contributions of members</unittitle>
+              <container type="volume" label="Oversize Volumes">15</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/gmwill.xml
+++ b/Real_Masters_all/gmwill.xml
@@ -32545,9 +32545,54 @@
                     </c08>
                     <c08 level="file">
                       <did>
-                        <container label="Box" type="box">355-360</container>
                         <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
+                        <container label="Box" type="box">355</container>
                       </did>
+                    </c08>
+                    <c08 level="file">
+                      <did>
+                        <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
+                        <container label="Box" type="box">356</container>
+                      </did>
+                      <odd>
+                        <p>(continued)</p>
+                      </odd>
+                    </c08>
+                    <c08 level="file">
+                      <did>
+                        <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
+                        <container label="Box" type="box">357</container>
+                      </did>
+                      <odd>
+                        <p>(continued)</p>
+                      </odd>
+                    </c08>
+                    <c08 level="file">
+                      <did>
+                        <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
+                        <container label="Box" type="box">358</container>
+                      </did>
+                      <odd>
+                        <p>(continued)</p>
+                      </odd>
+                    </c08>
+                    <c08 level="file">
+                      <did>
+                        <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
+                        <container label="Box" type="box">359</container>
+                      </did>
+                      <odd>
+                        <p>(continued)</p>
+                      </odd>
+                    </c08>
+                    <c08 level="file">
+                      <did>
+                        <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
+                        <container label="Box" type="box">360</container>
+                      </did>
+                      <odd>
+                        <p>(continued)</p>
+                      </odd>
                     </c08>
                     <c08 level="file">
                       <did>
@@ -35583,9 +35628,27 @@
                 </c06>
                 <c06 level="file">
                   <did>
-                    <container label="Box" type="box">369-371</container>
                     <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
+                    <container label="Box" type="box">369</container>
                   </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
+                    <container label="Box" type="box">370</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>[box numbers eliminated during the 1983-1984 reprocessing of the Williams Collection]</unittitle>
+                    <container label="Box" type="box">371</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
                 </c06>
                 <c06 level="file">
                   <did>
@@ -35789,12 +35852,26 @@
               </did>
               <c05 level="file">
                 <did>
-                  <container label="Box" type="box">389-390</container>
                   <unittitle>re Civil Defense</unittitle>
                 </did>
                 <odd>
                   <p>(Plans and Surveys)</p>
                 </odd>
+                <c06 level="file">
+                  <did>
+                    <unittitle>re Civil Defense</unittitle>
+                    <container label="Box" type="box">389</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>re Civil Defense</unittitle>
+                    <container label="Box" type="box">390</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
             </c04>
             <c04 level="otherlevel" otherlevel="sub-subseries">
@@ -38746,11 +38823,22 @@
               </did>
               <c05 level="file">
                 <did>
-                  <container label="Box" type="box">420-421</container>
                   <unittitle>
                     <unitdate type="inclusive" normal="1960-11/1961-01">November 1960-January 1961</unitdate>
                   </unittitle>
+                  <container label="Box" type="box">420</container>
                 </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1960-11/1961-01">November 1960-January 1961</unitdate>
+                  </unittitle>
+                  <container label="Box" type="box">421</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
               </c05>
             </c04>
             <c04 level="otherlevel" otherlevel="sub-subseries">
@@ -41367,11 +41455,33 @@
             </scopecontent>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">505-507</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1951/1961">1951-1961</unitdate>
                 </unittitle>
+                <container label="Box" type="box">505</container>
               </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1951/1961">1951-1961</unitdate>
+                </unittitle>
+                <container label="Box" type="box">506</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1951/1961">1951-1961</unitdate>
+                </unittitle>
+                <container label="Box" type="box">507</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
             </c04>
           </c03>
           <c03 level="subseries">
@@ -42584,43 +42694,252 @@
             </scopecontent>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">558-561</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1949/1950">1949-1950</unitdate>
                 </unittitle>
+                <container label="Box" type="box">558</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">561-565</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1949/1950">1949-1950</unitdate>
+                </unittitle>
+                <container label="Box" type="box">559</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1949/1950">1949-1950</unitdate>
+                </unittitle>
+                <container label="Box" type="box">560</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1949/1950">1949-1950</unitdate>
+                </unittitle>
+                <container label="Box" type="box">561</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1951/1952">1951-1952</unitdate>
                 </unittitle>
+                <container label="Box" type="box">561</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">566-570</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1951/1952">1951-1952</unitdate>
+                </unittitle>
+                <container label="Box" type="box">562</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1951/1952">1951-1952</unitdate>
+                </unittitle>
+                <container label="Box" type="box">563</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1951/1952">1951-1952</unitdate>
+                </unittitle>
+                <container label="Box" type="box">564</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1951/1952">1951-1952</unitdate>
+                </unittitle>
+                <container label="Box" type="box">565</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1953/1954">1953-1954</unitdate>
                 </unittitle>
+                <container label="Box" type="box">566</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">570-574</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1953/1954">1953-1954</unitdate>
+                </unittitle>
+                <container label="Box" type="box">567</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1953/1954">1953-1954</unitdate>
+                </unittitle>
+                <container label="Box" type="box">568</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1953/1954">1953-1954</unitdate>
+                </unittitle>
+                <container label="Box" type="box">569</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1953/1954">1953-1954</unitdate>
+                </unittitle>
+                <container label="Box" type="box">570</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1955/1956">1955-1956</unitdate>
                 </unittitle>
+                <container label="Box" type="box">570</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">574-578</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1955/1956">1955-1956</unitdate>
+                </unittitle>
+                <container label="Box" type="box">571</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1955/1956">1955-1956</unitdate>
+                </unittitle>
+                <container label="Box" type="box">572</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1955/1956">1955-1956</unitdate>
+                </unittitle>
+                <container label="Box" type="box">573</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1955/1956">1955-1956</unitdate>
+                </unittitle>
+                <container label="Box" type="box">574</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1957/1958">1957-1958</unitdate>
                 </unittitle>
+                <container label="Box" type="box">574</container>
               </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1957/1958">1957-1958</unitdate>
+                </unittitle>
+                <container label="Box" type="box">575</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1957/1958">1957-1958</unitdate>
+                </unittitle>
+                <container label="Box" type="box">576</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1957/1958">1957-1958</unitdate>
+                </unittitle>
+                <container label="Box" type="box">577</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1957/1958">1957-1958</unitdate>
+                </unittitle>
+                <container label="Box" type="box">578</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>
@@ -42719,35 +43038,79 @@
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">587-588</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1955">1955</unitdate>
                 </unittitle>
+                <container label="Box" type="box">587</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">588-589</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1955">1955</unitdate>
+                </unittitle>
+                <container label="Box" type="box">588</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1956">1956</unitdate>
                 </unittitle>
+                <container label="Box" type="box">588</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">590-591</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1956">1956</unitdate>
+                </unittitle>
+                <container label="Box" type="box">589</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1957">1957</unitdate>
                 </unittitle>
+                <container label="Box" type="box">590</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">592-593</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1957">1957</unitdate>
+                </unittitle>
+                <container label="Box" type="box">591</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1958">1958</unitdate>
                 </unittitle>
+                <container label="Box" type="box">592</container>
               </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1958">1958</unitdate>
+                </unittitle>
+                <container label="Box" type="box">593</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>
@@ -42897,12 +43260,62 @@
             </scopecontent>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">610-615</container>
                 <unittitle>Papers</unittitle>
               </did>
               <odd>
                 <p>[include family and social correspondence, clippings, and memorabilia]</p>
               </odd>
+              <c05 level="file">
+                <did>
+                  <unittitle>Papers</unittitle>
+                  <container label="Box" type="box">610</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Papers</unittitle>
+                  <container label="Box" type="box">611</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Papers</unittitle>
+                  <container label="Box" type="box">612</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Papers</unittitle>
+                  <container label="Box" type="box">613</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Papers</unittitle>
+                  <container label="Box" type="box">614</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Papers</unittitle>
+                  <container label="Box" type="box">615</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
           </c03>
           <c03 level="subseries">
@@ -42914,12 +43327,80 @@
             </scopecontent>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">616-623</container>
                 <unittitle>Programs</unittitle>
               </did>
               <odd>
                 <p>(events which GMW attended, or to which he was invited)</p>
               </odd>
+              <c05 level="file">
+                <did>
+                  <unittitle>Programs</unittitle>
+                  <container label="Box" type="box">616</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Programs</unittitle>
+                  <container label="Box" type="box">617</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Programs</unittitle>
+                  <container label="Box" type="box">618</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Programs</unittitle>
+                  <container label="Box" type="box">619</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Programs</unittitle>
+                  <container label="Box" type="box">620</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Programs</unittitle>
+                  <container label="Box" type="box">621</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Programs</unittitle>
+                  <container label="Box" type="box">622</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Programs</unittitle>
+                  <container label="Box" type="box">623</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
           </c03>
           <c03 level="subseries">
@@ -42931,13 +43412,30 @@
             </scopecontent>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">624-626</container>
                 <unittitle>Executive Office Financial Records</unittitle>
+                <container label="Box" type="box">624</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">627-633</container>
+                <unittitle>Executive Office Financial Records</unittitle>
+                <container label="Box" type="box">625</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Executive Office Financial Records</unittitle>
+                <container label="Box" type="box">626</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>Personal Financial Records</unittitle>
               </did>
               <odd>
@@ -42946,6 +43444,66 @@
               <odd>
                 <p>(unarranged)</p>
               </odd>
+              <c05 level="file">
+                <did>
+                  <unittitle>Personal Financial Records</unittitle>
+                  <container label="Box" type="box">627</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Personal Financial Records</unittitle>
+                  <container label="Box" type="box">628</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Personal Financial Records</unittitle>
+                  <container label="Box" type="box">629</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Personal Financial Records</unittitle>
+                  <container label="Box" type="box">630</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Personal Financial Records</unittitle>
+                  <container label="Box" type="box">631</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Personal Financial Records</unittitle>
+                  <container label="Box" type="box">632</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Personal Financial Records</unittitle>
+                  <container label="Box" type="box">633</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
           </c03>
           <c03 level="subseries">
@@ -42957,111 +43515,670 @@
             </scopecontent>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">634-635</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1949">1949</unitdate>
                 </unittitle>
+                <container label="Box" type="box">634</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">636-637</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1949">1949</unitdate>
+                </unittitle>
+                <container label="Box" type="box">635</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1950">1950</unitdate>
                 </unittitle>
+                <container label="Box" type="box">636</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">638-641</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1950">1950</unitdate>
+                </unittitle>
+                <container label="Box" type="box">637</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1951">1951</unitdate>
                 </unittitle>
+                <container label="Box" type="box">638</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">642-646</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1951">1951</unitdate>
+                </unittitle>
+                <container label="Box" type="box">639</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1951">1951</unitdate>
+                </unittitle>
+                <container label="Box" type="box">640</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1951">1951</unitdate>
+                </unittitle>
+                <container label="Box" type="box">641</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1952">1952</unitdate>
                 </unittitle>
+                <container label="Box" type="box">642</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">647-649</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1952">1952</unitdate>
+                </unittitle>
+                <container label="Box" type="box">643</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1952">1952</unitdate>
+                </unittitle>
+                <container label="Box" type="box">644</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1952">1952</unitdate>
+                </unittitle>
+                <container label="Box" type="box">645</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1952">1952</unitdate>
+                </unittitle>
+                <container label="Box" type="box">646</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1953">1953</unitdate>
                 </unittitle>
+                <container label="Box" type="box">647</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">650-654</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1953">1953</unitdate>
+                </unittitle>
+                <container label="Box" type="box">648</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1953">1953</unitdate>
+                </unittitle>
+                <container label="Box" type="box">649</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1954">1954</unitdate>
                 </unittitle>
+                <container label="Box" type="box">650</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">655-658</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1954">1954</unitdate>
+                </unittitle>
+                <container label="Box" type="box">651</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1954">1954</unitdate>
+                </unittitle>
+                <container label="Box" type="box">652</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1954">1954</unitdate>
+                </unittitle>
+                <container label="Box" type="box">653</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1954">1954</unitdate>
+                </unittitle>
+                <container label="Box" type="box">654</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1955">1955</unitdate>
                 </unittitle>
+                <container label="Box" type="box">655</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">659-663</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1955">1955</unitdate>
+                </unittitle>
+                <container label="Box" type="box">656</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1955">1955</unitdate>
+                </unittitle>
+                <container label="Box" type="box">657</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1955">1955</unitdate>
+                </unittitle>
+                <container label="Box" type="box">658</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1956">1956</unitdate>
                 </unittitle>
+                <container label="Box" type="box">659</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">664-668</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1956">1956</unitdate>
+                </unittitle>
+                <container label="Box" type="box">660</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1956">1956</unitdate>
+                </unittitle>
+                <container label="Box" type="box">661</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1956">1956</unitdate>
+                </unittitle>
+                <container label="Box" type="box">662</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1956">1956</unitdate>
+                </unittitle>
+                <container label="Box" type="box">663</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1957">1957</unitdate>
                 </unittitle>
+                <container label="Box" type="box">664</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">669-675</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1957">1957</unitdate>
+                </unittitle>
+                <container label="Box" type="box">665</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1957">1957</unitdate>
+                </unittitle>
+                <container label="Box" type="box">666</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1957">1957</unitdate>
+                </unittitle>
+                <container label="Box" type="box">667</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1957">1957</unitdate>
+                </unittitle>
+                <container label="Box" type="box">668</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1958">1958</unitdate>
                 </unittitle>
+                <container label="Box" type="box">669</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">676-680</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1958">1958</unitdate>
+                </unittitle>
+                <container label="Box" type="box">670</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1958">1958</unitdate>
+                </unittitle>
+                <container label="Box" type="box">671</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1958">1958</unitdate>
+                </unittitle>
+                <container label="Box" type="box">672</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1958">1958</unitdate>
+                </unittitle>
+                <container label="Box" type="box">673</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1958">1958</unitdate>
+                </unittitle>
+                <container label="Box" type="box">674</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1958">1958</unitdate>
+                </unittitle>
+                <container label="Box" type="box">675</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1959">1959</unitdate>
                 </unittitle>
+                <container label="Box" type="box">676</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">681-688</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1959">1959</unitdate>
+                </unittitle>
+                <container label="Box" type="box">677</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1959">1959</unitdate>
+                </unittitle>
+                <container label="Box" type="box">678</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1959">1959</unitdate>
+                </unittitle>
+                <container label="Box" type="box">679</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1959">1959</unitdate>
+                </unittitle>
+                <container label="Box" type="box">680</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>[Box Nos. eliminated]</unittitle>
+                <container label="Box" type="box">681</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">689-694</container>
+                <unittitle>[Box Nos. eliminated]</unittitle>
+                <container label="Box" type="box">682</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Box Nos. eliminated]</unittitle>
+                <container label="Box" type="box">683</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Box Nos. eliminated]</unittitle>
+                <container label="Box" type="box">684</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Box Nos. eliminated]</unittitle>
+                <container label="Box" type="box">685</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Box Nos. eliminated]</unittitle>
+                <container label="Box" type="box">686</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Box Nos. eliminated]</unittitle>
+                <container label="Box" type="box">687</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Box Nos. eliminated]</unittitle>
+                <container label="Box" type="box">688</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1960">1960</unitdate>
                 </unittitle>
+                <container label="Box" type="box">689</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">695-700</container>
-                <unittitle>[Box Nos. eliminated]</unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1960">1960</unitdate>
+                </unittitle>
+                <container label="Box" type="box">690</container>
               </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1960">1960</unitdate>
+                </unittitle>
+                <container label="Box" type="box">691</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1960">1960</unitdate>
+                </unittitle>
+                <container label="Box" type="box">692</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1960">1960</unitdate>
+                </unittitle>
+                <container label="Box" type="box">693</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1960">1960</unitdate>
+                </unittitle>
+                <container label="Box" type="box">694</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Box Nos. eliminated]</unittitle>
+                <container label="Box" type="box">695</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Box Nos. eliminated]</unittitle>
+                <container label="Box" type="box">696</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Box Nos. eliminated]</unittitle>
+                <container label="Box" type="box">697</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Box Nos. eliminated]</unittitle>
+                <container label="Box" type="box">698</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Box Nos. eliminated]</unittitle>
+                <container label="Box" type="box">699</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Box Nos. eliminated]</unittitle>
+                <container label="Box" type="box">700</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/granholm.xml
+++ b/Real_Masters_all/granholm.xml
@@ -81396,9 +81396,18 @@ Jennifer Granholm papers, Bentley Historical Library, University of Michigan</p>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">224-225</container>
             <unittitle>Awards, certificates, and gifts from constituents related to First Gentleman Mulhern’s achievements and public activities</unittitle>
+            <container type="box" label="Box">224</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Awards, certificates, and gifts from constituents related to First Gentleman Mulhern’s achievements and public activities</unittitle>
+            <container type="box" label="Box">225</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -81414,9 +81423,63 @@ Jennifer Granholm papers, Bentley Historical Library, University of Michigan</p>
         </c02>
         <c02 level="file">
           <did>
-            <container type="object" label="Framed Citations">1-7</container>
             <unittitle>4 framed awards and certificates of Daniel Mulhern and 3 framed awards and certificates of Governor Granholm</unittitle>
+            <container type="object" label="Framed Citations">1</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>4 framed awards and certificates of Daniel Mulhern and 3 framed awards and certificates of Governor Granholm</unittitle>
+            <container type="object" label="Framed Citations">2</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>4 framed awards and certificates of Daniel Mulhern and 3 framed awards and certificates of Governor Granholm</unittitle>
+            <container type="object" label="Framed Citations">3</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>4 framed awards and certificates of Daniel Mulhern and 3 framed awards and certificates of Governor Granholm</unittitle>
+            <container type="object" label="Framed Citations">4</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>4 framed awards and certificates of Daniel Mulhern and 3 framed awards and certificates of Governor Granholm</unittitle>
+            <container type="object" label="Framed Citations">5</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>4 framed awards and certificates of Daniel Mulhern and 3 framed awards and certificates of Governor Granholm</unittitle>
+            <container type="object" label="Framed Citations">6</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>4 framed awards and certificates of Daniel Mulhern and 3 framed awards and certificates of Governor Granholm</unittitle>
+            <container type="object" label="Framed Citations">7</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/harrisgb.xml
+++ b/Real_Masters_all/harrisgb.xml
@@ -795,7 +795,6 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="reel" label="MF Reels">1-18</container>
             <physloc>mf cab.</physloc>
             <unittitle>Research material</unittitle>
             <physdesc>
@@ -805,6 +804,165 @@
           <odd>
             <p>(including copies of works of Elizabethan literature)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">7</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">15</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">16</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">17</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Research material</unittitle>
+              <container type="reel" label="MF Reels">18</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/hartphil.xml
+++ b/Real_Masters_all/hartphil.xml
@@ -7787,11 +7787,22 @@
           </c03>
           <c03 level="file">
             <did>
-              <container label="Box" type="box">111-112</container>
               <unittitle>
                 <unitdate>Undated</unitdate>
               </unittitle>
+              <container label="Box" type="box">111</container>
             </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate>Undated</unitdate>
+              </unittitle>
+              <container label="Box" type="box">112</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
@@ -34676,7 +34687,6 @@
         </scopecontent>
         <c02 level="file">
           <did>
-            <container label="Boxes" type="box">231-232</container>
             <unittitle>
               <unitdate type="inclusive" normal="1958/1959">1958-1959</unitdate>
             </unittitle>
@@ -34684,6 +34694,25 @@
           <odd>
             <p>(mainly 1959) (arranged by topic or legislative subject)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1958/1959">1958-1959</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">231</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1958/1959">1958-1959</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">232</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -34703,19 +34732,52 @@
         </c02>
         <c02 level="file">
           <did>
-            <container label="Boxes" type="box">234-236</container>
             <unittitle>
               <unitdate type="inclusive" normal="1961">1961</unitdate>
             </unittitle>
+            <container label="Boxes" type="box">234</container>
           </did>
         </c02>
         <c02 level="file">
           <did>
-            <container label="Boxes" type="box">237-238</container>
+            <unittitle>
+              <unitdate type="inclusive" normal="1961">1961</unitdate>
+            </unittitle>
+            <container label="Boxes" type="box">235</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1961">1961</unitdate>
+            </unittitle>
+            <container label="Boxes" type="box">236</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
             <unittitle>
               <unitdate type="inclusive" normal="1962">1962</unitdate>
             </unittitle>
+            <container label="Boxes" type="box">237</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1962">1962</unitdate>
+            </unittitle>
+            <container label="Boxes" type="box">238</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -34727,7 +34789,6 @@
         </c02>
         <c02 level="file">
           <did>
-            <container label="Boxes" type="box">238-241</container>
             <unittitle>
               <unitdate type="inclusive" normal="1964">1964</unitdate>
             </unittitle>
@@ -34735,14 +34796,77 @@
           <odd>
             <p>(includes .5 linear feet re Civil Rights Act)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1964">1964</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">238</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1964">1964</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">239</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1964">1964</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">240</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1964">1964</unitdate>
+              </unittitle>
+              <container label="Boxes" type="box">241</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container label="Boxes" type="box">241-243</container>
             <unittitle>
               <unitdate type="inclusive" normal="1965">1965</unitdate>
             </unittitle>
+            <container label="Boxes" type="box">241</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1965">1965</unitdate>
+            </unittitle>
+            <container label="Boxes" type="box">242</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1965">1965</unitdate>
+            </unittitle>
+            <container label="Boxes" type="box">243</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -35103,9 +35227,36 @@
         </c02>
         <c02 level="file">
           <did>
-            <container label="Boxes" type="box">260-263</container>
             <unittitle><unitdate type="inclusive" normal="1970">1970</unitdate> campaign</unittitle>
+            <container label="Boxes" type="box">260</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle><unitdate type="inclusive" normal="1970">1970</unitdate> campaign</unittitle>
+            <container label="Boxes" type="box">261</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle><unitdate type="inclusive" normal="1970">1970</unitdate> campaign</unittitle>
+            <container label="Boxes" type="box">262</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle><unitdate type="inclusive" normal="1970">1970</unitdate> campaign</unittitle>
+            <container label="Boxes" type="box">263</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -35132,9 +35283,18 @@
         </c02>
         <c02 level="file">
           <did>
-            <container label="Boxes" type="box">265-266</container>
             <unittitle>Microfiche of selective portions of the Hart papers</unittitle>
+            <container label="Boxes" type="box">265</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Microfiche of selective portions of the Hart papers</unittitle>
+            <container label="Boxes" type="box">266</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/hrecsurv.xml
+++ b/Real_Masters_all/hrecsurv.xml
@@ -8236,9 +8236,18 @@ s offices (as well as having some of its own work done by WPA workers), the Bent
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">1-2</container>
             <unittitle>Alpena County <unitdate type="inclusive" normal="1871/1919">1871-1919</unitdate>, <unitdate type="inclusive" normal="1937">1937</unitdate></unittitle>
+            <container type="box" label="Boxes">1</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Alpena County <unitdate type="inclusive" normal="1871/1919">1871-1919</unitdate>, <unitdate type="inclusive" normal="1937">1937</unitdate></unittitle>
+            <container type="box" label="Boxes">2</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -8322,9 +8331,27 @@ s offices (as well as having some of its own work done by WPA workers), the Bent
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">3-5</container>
             <unittitle>Berrien County <unitdate type="inclusive" normal="1832/1941">1832-1941</unitdate></unittitle>
+            <container type="box" label="Boxes">3</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Berrien County <unitdate type="inclusive" normal="1832/1941">1832-1941</unitdate></unittitle>
+            <container type="box" label="Boxes">4</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Berrien County <unitdate type="inclusive" normal="1832/1941">1832-1941</unitdate></unittitle>
+            <container type="box" label="Boxes">5</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -8374,9 +8401,18 @@ s offices (as well as having some of its own work done by WPA workers), the Bent
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">5-6</container>
             <unittitle>Clare County <unitdate type="inclusive" normal="1871/1925">1871-1925</unitdate>, <unitdate type="inclusive" normal="1940">1940</unitdate></unittitle>
+            <container type="box" label="Boxes">5</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Clare County <unitdate type="inclusive" normal="1871/1925">1871-1925</unitdate>, <unitdate type="inclusive" normal="1940">1940</unitdate></unittitle>
+            <container type="box" label="Boxes">6</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -8531,9 +8567,18 @@ s offices (as well as having some of its own work done by WPA workers), the Bent
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">8-9</container>
             <unittitle>Genesee County <unitdate type="inclusive" normal="1836/1895">1836-1895</unitdate></unittitle>
+            <container type="box" label="Boxes">8</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Genesee County <unitdate type="inclusive" normal="1836/1895">1836-1895</unitdate></unittitle>
+            <container type="box" label="Boxes">9</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -8759,9 +8804,18 @@ s offices (as well as having some of its own work done by WPA workers), the Bent
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">11-12</container>
             <unittitle>Jackson County <unitdate type="inclusive" normal="1837/1885">1837-1885</unitdate></unittitle>
+            <container type="box" label="Boxes">11</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Jackson County <unitdate type="inclusive" normal="1837/1885">1837-1885</unitdate></unittitle>
+            <container type="box" label="Boxes">12</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -8802,9 +8856,18 @@ s offices (as well as having some of its own work done by WPA workers), the Bent
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">13-14</container>
             <unittitle>Kent County <unitdate type="inclusive" normal="1845/1888">1845-1888</unitdate></unittitle>
+            <container type="box" label="Boxes">13</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Kent County <unitdate type="inclusive" normal="1845/1888">1845-1888</unitdate></unittitle>
+            <container type="box" label="Boxes">14</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -9426,9 +9489,27 @@ s offices (as well as having some of its own work done by WPA workers), the Bent
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">22-24</container>
             <unittitle>Grand Rapids <unitdate type="inclusive" normal="1838/1873">1838-1873</unitdate></unittitle>
+            <container type="box" label="Boxes">22</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Grand Rapids <unitdate type="inclusive" normal="1838/1873">1838-1873</unitdate></unittitle>
+            <container type="box" label="Boxes">23</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Grand Rapids <unitdate type="inclusive" normal="1838/1873">1838-1873</unitdate></unittitle>
+            <container type="box" label="Boxes">24</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/iogeront.xml
+++ b/Real_Masters_all/iogeront.xml
@@ -4152,12 +4152,26 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">23-24</container>
             <unittitle>Institute of Gerontology collection of speeches, conferences, training sessions</unittitle>
             <physdesc>
               <extent>approx. 100 cassettes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Institute of Gerontology collection of speeches, conferences, training sessions</unittitle>
+              <container type="box" label="Box">23</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Institute of Gerontology collection of speeches, conferences, training sessions</unittitle>
+              <container type="box" label="Box">24</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/iogt.xml
+++ b/Real_Masters_all/iogt.xml
@@ -540,12 +540,26 @@ International Organization of Good Templars records, Bentley Historical Library,
         </did>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">18-19</container>
             <unittitle>Temperance books and pamphlets <unitdate type="inclusive" normal="1865/1963">1865-1963</unitdate></unittitle>
           </did>
           <odd>
             <p>(in Swedish and Norwegian)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Temperance books and pamphlets <unitdate type="inclusive" normal="1865/1963">1865-1963</unitdate></unittitle>
+              <container type="box" label="Box">18</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Temperance books and pamphlets <unitdate type="inclusive" normal="1865/1963">1865-1963</unitdate></unittitle>
+              <container type="box" label="Box">19</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/ismrrd.xml
+++ b/Real_Masters_all/ismrrd.xml
@@ -1756,9 +1756,18 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">9-10</container>
             <unittitle>Developmental Disabilities Office (DDO)</unittitle>
+            <container type="box" label="Box">9</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Developmental Disabilities Office (DDO)</unittitle>
+            <container type="box" label="Box">10</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -1768,9 +1777,18 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">10-11</container>
             <unittitle>Early Intervention</unittitle>
+            <container type="box" label="Box">10</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Early Intervention</unittitle>
+            <container type="box" label="Box">11</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -1888,9 +1906,27 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">12-14</container>
             <unittitle>Maternal and Child Health</unittitle>
+            <container type="box" label="Box">12</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Maternal and Child Health</unittitle>
+            <container type="box" label="Box">13</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Maternal and Child Health</unittitle>
+            <container type="box" label="Box">14</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -2130,19 +2166,41 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">20-21</container>
             <unittitle>
               <unitdate type="inclusive" normal="1972/1973">1972/73</unitdate>
             </unittitle>
+            <container type="box" label="Box">20</container>
           </did>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">21-22</container>
+            <unittitle>
+              <unitdate type="inclusive" normal="1972/1973">1972/73</unitdate>
+            </unittitle>
+            <container type="box" label="Box">21</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
             <unittitle>
               <unitdate type="inclusive" normal="1973">1973</unitdate>
             </unittitle>
+            <container type="box" label="Box">21</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1973">1973</unitdate>
+            </unittitle>
+            <container type="box" label="Box">22</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -2154,19 +2212,52 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">23-24</container>
             <unittitle>
               <unitdate type="inclusive" normal="1974">1974</unitdate>
             </unittitle>
+            <container type="box" label="Box">23</container>
           </did>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">24-26</container>
+            <unittitle>
+              <unitdate type="inclusive" normal="1974">1974</unitdate>
+            </unittitle>
+            <container type="box" label="Box">24</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
             <unittitle>
               <unitdate type="inclusive" normal="1974/1975">1974/75</unitdate>
             </unittitle>
+            <container type="box" label="Box">24</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1974/1975">1974/75</unitdate>
+            </unittitle>
+            <container type="box" label="Box">25</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1974/1975">1974/75</unitdate>
+            </unittitle>
+            <container type="box" label="Box">26</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -2178,19 +2269,41 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">26-27</container>
             <unittitle>
               <unitdate type="inclusive" normal="1975/1976">1975/76</unitdate>
             </unittitle>
+            <container type="box" label="Box">26</container>
           </did>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">27-28</container>
+            <unittitle>
+              <unitdate type="inclusive" normal="1975/1976">1975/76</unitdate>
+            </unittitle>
+            <container type="box" label="Box">27</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
             <unittitle>
               <unitdate type="inclusive" normal="1976">1976</unitdate>
             </unittitle>
+            <container type="box" label="Box">27</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1976">1976</unitdate>
+            </unittitle>
+            <container type="box" label="Box">28</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -2202,35 +2315,112 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">28-31</container>
             <unittitle>
               <unitdate type="inclusive" normal="1977">1977</unitdate>
             </unittitle>
+            <container type="box" label="Box">28</container>
           </did>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">31-32</container>
+            <unittitle>
+              <unitdate type="inclusive" normal="1977">1977</unitdate>
+            </unittitle>
+            <container type="box" label="Box">29</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1977">1977</unitdate>
+            </unittitle>
+            <container type="box" label="Box">30</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1977">1977</unitdate>
+            </unittitle>
+            <container type="box" label="Box">31</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
             <unittitle>
               <unitdate type="inclusive" normal="1977/1978">1977/78</unitdate>
             </unittitle>
+            <container type="box" label="Box">31</container>
           </did>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">32-33</container>
+            <unittitle>
+              <unitdate type="inclusive" normal="1977/1978">1977/78</unitdate>
+            </unittitle>
+            <container type="box" label="Box">32</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
             <unittitle>
               <unitdate type="inclusive" normal="1978">1978</unitdate>
             </unittitle>
+            <container type="box" label="Box">32</container>
           </did>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">33-35</container>
+            <unittitle>
+              <unitdate type="inclusive" normal="1978">1978</unitdate>
+            </unittitle>
+            <container type="box" label="Box">33</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
             <unittitle>
               <unitdate type="inclusive" normal="1978/1979">1978/79</unitdate>
             </unittitle>
+            <container type="box" label="Box">33</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1978/1979">1978/79</unitdate>
+            </unittitle>
+            <container type="box" label="Box">34</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1978/1979">1978/79</unitdate>
+            </unittitle>
+            <container type="box" label="Box">35</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -2250,11 +2440,44 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">36-39</container>
             <unittitle>
               <unitdate type="inclusive" normal="1980">1980</unitdate>
             </unittitle>
+            <container type="box" label="Box">36</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1980">1980</unitdate>
+            </unittitle>
+            <container type="box" label="Box">37</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1980">1980</unitdate>
+            </unittitle>
+            <container type="box" label="Box">38</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1980">1980</unitdate>
+            </unittitle>
+            <container type="box" label="Box">39</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -2266,11 +2489,22 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">40-41</container>
             <unittitle>
               <unitdate type="inclusive" normal="1981">1981</unitdate>
             </unittitle>
+            <container type="box" label="Box">40</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1981">1981</unitdate>
+            </unittitle>
+            <container type="box" label="Box">41</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -2282,19 +2516,63 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">41-44</container>
             <unittitle>
               <unitdate type="inclusive" normal="1982">1982</unitdate>
             </unittitle>
+            <container type="box" label="Box">41</container>
           </did>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">44-45</container>
+            <unittitle>
+              <unitdate type="inclusive" normal="1982">1982</unitdate>
+            </unittitle>
+            <container type="box" label="Box">42</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1982">1982</unitdate>
+            </unittitle>
+            <container type="box" label="Box">43</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1982">1982</unitdate>
+            </unittitle>
+            <container type="box" label="Box">44</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
             <unittitle>
               <unitdate type="inclusive" normal="1982/1983">1982/83</unitdate>
             </unittitle>
+            <container type="box" label="Box">44</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>
+              <unitdate type="inclusive" normal="1982/1983">1982/83</unitdate>
+            </unittitle>
+            <container type="box" label="Box">45</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -2346,9 +2624,18 @@ Institute for the Study of Mental Retardation and Related Disabilities (Universi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">47-48</container>
             <unittitle>Publications</unittitle>
+            <container type="box" label="Box">47</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Publications</unittitle>
+            <container type="box" label="Box">48</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/kahnalb.xml
+++ b/Real_Masters_all/kahnalb.xml
@@ -6217,7 +6217,6 @@
           </did>
           <c03 level="file">
             <did>
-              <container label="Volume" type="volume">12-13</container>
               <unittitle>Furniture (Books I &amp; II)</unittitle>
               <physdesc>
                 <physfacet>catalogue photographs and prints of furniture drawings</physfacet>
@@ -6226,6 +6225,21 @@
             <odd>
               <p>[vols. 12 &amp; 13]</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Furniture (Books I &amp; II)</unittitle>
+                <container label="Volume" type="volume">12</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Furniture (Books I &amp; II)</unittitle>
+                <container label="Volume" type="volume">13</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="file">
@@ -6234,7 +6248,6 @@
           </did>
           <c03 level="file">
             <did>
-              <container label="Volume" type="volume">10-11</container>
               <unittitle>Furniture and Draperies by W. &amp; J. Sloane, New York (Books I &amp; II)</unittitle>
               <physdesc>
                 <physfacet>catalogue photographs, blueprints of furniture drawings, and fabric swatches</physfacet>
@@ -6243,6 +6256,21 @@
             <odd>
               <p>[vols. 10 &amp; 11]</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Furniture and Draperies by W. &amp; J. Sloane, New York (Books I &amp; II)</unittitle>
+                <container label="Volume" type="volume">10</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Furniture and Draperies by W. &amp; J. Sloane, New York (Books I &amp; II)</unittitle>
+                <container label="Volume" type="volume">11</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/mgleecl.xml
+++ b/Real_Masters_all/mgleecl.xml
@@ -520,9 +520,18 @@
         </did>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">5-6</container>
             <unittitle>Photos</unittitle>
+            <container type="box" label="Box">5</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Photos</unittitle>
+            <container type="box" label="Box">6</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/murphyf.xml
+++ b/Real_Masters_all/murphyf.xml
@@ -7021,9 +7021,27 @@
         </c02>
         <c02 level="file">
           <did>
-            <container label="Box" type="box">87-89</container>
             <unittitle>Memorandum to Attorney General Frank Murphy from the Federal Bureau of Investigation <unitdate type="inclusive" normal="1939">1939</unitdate></unittitle>
+            <container label="Box" type="box">87</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Memorandum to Attorney General Frank Murphy from the Federal Bureau of Investigation <unitdate type="inclusive" normal="1939">1939</unitdate></unittitle>
+            <container label="Box" type="box">88</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Memorandum to Attorney General Frank Murphy from the Federal Bureau of Investigation <unitdate type="inclusive" normal="1939">1939</unitdate></unittitle>
+            <container label="Box" type="box">89</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/nursing.xml
+++ b/Real_Masters_all/nursing.xml
@@ -16768,12 +16768,35 @@
           </scopecontent>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">69-71</container>
               <unittitle>[Unprocessed files]</unittitle>
             </did>
             <accessrestrict>
               <p>[ER RESTRICTED until <date type="restriction" normal="2024-07-01">July 1, 2024</date>]</p>
             </accessrestrict>
+            <c04 level="file">
+              <did>
+                <unittitle>[Unprocessed files]</unittitle>
+                <container type="box" label="Box">69</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Unprocessed files]</unittitle>
+                <container type="box" label="Box">70</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[Unprocessed files]</unittitle>
+                <container type="box" label="Box">71</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
       </c01>

--- a/Real_Masters_all/oharajas.xml
+++ b/Real_Masters_all/oharajas.xml
@@ -4809,9 +4809,27 @@
           </c03>
           <c03 level="file">
             <did>
-              <container label="Boxes" type="box">41-43</container>
               <unittitle>Newspaper Clippings</unittitle>
+              <container label="Boxes" type="box">41</container>
             </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Newspaper Clippings</unittitle>
+              <container label="Boxes" type="box">42</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Newspaper Clippings</unittitle>
+              <container label="Boxes" type="box">43</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
           </c03>
         </c02>
         <c02 level="series">

--- a/Real_Masters_all/parsonsj.xml
+++ b/Real_Masters_all/parsonsj.xml
@@ -20643,7 +20643,6 @@ Jeffrey R. Parsons papers, Bentley Historical Library, University of Michigan</p
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Box">26-27</container>
                 <unittitle>Rolls 51-55</unittitle>
                 <dao href="MTE-11" show="new" actuate="onrequest">
                   <daodesc>
@@ -20651,6 +20650,21 @@ Jeffrey R. Parsons papers, Bentley Historical Library, University of Michigan</p
                   </daodesc>
                 </dao>
               </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Rolls 51-55</unittitle>
+                  <container type="box" label="Box">26</container>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Rolls 51-55</unittitle>
+                  <container type="box" label="Box">27</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/penncent.xml
+++ b/Real_Masters_all/penncent.xml
@@ -9303,11 +9303,22 @@
                 </c06>
                 <c06 level="file">
                   <did>
-                    <container type="volume" label="Oversize Volume">45-46</container>
                     <unittitle>
                       <unitdate type="inclusive" normal="1882">1882</unitdate>
                     </unittitle>
+                    <container type="volume" label="Oversize Volume">45</container>
                   </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>
+                      <unitdate type="inclusive" normal="1882">1882</unitdate>
+                    </unittitle>
+                    <container type="volume" label="Oversize Volume">46</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
                 </c06>
                 <c06 level="file">
                   <did>

--- a/Real_Masters_all/pharmacy.xml
+++ b/Real_Masters_all/pharmacy.xml
@@ -7267,7 +7267,6 @@
         </scopecontent>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">35-37</container>
             <unittitle>
               <unitdate type="inclusive" normal="1989/1994">1989-1994</unitdate>
             </unittitle>
@@ -7275,6 +7274,36 @@
           <accessrestrict>
             <p>[PR RESTRICTED until July 1 <date type="restriction" normal="2034-07-01">2034</date>]</p>
           </accessrestrict>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1989/1994">1989-1994</unitdate>
+              </unittitle>
+              <container type="box" label="Box">35</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1989/1994">1989-1994</unitdate>
+              </unittitle>
+              <container type="box" label="Box">36</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1989/1994">1989-1994</unitdate>
+              </unittitle>
+              <container type="box" label="Box">37</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/plantext.xml
+++ b/Real_Masters_all/plantext.xml
@@ -148,12 +148,35 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="tube" label="Tubes">1-3</container>
             <unittitle>Detroit Observatory <unitdate type="inclusive" normal="1907/1909">1907-1909</unitdate></unittitle>
             <physdesc>
               <physfacet>oversize tubes</physfacet>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Detroit Observatory <unitdate type="inclusive" normal="1907/1909">1907-1909</unitdate></unittitle>
+              <container type="tube" label="Tubes">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Detroit Observatory <unitdate type="inclusive" normal="1907/1909">1907-1909</unitdate></unittitle>
+              <container type="tube" label="Tubes">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Detroit Observatory <unitdate type="inclusive" normal="1907/1909">1907-1909</unitdate></unittitle>
+              <container type="tube" label="Tubes">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -382,21 +405,58 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="tube" label="Tube">10-11</container>
             <unittitle>Michigan Union <unitdate type="inclusive" normal="1917">1917</unitdate></unittitle>
             <physdesc>
               <physfacet>oversize tubes</physfacet>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Michigan Union <unitdate type="inclusive" normal="1917">1917</unitdate></unittitle>
+              <container type="tube" label="Tube">10</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Michigan Union <unitdate type="inclusive" normal="1917">1917</unitdate></unittitle>
+              <container type="tube" label="Tube">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="tube" label="Tubes">12-14</container>
             <unittitle>Natural Science Building <unitdate type="inclusive" normal="1914">1914</unitdate></unittitle>
             <physdesc>
               <physfacet>oversize tubes</physfacet>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Natural Science Building <unitdate type="inclusive" normal="1914">1914</unitdate></unittitle>
+              <container type="tube" label="Tubes">12</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Natural Science Building <unitdate type="inclusive" normal="1914">1914</unitdate></unittitle>
+              <container type="tube" label="Tubes">13</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Natural Science Building <unitdate type="inclusive" normal="1914">1914</unitdate></unittitle>
+              <container type="tube" label="Tubes">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -430,10 +490,24 @@
         </c02>
         <c02 level="file">
           <did>
-            <container type="tube" label="Tubes">15-16</container>
             <unittitle>Planting Diagrams <unitdate type="inclusive" normal="1910/1938">1910-1938</unitdate></unittitle>
             <physdesc>oversize tubes</physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Planting Diagrams <unitdate type="inclusive" normal="1910/1938">1910-1938</unitdate></unittitle>
+              <container type="tube" label="Tubes">15</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Planting Diagrams <unitdate type="inclusive" normal="1910/1938">1910-1938</unitdate></unittitle>
+              <container type="tube" label="Tubes">16</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/rackhamg.xml
+++ b/Real_Masters_all/rackhamg.xml
@@ -2027,9 +2027,27 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">76-78</container>
               <unittitle>Topical File (A-Z)</unittitle>
+              <container type="box" label="Box">76</container>
             </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Topical File (A-Z)</unittitle>
+              <container type="box" label="Box">77</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Topical File (A-Z)</unittitle>
+              <container type="box" label="Box">78</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
           </c03>
         </c02>
         <c02 level="subseries">

--- a/Real_Masters_all/romneyg.xml
+++ b/Real_Masters_all/romneyg.xml
@@ -24071,9 +24071,18 @@
             </c04>
             <c04 level="file">
               <did>
-                <container label="Boxes" type="box">302-303</container>
                 <unittitle>Invitations to Lenore Romney</unittitle>
+                <container label="Boxes" type="box">302</container>
               </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Invitations to Lenore Romney</unittitle>
+                <container label="Boxes" type="box">303</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
             </c04>
           </c03>
           <c03 level="subseries">
@@ -24085,43 +24094,98 @@
             </scopecontent>
             <c04 level="file">
               <did>
-                <container label="Box" type="box">304-305</container>
                 <unittitle>
                   <unitdate type="inclusive" normal="1963">1963</unitdate>
                 </unittitle>
+                <container label="Box" type="box">304</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Boxes" type="box">306-307</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1963">1963</unitdate>
+                </unittitle>
+                <container label="Box" type="box">305</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1964">1964</unitdate>
                 </unittitle>
+                <container label="Boxes" type="box">306</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Boxes" type="box">308-309</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1964">1964</unitdate>
+                </unittitle>
+                <container label="Boxes" type="box">307</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1965">1965</unitdate>
                 </unittitle>
+                <container label="Boxes" type="box">308</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Boxes" type="box">309-310</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1965">1965</unitdate>
+                </unittitle>
+                <container label="Boxes" type="box">309</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1966">1966</unitdate>
                 </unittitle>
+                <container label="Boxes" type="box">309</container>
               </did>
             </c04>
             <c04 level="file">
               <did>
-                <container label="Boxes" type="box">310-311</container>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1966">1966</unitdate>
+                </unittitle>
+                <container label="Boxes" type="box">310</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
                 <unittitle>
                   <unitdate type="inclusive" normal="1967">1967</unitdate>
                 </unittitle>
+                <container label="Boxes" type="box">310</container>
               </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1967">1967</unitdate>
+                </unittitle>
+                <container label="Boxes" type="box">311</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>
@@ -31367,9 +31431,162 @@
               </did>
               <c05 level="file">
                 <did>
-                  <container label="Box" type="box">379-396</container>
                   <unittitle>Name files</unittitle>
+                  <container label="Box" type="box">379</container>
                 </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Name files</unittitle>
+                  <container label="Box" type="box">380</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Name files</unittitle>
+                  <container label="Box" type="box">381</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Name files</unittitle>
+                  <container label="Box" type="box">382</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Name files</unittitle>
+                  <container label="Box" type="box">383</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Name files</unittitle>
+                  <container label="Box" type="box">384</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Name files</unittitle>
+                  <container label="Box" type="box">385</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Name files</unittitle>
+                  <container label="Box" type="box">386</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Name files</unittitle>
+                  <container label="Box" type="box">387</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Name files</unittitle>
+                  <container label="Box" type="box">388</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Name files</unittitle>
+                  <container label="Box" type="box">389</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Name files</unittitle>
+                  <container label="Box" type="box">390</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Name files</unittitle>
+                  <container label="Box" type="box">391</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Name files</unittitle>
+                  <container label="Box" type="box">392</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Name files</unittitle>
+                  <container label="Box" type="box">393</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Name files</unittitle>
+                  <container label="Box" type="box">394</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Name files</unittitle>
+                  <container label="Box" type="box">395</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Name files</unittitle>
+                  <container label="Box" type="box">396</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
               </c05>
             </c04>
             <c04 level="otherlevel" otherlevel="sub-subseries">
@@ -31378,9 +31595,18 @@
               </did>
               <c05 level="file">
                 <did>
-                  <container label="Box" type="box">397-398</container>
                   <unittitle>Case files</unittitle>
+                  <container label="Box" type="box">397</container>
                 </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Case files</unittitle>
+                  <container label="Box" type="box">398</container>
+                </did>
+                <odd>
+                  <p>(continued)</p>
+                </odd>
               </c05>
             </c04>
             <c04 level="otherlevel" otherlevel="sub-subseries">

--- a/Real_Masters_all/ruthvena.xml
+++ b/Real_Masters_all/ruthvena.xml
@@ -15911,9 +15911,18 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">60-61</container>
               <unittitle>Speeches as president (various topics) <unitdate type="inclusive" normal="1929/1951">1929-1951</unitdate></unittitle>
+              <container type="box" label="Box">60</container>
             </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Speeches as president (various topics) <unitdate type="inclusive" normal="1929/1951">1929-1951</unitdate></unittitle>
+              <container type="box" label="Box">61</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/saxj.xml
+++ b/Real_Masters_all/saxj.xml
@@ -1530,9 +1530,27 @@ Joseph L. Sax papers, Bentley Historical Library, University of Michigan</p>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">13-15</container>
               <unittitle>Pigeon River Case (West Michigan Environmental Action Council v. Natural Resources Commission)</unittitle>
+              <container type="box" label="Box">13</container>
             </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Pigeon River Case (West Michigan Environmental Action Council v. Natural Resources Commission)</unittitle>
+              <container type="box" label="Box">14</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Pigeon River Case (West Michigan Environmental Action Council v. Natural Resources Commission)</unittitle>
+              <container type="box" label="Box">15</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/sibleyjb.xml
+++ b/Real_Masters_all/sibleyjb.xml
@@ -135,12 +135,26 @@
         </did>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">1-2</container>
             <unittitle>Helmet, shell casing trench art (75 mm), 37 mm shell, VFW Post 436 cap, and uniform insignia</unittitle>
           </did>
           <odd>
             <p>Artifacts have not been digitized</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Helmet, shell casing trench art (75 mm), 37 mm shell, VFW Post 436 cap, and uniform insignia</unittitle>
+              <container type="box" label="Box">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Helmet, shell casing trench art (75 mm), 37 mm shell, VFW Post 436 cap, and uniform insignia</unittitle>
+              <container type="box" label="Box">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/sincljl.xml
+++ b/Real_Masters_all/sincljl.xml
@@ -7712,12 +7712,35 @@
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">33-35</container>
               <unittitle>Underground and White Panther publications</unittitle>
             </did>
             <odd>
               <p>See inventory in Appendix I</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Underground and White Panther publications</unittitle>
+                <container type="box" label="Box">33</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Underground and White Panther publications</unittitle>
+                <container type="box" label="Box">34</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Underground and White Panther publications</unittitle>
+                <container type="box" label="Box">35</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/snre.xml
+++ b/Real_Masters_all/snre.xml
@@ -8515,9 +8515,18 @@
         </scopecontent>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">42-43</container>
             <unittitle>Course Files</unittitle>
+            <container type="box" label="Box">42</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Course Files</unittitle>
+            <container type="box" label="Box">43</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/taubmana.xml
+++ b/Real_Masters_all/taubmana.xml
@@ -14340,9 +14340,36 @@ A. Alfred Taubman papers, Bentley Historical Library, University of Michigan</p>
             </c04>
             <c04 level="file">
               <did>
-                <container type="box" label="Boxes">150-153</container>
                 <unittitle>[With additional processing and consolidation these box numbers were eliminated.]</unittitle>
+                <container type="box" label="Boxes">150</container>
               </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[With additional processing and consolidation these box numbers were eliminated.]</unittitle>
+                <container type="box" label="Boxes">151</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[With additional processing and consolidation these box numbers were eliminated.]</unittitle>
+                <container type="box" label="Boxes">152</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>[With additional processing and consolidation these box numbers were eliminated.]</unittitle>
+                <container type="box" label="Boxes">153</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
             </c04>
           </c03>
           <c03 level="otherlevel" otherlevel="sub-subseries">
@@ -24036,7 +24063,6 @@ A. Alfred Taubman papers, Bentley Historical Library, University of Michigan</p>
         </did>
         <c02 level="file">
           <did>
-            <container type="object" label="Display Panels">1-12</container>
             <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
             <physdesc>
               <extent>12 panels</extent>
@@ -24045,6 +24071,111 @@ A. Alfred Taubman papers, Bentley Historical Library, University of Michigan</p>
           <odd>
             <p>(The panels include photographs together with a time-line of significant events in Taubman's career)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">5</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">7</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">9</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">11</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Exhibit produced by Lawrence Technological University in <unitdate type="inclusive" normal="2012">2012</unitdate> entitled "Pioneering the Purchase: A Retrospective Exhibition Honoring A. Alfred Taubman"</unittitle>
+              <container type="object" label="Display Panels">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02>
           <did>

--- a/Real_Masters_all/umhosp.xml
+++ b/Real_Masters_all/umhosp.xml
@@ -9813,7 +9813,6 @@ Hospitals (University of Michigan) records, Bentley Historical Library, Universi
           </c03>
           <c03 level="file">
             <did>
-              <container type="volume" label="Oversize volumes">2-33</container>
               <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
             </did>
             <odd>
@@ -9822,6 +9821,291 @@ Hospitals (University of Michigan) records, Bentley Historical Library, Universi
             <accessrestrict>
               <p>Closed to research</p>
             </accessrestrict>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">2</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">3</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">4</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">5</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">6</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">7</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">8</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">9</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">10</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">11</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">12</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">13</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">14</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">15</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">16</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">17</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">18</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">19</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">20</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">21</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">22</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">23</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">24</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">25</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">26</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">27</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">28</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">29</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">30</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">31</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">32</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Patient Registration Books <unitdate type="inclusive" normal="1923-07/1975-04" certainty="approximate">July 1923-April 1975</unitdate></unittitle>
+                <container type="volume" label="Oversize volumes">33</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
       </c01>
@@ -9838,12 +10122,89 @@ Hospitals (University of Michigan) records, Bentley Historical Library, Universi
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">40-48</container>
               <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
             </did>
             <accessrestrict>
               <p>Closed to research</p>
             </accessrestrict>
+            <c04 level="file">
+              <did>
+                <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
+                <container type="box" label="Box">40</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
+                <container type="box" label="Box">41</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
+                <container type="box" label="Box">42</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
+                <container type="box" label="Box">43</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
+                <container type="box" label="Box">44</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
+                <container type="box" label="Box">45</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
+                <container type="box" label="Box">46</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
+                <container type="box" label="Box">47</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Replacement Hospital Plans (Microfiche)</unittitle>
+                <container type="box" label="Box">48</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/umpresid.xml
+++ b/Real_Masters_all/umpresid.xml
@@ -65671,7 +65671,6 @@
               </c05>
               <c05 level="file">
                 <did>
-                  <container type="box" label="Box">229-230</container>
                   <unittitle>Faculty and Staff Case Materials (1970s-1980s bulk 1980s)</unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">19 folders</extent>
@@ -65680,6 +65679,21 @@
                 <accessrestrict>
                   <p>[PR RESTRICTED until 30 years from date of creation]</p>
                 </accessrestrict>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Faculty and Staff Case Materials (1970s-1980s bulk 1980s)</unittitle>
+                    <container type="box" label="Box">229</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Faculty and Staff Case Materials (1970s-1980s bulk 1980s)</unittitle>
+                    <container type="box" label="Box">230</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
               <c05 level="file">
                 <did>

--- a/Real_Masters_all/umpubs.xml
+++ b/Real_Masters_all/umpubs.xml
@@ -764,12 +764,26 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">15-16</container>
               <unittitle>Center for Great Lakes and Aquatic Sciences</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Center for Great Lakes and Aquatic Sciences</unittitle>
+                <container type="box" label="Box">15</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Center for Great Lakes and Aquatic Sciences</unittitle>
+                <container type="box" label="Box">16</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -829,12 +843,35 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">19-21</container>
               <unittitle>Center for Research on Economic Development (CRED)</unittitle>
               <physdesc>
                 <extent>3 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Center for Research on Economic Development (CRED)</unittitle>
+                <container type="box" label="Box">19</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Center for Research on Economic Development (CRED)</unittitle>
+                <container type="box" label="Box">20</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Center for Research on Economic Development (CRED)</unittitle>
+                <container type="box" label="Box">21</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -964,12 +1001,53 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">26-30</container>
               <unittitle>College of Engineering</unittitle>
               <physdesc>
                 <extent>4 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>College of Engineering</unittitle>
+                <container type="box" label="Box">26</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>College of Engineering</unittitle>
+                <container type="box" label="Box">27</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>College of Engineering</unittitle>
+                <container type="box" label="Box">28</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>College of Engineering</unittitle>
+                <container type="box" label="Box">29</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>College of Engineering</unittitle>
+                <container type="box" label="Box">30</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -1685,21 +1763,58 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">70-72</container>
               <unittitle>Executive Vice President and Chief Financial Officer</unittitle>
               <physdesc>
                 <extent>3 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Executive Vice President and Chief Financial Officer</unittitle>
+                <container type="box" label="Box">70</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Executive Vice President and Chief Financial Officer</unittitle>
+                <container type="box" label="Box">71</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Executive Vice President and Chief Financial Officer</unittitle>
+                <container type="box" label="Box">72</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">73-74</container>
               <unittitle>Extension Service</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Extension Service</unittitle>
+                <container type="box" label="Box">73</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Extension Service</unittitle>
+                <container type="box" label="Box">74</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2038,12 +2153,26 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">88-89</container>
               <unittitle>Horace H. Rackham School of Graduate Studies</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Horace H. Rackham School of Graduate Studies</unittitle>
+                <container type="box" label="Box">88</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Horace H. Rackham School of Graduate Studies</unittitle>
+                <container type="box" label="Box">89</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2106,12 +2235,26 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">92-93</container>
               <unittitle>Information Technology Division/Information Technology Central Services</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Information Technology Division/Information Technology Central Services</unittitle>
+                <container type="box" label="Box">92</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Information Technology Division/Information Technology Central Services</unittitle>
+                <container type="box" label="Box">93</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2156,12 +2299,26 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">95-96</container>
               <unittitle>Institute for Social Research -- Monitoring the Future</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Institute for Social Research -- Monitoring the Future</unittitle>
+                <container type="box" label="Box">95</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Institute for Social Research -- Monitoring the Future</unittitle>
+                <container type="box" label="Box">96</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2195,12 +2352,44 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">99-102</container>
               <unittitle>Institute of Gerontology</unittitle>
               <physdesc>
                 <extent>4 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Institute of Gerontology</unittitle>
+                <container type="box" label="Box">99</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Institute of Gerontology</unittitle>
+                <container type="box" label="Box">100</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Institute of Gerontology</unittitle>
+                <container type="box" label="Box">101</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Institute of Gerontology</unittitle>
+                <container type="box" label="Box">102</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2255,9 +2444,18 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">109-110</container>
               <unittitle>International Institute</unittitle>
+              <container type="box" label="Box">109</container>
             </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>International Institute</unittitle>
+              <container type="box" label="Box">110</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
@@ -2498,12 +2696,26 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">117-118</container>
               <unittitle>M-Care</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>M-Care</unittitle>
+                <container type="box" label="Box">117</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>M-Care</unittitle>
+                <container type="box" label="Box">118</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2606,12 +2818,44 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">121-124</container>
               <unittitle>Medical School</unittitle>
               <physdesc>
                 <extent>4 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Medical School</unittitle>
+                <container type="box" label="Box">121</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Medical School</unittitle>
+                <container type="box" label="Box">122</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Medical School</unittitle>
+                <container type="box" label="Box">123</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Medical School</unittitle>
+                <container type="box" label="Box">124</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -2901,12 +3145,26 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">139-140</container>
               <unittitle>News and Information Services</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>News and Information Services</unittitle>
+                <container type="box" label="Box">139</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>News and Information Services</unittitle>
+                <container type="box" label="Box">140</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3062,12 +3320,35 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">149-151</container>
               <unittitle>Office of Orientation</unittitle>
               <physdesc>
                 <extent>3 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Office of Orientation</unittitle>
+                <container type="box" label="Box">149</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Office of Orientation</unittitle>
+                <container type="box" label="Box">150</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Office of Orientation</unittitle>
+                <container type="box" label="Box">151</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3729,30 +4010,81 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">174-175</container>
               <unittitle>School of Business Administration</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>School of Business Administration</unittitle>
+                <container type="box" label="Box">174</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>School of Business Administration</unittitle>
+                <container type="box" label="Box">175</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">176-177</container>
               <unittitle>School of Dentistry</unittitle>
               <physdesc>
                 <extent/>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>School of Dentistry</unittitle>
+                <container type="box" label="Box">176</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>School of Dentistry</unittitle>
+                <container type="box" label="Box">177</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">178-180</container>
               <unittitle>School of Education</unittitle>
               <physdesc>
                 <extent>3 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>School of Education</unittitle>
+                <container type="box" label="Box">178</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>School of Education</unittitle>
+                <container type="box" label="Box">179</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>School of Education</unittitle>
+                <container type="box" label="Box">180</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -3881,12 +4213,26 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">190-191</container>
               <unittitle>Solar Car Project</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Solar Car Project</unittitle>
+                <container type="box" label="Box">190</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Solar Car Project</unittitle>
+                <container type="box" label="Box">191</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -4467,12 +4813,26 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">211-212</container>
               <unittitle>University of Michigan Library</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>University of Michigan Library</unittitle>
+                <container type="box" label="Box">211</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>University of Michigan Library</unittitle>
+                <container type="box" label="Box">212</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -4565,30 +4925,72 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">220-221</container>
               <unittitle>Vice President for Academic Affairs</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Vice President for Academic Affairs</unittitle>
+                <container type="box" label="Box">220</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Vice President for Academic Affairs</unittitle>
+                <container type="box" label="Box">221</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">222-223</container>
               <unittitle>Vice President for Development</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Vice President for Development</unittitle>
+                <container type="box" label="Box">222</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Vice President for Development</unittitle>
+                <container type="box" label="Box">223</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">224-225</container>
               <unittitle>Vice President for State and Community Relations/Vice President for State and Government Relations</unittitle>
               <physdesc>
                 <extent>2 boxes</extent>
               </physdesc>
             </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Vice President for State and Community Relations/Vice President for State and Government Relations</unittitle>
+                <container type="box" label="Box">224</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Vice President for State and Community Relations/Vice President for State and Government Relations</unittitle>
+                <container type="box" label="Box">225</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/umussoc.xml
+++ b/Real_Masters_all/umussoc.xml
@@ -4753,7 +4753,6 @@ University Musical Society (University of Michigan) Records, Bentley Historical 
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">124-127</container>
             <unittitle>
               <unitdate type="inclusive" normal="1986/2005">1986/87-2004/05</unitdate>
             </unittitle>
@@ -4761,6 +4760,47 @@ University Musical Society (University of Michigan) Records, Bentley Historical 
           <accessrestrict>
             <p>[Closed for Research, Records Center Storage]</p>
           </accessrestrict>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1986/2005">1986/87-2004/05</unitdate>
+              </unittitle>
+              <container type="box" label="Boxes">124</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1986/2005">1986/87-2004/05</unitdate>
+              </unittitle>
+              <container type="box" label="Boxes">125</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1986/2005">1986/87-2004/05</unitdate>
+              </unittitle>
+              <container type="box" label="Boxes">126</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1986/2005">1986/87-2004/05</unitdate>
+              </unittitle>
+              <container type="box" label="Boxes">127</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/vpcfo.xml
+++ b/Real_Masters_all/vpcfo.xml
@@ -4285,9 +4285,72 @@ Vice President and Chief Financial Officer (University of Michigan) Records, Ben
           </c03>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">26-33</container>
               <unittitle>[Eliminated During Reprocessing]</unittitle>
+              <container type="box" label="Box">26</container>
             </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>[Eliminated During Reprocessing]</unittitle>
+              <container type="box" label="Box">27</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>[Eliminated During Reprocessing]</unittitle>
+              <container type="box" label="Box">28</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>[Eliminated During Reprocessing]</unittitle>
+              <container type="box" label="Box">29</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>[Eliminated During Reprocessing]</unittitle>
+              <container type="box" label="Box">30</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>[Eliminated During Reprocessing]</unittitle>
+              <container type="box" label="Box">31</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>[Eliminated During Reprocessing]</unittitle>
+              <container type="box" label="Box">32</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>[Eliminated During Reprocessing]</unittitle>
+              <container type="box" label="Box">33</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
           </c03>
         </c02>
         <c02 level="subseries">

--- a/Real_Masters_all/wallm60m.xml
+++ b/Real_Masters_all/wallm60m.xml
@@ -24526,9 +24526,18 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">147-148</container>
             <unittitle>Biographies and clippings about MW <unitdate type="inclusive" normal="1990/1999" certainty="approximate">1990s</unitdate></unittitle>
+            <container type="box" label="Box">147</container>
           </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Biographies and clippings about MW <unitdate type="inclusive" normal="1990/1999" certainty="approximate">1990s</unitdate></unittitle>
+            <container type="box" label="Box">148</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -25894,21 +25903,76 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
         </accessrestrict>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">98-99</container>
             <unittitle>Anthony Herbert law suit</unittitle>
           </did>
           <accessrestrict>
             <p>[Closed until <date normal="2030-12-01" type="restriction">December 1, 2030</date>]</p>
           </accessrestrict>
+          <c03 level="file">
+            <did>
+              <unittitle>Anthony Herbert law suit</unittitle>
+              <container type="box" label="Box">98</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Anthony Herbert law suit</unittitle>
+              <container type="box" label="Box">99</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Box">100-104</container>
             <unittitle>William Westmoreland law suit</unittitle>
           </did>
           <accessrestrict>
             <p>[Closed until <date normal="2030-12-01" type="restriction">December 1, 2030</date>]</p>
           </accessrestrict>
+          <c03 level="file">
+            <did>
+              <unittitle>William Westmoreland law suit</unittitle>
+              <container type="box" label="Box">100</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>William Westmoreland law suit</unittitle>
+              <container type="box" label="Box">101</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>William Westmoreland law suit</unittitle>
+              <container type="box" label="Box">102</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>William Westmoreland law suit</unittitle>
+              <container type="box" label="Box">103</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>William Westmoreland law suit</unittitle>
+              <container type="box" label="Box">104</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/weillou.xml
+++ b/Real_Masters_all/weillou.xml
@@ -359,7 +359,6 @@ Louis A. Weil papers, Bentley Historical Library, University of Michigan</p>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Sound Discs">1-3</container>
             <unittitle><genreform normal="Phonograph records">Phonograph records</genreform> of broadcast featuring Supreme Court Justice Eugene Black in which he exposes "Michigan Gang" <unitdate type="inclusive" normal="1948-05-27">May 27, 1948</unitdate></unittitle>
             <physdesc>
               <extent>3 phonograph records</extent>
@@ -368,6 +367,30 @@ Louis A. Weil papers, Bentley Historical Library, University of Michigan</p>
               <physfacet>78 rpm</physfacet>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle><genreform normal="Phonograph records">Phonograph records</genreform> of broadcast featuring Supreme Court Justice Eugene Black in which he exposes "Michigan Gang" <unitdate type="inclusive" normal="1948-05-27">May 27, 1948</unitdate></unittitle>
+              <container type="box" label="Sound Discs">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle><genreform normal="Phonograph records">Phonograph records</genreform> of broadcast featuring Supreme Court Justice Eugene Black in which he exposes "Michigan Gang" <unitdate type="inclusive" normal="1948-05-27">May 27, 1948</unitdate></unittitle>
+              <container type="box" label="Sound Discs">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle><genreform normal="Phonograph records">Phonograph records</genreform> of broadcast featuring Supreme Court Justice Eugene Black in which he exposes "Michigan Gang" <unitdate type="inclusive" normal="1948-05-27">May 27, 1948</unitdate></unittitle>
+              <container type="box" label="Sound Discs">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/willekel.xml
+++ b/Real_Masters_all/willekel.xml
@@ -1968,8 +1968,6 @@ Leonard Bernard Willeke papers, Bentley Historical Library, University of Michig
               </odd>
               <c05 level="file">
                 <did>
-                  <container type="map-case" label="Drawer">8</container>
-                  <container type="folder" label="Folders">50-54</container>
                   <unittitle>Architectural Drawings <unitdate type="inclusive">undated</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">5 folders</extent>
@@ -1978,6 +1976,53 @@ Leonard Bernard Willeke papers, Bentley Historical Library, University of Michig
                 <odd>
                   <p>(original pencil drawings, blueprints, and mounted renderings)</p>
                 </odd>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Architectural Drawings <unitdate type="inclusive">undated</unitdate></unittitle>
+                    <container type="map-case" label="Drawer">8</container>
+                    <container type="folder" label="Folders">50</container>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Architectural Drawings <unitdate type="inclusive">undated</unitdate></unittitle>
+                    <container type="map-case" label="Drawer">8</container>
+                    <container type="folder" label="Folders">51</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Architectural Drawings <unitdate type="inclusive">undated</unitdate></unittitle>
+                    <container type="map-case" label="Drawer">8</container>
+                    <container type="folder" label="Folders">52</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Architectural Drawings <unitdate type="inclusive">undated</unitdate></unittitle>
+                    <container type="map-case" label="Drawer">8</container>
+                    <container type="folder" label="Folders">53</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Architectural Drawings <unitdate type="inclusive">undated</unitdate></unittitle>
+                    <container type="map-case" label="Drawer">8</container>
+                    <container type="folder" label="Folders">54</container>
+                  </did>
+                  <odd>
+                    <p>(continued)</p>
+                  </odd>
+                </c06>
               </c05>
               <c05 level="file">
                 <did>

--- a/Real_Masters_all/willrunl.xml
+++ b/Real_Masters_all/willrunl.xml
@@ -137,12 +137,35 @@ Willow Run Public School Library records, Bentley Historical Library, University
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Oversize Volumes">1-3</container>
             <unittitle><genreform normal="Scrapbooks">Scrapbooks</genreform> relating to Willow Run, <unitdate type="inclusive" normal="1942/1944">1942-1944</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle><genreform normal="Scrapbooks">Scrapbooks</genreform> relating to Willow Run, <unitdate type="inclusive" normal="1942/1944">1942-1944</unitdate></unittitle>
+              <container type="volume" label="Oversize Volumes">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle><genreform normal="Scrapbooks">Scrapbooks</genreform> relating to Willow Run, <unitdate type="inclusive" normal="1942/1944">1942-1944</unitdate></unittitle>
+              <container type="volume" label="Oversize Volumes">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle><genreform normal="Scrapbooks">Scrapbooks</genreform> relating to Willow Run, <unitdate type="inclusive" normal="1942/1944">1942-1944</unitdate></unittitle>
+              <container type="volume" label="Oversize Volumes">3</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/winesher.xml
+++ b/Real_Masters_all/winesher.xml
@@ -4450,12 +4450,98 @@ Sherwin T. Wine papers, Bentley Historical Library, University of Michigan</p>
         </scopecontent>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">29-38</container>
             <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
           </did>
           <odd>
             <p>(unarranged)</p>
           </odd>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">29</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">30</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">31</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">32</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">33</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">34</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">35</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">36</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">37</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Cassettes of various lectures delivered at the Center for New Thinking <unitdate type="inclusive" normal="1970/2007" certainty="approximate">1970s-2007</unitdate></unittitle>
+              <container type="box" label="Boxes">38</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/wislanlu.xml
+++ b/Real_Masters_all/wislanlu.xml
@@ -636,21 +636,120 @@ Wisconsin Land &amp; Lumber Company records, Bentley Historical Library, Univers
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">13-14</container>
             <unittitle>Order Books</unittitle>
+            <container type="box" label="Boxes">13</container>
           </did>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">32-37</container>
+            <unittitle>Order Books</unittitle>
+            <container type="box" label="Boxes">14</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
             <unittitle>Inventory books</unittitle>
+            <container type="box" label="Boxes">32</container>
           </did>
         </c02>
         <c02 level="file">
           <did>
-            <container type="box" label="Boxes">40-45</container>
-            <unittitle>Miscellaneous volumes (unlisted)</unittitle>
+            <unittitle>Inventory books</unittitle>
+            <container type="box" label="Boxes">33</container>
           </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Inventory books</unittitle>
+            <container type="box" label="Boxes">34</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Inventory books</unittitle>
+            <container type="box" label="Boxes">35</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Inventory books</unittitle>
+            <container type="box" label="Boxes">36</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Inventory books</unittitle>
+            <container type="box" label="Boxes">37</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Miscellaneous volumes (unlisted)</unittitle>
+            <container type="box" label="Boxes">40</container>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Miscellaneous volumes (unlisted)</unittitle>
+            <container type="box" label="Boxes">41</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Miscellaneous volumes (unlisted)</unittitle>
+            <container type="box" label="Boxes">42</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Miscellaneous volumes (unlisted)</unittitle>
+            <container type="box" label="Boxes">43</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Miscellaneous volumes (unlisted)</unittitle>
+            <container type="box" label="Boxes">44</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Miscellaneous volumes (unlisted)</unittitle>
+            <container type="box" label="Boxes">45</container>
+          </did>
+          <odd>
+            <p>(continued)</p>
+          </odd>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/ymcadet.xml
+++ b/Real_Masters_all/ymcadet.xml
@@ -1702,7 +1702,6 @@
         </scopecontent>
         <c02 level="file">
           <did>
-            <container type="volume" label="Volumes">1-2</container>
             <unittitle>
               <unitdate type="inclusive" normal="1936">1936</unitdate>
             </unittitle>
@@ -1710,10 +1709,28 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1936">1936</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">1</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1936">1936</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">2</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Volumes">3-4</container>
             <unittitle>
               <unitdate type="inclusive" normal="1937">1937</unitdate>
             </unittitle>
@@ -1721,10 +1738,28 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1937">1937</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">3</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1937">1937</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">4</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Volumes">5-6</container>
             <unittitle>
               <unitdate type="inclusive" normal="1938">1938</unitdate>
             </unittitle>
@@ -1732,10 +1767,28 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1938">1938</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">5</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1938">1938</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">6</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Volumes">7-8</container>
             <unittitle>
               <unitdate type="inclusive" normal="1939">1939</unitdate>
             </unittitle>
@@ -1743,10 +1796,28 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1939">1939</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">7</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1939">1939</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">8</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Volumes">9-10</container>
             <unittitle>
               <unitdate type="inclusive" normal="1940">1940</unitdate>
             </unittitle>
@@ -1754,10 +1825,28 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1940">1940</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">9</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1940">1940</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">10</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
-            <container type="volume" label="Volumes">11-12</container>
             <unittitle>
               <unitdate type="inclusive" normal="1941">1941</unitdate>
             </unittitle>
@@ -1765,6 +1854,25 @@
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
           </did>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1941">1941</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">11</container>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>
+                <unitdate type="inclusive" normal="1941">1941</unitdate>
+              </unittitle>
+              <container type="volume" label="Volumes">12</container>
+            </did>
+            <odd>
+              <p>(continued)</p>
+            </odd>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/ztgergan.xml
+++ b/Real_Masters_all/ztgergan.xml
@@ -215,7 +215,6 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
           </c03>
           <c03 level="file">
             <did>
-              <container type="folder" label="Folders">3-4</container>
               <unittitle>Dearborn. St. Clement Orthodox Church <unitdate type="inclusive" normal="1964">1964</unitdate> (Job No. 921)</unittitle>
               <physdesc>
                 <extent>50 drawings</extent>
@@ -230,6 +229,21 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
             <odd>
               <p>(specification in Box 1)</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Dearborn. St. Clement Orthodox Church <unitdate type="inclusive" normal="1964">1964</unitdate> (Job No. 921)</unittitle>
+                <container type="folder" label="Folders">3</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Dearborn. St. Clement Orthodox Church <unitdate type="inclusive" normal="1964">1964</unitdate> (Job No. 921)</unittitle>
+                <container type="folder" label="Folders">4</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -759,7 +773,6 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
           </did>
           <c03 level="file">
             <did>
-              <container type="folder" label="Folders">14-15</container>
               <unittitle>Ann Arbor. Washtenaw County Building, Huron and Main Street <unitdate type="inclusive" normal="1946">1946</unitdate> (Job No. 592)</unittitle>
               <physdesc>
                 <extent>58 drawings</extent>
@@ -774,6 +787,21 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
             <odd>
               <p>(specifications in Box 1)</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Ann Arbor. Washtenaw County Building, Huron and Main Street <unitdate type="inclusive" normal="1946">1946</unitdate> (Job No. 592)</unittitle>
+                <container type="folder" label="Folders">14</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Ann Arbor. Washtenaw County Building, Huron and Main Street <unitdate type="inclusive" normal="1946">1946</unitdate> (Job No. 592)</unittitle>
+                <container type="folder" label="Folders">15</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -969,7 +997,6 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
           </c03>
           <c03 level="file">
             <did>
-              <container type="folder" label="Folders">25-27</container>
               <unittitle>Miscellaneous (single family residences) (No Job No.)</unittitle>
               <physdesc>
                 <extent>ca. 50 drawings</extent>
@@ -981,6 +1008,30 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
             <odd>
               <p>(Renderings)</p>
             </odd>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous (single family residences) (No Job No.)</unittitle>
+                <container type="folder" label="Folders">25</container>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous (single family residences) (No Job No.)</unittitle>
+                <container type="folder" label="Folders">26</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Miscellaneous (single family residences) (No Job No.)</unittitle>
+                <container type="folder" label="Folders">27</container>
+              </did>
+              <odd>
+                <p>(continued)</p>
+              </odd>
+            </c04>
           </c03>
         </c02>
       </c01>


### PR DESCRIPTION
Second pass at expanding container ranges. This time nodes with two containers were ignored if the first container was not a drawer, and nodes containing only a unittitle and a container (no additional tags like notes or extents) were expanded in a flat manner, without enclosing the new items in an additional parent c0x node.

Code used in making the changes can be seen [here](https://github.com/walkerdb/bentley_code/tree/master/one-off%20scripts/expand_container_ranges)
