### PR TITLE
fixing some things based on eadtojson test

### DIFF
--- a/Real_Masters_all/angelof.xml
+++ b/Real_Masters_all/angelof.xml
@@ -1966,7 +1966,7 @@
               <did>
                 <container type="box" label="Box">6</container>
                 <unittitle>
-                  <unitdate type="inclusive" normal="1979-11-16/1979-11-31">November 16-November 31 1979</unitdate>
+                  <unitdate type="inclusive" normal="1979-11-16/1979-11-30">November 16-November 30 1979</unitdate>
                 </unittitle>
               </did>
             </c04>

--- a/Real_Masters_all/annahoyt.xml
+++ b/Real_Masters_all/annahoyt.xml
@@ -23,7 +23,7 @@
         <item>Converted to EAD2002 using Word macro and Xmetal</item>
       </change>
       <change>
-        <date/>
+        <date>1997</date>
         <item>Original encoding in EAD ver. 1.0, manual tagging in A/E.</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/bentleya.xml
+++ b/Real_Masters_all/bentleya.xml
@@ -27,7 +27,7 @@
         <item>Converted to EAD version 1.0 an d new box style using WORD 6 macros and some hand tagging.</item>
       </change>
       <change>
-        <date/>
+        <date>199807</date>
         <item>Original encoding from Word 6.0 file</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/blanshar.xml
+++ b/Real_Masters_all/blanshar.xml
@@ -35,7 +35,7 @@
         <item>Converted to EAD version 1.0 using WORD 6 macro and some hand tagging.</item>
       </change>
       <change>
-        <date/>
+        <date>1998-09</date>
         <item>Original encoding from Word 6.0 file</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/cogmich.xml
+++ b/Real_Masters_all/cogmich.xml
@@ -27,7 +27,7 @@
         <item>Converted to EAD2002 using Word macro and Xmetal</item>
       </change>
       <change>
-        <date/>
+        <date>199903</date>
         <item>Original encoding in EAD ver. 1.0 from Word 6.0 file using word macros and manual tagging in A/E.</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/copeland.xml
+++ b/Real_Masters_all/copeland.xml
@@ -31,7 +31,7 @@
         <item>Converted to EAD version 1.0 using WORD 6 macro and some hand tagging.</item>
       </change>
       <change>
-        <date/>
+        <date>199809</date>
         <item>Original encoding from Word 6.0 file</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/danast.xml
+++ b/Real_Masters_all/danast.xml
@@ -31,7 +31,7 @@
         <item>Converted to EAD version 1.0 using WORD 6 macro and some hand tagging.</item>
       </change>
       <change>
-        <date/>
+        <date>1998-06</date>
         <item>Original encoding from Word 6.0 file</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/drewwalt.xml
+++ b/Real_Masters_all/drewwalt.xml
@@ -35,7 +35,7 @@
         <item>Converted to EAD version 1.0 using WORD 6 macro and some hand tagging.</item>
       </change>
       <change>
-        <date/>
+        <date>1998-07</date>
         <item>Original encoding from Word 6.0 file, 1998</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/dunhamar.xml
+++ b/Real_Masters_all/dunhamar.xml
@@ -31,7 +31,7 @@
         <item>Converted to EAD version 1.0 using WORD 6 macro and some hand tagging.</item>
       </change>
       <change>
-        <date/>
+        <date>1998-09</date>
         <item>Original encoding from Word 6.0 file.</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/dustin.xml
+++ b/Real_Masters_all/dustin.xml
@@ -27,7 +27,7 @@
         <item>Converted to EAD2002 using Word macro and Xmetal</item>
       </change>
       <change>
-        <date/>
+        <date>200304</date>
         <item>Original encoding from Word 6.0 file using Word macros and manual tagging in A/E.</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/esquire.xml
+++ b/Real_Masters_all/esquire.xml
@@ -35,7 +35,7 @@
         <item>Converted to EAD version 1.0 using WORD 6 macro and some hand tagging.</item>
       </change>
       <change>
-        <date/>
+        <date>1998-08</date>
         <item>Original encoding from Word 6.0 file</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/fajans.xml
+++ b/Real_Masters_all/fajans.xml
@@ -43,7 +43,7 @@
         <item>Converted to EAD version 1.0 using WORD 6 macro and some hand tagging.</item>
       </change>
       <change>
