### PR TITLE
removing unnecessary dao tag from romneyg

### DIFF
--- a/Real_Masters_all/romneyg.xml
+++ b/Real_Masters_all/romneyg.xml
@@ -36226,7 +36226,6 @@
                 <physdesc>
                   <physfacet>flv</physfacet>
                 </physdesc>
-                <dao href="852178_5-2" show="new" actuate="onrequest"/>
               </did>
             </c04>
           </c03>


### PR DESCRIPTION
S/FindingAids/EAD/Master is up-to-date with vandura/Real_Masters_all as of 3:45pm, 2015-08-12