-        <date/>
+        <date>1998-10</date>
         <item>Original encoding from Word 6.0 file, October 1998</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/gingrich.xml
+++ b/Real_Masters_all/gingrich.xml
@@ -35,7 +35,7 @@
         <item>Converted to EAD version 1.0 using WORD 6 macro and some hand tagging.</item>
       </change>
       <change>
-        <date/>
+        <date>1998-08</date>
         <item>Original encoding from Word 6.0 file.</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/gingrich.xml
+++ b/Real_Masters_all/gingrich.xml
@@ -4526,13 +4526,6 @@
               </unittitle>
             </did>
           </c03>
-          <c03 level="file">
-            <did>
-              <container type="box" label="Box">23</container>
-              <unittitle>
-              </unittitle>
-            </did>
-          </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/horace.xml
+++ b/Real_Masters_all/horace.xml
@@ -24,7 +24,7 @@
         <item>Converted to EAD2002 using Word macro and Xmetal</item>
       </change>
       <change>
-        <date/>
+        <date>200005</date>
         <item>Original encoding from Word 6.0 file using Word macros and manual tagging in A/E.</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/iogeront.xml
+++ b/Real_Masters_all/iogeront.xml
@@ -27,7 +27,7 @@
         <item>Converted to EAD2002 using Word macro and Xmetal</item>
       </change>
       <change>
-        <date/>
+        <date>200107</date>
         <item>Original encoding in EAD ver. 1.0 from Word 6.0 file using word macros and manual tagging in A/E.</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/katzdan.xml
+++ b/Real_Masters_all/katzdan.xml
@@ -35,7 +35,7 @@
         <item>Converted to EAD version 1.0 using WORD 6 macro and some hand tagging.</item>
       </change>
       <change>
-        <date/>
+        <date>1998-06</date>
         <item>Original encoding from Word 6.0 file</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/lawsch.xml
+++ b/Real_Masters_all/lawsch.xml
@@ -35,7 +35,7 @@
         <item>Converted to EAD2002 using Word macro and Xmetal</item>
       </change>
       <change>
-        <date/>
+        <date>200103</date>
         <item>Original encoding in EAD ver. 1.0 from Word 6.0 file using word macros and manual tagging in A/E.</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/leonardd.xml
+++ b/Real_Masters_all/leonardd.xml
@@ -31,7 +31,7 @@
         <item>Converted to EAD version 1.0 using WORD 6 macro and some hand tagging.</item>
       </change>
       <change>
-        <date/>
+        <date>1998-08</date>
         <item>Original encoding from Word 6.0 file</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/loomis.xml
+++ b/Real_Masters_all/loomis.xml
@@ -31,7 +31,7 @@
         <item>Converted to EAD version 1.0 using WORD 6 macro and some hand tagging.</item>
       </change>
       <change>
-        <date/>
+        <date>1998-07</date>
         <item>Original encoding from Word 6.0 file</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/mannyf.xml
+++ b/Real_Masters_all/mannyf.xml
@@ -27,7 +27,7 @@
         <item>Converted to EAD version 1.0 using WORD 6 macro and some hand tagging.</item>
       </change>
       <change>
-        <date/>
+        <date>1998-06</date>
         <item>Original encoding from Word 6.0 file.</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/murfinjo.xml
+++ b/Real_Masters_all/murfinjo.xml
@@ -23,7 +23,7 @@
         <item>Converted to EAD2002 using Word macro and Xmetal</item>
       </change>
       <change>
-        <date/>
+        <date>200210</date>
         <item>Original encoding in EAD ver. 1.0 from Word 6.0 file using word macros and manual tagging in A/E.</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/ppldet.xml
+++ b/Real_Masters_all/ppldet.xml
@@ -31,7 +31,7 @@
         <item>Converted to EAD version 1.0 using WORD 6 macro and some hand tagging.</item>
       </change>
       <change>
-        <date/>
+        <date>1998-08</date>
         <item>Original encoding from Word 6.0 file</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/ppolicy.xml
+++ b/Real_Masters_all/ppolicy.xml
@@ -39,7 +39,7 @@
         <item>converted to new container style</item>
       </change>
       <change>
-        <date/>
+        <date>1999-10</date>
         <item>Original encoding in EAD ver. 1.0 from Word 6.0 file using word macros and manual tagging in A/E.</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/quaalw.xml
+++ b/Real_Masters_all/quaalw.xml
@@ -199,7 +199,7 @@ Ward L. Quaal Papers, Bentley Historical Library, University of Michigan</p>
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Ward Quaal Tribute</unittitle>
-            <physdesc altrender="whle">
+            <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 CD-ROM and 1 DVD</extent>
             </physdesc>
           </did>

--- a/Real_Masters_all/riegled.xml
+++ b/Real_Masters_all/riegled.xml
@@ -39573,7 +39573,7 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
             <did>
               <container type="reel" label="Roll">600</container>
               <unittitle>
-                <unitdate type="inclusive" normal="1986-08-07/1986-04-23">August 7, 1986-April 23, 1986</unitdate>
+                <unitdate type="inclusive" normal="1986-04-23/1986-08-07">August 7, 1986-April 23, 1986</unitdate>
               </unittitle>
             </did>
           </c03>
@@ -39581,7 +39581,7 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
             <did>
               <container type="reel" label="Roll">601</container>
               <unittitle>
-                <unitdate type="inclusive" normal="1986-01-14/1973-12-03">January 14, 1986-December 3, 1973</unitdate>
+                <unitdate type="inclusive" normal="1973-12-03/1986-01-14">January 14, 1986-December 3, 1973</unitdate>
               </unittitle>
             </did>
           </c03>

--- a/Real_Masters_all/uaao.xml
+++ b/Real_Masters_all/uaao.xml
@@ -31,7 +31,7 @@
         <item>Converted to EAD version 1.0 using WORD 6 macro and some hand tagging.</item>
       </change>
       <change>
-        <date/>
+        <date>1998-08</date>
         <item>Original encoding from Word 6.0 file.</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/vpcfo.xml
+++ b/Real_Masters_all/vpcfo.xml
@@ -11055,7 +11055,7 @@ Vice President and Chief Financial Officer (University of Michigan) Records, Ben
           <c03 level="file">
             <did>
               <container type="box" label="Box">188</container>
-              <unittitle>Washington -- Residential Study Center <unitdate type="inclusive" normal="1990/1901">1990-1901</unitdate></unittitle>
+              <unittitle>Washington -- Residential Study Center <unitdate type="inclusive" normal="1990/1901">1990-1991</unitdate></unittitle>
             </did>
             <accessrestrict>
               <p>[ER RESTRICTED until <date type="restriction" normal="2026-07-01">July 1, 2026</date>]</p>

--- a/Real_Masters_all/vpcfo.xml
+++ b/Real_Masters_all/vpcfo.xml
@@ -11055,7 +11055,7 @@ Vice President and Chief Financial Officer (University of Michigan) Records, Ben
           <c03 level="file">
             <did>
               <container type="box" label="Box">188</container>
-              <unittitle>Washington -- Residential Study Center <unitdate type="inclusive" normal="1990/1001">1990-1001</unitdate></unittitle>
+              <unittitle>Washington -- Residential Study Center <unitdate type="inclusive" normal="1990/1901">1990-1901</unitdate></unittitle>
             </did>
             <accessrestrict>
               <p>[ER RESTRICTED until <date type="restriction" normal="2026-07-01">July 1, 2026</date>]</p>

--- a/Real_Masters_all/westoni.xml
+++ b/Real_Masters_all/westoni.xml
@@ -31,7 +31,7 @@
         <item>Converted to EAD version 1.0 using WORD 6 macro and some hand tagging.</item>
       </change>
       <change>
-        <date/>
+        <date>199809</date>
         <item>Original encoding from Word 6.0 file.</item>
       </change>
     </revisiondesc>

--- a/Real_Masters_all/worcestd.xml
+++ b/Real_Masters_all/worcestd.xml
@@ -31,7 +31,7 @@
         <item>Converted to EAD version 1.0 using WORD 6 macro and some hand tagging and converted to new container style.</item>
       </change>
       <change>
-        <date/>
+        <date>1998-08</date>
         <item>Original encoding from Word 6.0 file</item>
       </change>
     </revisiondesc>


### PR DESCRIPTION
The new version of ASpace splits out <change>s in <revisiondesc>, requiring both a date and an item for each. Some of ours did not have dates.

Also fixed some dates and some empty titles.
