### PR TITLE
Move extents in unittitle parentheticals to new extent tags

### DIFF
--- a/Real_Masters_all/admissls.xml
+++ b/Real_Masters_all/admissls.xml
@@ -2466,7 +2466,10 @@ University of Michigan admissions lawsuits collection, Bentley Historical Librar
           <c03 level="file">
             <did>
               <container type="box" label="Box">18</container>
-              <unittitle>Articles (1 folder)</unittitle>
+              <unittitle>Articles</unittitle>
+              <physdesc>
+                <extent>1 folder</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/aldridge.xml
+++ b/Real_Masters_all/aldridge.xml
@@ -1439,7 +1439,12 @@ John W. Aldridge papers, Bentley Historical Library, University of Michigan</p>
         <c02 level="file">
           <did>
             <container type="box" label="Box">5</container>
-            <unittitle><unitdate type="inclusive">Undated</unitdate> (2 books)</unittitle>
+            <unittitle>
+              <unitdate type="inclusive">Undated</unitdate>
+            </unittitle>
+            <physdesc>
+              <extent>2 books</extent>
+            </physdesc>
           </did>
         </c02>
       </c01>

--- a/Real_Masters_all/alumasso.xml
+++ b/Real_Masters_all/alumasso.xml
@@ -4055,7 +4055,10 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">127</container>
-            <unittitle>Alumni Association Financial Records <unitdate type="inclusive" normal="1932/1933">1932-1933</unitdate> (3 v.)</unittitle>
+            <unittitle>Alumni Association Financial Records <unitdate type="inclusive" normal="1932/1933">1932-1933</unitdate></unittitle>
+            <physdesc>
+              <extent>3 v.</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
@@ -15493,7 +15496,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">161</container>
-              <unittitle>Amaizin' Blues and Wisconsin Collegiates <unitdate type="inclusive" normal="1976">1976</unitdate> (2 reels)</unittitle>
+              <unittitle>Amaizin' Blues and Wisconsin Collegiates <unitdate type="inclusive" normal="1976">1976</unitdate></unittitle>
+              <physdesc>
+                <extent>2 reels</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/angelof.xml
+++ b/Real_Masters_all/angelof.xml
@@ -2469,7 +2469,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">8</container>
-              <unittitle>Board Members Manual (1 volume)</unittitle>
+              <unittitle>Board Members Manual</unittitle>
+              <physdesc>
+                <extent>1 volume</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/archcoll.xml
+++ b/Real_Masters_all/archcoll.xml
@@ -8706,7 +8706,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">36</container>
-                  <unittitle>Moore, Charles (2 folders) <unitdate type="inclusive" normal="1987/1994">1987-1994</unitdate></unittitle>
+                  <unittitle>Moore, Charles <unitdate type="inclusive" normal="1987/1994">1987-1994</unitdate></unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
                 <odd>
                   <p>(includes material relating to honorary degree and 2 photographs)</p>
@@ -13264,7 +13267,10 @@
                   <c07 level="file">
                     <did>
                       <container type="box" label="Box">75</container>
-                      <unittitle>January-September (2 folders)</unittitle>
+                      <unittitle>January-September</unittitle>
+                      <physdesc>
+                        <extent>2 folders</extent>
+                      </physdesc>
                     </did>
                     <accessrestrict>
                       <p>[ER RESTRICTED until <date normal="2030-07-01" type="restriction">July 1, 2030</date>]</p>

--- a/Real_Masters_all/asstpres.xml
+++ b/Real_Masters_all/asstpres.xml
@@ -2797,7 +2797,10 @@ Assistant to the President (University of Michigan) Records, Bentley Historical 
           <c03 level="file">
             <did>
               <container type="box" label="Box">56</container>
-              <unittitle>Miscellaneous People, including university officials, award recipients, and visiting dignitaries (3 envelopes)</unittitle>
+              <unittitle>Miscellaneous People, including university officials, award recipients, and visiting dignitaries</unittitle>
+              <physdesc>
+                <extent>3 envelopes</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>
@@ -2808,7 +2811,10 @@ Assistant to the President (University of Michigan) Records, Bentley Historical 
           <c03 level="file">
             <did>
               <container type="box" label="Box">56</container>
-              <unittitle><unitdate type="inclusive" normal="1975">1975</unitdate> Winter-1985 Winter (27 envelopes)</unittitle>
+              <unittitle><unitdate type="inclusive" normal="1975">1975</unitdate> Winter-1985 Winter</unittitle>
+              <physdesc>
+                <extent>27 envelopes</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>
@@ -2819,7 +2825,12 @@ Assistant to the President (University of Michigan) Records, Bentley Historical 
           <c03 level="file">
             <did>
               <container type="box" label="Box">56</container>
-              <unittitle><unitdate type="inclusive" normal="1978/1981">1978/79-1980/81</unitdate> (3 envelopes)</unittitle>
+              <unittitle>
+                <unitdate type="inclusive" normal="1978/1981">1978/79-1980/81</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>3 envelopes</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>
@@ -2830,7 +2841,12 @@ Assistant to the President (University of Michigan) Records, Bentley Historical 
           <c03 level="file">
             <did>
               <container type="box" label="Box">56</container>
-              <unittitle><unitdate type="inclusive" normal="1981/1985">1981-1985</unitdate> (5 envelopes)</unittitle>
+              <unittitle>
+                <unitdate type="inclusive" normal="1981/1985">1981-1985</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>5 envelopes</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/athdept.xml
+++ b/Real_Masters_all/athdept.xml
@@ -11796,7 +11796,10 @@ and files,  including Media Guides, Photographs (usually subdivided into files o
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">161</container>
-                    <unittitle>Boston College <unitdate type="inclusive" normal="2001-12-01">12/1/2001</unitdate> (2 disks)</unittitle>
+                    <unittitle>Boston College <unitdate type="inclusive" normal="2001-12-01">12/1/2001</unitdate></unittitle>
+                    <physdesc>
+                      <extent>2 disks</extent>
+                    </physdesc>
                   </did>
                   <odd>
                     <p>(by UM Photo Services and Amir Gamzu)</p>
@@ -11823,7 +11826,10 @@ and files,  including Media Guides, Photographs (usually subdivided into files o
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">161</container>
-                    <unittitle>Purdue <unitdate type="inclusive" normal="2002-01-05">1/5/2002</unitdate> (2 disks)</unittitle>
+                    <unittitle>Purdue <unitdate type="inclusive" normal="2002-01-05">1/5/2002</unitdate></unittitle>
+                    <physdesc>
+                      <extent>2 disks</extent>
+                    </physdesc>
                   </did>
                   <odd>
                     <p>(by UM Photo Services and Amir Gamzu)</p>
@@ -11832,7 +11838,10 @@ and files,  including Media Guides, Photographs (usually subdivided into files o
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">161</container>
-                    <unittitle>Northwestern and Minnesota <unitdate type="inclusive" normal="2002-01-16">1/16/2002</unitdate>, <unitdate type="inclusive" normal="2002-01-19">1/19/2002</unitdate> (2 disks)</unittitle>
+                    <unittitle>Northwestern and Minnesota <unitdate type="inclusive" normal="2002-01-16">1/16/2002</unitdate>, <unitdate type="inclusive" normal="2002-01-19">1/19/2002</unitdate></unittitle>
+                    <physdesc>
+                      <extent>2 disks</extent>
+                    </physdesc>
                   </did>
                   <odd>
                     <p>(by Amir Gamzu)</p>
@@ -13697,7 +13706,12 @@ and files,  including Media Guides, Photographs (usually subdivided into files o
             <c04 level="file">
               <did>
                 <container type="box" label="Box">110</container>
-                <unittitle><unitdate type="inclusive" normal="1989/1990">1989/90</unitdate> (3  folders)</unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1989/1990">1989/90</unitdate>
+                </unittitle>
+                <physdesc>
+                  <extent>3  folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -20112,7 +20126,10 @@ and files,  including Media Guides, Photographs (usually subdivided into files o
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">161</container>
-                    <unittitle><unitdate type="inclusive" normal="2003/2004">2003/04</unitdate> UM vs. Stanford  (2 disks)</unittitle>
+                    <unittitle><unitdate type="inclusive" normal="2003/2004">2003/04</unitdate> UM vs. Stanford</unittitle>
+                    <physdesc>
+                      <extent>2 disks</extent>
+                    </physdesc>
                   </did>
                   <odd>
                     <p>(photographs, meet action)</p>
@@ -20284,7 +20301,10 @@ and files,  including Media Guides, Photographs (usually subdivided into files o
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">161</container>
-                    <unittitle><unitdate type="inclusive" normal="2004/2005">2004/05</unitdate> NCAA Championships  (2 disks)</unittitle>
+                    <unittitle><unitdate type="inclusive" normal="2004/2005">2004/05</unitdate> NCAA Championships</unittitle>
+                    <physdesc>
+                      <extent>2 disks</extent>
+                    </physdesc>
                   </did>
                   <odd>
                     <p>(meet action)</p>
@@ -25292,7 +25312,10 @@ and files,  including Media Guides, Photographs (usually subdivided into files o
             <c04 level="file">
               <did>
                 <container type="box" label="Box">186</container>
-                <unittitle><unitdate type="inclusive" normal="1990/1991">1990/91</unitdate> Results  (2 folders)</unittitle>
+                <unittitle><unitdate type="inclusive" normal="1990/1991">1990/91</unitdate> Results</unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -29644,7 +29667,12 @@ and files,  including Media Guides, Photographs (usually subdivided into files o
             <c04 level="file">
               <did>
                 <container type="box" label="Box">149</container>
-                <unittitle><unitdate type="inclusive" normal="2003/2004">2003/04</unitdate> (2 folders)</unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="2003/2004">2003/04</unitdate>
+                </unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -29718,7 +29746,10 @@ and files,  including Media Guides, Photographs (usually subdivided into files o
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">218</container>
-                  <unittitle>Meet Results (2 folders)</unittitle>
+                  <unittitle>Meet Results</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -31154,7 +31185,10 @@ and files,  including Media Guides, Photographs (usually subdivided into files o
             <c04 level="file">
               <did>
                 <container type="box" label="Box">185</container>
-                <unittitle><unitdate type="inclusive" normal="2003">2003</unitdate> Releases(2 folders)</unittitle>
+                <unittitle><unitdate type="inclusive" normal="2003">2003</unitdate> Releases</unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>
@@ -33838,7 +33872,10 @@ and files,  including Media Guides, Photographs (usually subdivided into files o
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">238</container>
-                    <unittitle><unitdate type="inclusive" normal="2003/2004">2003/04</unitdate> Northwestern at UM  (2 disks)</unittitle>
+                    <unittitle><unitdate type="inclusive" normal="2003/2004">2003/04</unitdate> Northwestern at UM</unittitle>
+                    <physdesc>
+                      <extent>2 disks</extent>
+                    </physdesc>
                   </did>
                   <odd>
                     <p>(photographs, meet action)</p>
@@ -33947,7 +33984,10 @@ and files,  including Media Guides, Photographs (usually subdivided into files o
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">238</container>
-                    <unittitle>Wendy Shieh <unitdate type="inclusive" normal="2005/2009">2005-2009</unitdate> (3 discs)</unittitle>
+                    <unittitle>Wendy Shieh <unitdate type="inclusive" normal="2005/2009">2005-2009</unitdate></unittitle>
+                    <physdesc>
+                      <extent>3 discs</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
@@ -33971,7 +34011,10 @@ and files,  including Media Guides, Photographs (usually subdivided into files o
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">238</container>
-                    <unittitle>Michelle Uhlig <unitdate type="inclusive" normal="2005/2008">2005-2008</unitdate> (2 discs)</unittitle>
+                    <unittitle>Michelle Uhlig <unitdate type="inclusive" normal="2005/2008">2005-2008</unitdate></unittitle>
+                    <physdesc>
+                      <extent>2 discs</extent>
+                    </physdesc>
                   </did>
                 </c06>
               </c05>
@@ -40966,43 +41009,64 @@ and files,  including Media Guides, Photographs (usually subdivided into files o
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">221</container>
-                    <unittitle>Ed Martin. Articles <unitdate type="inclusive" normal="1997/2001">1997-2001</unitdate> General Information Releases; Corrective Actions; Timelines  (1 binder)</unittitle>
+                    <unittitle>Ed Martin. Articles <unitdate type="inclusive" normal="1997/2001">1997-2001</unitdate> General Information Releases; Corrective Actions; Timelines</unittitle>
+                    <physdesc>
+                      <extent>1 binder</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">221</container>
-                    <unittitle>Ed Martin, News and Information Filing  (1 binder)</unittitle>
+                    <unittitle>Ed Martin, News and Information Filing</unittitle>
+                    <physdesc>
+                      <extent>1 binder</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">221</container>
-                    <unittitle>Ed Martin, Articles <unitdate type="inclusive" normal="1997/2001">1997-2001</unitdate> (1 binder)</unittitle>
+                    <unittitle>Ed Martin, Articles <unitdate type="inclusive" normal="1997/2001">1997-2001</unitdate></unittitle>
+                    <physdesc>
+                      <extent>1 binder</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">221</container>
-                    <unittitle>Ed Martin, Articles <unitdate type="inclusive" normal="2002">2002</unitdate> (1 binder)</unittitle>
+                    <unittitle>Ed Martin, Articles <unitdate type="inclusive" normal="2002">2002</unitdate></unittitle>
+                    <physdesc>
+                      <extent>1 binder</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">221</container>
-                    <unittitle>Subject: Ed Martin. Ed Martin Passes Away; Chris Webber Articles--various; Steve Fisher Dismissal  (1 binder)</unittitle>
+                    <unittitle>Subject: Ed Martin. Ed Martin Passes Away; Chris Webber Articles--various; Steve Fisher Dismissal</unittitle>
+                    <physdesc>
+                      <extent>1 binder</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">221</container>
-                    <unittitle>Ed Martin. Articles <unitdate type="inclusive" normal="2002">2002</unitdate> (1 binder)</unittitle>
+                    <unittitle>Ed Martin. Articles <unitdate type="inclusive" normal="2002">2002</unitdate></unittitle>
+                    <physdesc>
+                      <extent>1 binder</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">221</container>
-                    <unittitle>NCAA Sanctions-U-M Self Imposed Sanctions, Articles <unitdate type="inclusive" normal="2002-11">November 2002</unitdate> (1 binder)</unittitle>
+                    <unittitle>NCAA Sanctions-U-M Self Imposed Sanctions, Articles <unitdate type="inclusive" normal="2002-11">November 2002</unitdate></unittitle>
+                    <physdesc>
+                      <extent>1 binder</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">

--- a/Real_Masters_all/auditscharts.xml
+++ b/Real_Masters_all/auditscharts.xml
@@ -159,7 +159,10 @@ Office of University Audits (University of Michigan) organizational charts, Bent
         <c02 level="file">
           <did>
             <container type="box" label="Box">1</container>
-            <unittitle>Organizational charts, University of Michigan <unitdate type="inclusive" normal="1969/1991">1969/70-1990/91</unitdate> (22 folders, comprehensive and inclusive)</unittitle>
+            <unittitle>Organizational charts, University of Michigan <unitdate type="inclusive" normal="1969/1991">1969/70-1990/91</unitdate></unittitle>
+            <physdesc>
+              <extent>22 folders, comprehensive and inclusive</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/baloght.xml
+++ b/Real_Masters_all/baloght.xml
@@ -732,7 +732,10 @@ Tivadar Balogh papers, Bentley Historical Library, University of Michigan</p>
           </did>
           <c03 level="file">
             <did>
-              <unittitle>Aardema, Hedy, Ontario, June 30, 1993(2 folders)</unittitle>
+              <unittitle>Aardema, Hedy, Ontario, June 30, 1993</unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/bandum.xml
+++ b/Real_Masters_all/bandum.xml
@@ -925,7 +925,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">5</container>
-              <unittitle>Symphony Band Spring Tour <unitdate type="inclusive" normal="1960">1960</unitdate> (2 folders)</unittitle>
+              <unittitle>Symphony Band Spring Tour <unitdate type="inclusive" normal="1960">1960</unitdate></unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/barnettd.xml
+++ b/Real_Masters_all/barnettd.xml
@@ -787,7 +787,10 @@ Doug Barnett Photographs and Scrapbooks, Bentley Historical Library, University 
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">1</container>
-                  <unittitle>Al Brook (2 photos)</unittitle>
+                  <unittitle>Al Brook</unittitle>
+                  <physdesc>
+                    <extent>2 photos</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="item">
@@ -1200,7 +1203,10 @@ Doug Barnett Photographs and Scrapbooks, Bentley Historical Library, University 
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">1</container>
-                  <unittitle>Al Renfrew (2 photos, one with Mike Martilla)</unittitle>
+                  <unittitle>Al Renfrew</unittitle>
+                  <physdesc>
+                    <extent>2 photos, one with Mike Martilla</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -1256,7 +1262,10 @@ Doug Barnett Photographs and Scrapbooks, Bentley Historical Library, University 
             <c04 level="file">
               <did>
                 <container type="box" label="Box">1</container>
-                <unittitle>Reunion (5 photos)</unittitle>
+                <unittitle>Reunion</unittitle>
+                <physdesc>
+                  <extent>5 photos</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/bentleya.xml
+++ b/Real_Masters_all/bentleya.xml
@@ -1925,7 +1925,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">14</container>
-                  <unittitle>Public Works Committee-Saginaw Valley Flood Control (1 folder)</unittitle>
+                  <unittitle>Public Works Committee-Saginaw Valley Flood Control</unittitle>
+                  <physdesc>
+                    <extent>1 folder</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -12703,7 +12706,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">103</container>
-              <unittitle>Album given to AMB by Puerto Rican school children (1 volumes)</unittitle>
+              <unittitle>Album given to AMB by Puerto Rican school children</unittitle>
+              <physdesc>
+                <extent>1 volumes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/benzf.xml
+++ b/Real_Masters_all/benzf.xml
@@ -941,7 +941,10 @@ Fred E. Benz motion picture collection, Bentley Historical Library, University o
       </c01>
       <c01 level="series">
         <did>
-          <unittitle>Non-Benz film (1 reel; black and white)</unittitle>
+          <unittitle>Non-Benz film</unittitle>
+          <physdesc>
+            <extent>1 reel; black and white</extent>
+          </physdesc>
         </did>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/bhl.xml
+++ b/Real_Masters_all/bhl.xml
@@ -2342,7 +2342,10 @@ Bentley Historical Library records, Bentley Historical Library, University of Mi
             <c04 level="file">
               <did>
                 <container type="box" label="Box">8</container>
-                <unittitle>Pugh, Mary Jo Farewell Party (2 folders. includes snapshot photographs)</unittitle>
+                <unittitle>Pugh, Mary Jo Farewell Party</unittitle>
+                <physdesc>
+                  <extent>2 folders. includes snapshot photographs</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -4361,7 +4364,10 @@ Bentley Historical Library records, Bentley Historical Library, University of Mi
           <c03 level="subseries">
             <did>
               <container type="box" label="Box">63</container>
-              <unittitle>Staff meetings of the Bentley Historical Library <unitdate type="inclusive" normal="1972/2008">1972-2008</unitdate> (0.3 linear feet)</unittitle>
+              <unittitle>Staff meetings of the Bentley Historical Library <unitdate type="inclusive" normal="1972/2008">1972-2008</unitdate></unittitle>
+              <physdesc>
+                <extent>0.3 linear feet</extent>
+              </physdesc>
             </did>
             <c04 level="file">
               <did>
@@ -5936,7 +5942,10 @@ Bentley Historical Library records, Bentley Historical Library, University of Mi
             <c04 level="file">
               <did>
                 <container type="box" label="Box">25</container>
-                <unittitle>Non Donor Files <unitdate type="inclusive" normal="1996/2001">1996-2001</unitdate> A-Z (146 files)</unittitle>
+                <unittitle>Non Donor Files <unitdate type="inclusive" normal="1996/2001">1996-2001</unitdate> A-Z</unittitle>
+                <physdesc>
+                  <extent>146 files</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -14037,7 +14046,10 @@ Bentley Historical Library records, Bentley Historical Library, University of Mi
             <c04 level="file">
               <did>
                 <container type="box" label="Box">53</container>
-                <unittitle>Ann Arbor. <title render="italic">Pictorial History of Ann Arbor</title>, <unitdate type="inclusive" normal="1974">1974</unitdate> (7 envelopes)</unittitle>
+                <unittitle>Ann Arbor. <title render="italic">Pictorial History of Ann Arbor</title>, <unitdate type="inclusive" normal="1974">1974</unitdate></unittitle>
+                <physdesc>
+                  <extent>7 envelopes</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -14356,19 +14368,28 @@ Bentley Historical Library records, Bentley Historical Library, University of Mi
           <c03 level="file">
             <did>
               <container type="box" label="Box">54</container>
-              <unittitle>Tom Hemingway, Narration of "Moving Archives," <unitdate type="inclusive" normal="1991">1991</unitdate> (1 cassette)</unittitle>
+              <unittitle>Tom Hemingway, Narration of "Moving Archives," <unitdate type="inclusive" normal="1991">1991</unitdate></unittitle>
+              <physdesc>
+                <extent>1 cassette</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">54</container>
-              <unittitle>Margot Halsted, Band Carillon <unitdate type="inclusive" normal="1990">1990</unitdate> (1 cassette)</unittitle>
+              <unittitle>Margot Halsted, Band Carillon <unitdate type="inclusive" normal="1990">1990</unitdate></unittitle>
+              <physdesc>
+                <extent>1 cassette</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">54</container>
-              <unittitle>2nd European Conference on Archives <unitdate type="inclusive" normal="1989">1989</unitdate> (12 cassette and Conference program)</unittitle>
+              <unittitle>2nd European Conference on Archives <unitdate type="inclusive" normal="1989">1989</unitdate></unittitle>
+              <physdesc>
+                <extent>12 cassette and Conference program</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/biciath.xml
+++ b/Real_Masters_all/biciath.xml
@@ -1319,13 +1319,19 @@ Board in Control of Intercollegiate Athletics (University of Michigan) records, 
         <c02 level="file">
           <did>
             <container type="box" label="Box">43</container>
-            <unittitle>Miscellaneous Notes on Football <unitdate type="inclusive" normal="1921/1928">1921-1928</unitdate> (10 vol.)</unittitle>
+            <unittitle>Miscellaneous Notes on Football <unitdate type="inclusive" normal="1921/1928">1921-1928</unitdate></unittitle>
+            <physdesc>
+              <extent>10 vol.</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">44</container>
-            <unittitle>Miscellaneous Notes on Football <unitdate type="inclusive" normal="1921/1928">1921-1928</unitdate> (11 vol.)</unittitle>
+            <unittitle>Miscellaneous Notes on Football <unitdate type="inclusive" normal="1921/1928">1921-1928</unitdate></unittitle>
+            <physdesc>
+              <extent>11 vol.</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/billingsa.xml
+++ b/Real_Masters_all/billingsa.xml
@@ -150,7 +150,10 @@ Alan G. Billings set renderings, Bentley Historical Library, University of Michi
         <c02 level="item">
           <did>
             <container type="box" label="Box">1</container>
-            <unittitle><title render="italic">The Balcony</title> by Jean Genet (2 drawings)</unittitle>
+            <unittitle><title render="italic">The Balcony</title> by Jean Genet</unittitle>
+            <physdesc>
+              <extent>2 drawings</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="item">

--- a/Real_Masters_all/bimedcom.xml
+++ b/Real_Masters_all/bimedcom.xml
@@ -10614,7 +10614,10 @@ Thiele, Maria, Technology Transfer Office <unitdate type="inclusive" normal="199
           <c03 level="file">
             <did>
               <container type="box" label="Box">12</container>
-              <unittitle>Pediatrics, 1947-(2 folders)</unittitle>
+              <unittitle>Pediatrics, 1947-</unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -14697,7 +14700,10 @@ Thiele, Maria, Technology Transfer Office <unitdate type="inclusive" normal="199
             <c04 level="file">
               <did>
                 <container type="box" label="Box">18</container>
-                <unittitle>LRC <unitdate type="inclusive" normal="1987">1987</unitdate> (2 envelopes)</unittitle>
+                <unittitle>LRC <unitdate type="inclusive" normal="1987">1987</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 envelopes</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/birkertg.xml
+++ b/Real_Masters_all/birkertg.xml
@@ -2493,7 +2493,10 @@
                 <did>
                   <container type="box" label="Box">3</container>
                   <container type="othertype" label="Con.">6</container>
-                  <unittitle>Andrews University Lecture <unitdate type="inclusive" normal="1985-04-18">April 18, 1985</unitdate> (2 tapes)</unittitle>
+                  <unittitle>Andrews University Lecture <unitdate type="inclusive" normal="1985-04-18">April 18, 1985</unitdate></unittitle>
+                  <physdesc>
+                    <extent>2 tapes</extent>
+                  </physdesc>
                 </did>
                 <odd>
                   <p>*</p>
@@ -2770,7 +2773,10 @@
                 <did>
                   <container type="box" label="Box">4</container>
                   <container type="othertype" label="Con.">8</container>
-                  <unittitle>AIA Omaha Convention Panel Discussion: H. N. Jacobson, Gibbs, G. Birkerts, Rose <unitdate type="inclusive" normal="1987-10">October 1987</unitdate> (2 tapes)</unittitle>
+                  <unittitle>AIA Omaha Convention Panel Discussion: H. N. Jacobson, Gibbs, G. Birkerts, Rose <unitdate type="inclusive" normal="1987-10">October 1987</unitdate></unittitle>
+                  <physdesc>
+                    <extent>2 tapes</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -2804,7 +2810,10 @@
                 <did>
                   <container type="box" label="Box">4</container>
                   <container type="othertype" label="Con.">8</container>
-                  <unittitle>Kathy Blair Interview for <title render="italic">Ann Arbor News</title>, <unitdate type="inclusive" normal="1987-12-29">December 29, 1987</unitdate> (2 tapes)</unittitle>
+                  <unittitle>Kathy Blair Interview for <title render="italic">Ann Arbor News</title>, <unitdate type="inclusive" normal="1987-12-29">December 29, 1987</unitdate></unittitle>
+                  <physdesc>
+                    <extent>2 tapes</extent>
+                  </physdesc>
                 </did>
                 <odd>
                   <p>*</p>
@@ -3216,7 +3225,10 @@
                 <did>
                   <container type="box" label="Box">4</container>
                   <container type="othertype" label="Con.">11</container>
-                  <unittitle>Interview with Dr. George M. Goodwin-"Frank Lloyd Wright and Domino's Farms" <unitdate type="inclusive" normal="1993-12-16">December 16, 1993</unitdate> (2 tapes)</unittitle>
+                  <unittitle>Interview with Dr. George M. Goodwin-"Frank Lloyd Wright and Domino's Farms" <unitdate type="inclusive" normal="1993-12-16">December 16, 1993</unitdate></unittitle>
+                  <physdesc>
+                    <extent>2 tapes</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -3329,7 +3341,10 @@
                 <did>
                   <container type="box" label="Box">4</container>
                   <container type="othertype" label="Con.">12</container>
-                  <unittitle>Modena Speech <unitdate type="inclusive" normal="1997-09-19/1997-09-20">September 19-20, 1997</unitdate> (2 tapes)</unittitle>
+                  <unittitle>Modena Speech <unitdate type="inclusive" normal="1997-09-19/1997-09-20">September 19-20, 1997</unitdate></unittitle>
+                  <physdesc>
+                    <extent>2 tapes</extent>
+                  </physdesc>
                 </did>
                 <odd>
                   <p>*</p>

--- a/Real_Masters_all/blakeman.xml
+++ b/Real_Masters_all/blakeman.xml
@@ -240,7 +240,10 @@ Edward W. Blakeman Papers, Bentley Historical Library, University of Michigan</p
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unittitle>Surveys of the administration of religion in various American universities and colleges (2 expandable folders)</unittitle>
+            <unittitle>Surveys of the administration of religion in various American universities and colleges</unittitle>
+            <physdesc>
+              <extent>2 expandable folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/blanchjj.xml
+++ b/Real_Masters_all/blanchjj.xml
@@ -8326,7 +8326,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">133</container>
-                  <unittitle>Speeches <unitdate type="inclusive" normal="1984/1986">1984-1986</unitdate> (4 folders, audiotapes)</unittitle>
+                  <unittitle>Speeches <unitdate type="inclusive" normal="1984/1986">1984-1986</unitdate></unittitle>
+                  <physdesc>
+                    <extent>4 folders, audiotapes</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -14422,7 +14425,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">245</container>
-                <unittitle>Blanchard Formal Portraits (2 images)</unittitle>
+                <unittitle>Blanchard Formal Portraits</unittitle>
+                <physdesc>
+                  <extent>2 images</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -14458,7 +14464,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">245</container>
-                <unittitle>Campaign for Governor <unitdate type="inclusive" normal="1982">1982</unitdate> (7 posters)</unittitle>
+                <unittitle>Campaign for Governor <unitdate type="inclusive" normal="1982">1982</unitdate></unittitle>
+                <physdesc>
+                  <extent>7 posters</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -16551,13 +16560,19 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">228</container>
-                <unittitle>Chronological <unitdate type="inclusive" normal="1985/1990">1985-1990</unitdate> (6 annual folders)</unittitle>
+                <unittitle>Chronological <unitdate type="inclusive" normal="1985/1990">1985-1990</unitdate></unittitle>
+                <physdesc>
+                  <extent>6 annual folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">228</container>
-                <unittitle>Incoming Log <unitdate type="inclusive" normal="1983/1989">1983-1989</unitdate> (7 annual folders)</unittitle>
+                <unittitle>Incoming Log <unitdate type="inclusive" normal="1983/1989">1983-1989</unitdate></unittitle>
+                <physdesc>
+                  <extent>7 annual folders</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>
@@ -20747,7 +20762,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">335</container>
-                <unittitle>Michigan Democratic Party Poll #10 <unitdate type="inclusive" normal="1990-05-28/1990-05-30">May 28-30, 1990</unitdate> (1 volume)</unittitle>
+                <unittitle>Michigan Democratic Party Poll #10 <unitdate type="inclusive" normal="1990-05-28/1990-05-30">May 28-30, 1990</unitdate></unittitle>
+                <physdesc>
+                  <extent>1 volume</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(conducted by Harrison &amp; Goldberg)</p>
@@ -21055,7 +21073,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">333</container>
-                <unittitle>Official Transcript <unitdate type="inclusive" normal="1988">1988</unitdate> Platform Hearing, <unitdate type="inclusive" normal="1988-05-10">May 10, 1988</unitdate> (1 volume)</unittitle>
+                <unittitle>Official Transcript <unitdate type="inclusive" normal="1988">1988</unitdate> Platform Hearing, <unitdate type="inclusive" normal="1988-05-10">May 10, 1988</unitdate></unittitle>
+                <physdesc>
+                  <extent>1 volume</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/blanfam.xml
+++ b/Real_Masters_all/blanfam.xml
@@ -3212,7 +3212,10 @@ Blanchard Family Papers, Bentley Historical Library, University of Michigan</p>
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">11</container>
-                    <unittitle>General (3 negatives)</unittitle>
+                    <unittitle>General</unittitle>
+                    <physdesc>
+                      <extent>3 negatives</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
@@ -5658,7 +5661,10 @@ Blanchard Family Papers, Bentley Historical Library, University of Michigan</p>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">15</container>
-                  <unittitle>Shutter Timer (2 negatives)</unittitle>
+                  <unittitle>Shutter Timer</unittitle>
+                  <physdesc>
+                    <extent>2 negatives</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -6206,7 +6212,10 @@ Blanchard Family Papers, Bentley Historical Library, University of Michigan</p>
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <unittitle>Group portrait: Tucker and Cobb families (2 negatives)</unittitle>
+                    <unittitle>Group portrait: Tucker and Cobb families</unittitle>
+                    <physdesc>
+                      <extent>2 negatives</extent>
+                    </physdesc>
                   </did>
                 </c06>
               </c05>

--- a/Real_Masters_all/blumeww.xml
+++ b/Real_Masters_all/blumeww.xml
@@ -331,7 +331,10 @@ William W. Blume Papers, Bentley Historical Library, University of Michigan</p>
         </scopecontent>
         <c02 level="file">
           <did>
-            <unittitle>Copies and Summaries of Pleadings (1 v.)</unittitle>
+            <unittitle>Copies and Summaries of Pleadings</unittitle>
+            <physdesc>
+              <extent>1 v.</extent>
+            </physdesc>
           </did>
           <c03 level="file">
             <did>
@@ -354,7 +357,10 @@ William W. Blume Papers, Bentley Historical Library, University of Michigan</p>
         </c02>
         <c02 level="file">
           <did>
-            <unittitle>Calendar of Cases (1 v.)</unittitle>
+            <unittitle>Calendar of Cases</unittitle>
+            <physdesc>
+              <extent>1 v.</extent>
+            </physdesc>
           </did>
           <c03 level="file">
             <did>
@@ -377,7 +383,10 @@ William W. Blume Papers, Bentley Historical Library, University of Michigan</p>
         </c02>
         <c02 level="file">
           <did>
-            <unittitle>Calendar of Cases, District Courts, Michigan Territory <unitdate type="inclusive" normal="1805/1810">1805-1810</unitdate> (1 vol.)</unittitle>
+            <unittitle>Calendar of Cases, District Courts, Michigan Territory <unitdate type="inclusive" normal="1805/1810">1805-1810</unitdate></unittitle>
+            <physdesc>
+              <extent>1 vol.</extent>
+            </physdesc>
           </did>
           <c03 level="file">
             <did>
@@ -400,7 +409,10 @@ William W. Blume Papers, Bentley Historical Library, University of Michigan</p>
         </c02>
         <c02 level="file">
           <did>
-            <unittitle>County Court, Wayne County (1 v.)</unittitle>
+            <unittitle>County Court, Wayne County</unittitle>
+            <physdesc>
+              <extent>1 v.</extent>
+            </physdesc>
           </did>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/brownpre.xml
+++ b/Real_Masters_all/brownpre.xml
@@ -3697,7 +3697,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">29</container>
-                <unittitle>Minute Man Spots, Prentiss Brown on defense savings bonds (1 disc)</unittitle>
+                <unittitle>Minute Man Spots, Prentiss Brown on defense savings bonds</unittitle>
+                <physdesc>
+                  <extent>1 disc</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/bruckerw.xml
+++ b/Real_Masters_all/bruckerw.xml
@@ -3786,7 +3786,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">33</container>
-              <unittitle><unitdate type="inclusive" normal="1958-04-10">April 10, 1958</unitdate> Union League Club, New York City (7 in. and 10 in. tapes)</unittitle>
+              <unittitle><unitdate type="inclusive" normal="1958-04-10">April 10, 1958</unitdate> Union League Club, New York City</unittitle>
+              <physdesc>
+                <extent>7 in. and 10 in. tapes</extent>
+              </physdesc>
             </did>
             <odd>
               <p>(Tapes 149, 150)</p>
@@ -3948,7 +3951,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">33</container>
-              <unittitle><unitdate type="inclusive" normal="1958-01-31">January 31, 1958</unitdate> Explorer Launching (7 tapes)</unittitle>
+              <unittitle><unitdate type="inclusive" normal="1958-01-31">January 31, 1958</unitdate> Explorer Launching</unittitle>
+              <physdesc>
+                <extent>7 tapes</extent>
+              </physdesc>
             </did>
             <odd>
               <p>(Tapes 174-180)</p>

--- a/Real_Masters_all/busadp.xml
+++ b/Real_Masters_all/busadp.xml
@@ -1796,7 +1796,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">10</container>
-              <unittitle><title render="italic">The Global Blue</title>, 1996-1999(4 folders)</unittitle>
+              <unittitle><title render="italic">The Global Blue</title>, 1996-1999</unittitle>
+              <physdesc>
+                <extent>4 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -2064,13 +2067,19 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">12</container>
-                  <unittitle><unitdate type="inclusive" normal="1926/1934">1926-1934</unitdate> vol. 1-6 (6 bound volumes)</unittitle>
+                  <unittitle><unitdate type="inclusive" normal="1926/1934">1926-1934</unitdate> vol. 1-6</unittitle>
+                  <physdesc>
+                    <extent>6 bound volumes</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">13</container>
-                  <unittitle><unitdate type="inclusive" normal="1935/1941">1935-1941</unitdate> vol. 7-9 (3 bound volumes)</unittitle>
+                  <unittitle><unitdate type="inclusive" normal="1935/1941">1935-1941</unitdate> vol. 7-9</unittitle>
+                  <physdesc>
+                    <extent>3 bound volumes</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">

--- a/Real_Masters_all/caasum.xml
+++ b/Real_Masters_all/caasum.xml
@@ -4295,7 +4295,10 @@ Center for Afroamerican and African Studies (University of Michigan) records, Be
           <c03 level="file">
             <did>
               <container type="box" label="Box">21</container>
-              <unittitle>Wagaw, Teshome, Publications, 1971-1991(3 folders)</unittitle>
+              <unittitle>Wagaw, Teshome, Publications, 1971-1991</unittitle>
+              <physdesc>
+                <extent>3 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -15630,7 +15633,10 @@ Center for Afroamerican and African Studies (University of Michigan) records, Be
           <c03 level="file">
             <did>
               <container type="box" label="Box">49</container>
-              <unittitle><unitdate normal="1992-02-18">1992-02-18</unitdate> Dr Lionel Jeffries, Black Student Union (2 tapes)</unittitle>
+              <unittitle><unitdate normal="1992-02-18">1992-02-18</unitdate> Dr Lionel Jeffries, Black Student Union</unittitle>
+              <physdesc>
+                <extent>2 tapes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -15695,7 +15701,10 @@ Center for Afroamerican and African Studies (University of Michigan) records, Be
           <c03 level="file">
             <did>
               <container type="box" label="Box">50</container>
-              <unittitle><unitdate normal="1992-10-11">1992-10-11/12</unitdate> "500 Years of Resistance: Political Prisoners" (2 tapes)</unittitle>
+              <unittitle><unitdate normal="1992-10-11">1992-10-11/12</unitdate> "500 Years of Resistance: Political Prisoners"</unittitle>
+              <physdesc>
+                <extent>2 tapes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/cauppub.xml
+++ b/Real_Masters_all/cauppub.xml
@@ -603,7 +603,10 @@ A. Alfred Taubman College of Architecture and Urban Planning (University of Mich
           <c03 level="file">
             <did>
               <container type="box" label="Box">3</container>
-              <unittitle><title render="italic">College of Architecture and Design Announcement</title>, <unitdate type="inclusive" normal="1947/1973">1947-1973</unitdate> (2 bound volumes)</unittitle>
+              <unittitle><title render="italic">College of Architecture and Design Announcement</title>, <unitdate type="inclusive" normal="1947/1973">1947-1973</unitdate></unittitle>
+              <physdesc>
+                <extent>2 bound volumes</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/ccspub.xml
+++ b/Real_Masters_all/ccspub.xml
@@ -293,7 +293,10 @@ Center for Chinese Studies (University of Michigan) Publications, Bentley Histor
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unittitle><title render="italic">Ta Tzu Pao</title>, <unitdate type="inclusive" normal="1969/1970">1969-1970</unitdate> (3 folders)</unittitle>
+              <unittitle><title render="italic">Ta Tzu Pao</title>, <unitdate type="inclusive" normal="1969/1970">1969-1970</unitdate></unittitle>
+              <physdesc>
+                <extent>3 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/cdwill.xml
+++ b/Real_Masters_all/cdwill.xml
@@ -699,7 +699,10 @@
           <c03 level="item">
             <did>
               <container type="box" label="Box">2</container>
-              <unittitle>Fragmentary, untitled and/or undated (3 folders)</unittitle>
+              <unittitle>Fragmentary, untitled and/or undated</unittitle>
+              <physdesc>
+                <extent>3 folders</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/centcams.xml
+++ b/Real_Masters_all/centcams.xml
@@ -185,7 +185,10 @@ Center for Coordination of Ancient and Modern studies (University of Michigan) R
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unittitle>W-Z (4 folders)</unittitle>
+            <unittitle>W-Z</unittitle>
+            <physdesc>
+              <extent>4 folders</extent>
+            </physdesc>
           </did>
         </c02>
       </c01>

--- a/Real_Masters_all/cew.xml
+++ b/Real_Masters_all/cew.xml
@@ -8048,7 +8048,10 @@ Center for the Education of Women (University of Michigan) Records, Bentley Hist
           <c03 level="file">
             <did>
               <container type="box" label="Box">40</container>
-              <unittitle>"Women's Lives: Breaking the Barriers" <unitdate type="inclusive" normal="1992">1992</unitdate> (2 cassettes)</unittitle>
+              <unittitle>"Women's Lives: Breaking the Barriers" <unitdate type="inclusive" normal="1992">1992</unitdate></unittitle>
+              <physdesc>
+                <extent>2 cassettes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -8066,7 +8069,10 @@ Center for the Education of Women (University of Michigan) Records, Bentley Hist
           <c03 level="file">
             <did>
               <container type="box" label="Box">40</container>
-              <unittitle>Working Women Seminar <unitdate type="inclusive">undated</unitdate> (2 tapes)</unittitle>
+              <unittitle>Working Women Seminar <unitdate type="inclusive">undated</unitdate></unittitle>
+              <physdesc>
+                <extent>2 tapes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -8291,13 +8297,19 @@ Center for the Education of Women (University of Michigan) Records, Bentley Hist
           <c03 level="file">
             <did>
               <container type="box" label="Box">41</container>
-              <unittitle>"Role of Women in Conflict and Peace" Symposium <unitdate type="inclusive" normal="1976-03-24">3/24/1976</unitdate> (2 tapes)</unittitle>
+              <unittitle>"Role of Women in Conflict and Peace" Symposium <unitdate type="inclusive" normal="1976-03-24">3/24/1976</unitdate></unittitle>
+              <physdesc>
+                <extent>2 tapes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">41</container>
-              <unittitle>"Problems of Women's Continuing Education" Research Symposium <unitdate type="inclusive" normal="1977-03-01">3/1/1977</unitdate> (2 tapes)</unittitle>
+              <unittitle>"Problems of Women's Continuing Education" Research Symposium <unitdate type="inclusive" normal="1977-03-01">3/1/1977</unitdate></unittitle>
+              <physdesc>
+                <extent>2 tapes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -8321,7 +8333,10 @@ Center for the Education of Women (University of Michigan) Records, Bentley Hist
           <c03 level="file">
             <did>
               <container type="box" label="Box">41</container>
-              <unittitle>"Janet's tapes on supervision of interns" <unitdate type="inclusive">undated</unitdate> (2 tapes)</unittitle>
+              <unittitle>"Janet's tapes on supervision of interns" <unitdate type="inclusive">undated</unitdate></unittitle>
+              <physdesc>
+                <extent>2 tapes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -8421,13 +8436,19 @@ Center for the Education of Women (University of Michigan) Records, Bentley Hist
           <c03 level="file">
             <did>
               <container type="box" label="Box">41</container>
-              <unittitle>Women in Action Conference-Workshop <unitdate type="inclusive" normal="1969-03-26">3/26/1969</unitdate> (2 reels)</unittitle>
+              <unittitle>Women in Action Conference-Workshop <unitdate type="inclusive" normal="1969-03-26">3/26/1969</unitdate></unittitle>
+              <physdesc>
+                <extent>2 reels</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">41</container>
-              <unittitle>Unlabeled <unitdate type="inclusive">undated</unitdate> (2 reels)</unittitle>
+              <unittitle>Unlabeled <unitdate type="inclusive">undated</unitdate></unittitle>
+              <physdesc>
+                <extent>2 reels</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/cglas.xml
+++ b/Real_Masters_all/cglas.xml
@@ -2864,7 +2864,10 @@
         </c02>
         <c02 level="subseries">
           <did>
-            <unittitle>Biological Studies (8 folders, principal reports in each folder are listed below)</unittitle>
+            <unittitle>Biological Studies</unittitle>
+            <physdesc>
+              <extent>8 folders, principal reports in each folder are listed below</extent>
+            </physdesc>
           </did>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/charlesg.xml
+++ b/Real_Masters_all/charlesg.xml
@@ -243,7 +243,10 @@ Gordon Charles papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">2</container>
-              <unittitle><title render="italic">A Boy, A Bike and Buster</title> material and press clippings (2 folders)</unittitle>
+              <unittitle><title render="italic">A Boy, A Bike and Buster</title> material and press clippings</unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/charnetski.xml
+++ b/Real_Masters_all/charnetski.xml
@@ -254,7 +254,10 @@ Clark J. Charnetski papers, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">1</container>
-            <unittitle>Pulsed hologram viewer (2 photos) <unitdate type="inclusive" normal="1968">1968</unitdate></unittitle>
+            <unittitle>Pulsed hologram viewer <unitdate type="inclusive" normal="1968">1968</unitdate></unittitle>
+            <physdesc>
+              <extent>2 photos</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
@@ -307,7 +310,10 @@ Clark J. Charnetski papers, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">1</container>
-            <unittitle>University of Michigan photographs of equipment (6 photos) <unitdate type="inclusive" normal="1968">1968</unitdate></unittitle>
+            <unittitle>University of Michigan photographs of equipment <unitdate type="inclusive" normal="1968">1968</unitdate></unittitle>
+            <physdesc>
+              <extent>6 photos</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
@@ -568,7 +574,10 @@ Clark J. Charnetski papers, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unittitle>Distortion correction (6 photos) <unitdate type="inclusive" normal="1968">1968</unitdate></unittitle>
+            <unittitle>Distortion correction <unitdate type="inclusive" normal="1968">1968</unitdate></unittitle>
+            <physdesc>
+              <extent>6 photos</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
@@ -628,7 +637,10 @@ Clark J. Charnetski papers, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unittitle>Holographic template (2 photos) <unitdate type="inclusive">undated</unitdate></unittitle>
+            <unittitle>Holographic template <unitdate type="inclusive">undated</unitdate></unittitle>
+            <physdesc>
+              <extent>2 photos</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
@@ -682,7 +694,10 @@ Clark J. Charnetski papers, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unittitle>Moon spatial filtering (4 photos) <unitdate type="inclusive">undated</unitdate></unittitle>
+            <unittitle>Moon spatial filtering <unitdate type="inclusive">undated</unitdate></unittitle>
+            <physdesc>
+              <extent>4 photos</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/chfundmi.xml
+++ b/Real_Masters_all/chfundmi.xml
@@ -252,7 +252,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">2</container>
-              <unittitle>Annual reports <unitdate type="inclusive" normal="1931/1952">1931/32-1951/52</unitdate> (19 booklets and 1 folder) (lacks 1932/33)</unittitle>
+              <unittitle>Annual reports <unitdate type="inclusive" normal="1931/1952">1931/32-1951/52</unitdate> (lacks 1932/33)</unittitle>
+              <physdesc>
+                <extent>19 booklets and 1 folder</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -272,7 +275,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">3</container>
-              <unittitle>Annual reports <unitdate type="inclusive" normal="1929/1954">1929/30-1953/54</unitdate> (3 expandable folders)</unittitle>
+              <unittitle>Annual reports <unitdate type="inclusive" normal="1929/1954">1929/30-1953/54</unitdate></unittitle>
+              <physdesc>
+                <extent>3 expandable folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/chmoral.xml
+++ b/Real_Masters_all/chmoral.xml
@@ -375,7 +375,10 @@ Center for the History of Medicine (University of Michigan) Oral History Intervi
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unittitle>Fajans, Stefan <unitdate type="inclusive" normal="2005">2005</unitdate> (3 discs-see transcript above)</unittitle>
+            <unittitle>Fajans, Stefan <unitdate type="inclusive" normal="2005">2005</unitdate></unittitle>
+            <physdesc>
+              <extent>3 discs-see transcript above</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/choffman.xml
+++ b/Real_Masters_all/choffman.xml
@@ -4867,7 +4867,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">20</container>
-              <unittitle>Unions (2 folders)</unittitle>
+              <unittitle>Unions</unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/classalb.xml
+++ b/Real_Masters_all/classalb.xml
@@ -8731,7 +8731,10 @@ University of Michigan Class Albums, Bentley Historical Library, University of M
           <c03 level="item">
             <did>
               <container type="box" label="Box">45</container>
-              <unittitle>Marsh, Milo E. (2 photos)</unittitle>
+              <unittitle>Marsh, Milo E.</unittitle>
+              <physdesc>
+                <extent>2 photos</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="item">

--- a/Real_Masters_all/cmpdavis.xml
+++ b/Real_Masters_all/cmpdavis.xml
@@ -1308,7 +1308,10 @@
               <did>
                 <container type="box" label="Box">5</container>
                 <unitid>55a-e)</unitid>
-                <unittitle>Camp Davis <unitdate type="inclusive" normal="1940/1949" certainty="approximate">1940s</unitdate>, <unitdate type="inclusive" normal="1950/1959" certainty="approximate">1950s</unitdate> (5 negatives)</unittitle>
+                <unittitle>Camp Davis <unitdate type="inclusive" normal="1940/1949" certainty="approximate">1940s</unitdate>, <unitdate type="inclusive" normal="1950/1959" certainty="approximate">1950s</unitdate></unittitle>
+                <physdesc>
+                  <extent>5 negatives</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">

--- a/Real_Masters_all/coepub.xml
+++ b/Real_Masters_all/coepub.xml
@@ -603,7 +603,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">5</container>
-              <unittitle><title render="italic">The Two Weeks Ahead</title>, <unitdate type="inclusive" normal="1967/1978">1967-1978</unitdate> (5 bound volumes)</unittitle>
+              <unittitle><title render="italic">The Two Weeks Ahead</title>, <unitdate type="inclusive" normal="1967/1978">1967-1978</unitdate></unittitle>
+              <physdesc>
+                <extent>5 bound volumes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/compcent.xml
+++ b/Real_Masters_all/compcent.xml
@@ -1084,7 +1084,10 @@ Computing Center (University of Michigan) records, Bentley Historical Library, U
             <c04 level="file">
               <did>
                 <container type="box" label="Box">6</container>
-                <unittitle>NSF Site Visit, (2 folders) <unitdate type="inclusive" normal="1984">1984</unitdate></unittitle>
+                <unittitle>NSF Site Visit, <unitdate type="inclusive" normal="1984">1984</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -2188,7 +2191,10 @@ Computing Center (University of Michigan) records, Bentley Historical Library, U
           <c03 level="file">
             <did>
               <container type="box" label="Box">43</container>
-              <unittitle>Research Systems Associate Director Search <unitdate type="inclusive" normal="1990">1990</unitdate> (1 folder)</unittitle>
+              <unittitle>Research Systems Associate Director Search <unitdate type="inclusive" normal="1990">1990</unitdate></unittitle>
+              <physdesc>
+                <extent>1 folder</extent>
+              </physdesc>
             </did>
             <accessrestrict>
               <p>[PR RESTRICTED until <date type="restriction" normal="2021-07-01">July 1, 2021</date>]</p>
@@ -2582,7 +2588,10 @@ Computing Center (University of Michigan) records, Bentley Historical Library, U
         <c02 level="file">
           <did>
             <container type="box" label="Box">16</container>
-            <unittitle>(39 3 ½" diskettes) (Includes administrative documents, "MTS Run Data," "CLS Data and UB," and "UB Summaries." Sample printouts included in folder)</unittitle>
+            <unittitle> (Includes administrative documents, "MTS Run Data," "CLS Data and UB," and "UB Summaries." Sample printouts included in folder)</unittitle>
+            <physdesc>
+              <extent>39 3 &amp;#189;" diskettes</extent>
+            </physdesc>
           </did>
         </c02>
       </c01>

--- a/Real_Masters_all/converse.xml
+++ b/Real_Masters_all/converse.xml
@@ -1968,7 +1968,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">8</container>
-                <unittitle>Advanced Research Seminar on Cognitive Aspects of Survey Methodology (2 notebooks)</unittitle>
+                <unittitle>Advanced Research Seminar on Cognitive Aspects of Survey Methodology</unittitle>
+                <physdesc>
+                  <extent>2 notebooks</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>

--- a/Real_Masters_all/cranehh.xml
+++ b/Real_Masters_all/cranehh.xml
@@ -713,7 +713,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">13</container>
-              <unittitle>Oxnam, G. Bromley, 1939-1958 (3 folders)</unittitle>
+              <unittitle>Oxnam, G. Bromley, 1939-1958</unittitle>
+              <physdesc>
+                <extent>3 folders</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>
@@ -757,7 +760,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">14</container>
-              <unittitle>Price, Bill and Helen, 1946-1958 (2 folders)</unittitle>
+              <unittitle>Price, Bill and Helen, 1946-1958</unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>
@@ -777,7 +783,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">14</container>
-              <unittitle>Reisner, Ensworth, 1939-1958 (2 folders)</unittitle>
+              <unittitle>Reisner, Ensworth, 1939-1958</unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -962,7 +971,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">16</container>
-              <unittitle>Vandercook, Del C., 1940-1958 (3 folders)</unittitle>
+              <unittitle>Vandercook, Del C., 1940-1958</unittitle>
+              <physdesc>
+                <extent>3 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/crarydou.xml
+++ b/Real_Masters_all/crarydou.xml
@@ -996,7 +996,12 @@ Douglas D. Crary Papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">10</container>
-              <unittitle><unitdate type="inclusive" normal="1969">1969</unitdate> (3 folders)</unittitle>
+              <unittitle>
+                <unitdate type="inclusive" normal="1969">1969</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>3 folders</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/crawfrdr.xml
+++ b/Real_Masters_all/crawfrdr.xml
@@ -995,7 +995,10 @@ Richard Crawford (1935- )Papers, Bentley Historical Library, University of Michi
         <c02 level="file">
           <did>
             <container type="box" label="Box">4</container>
-            <unittitle>Earl V. Moore Interviews <unitdate type="inclusive" normal="1979">1979</unitdate> (17 cassettes)</unittitle>
+            <unittitle>Earl V. Moore Interviews <unitdate type="inclusive" normal="1979">1979</unitdate></unittitle>
+            <physdesc>
+              <extent>17 cassettes</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/crlt.xml
+++ b/Real_Masters_all/crlt.xml
@@ -756,7 +756,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">14</container>
-              <unittitle>Policy Committee (2 folders) <unitdate type="inclusive" normal="1994/1995">1994-1995</unitdate></unittitle>
+              <unittitle>Policy Committee <unitdate type="inclusive" normal="1994/1995">1994-1995</unitdate></unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/crossal.xml
+++ b/Real_Masters_all/crossal.xml
@@ -696,7 +696,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">16</container>
-              <unittitle>Portraits and informal snapshots of Cross, family members and friends (5 folders and 3 albums)</unittitle>
+              <unittitle>Portraits and informal snapshots of Cross, family members and friends</unittitle>
+              <physdesc>
+                <extent>5 folders and 3 albums</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/cssmith.xml
+++ b/Real_Masters_all/cssmith.xml
@@ -243,7 +243,10 @@
         </c02>
         <c02 level="series">
           <did>
-            <unittitle>Stenographer's notepads of correspondence and other writings, 1921-1923 (2 folders)</unittitle>
+            <unittitle>Stenographer's notepads of correspondence and other writings, 1921-1923</unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
           </did>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/dalglfam.xml
+++ b/Real_Masters_all/dalglfam.xml
@@ -184,7 +184,10 @@ Dalgleish family business records, Bentley Historical Library, University of Mic
         <c02 level="file">
           <did>
             <container type="box" label="Box">1</container>
-            <unittitle>Photographs <unitdate type="inclusive" normal="1928/1953">1928-1953</unitdate>, <unitdate type="inclusive">undated</unitdate> (2 folders and outsize)</unittitle>
+            <unittitle>Photographs <unitdate type="inclusive" normal="1928/1953">1928-1953</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
+            <physdesc>
+              <extent>2 folders and outsize</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/dancegal.xml
+++ b/Real_Masters_all/dancegal.xml
@@ -938,18 +938,24 @@ Dance Gallery Foundation records, Bentley Historical Library, University of Mich
           <c03 level="file">
             <did>
               <container type="box" label="Box">4</container>
-              <unittitle>Peninsula at Film Festival <unitdate type="inclusive" normal="2004-03">March 2004</unitdate> (2 discs)</unittitle>
+              <unittitle>Peninsula at Film Festival <unitdate type="inclusive" normal="2004-03">March 2004</unitdate></unittitle>
               <physdesc>
                 <physfacet>CD-R</physfacet>
+              </physdesc>
+              <physdesc>
+                <extent>2 discs</extent>
               </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">4</container>
-              <unittitle>Peninsula Rehearsal <unitdate type="inclusive" normal="2004-06-23">June 23, 2004</unitdate> (3 discs)</unittitle>
+              <unittitle>Peninsula Rehearsal <unitdate type="inclusive" normal="2004-06-23">June 23, 2004</unitdate></unittitle>
               <physdesc>
                 <physfacet>CD-R</physfacet>
+              </physdesc>
+              <physdesc>
+                <extent>3 discs</extent>
               </physdesc>
             </did>
           </c03>
@@ -965,9 +971,12 @@ Dance Gallery Foundation records, Bentley Historical Library, University of Mich
           <c03 level="file">
             <did>
               <container type="box" label="Box">4</container>
-              <unittitle>Peninsula at Power Center <unitdate type="inclusive" normal="2004-06">June 2004</unitdate> (3 discs)</unittitle>
+              <unittitle>Peninsula at Power Center <unitdate type="inclusive" normal="2004-06">June 2004</unitdate></unittitle>
               <physdesc>
                 <physfacet>CD-R</physfacet>
+              </physdesc>
+              <physdesc>
+                <extent>3 discs</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/davisde.xml
+++ b/Real_Masters_all/davisde.xml
@@ -1888,7 +1888,10 @@ David E. Davis papers, Bentley Historical Library, University of Michigan</p>
         <c02 level="file">
           <did>
             <container type="box" label="Box">8</container>
-            <unittitle>Reporter's notebooks (12 items)</unittitle>
+            <unittitle>Reporter's notebooks</unittitle>
+            <physdesc>
+              <extent>12 items</extent>
+            </physdesc>
           </did>
         </c02>
       </c01>

--- a/Real_Masters_all/delanghe.xml
+++ b/Real_Masters_all/delanghe.xml
@@ -3283,7 +3283,10 @@ Gay Delanghe papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">12</container>
-              <unittitle>"Aubade," <unitdate type="inclusive" normal="1973">Summer 1973</unitdate> (3 reels)</unittitle>
+              <unittitle>"Aubade," <unitdate type="inclusive" normal="1973">Summer 1973</unitdate></unittitle>
+              <physdesc>
+                <extent>3 reels</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -3313,19 +3316,28 @@ Gay Delanghe papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">12</container>
-              <unittitle>"Perez," <unitdate type="inclusive" normal="1973">Summer 1973</unitdate> (4 reels)</unittitle>
+              <unittitle>"Perez," <unitdate type="inclusive" normal="1973">Summer 1973</unitdate></unittitle>
+              <physdesc>
+                <extent>4 reels</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">12</container>
-              <unittitle>"Seven Deadly Sins" (6 reels)</unittitle>
+              <unittitle>"Seven Deadly Sins"</unittitle>
+              <physdesc>
+                <extent>6 reels</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">12</container>
-              <unittitle>"Bassett" (3 reels)</unittitle>
+              <unittitle>"Bassett"</unittitle>
+              <physdesc>
+                <extent>3 reels</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -3343,7 +3355,10 @@ Gay Delanghe papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">12</container>
-              <unittitle>"H. Delanghe 2975 Beals, Detroit 14, Michigan" (2 reels)</unittitle>
+              <unittitle>"H. Delanghe 2975 Beals, Detroit 14, Michigan"</unittitle>
+              <physdesc>
+                <extent>2 reels</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -3471,7 +3486,10 @@ Gay Delanghe papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">13</container>
-              <unittitle>Limon Workshop (2 cases)</unittitle>
+              <unittitle>Limon Workshop</unittitle>
+              <physdesc>
+                <extent>2 cases</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/dennison.xml
+++ b/Real_Masters_all/dennison.xml
@@ -1379,7 +1379,10 @@ David M. Dennison Papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">8</container>
-              <unittitle>Dennison talks Cassette tapes (2 tapes)</unittitle>
+              <unittitle>Dennison talks Cassette tapes</unittitle>
+              <physdesc>
+                <extent>2 tapes</extent>
+              </physdesc>
             </did>
             <odd>
               <p>((1)Trial run of talk for the Physical Society in Chicago, February 6, 1974 and (2)Ralph Baldwin, Dick [...], and David Dennison talk about The Early Days of the Proximity Fuze, undated)</p>

--- a/Real_Masters_all/deppathp.xml
+++ b/Real_Masters_all/deppathp.xml
@@ -192,7 +192,10 @@ Dept. of Pathology (University of Michigan) publications, Bentley Historical Lib
             <c04 level="file">
               <did>
                 <container type="box" label="Box">2</container>
-                <unittitle>Pathology Laboratories Handbook <unitdate type="inclusive" normal="1979/1996">1979-1996</unitdate> (8 folders)</unittitle>
+                <unittitle>Pathology Laboratories Handbook <unitdate type="inclusive" normal="1979/1996">1979-1996</unitdate></unittitle>
+                <physdesc>
+                  <extent>8 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/detobs.xml
+++ b/Real_Masters_all/detobs.xml
@@ -2884,7 +2884,12 @@ Detroit Observatory (University of Michigan) records, Bentley Historical Library
               </c05>
               <c05 level="item">
                 <did>
-                  <unittitle><unitdate type="inclusive" normal="1910-05-26">May 26, 1910</unitdate> (2 slides)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1910-05-26">May 26, 1910</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 slides</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="item">

--- a/Real_Masters_all/devries.xml
+++ b/Real_Masters_all/devries.xml
@@ -1649,7 +1649,10 @@ Walter De Vries Papers, Bentley Historical Library, University of Michigan</p>
           </c03>
           <c03 level="file">
             <did>
-              <unittitle>North Carolina (5 binders)</unittitle>
+              <unittitle>North Carolina</unittitle>
+              <physdesc>
+                <extent>5 binders</extent>
+              </physdesc>
             </did>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/drewwalt.xml
+++ b/Real_Masters_all/drewwalt.xml
@@ -4338,13 +4338,19 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">36</container>
-            <unittitle>"Delegates. Pickets and Characters, Leberman and Sanford, Rubin and Rubin <unitdate type="inclusive" normal="1911-09/1911-10">September-October 1911</unitdate>" (1 album)</unittitle>
+            <unittitle>"Delegates. Pickets and Characters, Leberman and Sanford, Rubin and Rubin <unitdate type="inclusive" normal="1911-09/1911-10">September-October 1911</unitdate>"</unittitle>
+            <physdesc>
+              <extent>1 album</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">36</container>
-            <unittitle>Damage to steel work at various sites in the U.S., time bombs used, company officials, union members, convicts, police records, hotel records, transportation records, and other court evidence (1 album)</unittitle>
+            <unittitle>Damage to steel work at various sites in the U.S., time bombs used, company officials, union members, convicts, police records, hotel records, transportation records, and other court evidence</unittitle>
+            <physdesc>
+              <extent>1 album</extent>
+            </physdesc>
           </did>
         </c02>
       </c01>

--- a/Real_Masters_all/duderst.xml
+++ b/Real_Masters_all/duderst.xml
@@ -256,7 +256,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unittitle>Clippings (2 folders) <unitdate normal="1974/1995">1974-1995</unitdate></unittitle>
+              <unittitle>Clippings <unitdate normal="1974/1995">1974-1995</unitdate></unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -2424,7 +2427,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">22</container>
-                <unittitle>Speeches, not dated (1 folder)</unittitle>
+                <unittitle>Speeches, not dated</unittitle>
+                <physdesc>
+                  <extent>1 folder</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -5392,7 +5398,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">19</container>
-                <unittitle>Slides used in Publications (5 slides)</unittitle>
+                <unittitle>Slides used in Publications</unittitle>
+                <physdesc>
+                  <extent>5 slides</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>

--- a/Real_Masters_all/duffivan.xml
+++ b/Real_Masters_all/duffivan.xml
@@ -136,7 +136,10 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">1</container>
-            <unittitle>Sabbaticals <unitdate type="inclusive" normal="1957">1957</unitdate>, <unitdate type="inclusive" normal="1964/1967">1964-1967</unitdate> 1983-1984(3 folders)</unittitle>
+            <unittitle>Sabbaticals <unitdate type="inclusive" normal="1957">1957</unitdate>, <unitdate type="inclusive" normal="1964/1967">1964-1967</unitdate> 1983-1984</unittitle>
+            <physdesc>
+              <extent>3 folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
@@ -281,7 +284,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unittitle>Turner Community Advisory Committee <unitdate type="inclusive" normal="1979/1985">1979-1985</unitdate> (3 folders, includes scattered minutes)</unittitle>
+              <unittitle>Turner Community Advisory Committee <unitdate type="inclusive" normal="1979/1985">1979-1985</unitdate></unittitle>
+              <physdesc>
+                <extent>3 folders, includes scattered minutes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/durbanl.xml
+++ b/Real_Masters_all/durbanl.xml
@@ -4895,7 +4895,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">64</container>
-                  <unittitle>Communications Weekly Reports (2 folders)</unittitle>
+                  <unittitle>Communications Weekly Reports</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -5514,7 +5517,10 @@
               <c05 level="file">
                 <did>
                   <container label="Box" type="box">68</container>
-                  <unittitle>Detroit Public Schools, high school survey (5 folders)</unittitle>
+                  <unittitle>Detroit Public Schools, high school survey</unittitle>
+                  <physdesc>
+                    <extent>5 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -5704,7 +5710,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">69</container>
-                  <unittitle>Greater Detroit Area Hospital Council (3 folders)</unittitle>
+                  <unittitle>Greater Detroit Area Hospital Council</unittitle>
+                  <physdesc>
+                    <extent>3 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -5722,7 +5731,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">69</container>
-                  <unittitle>Hospital Survey (2 folders)</unittitle>
+                  <unittitle>Hospital Survey</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -5740,7 +5752,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">69</container>
-                  <unittitle>Miscellaneous (2 folders)</unittitle>
+                  <unittitle>Miscellaneous</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -5931,7 +5946,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">70</container>
-                <unittitle>New Thrust Program (2 folders)</unittitle>
+                <unittitle>New Thrust Program</unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/ellisrut.xml
+++ b/Real_Masters_all/ellisrut.xml
@@ -256,7 +256,10 @@ Ruth Ellis papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">3</container>
-              <unittitle>Miscellaneous (4 albums)</unittitle>
+              <unittitle>Miscellaneous</unittitle>
+              <physdesc>
+                <extent>4 albums</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/engcoll.xml
+++ b/Real_Masters_all/engcoll.xml
@@ -7812,7 +7812,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">35</container>
-                <unittitle>The University College, 1927-28 (1 volume)</unittitle>
+                <unittitle>The University College, 1927-28</unittitle>
+                <physdesc>
+                  <extent>1 volume</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -8343,7 +8346,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">92</container>
-                <unittitle>Moore, Arthur, (2 folders) <unitdate type="inclusive" normal="1960/1990">1960-1990</unitdate></unittitle>
+                <unittitle>Moore, Arthur, <unitdate type="inclusive" normal="1960/1990">1960-1990</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -9115,13 +9121,19 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">62</container>
-              <unittitle>Enrollment Statistics <unitdate type="inclusive" normal="1947/1953">1947-1953</unitdate> (7 volumes)</unittitle>
+              <unittitle>Enrollment Statistics <unitdate type="inclusive" normal="1947/1953">1947-1953</unitdate></unittitle>
+              <physdesc>
+                <extent>7 volumes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container label="Box" type="box">63</container>
-              <unittitle>Enrollment Statistics <unitdate type="inclusive" normal="1954/1955">1954-1955</unitdate> (2 volumes)</unittitle>
+              <unittitle>Enrollment Statistics <unitdate type="inclusive" normal="1954/1955">1954-1955</unitdate></unittitle>
+              <physdesc>
+                <extent>2 volumes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/engcomm.xml
+++ b/Real_Masters_all/engcomm.xml
@@ -6561,7 +6561,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">18</container>
-                  <unittitle>Graduation, <unitdate type="inclusive" normal="2001">Spring 2001</unitdate> 4/28/2001(2 folders)</unittitle>
+                  <unittitle>Graduation, <unitdate type="inclusive" normal="2001">Spring 2001</unitdate> 4/28/2001</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">

--- a/Real_Masters_all/englerj.xml
+++ b/Real_Masters_all/englerj.xml
@@ -15973,7 +15973,10 @@ Topics extensively documented include state welfare and school funding reform, r
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">94</container>
-                  <unittitle>Physician Assisted Suicide <unitdate type="inclusive" normal="1992/1998">1992-1998</unitdate> (2 folders)</unittitle>
+                  <unittitle>Physician Assisted Suicide <unitdate type="inclusive" normal="1992/1998">1992-1998</unitdate></unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
                 <odd>
                   <p>(Proposal "B")</p>
@@ -54414,7 +54417,10 @@ Topics extensively documented include state welfare and school funding reform, r
             <c04 level="file">
               <did>
                 <container type="box" label="Box">242</container>
-                <unittitle>Public Acts of <unitdate type="inclusive" normal="1992">1992</unitdate> (281 folders)</unittitle>
+                <unittitle>Public Acts of <unitdate type="inclusive" normal="1992">1992</unitdate></unittitle>
+                <physdesc>
+                  <extent>281 folders</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(nos. 1-281)</p>

--- a/Real_Masters_all/englishd.xml
+++ b/Real_Masters_all/englishd.xml
@@ -693,7 +693,12 @@ Department of English Language and Literature (University of Michigan) records, 
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">4</container>
-                    <unittitle><unitdate type="inclusive" normal="1981/1984-06">1981-1984 June</unitdate> (4 folders)</unittitle>
+                    <unittitle>
+                      <unitdate type="inclusive" normal="1981/1984-06">1981-1984 June</unitdate>
+                    </unittitle>
+                    <physdesc>
+                      <extent>4 folders</extent>
+                    </physdesc>
                   </did>
                 </c06>
               </c05>

--- a/Real_Masters_all/epismich.xml
+++ b/Real_Masters_all/epismich.xml
@@ -1953,7 +1953,10 @@ Episcopal Church, Diocese of Michigan records, Bentley Historical Library, Unive
           <c03 level="file">
             <did>
               <container type="box" label="Box">14</container>
-              <unittitle>Papers <unitdate type="inclusive" normal="1982/1983">1982-1983</unitdate> re 150th anniversary celebration of the Diocese of Michigan (1 expandable folder)</unittitle>
+              <unittitle>Papers <unitdate type="inclusive" normal="1982/1983">1982-1983</unitdate> re 150th anniversary celebration of the Diocese of Michigan</unittitle>
+              <physdesc>
+                <extent>1 expandable folder</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/equadmem.xml
+++ b/Real_Masters_all/equadmem.xml
@@ -119,12 +119,15 @@ East Quad Memory Project (University of Michigan) records, Bentley Historical Li
         <c02 level="file">
           <did>
             <physloc>Online</physloc>
-            <unittitle>Video footage of individuals sharing stories about East Quad <unitdate type="inclusive" normal="2012">2012</unitdate> (10 files)</unittitle>
+            <unittitle>Video footage of individuals sharing stories about East Quad <unitdate type="inclusive" normal="2012">2012</unitdate></unittitle>
             <dao href="http://hdl.handle.net/2027.42/90953" show="new" actuate="onrequest">
               <daodesc>
                 <p>[download file]</p>
               </daodesc>
             </dao>
+            <physdesc>
+              <extent>10 files</extent>
+            </physdesc>
           </did>
         </c02>
       </c01>

--- a/Real_Masters_all/esgeorge.xml
+++ b/Real_Masters_all/esgeorge.xml
@@ -3907,7 +3907,10 @@ Edwin S. George Reserve (Mich.) records, Bentley Historical Library, University 
         <c02 level="file">
           <did>
             <container type="box" label="Box">13</container>
-            <unittitle>Negative Albums (4 albums)</unittitle>
+            <unittitle>Negative Albums</unittitle>
+            <physdesc>
+              <extent>4 albums</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/esquire.xml
+++ b/Real_Masters_all/esquire.xml
@@ -2611,8 +2611,11 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>
-                <persname>Gardner, John (2 folders)</persname>
+                <persname>Gardner, John </persname>
               </unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/extservp.xml
+++ b/Real_Masters_all/extservp.xml
@@ -159,31 +159,54 @@ Extension Service (University of Michigan) publications, Bentley Historical Libr
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unittitle><unitdate type="inclusive" normal="1911/1946">1911-1946</unitdate> (4 bound volumes and 18 folders)</unittitle>
+              <unittitle>
+                <unitdate type="inclusive" normal="1911/1946">1911-1946</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>4 bound volumes and 18 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">2</container>
-              <unittitle><unitdate type="inclusive" normal="1946/1956">1946-1956</unitdate> (7 bound volumes and 9 folders)</unittitle>
+              <unittitle>
+                <unitdate type="inclusive" normal="1946/1956">1946-1956</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>7 bound volumes and 9 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">3</container>
-              <unittitle><unitdate type="inclusive" normal="1956/1962">1956-1962</unitdate> (6 bound volumes and 6 folders)</unittitle>
+              <unittitle>
+                <unitdate type="inclusive" normal="1956/1962">1956-1962</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>6 bound volumes and 6 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">4</container>
-              <unittitle><unitdate type="inclusive" normal="1962/1968">1962-1968</unitdate> (6 bound volumes and 2 folders)</unittitle>
+              <unittitle>
+                <unitdate type="inclusive" normal="1962/1968">1962-1968</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>6 bound volumes and 2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">5</container>
-              <unittitle>1968/1985-1994 (3 bound volumes and 18 folders)</unittitle>
+              <unittitle>1968/1985-1994</unittitle>
+              <physdesc>
+                <extent>3 bound volumes and 18 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -851,7 +874,10 @@ Extension Service (University of Michigan) publications, Bentley Historical Libr
           <c03 level="file">
             <did>
               <container type="box" label="Box">8</container>
-              <unittitle>Bulletins <unitdate type="inclusive" normal="1932/1965">1932-1965</unitdate> (1 bound volume and 1 folder)</unittitle>
+              <unittitle>Bulletins <unitdate type="inclusive" normal="1932/1965">1932-1965</unitdate></unittitle>
+              <physdesc>
+                <extent>1 bound volume and 1 folder</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/fajans.xml
+++ b/Real_Masters_all/fajans.xml
@@ -618,7 +618,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">3</container>
-              <unittitle>Karreman, George (3 folders)</unittitle>
+              <unittitle>Karreman, George</unittitle>
+              <physdesc>
+                <extent>3 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/felcha.xml
+++ b/Real_Masters_all/felcha.xml
@@ -2723,7 +2723,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">4</container>
-              <unittitle>Manuscript map of the United States drawn while student at Bowdoin College (1 item in oversize folder)</unittitle>
+              <unittitle>Manuscript map of the United States drawn while student at Bowdoin College</unittitle>
+              <physdesc>
+                <extent>1 item in oversize folder</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/fojw.xml
+++ b/Real_Masters_all/fojw.xml
@@ -1506,7 +1506,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">7</container>
-              <unittitle><title render="italic">Planning &amp; Zoning News</title> magazine (3 issues), <unitdate type="inclusive" normal="1999">1999</unitdate>, <unitdate type="inclusive" normal="2000">2000</unitdate></unittitle>
+              <unittitle><title render="italic">Planning &amp; Zoning News</title> magazine , <unitdate type="inclusive" normal="1999">1999</unitdate>, <unitdate type="inclusive" normal="2000">2000</unitdate></unittitle>
+              <physdesc>
+                <extent>3 issues</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/fordri.xml
+++ b/Real_Masters_all/fordri.xml
@@ -3198,7 +3198,10 @@ Richard I. Ford papers, Bentley Historical Library, University of Michigan</p>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">17</container>
-                <unittitle>Eriacho, Sefferino (2 tapes)</unittitle>
+                <unittitle>Eriacho, Sefferino</unittitle>
+                <physdesc>
+                  <extent>2 tapes</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -3222,7 +3225,10 @@ Richard I. Ford papers, Bentley Historical Library, University of Michigan</p>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">17</container>
-                <unittitle>Kaaymasee, Letse (2 tapes)</unittitle>
+                <unittitle>Kaaymasee, Letse</unittitle>
+                <physdesc>
+                  <extent>2 tapes</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -3264,7 +3270,10 @@ Richard I. Ford papers, Bentley Historical Library, University of Michigan</p>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">17</container>
-                <unittitle>Mahooty, Chester (3 tapes)</unittitle>
+                <unittitle>Mahooty, Chester</unittitle>
+                <physdesc>
+                  <extent>3 tapes</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -3288,7 +3297,10 @@ Richard I. Ford papers, Bentley Historical Library, University of Michigan</p>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">17</container>
-                <unittitle>Ondelacy, Sol (4 tapes)</unittitle>
+                <unittitle>Ondelacy, Sol</unittitle>
+                <physdesc>
+                  <extent>4 tapes</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -3300,7 +3312,10 @@ Richard I. Ford papers, Bentley Historical Library, University of Michigan</p>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">17</container>
-                <unittitle>Pekatewa, LaVerne(3 tapes)</unittitle>
+                <unittitle>Pekatewa, LaVerne</unittitle>
+                <physdesc>
+                  <extent>3 tapes</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -3339,13 +3354,19 @@ Richard I. Ford papers, Bentley Historical Library, University of Michigan</p>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">17</container>
-                <unittitle>Quam, Dallas (2 tapes)</unittitle>
+                <unittitle>Quam, Dallas</unittitle>
+                <physdesc>
+                  <extent>2 tapes</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">17</container>
-                <unittitle>Simplicio, Chauncy (3 tapes)</unittitle>
+                <unittitle>Simplicio, Chauncy</unittitle>
+                <physdesc>
+                  <extent>3 tapes</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -3357,7 +3378,10 @@ Richard I. Ford papers, Bentley Historical Library, University of Michigan</p>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">17</container>
-                <unittitle>Vacit, Frank (2 tapes)</unittitle>
+                <unittitle>Vacit, Frank</unittitle>
+                <physdesc>
+                  <extent>2 tapes</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -5696,7 +5720,10 @@ Richard I. Ford papers, Bentley Historical Library, University of Michigan</p>
           </did>
           <c03 level="file">
             <did>
-              <unittitle>Recordable Compact Discs (4 disks)</unittitle>
+              <unittitle>Recordable Compact Discs</unittitle>
+              <physdesc>
+                <extent>4 disks</extent>
+              </physdesc>
             </did>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/galbraij.xml
+++ b/Real_Masters_all/galbraij.xml
@@ -3212,7 +3212,10 @@ D. James Galbraith Photographic Collection, Bentley Historical Library, Universi
           <c03 level="file">
             <did>
               <container type="box" label="Box">9</container>
-              <unittitle>Ypsilanti Greek Theater <unitdate type="inclusive" normal="1963/1968">1963-1968</unitdate> (3 folders and oversize)</unittitle>
+              <unittitle>Ypsilanti Greek Theater <unitdate type="inclusive" normal="1963/1968">1963-1968</unitdate></unittitle>
+              <physdesc>
+                <extent>3 folders and oversize</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -3316,7 +3319,10 @@ D. James Galbraith Photographic Collection, Bentley Historical Library, Universi
           <c03 level="file">
             <did>
               <container type="box" label="Box">10</container>
-              <unittitle>Miscellaneous <unitdate type="inclusive">undated</unitdate> (5 folders and also see oversize)</unittitle>
+              <unittitle>Miscellaneous <unitdate type="inclusive">undated</unitdate></unittitle>
+              <physdesc>
+                <extent>5 folders and also see oversize</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/geoum.xml
+++ b/Real_Masters_all/geoum.xml
@@ -4384,13 +4384,23 @@ Graduate Employees Organization (University of Michigan) records, Bentley Histor
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">10</container>
-                  <unittitle><unitdate type="inclusive" normal="1977-05/1979-04">May 1977-April 1979</unitdate> (2 books)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1977-05/1979-04">May 1977-April 1979</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 books</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">11</container>
-                  <unittitle><unitdate type="inclusive" normal="1979-05/1983-01">May 1979-January 1983</unitdate> (3 books)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1979-05/1983-01">May 1979-January 1983</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>3 books</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">

--- a/Real_Masters_all/gingrich.xml
+++ b/Real_Masters_all/gingrich.xml
@@ -3327,7 +3327,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">14</container>
-                <unittitle>35th Anniversary Issue (2 folders).</unittitle>
+                <unittitle>35th Anniversary Issue .</unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/gmwill.xml
+++ b/Real_Masters_all/gmwill.xml
@@ -19540,7 +19540,10 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">171</container>
-                    <unittitle>Turnpike Reports (2 v.)</unittitle>
+                    <unittitle>Turnpike Reports</unittitle>
+                    <physdesc>
+                      <extent>2 v.</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
@@ -27091,7 +27094,10 @@
               <c05 level="file">
                 <did>
                   <container label="Box" type="box">242</container>
-                  <unittitle>International Students Day, 1957-1958 (11 folders)</unittitle>
+                  <unittitle>International Students Day, 1957-1958</unittitle>
+                  <physdesc>
+                    <extent>11 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -39698,7 +39704,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">489</container>
-                  <unittitle>Campaign Material (2 folders)</unittitle>
+                  <unittitle>Campaign Material</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -56086,8 +56095,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>African Trip <unitdate type="inclusive" normal="1967">1967</unitdate> (5 reels), (178), <unitdate type="inclusive" normal="1967-06">June 1967</unitdate></unittitle>
+                <unittitle>African Trip <unitdate type="inclusive" normal="1967">1967</unitdate> , (178), <unitdate type="inclusive" normal="1967-06">June 1967</unitdate></unittitle>
                 <unitid>86303-109</unitid>
+                <physdesc>
+                  <extent>5 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film one of five)</p>
@@ -56107,8 +56119,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>African Trip <unitdate type="inclusive" normal="1967">1967</unitdate> (5 reels), (179), <unitdate type="inclusive" normal="1967-06">June 1967</unitdate></unittitle>
+                <unittitle>African Trip <unitdate type="inclusive" normal="1967">1967</unitdate> , (179), <unitdate type="inclusive" normal="1967-06">June 1967</unitdate></unittitle>
                 <unitid>86303-110</unitid>
+                <physdesc>
+                  <extent>5 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film two of five)</p>
@@ -56128,8 +56143,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>African Trip <unitdate type="inclusive" normal="1967">1967</unitdate> (5 reels), (180), <unitdate type="inclusive" normal="1967-06">June 1967</unitdate></unittitle>
+                <unittitle>African Trip <unitdate type="inclusive" normal="1967">1967</unitdate> , (180), <unitdate type="inclusive" normal="1967-06">June 1967</unitdate></unittitle>
                 <unitid>86303-111</unitid>
+                <physdesc>
+                  <extent>5 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film three of five)</p>
@@ -56149,8 +56167,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>African Trip <unitdate type="inclusive" normal="1967">1967</unitdate> (5 reels), (181), <unitdate type="inclusive" normal="1967-06">June 1967</unitdate></unittitle>
+                <unittitle>African Trip <unitdate type="inclusive" normal="1967">1967</unitdate> , (181), <unitdate type="inclusive" normal="1967-06">June 1967</unitdate></unittitle>
                 <unitid>86303-112</unitid>
+                <physdesc>
+                  <extent>5 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film four of five)</p>
@@ -56170,8 +56191,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>African Trip <unitdate type="inclusive" normal="1967">1967</unitdate> (5 reels), (182), <unitdate type="inclusive" normal="1967-06">June 1967</unitdate></unittitle>
+                <unittitle>African Trip <unitdate type="inclusive" normal="1967">1967</unitdate> , (182), <unitdate type="inclusive" normal="1967-06">June 1967</unitdate></unittitle>
                 <unitid>86303-113</unitid>
+                <physdesc>
+                  <extent>5 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film five of five)</p>
@@ -56335,8 +56359,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>Mackinac, Rome, Pickford <unitdate type="inclusive" normal="1969">1969</unitdate> (3 reels), (190), September1969</unittitle>
+                <unittitle>Mackinac, Rome, Pickford <unitdate type="inclusive" normal="1969">1969</unitdate> , (190), September1969</unittitle>
                 <unitid>86303-121</unitid>
+                <physdesc>
+                  <extent>3 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film one of three)</p>
@@ -56356,8 +56383,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>Mackinac, Rome, Pickford <unitdate type="inclusive" normal="1969">1969</unitdate> (3 reels), (191), September1969</unittitle>
+                <unittitle>Mackinac, Rome, Pickford <unitdate type="inclusive" normal="1969">1969</unitdate> , (191), September1969</unittitle>
                 <unitid>86303-122</unitid>
+                <physdesc>
+                  <extent>3 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film two of three)</p>
@@ -56377,8 +56407,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>Mackinac, Rome, Pickford <unitdate type="inclusive" normal="1969">1969</unitdate> (3 reels), (192), September1969</unittitle>
+                <unittitle>Mackinac, Rome, Pickford <unitdate type="inclusive" normal="1969">1969</unitdate> , (192), September1969</unittitle>
                 <unitid>86303-123</unitid>
+                <physdesc>
+                  <extent>3 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film three of three)</p>
@@ -56398,8 +56431,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>Christmas <unitdate type="inclusive" normal="1969">1969</unitdate> (5 reels), (193), December1969</unittitle>
+                <unittitle>Christmas <unitdate type="inclusive" normal="1969">1969</unitdate> , (193), December1969</unittitle>
                 <unitid>86303-124</unitid>
+                <physdesc>
+                  <extent>5 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film one of five)</p>
@@ -56419,8 +56455,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>Christmas <unitdate type="inclusive" normal="1969">1969</unitdate> (5 reels), (194), December1969</unittitle>
+                <unittitle>Christmas <unitdate type="inclusive" normal="1969">1969</unitdate> , (194), December1969</unittitle>
                 <unitid>86303-125</unitid>
+                <physdesc>
+                  <extent>5 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film two of five)</p>
@@ -56440,8 +56479,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>Christmas <unitdate type="inclusive" normal="1969">1969</unitdate> (5 reels), (195), December1969</unittitle>
+                <unittitle>Christmas <unitdate type="inclusive" normal="1969">1969</unitdate> , (195), December1969</unittitle>
                 <unitid>86303-126</unitid>
+                <physdesc>
+                  <extent>5 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film three of five)</p>
@@ -56461,8 +56503,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>Christmas <unitdate type="inclusive" normal="1969">1969</unitdate> (5 reels), (196), December1969</unittitle>
+                <unittitle>Christmas <unitdate type="inclusive" normal="1969">1969</unitdate> , (196), December1969</unittitle>
                 <unitid>86303-127</unitid>
+                <physdesc>
+                  <extent>5 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film four of five)</p>
@@ -56482,8 +56527,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>Christmas <unitdate type="inclusive" normal="1969">1969</unitdate> (5 reels), (197), December1969</unittitle>
+                <unittitle>Christmas <unitdate type="inclusive" normal="1969">1969</unitdate> , (197), December1969</unittitle>
                 <unitid>86303-128</unitid>
+                <physdesc>
+                  <extent>5 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film five of five)</p>
@@ -56503,8 +56551,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>Philippines <unitdate type="inclusive" normal="1967/1968">1967-1968</unitdate> (2 reels), (8"), (198), <unitdate type="inclusive" normal="1967/1968">1967-1968</unitdate></unittitle>
+                <unittitle>Philippines <unitdate type="inclusive" normal="1967/1968">1967-1968</unitdate> , (8"), (198), <unitdate type="inclusive" normal="1967/1968">1967-1968</unitdate></unittitle>
                 <unitid>86303-129</unitid>
+                <physdesc>
+                  <extent>2 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film one of two)</p>
@@ -56524,8 +56575,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>Philippines <unitdate type="inclusive" normal="1967/1968">1967-1968</unitdate> (2 reels), (8"), (199), <unitdate type="inclusive" normal="1967/1968">1967-1968</unitdate></unittitle>
+                <unittitle>Philippines <unitdate type="inclusive" normal="1967/1968">1967-1968</unitdate> , (8"), (199), <unitdate type="inclusive" normal="1967/1968">1967-1968</unitdate></unittitle>
                 <unitid>86303-130</unitid>
+                <physdesc>
+                  <extent>2 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film two of two)</p>
@@ -56545,8 +56599,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>Philippines, Hawaii, Disneyland, (4 reels), (8"), (200) <unitdate type="inclusive">undated</unitdate></unittitle>
+                <unittitle>Philippines, Hawaii, Disneyland, , (8"), (200) <unitdate type="inclusive">undated</unitdate></unittitle>
                 <unitid>86303-131</unitid>
+                <physdesc>
+                  <extent>4 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film one of four; undated)</p>
@@ -56566,8 +56623,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>Philippines, Hawaii, Disneyland, (4 reels), (8"), (201) <unitdate type="inclusive">undated</unitdate></unittitle>
+                <unittitle>Philippines, Hawaii, Disneyland, , (8"), (201) <unitdate type="inclusive">undated</unitdate></unittitle>
                 <unitid>86303-132</unitid>
+                <physdesc>
+                  <extent>4 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film two of four; undated)</p>
@@ -56587,8 +56647,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>Philippines, Hawaii, Disneyland, (4 reels), (8"), (202) <unitdate type="inclusive">undated</unitdate></unittitle>
+                <unittitle>Philippines, Hawaii, Disneyland, , (8"), (202) <unitdate type="inclusive">undated</unitdate></unittitle>
                 <unitid>86303-133</unitid>
+                <physdesc>
+                  <extent>4 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film three of four; undated)</p>
@@ -56608,8 +56671,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>Philippines, Hawaii, Disneyland, (4 reels), (8"), (203) <unitdate type="inclusive">undated</unitdate></unittitle>
+                <unittitle>Philippines, Hawaii, Disneyland, , (8"), (203) <unitdate type="inclusive">undated</unitdate></unittitle>
                 <unitid>86303-134</unitid>
+                <physdesc>
+                  <extent>4 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film four of four; undated)</p>
@@ -56629,8 +56695,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>Mackinac Memories <unitdate type="inclusive">undated</unitdate> (2 reels), (204), <unitdate type="inclusive" normal="1970-07">July 1970</unitdate></unittitle>
+                <unittitle>Mackinac Memories <unitdate type="inclusive">undated</unitdate> , (204), <unitdate type="inclusive" normal="1970-07">July 1970</unitdate></unittitle>
                 <unitid>86303-135</unitid>
+                <physdesc>
+                  <extent>2 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film one of two)</p>
@@ -56650,8 +56719,11 @@
             </c04>
             <c04 level="item">
               <did>
-                <unittitle>Mackinac Memories <unitdate type="inclusive">undated</unitdate> (2 reels), (205), <unitdate type="inclusive" normal="1970-07">July 1970</unitdate></unittitle>
+                <unittitle>Mackinac Memories <unitdate type="inclusive">undated</unitdate> , (205), <unitdate type="inclusive" normal="1970-07">July 1970</unitdate></unittitle>
                 <unitid>86303-136</unitid>
+                <physdesc>
+                  <extent>2 reels</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(Film two of two)</p>

--- a/Real_Masters_all/granholm.xml
+++ b/Real_Masters_all/granholm.xml
@@ -9165,7 +9165,10 @@ Jennifer Granholm papers, Bentley Historical Library, University of Michigan</p>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">26</container>
-                <unittitle>University of Michigan/Gratz &amp; Grutter Cases/Amicus Filing, 1999-2003(4 folders)</unittitle>
+                <unittitle>University of Michigan/Gratz &amp; Grutter Cases/Amicus Filing, 1999-2003</unittitle>
+                <physdesc>
+                  <extent>4 folders</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[Restricted until <date type="restriction" normal="2018-01-01">Jan. 1, 2018</date>]</p>
@@ -67300,7 +67303,10 @@ Jennifer Granholm papers, Bentley Historical Library, University of Michigan</p>
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">195</container>
-                    <unittitle>B’nai B’rith Great Lakes Region Presents Jewish Community Council Honors David Techner “Activist of the Year” with Michigan Governor Jennifer Granholm (2 tapes)</unittitle>
+                    <unittitle>B’nai B’rith Great Lakes Region Presents Jewish Community Council Honors David Techner “Activist of the Year” with Michigan Governor Jennifer Granholm</unittitle>
+                    <physdesc>
+                      <extent>2 tapes</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
@@ -67875,7 +67881,10 @@ Jennifer Granholm papers, Bentley Historical Library, University of Michigan</p>
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">178</container>
-                    <unittitle>Business Now, A WBTE Production -- Governor Granholm of Michigan (2 tapes)</unittitle>
+                    <unittitle>Business Now, A WBTE Production -- Governor Granholm of Michigan</unittitle>
+                    <physdesc>
+                      <extent>2 tapes</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
@@ -72561,7 +72570,10 @@ Jennifer Granholm papers, Bentley Historical Library, University of Michigan</p>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">205</container>
-                  <unittitle>Governor Jennifer Granholm: Cool Cities <unitdate type="inclusive" normal="2004">2004</unitdate> (2 tapes)</unittitle>
+                  <unittitle>Governor Jennifer Granholm: Cool Cities <unitdate type="inclusive" normal="2004">2004</unitdate></unittitle>
+                  <physdesc>
+                    <extent>2 tapes</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -77279,7 +77291,10 @@ Jennifer Granholm papers, Bentley Historical Library, University of Michigan</p>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">216</container>
-                <unittitle>ATS Town Hall Meeting at The Christian Family Centre <unitdate type="inclusive" normal="2004">2004</unitdate> (2 tapes)</unittitle>
+                <unittitle>ATS Town Hall Meeting at The Christian Family Centre <unitdate type="inclusive" normal="2004">2004</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 tapes</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[Restricted until <date type="restriction" normal="2018-01-01">January 1, 2018</date>]</p>

--- a/Real_Masters_all/griffinj.xml
+++ b/Real_Masters_all/griffinj.xml
@@ -17164,7 +17164,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">84</container>
-                <unittitle>Photographs (1 expandable folder)</unittitle>
+                <unittitle>Photographs</unittitle>
+                <physdesc>
+                  <extent>1 expandable folder</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/griffmar.xml
+++ b/Real_Masters_all/griffmar.xml
@@ -3734,7 +3734,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">39</container>
-                <unittitle>Treasury Dept.(2 folders); include Bureau of Customs</unittitle>
+                <unittitle>Treasury Dept.; include Bureau of Customs</unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/guthece.xml
+++ b/Real_Masters_all/guthece.xml
@@ -940,22 +940,31 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>Dibabaon girl Minicayo-Davao (2 neg)</unittitle>
+                <unittitle>Dibabaon girl Minicayo-Davao</unittitle>
                 <unitid>1-26</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>Bagani Lino, Minicayo-Davao (2 neg)</unittitle>
+                <unittitle>Bagani Lino, Minicayo-Davao</unittitle>
                 <unitid>1-27</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>Bagani Lino's wife, Minicayo-Davao (2 neg)</unittitle>
+                <unittitle>Bagani Lino's wife, Minicayo-Davao</unittitle>
                 <unitid>1-28</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
@@ -1031,8 +1040,11 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>The forest around Bauguerohan-Davao (2 neg)</unittitle>
+                <unittitle>The forest around Bauguerohan-Davao</unittitle>
                 <unitid>1-39</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
@@ -1052,8 +1064,11 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>Scenes along Husgo Creek, Bauguerohan-Davao (2 neg)</unittitle>
+                <unittitle>Scenes along Husgo Creek, Bauguerohan-Davao</unittitle>
                 <unitid>1-42</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
@@ -1101,8 +1116,11 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>Mandaya bolos and scabbards-Davao (2 neg)</unittitle>
+                <unittitle>Mandaya bolos and scabbards-Davao</unittitle>
                 <unitid>1-49</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
@@ -1115,8 +1133,11 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>A new clearing stacked to burn-Davao (2 neg)</unittitle>
+                <unittitle>A new clearing stacked to burn-Davao</unittitle>
                 <unitid>1-51</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
@@ -1157,8 +1178,11 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>Bagabos near Davao-Davao (2 neg)</unittitle>
+                <unittitle>Bagabos near Davao-Davao</unittitle>
                 <unitid>1-57</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
@@ -1178,8 +1202,11 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>Detail of Bagobo coat-Davao (2 neg)</unittitle>
+                <unittitle>Detail of Bagobo coat-Davao</unittitle>
                 <unitid>1-60</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
@@ -1199,29 +1226,41 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>"Caves" on Malipano Isl., Samal-Davao (2 neg)</unittitle>
+                <unittitle>"Caves" on Malipano Isl., Samal-Davao</unittitle>
                 <unitid>1-63</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>Mt. Cipo and the Davao pier-Davao (2 neg)</unittitle>
+                <unittitle>Mt. Cipo and the Davao pier-Davao</unittitle>
                 <unitid>1-64</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>Panorama of Mati-Davao (2 neg)</unittitle>
+                <unittitle>Panorama of Mati-Davao</unittitle>
                 <unitid>1-65</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>Earthquake fault, Mati - Davao (2 neg)</unittitle>
+                <unittitle>Earthquake fault, Mati - Davao</unittitle>
                 <unitid>1-66</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
@@ -1430,8 +1469,11 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>Shrine at Fort Pilar, barracks, Zacubo (2 neg)</unittitle>
+                <unittitle>Shrine at Fort Pilar, barracks, Zacubo</unittitle>
                 <unitid>1-96</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
@@ -1736,8 +1778,11 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>AWD under full sail at Gato (2 neg)</unittitle>
+                <unittitle>AWD under full sail at Gato</unittitle>
                 <unitid>2-81</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
@@ -1771,15 +1816,21 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>View from AWD at Bagino anchorage (2 neg)</unittitle>
+                <unittitle>View from AWD at Bagino anchorage</unittitle>
                 <unitid>2-86</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>View of AWD at Bagino anchorage (2 neg)</unittitle>
+                <unittitle>View of AWD at Bagino anchorage</unittitle>
                 <unitid>2-87</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
@@ -1839,15 +1890,21 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>Hauling logs near Usou - Masbati (2 neg)</unittitle>
+                <unittitle>Hauling logs near Usou - Masbati</unittitle>
                 <unitid>3-4</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>Native jar in cave near Usou (2 neg)</unittitle>
+                <unittitle>Native jar in cave near Usou</unittitle>
                 <unitid>3-5</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
@@ -1909,8 +1966,11 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>A Siguijor sugar mill (2 neg)</unittitle>
+                <unittitle>A Siguijor sugar mill</unittitle>
                 <unitid>3-14</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
@@ -2161,8 +2221,11 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>Crude bridge near Cautilan Surigao, (2 neg)</unittitle>
+                <unittitle>Crude bridge near Cautilan Surigao,</unittitle>
                 <unitid>3-50</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">
@@ -2336,8 +2399,11 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>The Moro Collection in Dapitan (2 neg)</unittitle>
+                <unittitle>The Moro Collection in Dapitan</unittitle>
                 <unitid>3-75</unitid>
+                <physdesc>
+                  <extent>2 neg</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="item">

--- a/Real_Masters_all/hartphil.xml
+++ b/Real_Masters_all/hartphil.xml
@@ -4031,7 +4031,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">73</container>
-              <unittitle>Ford, Gerald R. (2 folders)</unittitle>
+              <unittitle>Ford, Gerald R.</unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
             <odd>
               <p>(also correspondence as vice president and president)</p>

--- a/Real_Masters_all/hollistr.xml
+++ b/Real_Masters_all/hollistr.xml
@@ -347,7 +347,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unittitle>Lectures and recitals (2 folders)</unittitle>
+              <unittitle>Lectures and recitals</unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/housing.xml
+++ b/Real_Masters_all/housing.xml
@@ -6440,7 +6440,10 @@ also files concerning the occupational status and treatment of Japanese-American
           <c03 level="file">
             <did>
               <container type="box" label="Box">36</container>
-              <unittitle>Aerial View of Campus <unitdate type="inclusive" normal="1975" certainty="approximate">circa 1975</unitdate> (1 b&amp;w photo)</unittitle>
+              <unittitle>Aerial View of Campus <unitdate type="inclusive" normal="1975" certainty="approximate">circa 1975</unitdate></unittitle>
+              <physdesc>
+                <extent>1 b&amp;amp;w photo</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/icc.xml
+++ b/Real_Masters_all/icc.xml
@@ -859,7 +859,10 @@ Inter-Cooperative Council (Ann Arbor, Mich.) records, Bentley Historical Library
             <c04 level="file">
               <did>
                 <container type="box" label="Box">9</container>
-                <unittitle><title render="italic">The Summer Cooperator</title>, <unitdate type="inclusive" normal="1974/2004">1974-2004</unitdate> (1 bound volume, 2 folders)</unittitle>
+                <unittitle><title render="italic">The Summer Cooperator</title>, <unitdate type="inclusive" normal="1974/2004">1974-2004</unitdate></unittitle>
+                <physdesc>
+                  <extent>1 bound volume, 2 folders</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>

--- a/Real_Masters_all/icpsr.xml
+++ b/Real_Masters_all/icpsr.xml
@@ -339,7 +339,10 @@ Inter-University Consortium for Political and Social Research records, Bentley H
           <c03 level="file">
             <did>
               <container type="box" label="Box">21</container>
-              <unittitle>Directors Review Committee <unitdate type="inclusive" normal="1998/1999">1998-1999</unitdate> (2 folders)</unittitle>
+              <unittitle>Directors Review Committee <unitdate type="inclusive" normal="1998/1999">1998-1999</unitdate></unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
             <accessrestrict>
               <p>[PR RESTRICTED until July 1 <date type="restriction" normal="2029-07-01">2029</date>]</p>

--- a/Real_Masters_all/infolib.xml
+++ b/Real_Masters_all/infolib.xml
@@ -2179,7 +2179,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">22</container>
-                  <unittitle>"Report on the School of Library Science of the University of Michigan" <unitdate type="inclusive" normal="1983">1983</unitdate> (2 bound volumes)</unittitle>
+                  <unittitle>"Report on the School of Library Science of the University of Michigan" <unitdate type="inclusive" normal="1983">1983</unitdate></unittitle>
+                  <physdesc>
+                    <extent>2 bound volumes</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">

--- a/Real_Masters_all/interloc.xml
+++ b/Real_Masters_all/interloc.xml
@@ -27915,7 +27915,10 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
             <c04 level="file">
               <did>
                 <container type="box" label="Box">80</container>
-                <unittitle>Interlochen, promotional records(2 discs)</unittitle>
+                <unittitle>Interlochen, promotional records</unittitle>
+                <physdesc>
+                  <extent>2 discs</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>

--- a/Real_Masters_all/isroral.xml
+++ b/Real_Masters_all/isroral.xml
@@ -189,7 +189,10 @@ Institute for Social Research Oral History Videotapes and Transcripts, Bentley H
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unittitle>Featherman, David (2 videotapes)</unittitle>
+              <unittitle>Featherman, David</unittitle>
+              <physdesc>
+                <extent>2 videotapes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/itdrec.xml
+++ b/Real_Masters_all/itdrec.xml
@@ -1312,7 +1312,10 @@ Information Technology Division (University of Michigan) records, Bentley Histor
             <c04 level="file">
               <did>
                 <container type="box" label="Box">26</container>
-                <unittitle>President's Council <unitdate type="inclusive" normal="1990/1996">1990-1996</unitdate> (2 folders)</unittitle>
+                <unittitle>President's Council <unitdate type="inclusive" normal="1990/1996">1990-1996</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(includes Subcommittee on Telecommunication and Information Systems)</p>
@@ -1932,7 +1935,10 @@ Information Technology Division (University of Michigan) records, Bentley Histor
             <c04 level="file">
               <did>
                 <container type="box" label="Box">29</container>
-                <unittitle>X.500 <unitdate type="inclusive" normal="1991/1993">1991-1993</unitdate> (4 expandable folders)</unittitle>
+                <unittitle>X.500 <unitdate type="inclusive" normal="1991/1993">1991-1993</unitdate></unittitle>
+                <physdesc>
+                  <extent>4 expandable folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -2190,13 +2196,23 @@ Information Technology Division (University of Michigan) records, Bentley Histor
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">7</container>
-                  <unittitle><unitdate type="inclusive" normal="1976/1977-08">1976-August 1977</unitdate> (5 files)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1976/1977-08">1976-August 1977</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>5 files</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">8</container>
-                  <unittitle><unitdate type="inclusive" normal="1977-09/1986">September 1977-1986</unitdate> (27 files)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1977-09/1986">September 1977-1986</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>27 files</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -7639,7 +7655,10 @@ Information Technology Division (University of Michigan) records, Bentley Histor
           <c03 level="file">
             <did>
               <container type="box" label="Box">43</container>
-              <unittitle>Networking (2 expandable folders)</unittitle>
+              <unittitle>Networking</unittitle>
+              <physdesc>
+                <extent>2 expandable folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/jabara.xml
+++ b/Real_Masters_all/jabara.xml
@@ -1538,7 +1538,10 @@ Abdeen Jabara papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">12</container>
-              <unittitle><title render="italic">In the Struggle</title> Newsletter, <unitdate type="inclusive" normal="1975">1975</unitdate> (3 issues)</unittitle>
+              <unittitle><title render="italic">In the Struggle</title> Newsletter, <unitdate type="inclusive" normal="1975">1975</unitdate></unittitle>
+              <physdesc>
+                <extent>3 issues</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/jessye.xml
+++ b/Real_Masters_all/jessye.xml
@@ -5656,7 +5656,10 @@ Eva Jessye Collection, Bentley Historical Library, University of Michigan</p>
         <c02 level="file">
           <did>
             <container type="box" label="Oversize Box">13</container>
-            <unittitle>Awards and Certificates, Originals (7 folders and 3 outsized Items)</unittitle>
+            <unittitle>Awards and Certificates, Originals</unittitle>
+            <physdesc>
+              <extent>7 folders and 3 outsized Items</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/johnstct.xml
+++ b/Real_Masters_all/johnstct.xml
@@ -1372,7 +1372,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">8:1</container>
-                <unittitle>(16 unidentified photographs, Tacoma)</unittitle>
+                <unittitle/>
+                <physdesc>
+                  <extent>16 unidentified photographs, Tacoma</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>[1081-1096]</p>

--- a/Real_Masters_all/joinerc.xml
+++ b/Real_Masters_all/joinerc.xml
@@ -1202,7 +1202,10 @@ Charles W. Joiner Papers, Bentley Historical Library, University of Michigan</p>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">18</container>
-                <unittitle>Committee Lists <unitdate type="inclusive" normal="1970/1971">1970-1971</unitdate> (2 files)</unittitle>
+                <unittitle>Committee Lists <unitdate type="inclusive" normal="1970/1971">1970-1971</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 files</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>
@@ -1411,7 +1414,10 @@ Charles W. Joiner Papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">19</container>
-              <unittitle>General <unitdate type="inclusive" normal="1968/1972">1968-1972</unitdate> (2 files)</unittitle>
+              <unittitle>General <unitdate type="inclusive" normal="1968/1972">1968-1972</unitdate></unittitle>
+              <physdesc>
+                <extent>2 files</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -1423,7 +1429,10 @@ Charles W. Joiner Papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">20</container>
-              <unittitle>Grievance Committee- <unitdate type="inclusive" normal="1969/1972">1969-1972</unitdate> (2 files)</unittitle>
+              <unittitle>Grievance Committee- <unitdate type="inclusive" normal="1969/1972">1969-1972</unitdate></unittitle>
+              <physdesc>
+                <extent>2 files</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -1556,31 +1565,46 @@ Charles W. Joiner Papers, Bentley Historical Library, University of Michigan</p>
         <c02 level="file">
           <did>
             <container type="box" label="Box">22</container>
-            <unittitle>American Law Institute (12 files)</unittitle>
+            <unittitle>American Law Institute</unittitle>
+            <physdesc>
+              <extent>12 files</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">22</container>
-            <unittitle>American Trial Lawyers Association (6 files)</unittitle>
+            <unittitle>American Trial Lawyers Association</unittitle>
+            <physdesc>
+              <extent>6 files</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">23</container>
-            <unittitle>Association American Law Schools (15 files)</unittitle>
+            <unittitle>Association American Law Schools</unittitle>
+            <physdesc>
+              <extent>15 files</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">23</container>
-            <unittitle>American Law Student Association (7 files)</unittitle>
+            <unittitle>American Law Student Association</unittitle>
+            <physdesc>
+              <extent>7 files</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">23</container>
-            <unittitle>American Judicature Society (9 files)</unittitle>
+            <unittitle>American Judicature Society</unittitle>
+            <physdesc>
+              <extent>9 files</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
@@ -1920,7 +1944,10 @@ Charles W. Joiner Papers, Bentley Historical Library, University of Michigan</p>
         <c02 level="file">
           <did>
             <container type="box" label="Box">26</container>
-            <unittitle>Specialization in Legal Practice No. 1 and 2 (2 files)</unittitle>
+            <unittitle>Specialization in Legal Practice No. 1 and 2</unittitle>
+            <physdesc>
+              <extent>2 files</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
@@ -2244,7 +2271,10 @@ Charles W. Joiner Papers, Bentley Historical Library, University of Michigan</p>
         <c02 level="file">
           <did>
             <container type="box" label="Box">30</container>
-            <unittitle>Law School space and building (4 files)</unittitle>
+            <unittitle>Law School space and building</unittitle>
+            <physdesc>
+              <extent>4 files</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
@@ -2423,7 +2453,10 @@ Charles W. Joiner Papers, Bentley Historical Library, University of Michigan</p>
         <c02 level="file">
           <did>
             <container type="box" label="Box">32</container>
-            <unittitle>Scribes (8 files)</unittitle>
+            <unittitle>Scribes</unittitle>
+            <physdesc>
+              <extent>8 files</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/judsonr.xml
+++ b/Real_Masters_all/judsonr.xml
@@ -239,7 +239,10 @@ Russell V. Judson Papers, Bentley Historical Library, University of Michigan</p>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unittitle>Miscellaneous (10 folders)</unittitle>
+            <unittitle>Miscellaneous</unittitle>
+            <physdesc>
+              <extent>10 folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/kaufmana.xml
+++ b/Real_Masters_all/kaufmana.xml
@@ -746,7 +746,10 @@ Arnold S. Kaufman Papers, Bentley Historical Library, University of Michigan</p>
         <c02 level="file">
           <did>
             <container type="box" label="Box">4</container>
-            <unittitle>International Days of Protest, 1965-(2 folders)</unittitle>
+            <unittitle>International Days of Protest, 1965-</unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/kauperp.xml
+++ b/Real_Masters_all/kauperp.xml
@@ -1072,7 +1072,10 @@ Paul G. Kauper Papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">34</container>
-              <unittitle>Old Notes-Part 11 (4 folder)</unittitle>
+              <unittitle>Old Notes-Part 11</unittitle>
+              <physdesc>
+                <extent>4 folder</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/kauschjk.xml
+++ b/Real_Masters_all/kauschjk.xml
@@ -714,19 +714,28 @@ Jack Kausch collection, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">5</container>
-              <unittitle><unitdate type="inclusive" normal="1980">1980</unitdate> Print (2 16 mm film reels)</unittitle>
+              <unittitle><unitdate type="inclusive" normal="1980">1980</unitdate> Print</unittitle>
+              <physdesc>
+                <extent>2 16 mm film reels</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">5</container>
-              <unittitle><unitdate type="inclusive" normal="1980">1980</unitdate> Mag (16 mm film reel)</unittitle>
+              <unittitle><unitdate type="inclusive" normal="1980">1980</unitdate> Mag</unittitle>
+              <physdesc>
+                <extent>16 mm film reel</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">5</container>
-              <unittitle>A Track and Internegative (2 16 mm film reels)</unittitle>
+              <unittitle>A Track and Internegative</unittitle>
+              <physdesc>
+                <extent>2 16 mm film reels</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -738,19 +747,28 @@ Jack Kausch collection, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">5</container>
-              <unittitle>Revised A &amp; B Rolls <unitdate type="inclusive" normal="1990">1990</unitdate> (2 16 mm film reels)</unittitle>
+              <unittitle>Revised A &amp; B Rolls <unitdate type="inclusive" normal="1990">1990</unitdate></unittitle>
+              <physdesc>
+                <extent>2 16 mm film reels</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">5</container>
-              <unittitle>From Revised A &amp; B Rolls <unitdate type="inclusive" normal="1990">1990</unitdate> (1 in. video reel)</unittitle>
+              <unittitle>From Revised A &amp; B Rolls <unitdate type="inclusive" normal="1990">1990</unitdate></unittitle>
+              <physdesc>
+                <extent>1 in. video reel</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">5</container>
-              <unittitle><unitdate type="inclusive" normal="1990">1990</unitdate> Revision Work Print, B Track, Title Trims (3 16 mm film reels)</unittitle>
+              <unittitle><unitdate type="inclusive" normal="1990">1990</unitdate> Revision Work Print, B Track, Title Trims</unittitle>
+              <physdesc>
+                <extent>3 16 mm film reels</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/kelloggj.xml
+++ b/Real_Masters_all/kelloggj.xml
@@ -1109,7 +1109,7 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">3</container>
-              <unittitle>Lecture series on topic of fevers <unitdate type="inclusive" normal="1898-10">October 1898</unitdate>, <unitdate type="inclusive" normal="1898">undated 1898</unitdate> (13 lectures in 2 folders)</unittitle>
+              <unittitle>Lecture series on topic of fevers <unitdate type="inclusive" normal="1898-10">October 1898</unitdate>, <unitdate type="inclusive" normal="1898">undated 1898</unitdate></unittitle>
               <physdesc>
                 <physfacet>.PDF and .ZIP files</physfacet>
               </physdesc>
@@ -1118,6 +1118,9 @@
                   <p>[download item]</p>
                 </daodesc>
               </dao>
+              <physdesc>
+                <extent>13 lectures in 2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/kendricp.xml
+++ b/Real_Masters_all/kendricp.xml
@@ -1989,7 +1989,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">7</container>
-              <unittitle>Collected Reprints of Pearl L. Kendrick and Grace Eldering (1 volume)</unittitle>
+              <unittitle>Collected Reprints of Pearl L. Kendrick and Grace Eldering</unittitle>
+              <physdesc>
+                <extent>1 volume</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/kennedycg.xml
+++ b/Real_Masters_all/kennedycg.xml
@@ -3194,19 +3194,28 @@ Cornelia G. Kennedy papers, Bentley Historical Library, University of Michigan</
           <c03 level="file">
             <did>
               <container type="box" label="Box">29</container>
-              <unittitle>Volumes 1-3 <unitdate type="inclusive" normal="1979/1980">1979-1980</unitdate>, <unitdate type="inclusive" normal="1981">1981</unitdate>, <unitdate type="inclusive" normal="1982">1982</unitdate> (3 three-ring binders)</unittitle>
+              <unittitle>Volumes 1-3 <unitdate type="inclusive" normal="1979/1980">1979-1980</unitdate>, <unitdate type="inclusive" normal="1981">1981</unitdate>, <unitdate type="inclusive" normal="1982">1982</unitdate></unittitle>
+              <physdesc>
+                <extent>3 three-ring binders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">30</container>
-              <unittitle>Volumes 4-8 and 10 <unitdate type="inclusive" normal="1983/1987">1983-1987</unitdate>, <unitdate type="inclusive" normal="1989">1989</unitdate> (6 three-ring binders)</unittitle>
+              <unittitle>Volumes 4-8 and 10 <unitdate type="inclusive" normal="1983/1987">1983-1987</unitdate>, <unitdate type="inclusive" normal="1989">1989</unitdate></unittitle>
+              <physdesc>
+                <extent>6 three-ring binders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">30</container>
-              <unittitle><unitdate type="inclusive" normal="2001/2002">2001-2002</unitdate>, <unitdate type="inclusive" normal="2003/2004">2003-2004</unitdate>, <unitdate type="inclusive" normal="2005/2006">2005-2006</unitdate> (3 bound, hardcover volumes)</unittitle>
+              <unittitle><unitdate type="inclusive" normal="2001/2002">2001-2002</unitdate>, <unitdate type="inclusive" normal="2003/2004">2003-2004</unitdate>, <unitdate type="inclusive" normal="2005/2006">2005-2006</unitdate></unittitle>
+              <physdesc>
+                <extent>3 bound, hardcover volumes</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>
@@ -3636,7 +3645,10 @@ Cornelia G. Kennedy papers, Bentley Historical Library, University of Michigan</
             <c04 level="file">
               <did>
                 <container type="box" label="Box">33</container>
-                <unittitle>Dockets No. 101-105, 1976-1978(80 folders)</unittitle>
+                <unittitle>Dockets No. 101-105, 1976-1978</unittitle>
+                <physdesc>
+                  <extent>80 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/lawpub.xml
+++ b/Real_Masters_all/lawpub.xml
@@ -1195,13 +1195,19 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">7</container>
-                  <unittitle>1978-2001 (13 folders)</unittitle>
+                  <unittitle>1978-2001</unittitle>
+                  <physdesc>
+                    <extent>13 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">8</container>
-                  <unittitle>2001-2005 (3 folders)</unittitle>
+                  <unittitle>2001-2005</unittitle>
+                  <physdesc>
+                    <extent>3 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -1976,7 +1982,12 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">14</container>
-                  <unittitle><unitdate type="inclusive" normal="1950/1985">1950/51-1984/85</unitdate> (7 folders)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1950/1985">1950/51-1984/85</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>7 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>

--- a/Real_Masters_all/lgbtum.xml
+++ b/Real_Masters_all/lgbtum.xml
@@ -426,7 +426,12 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle><unitdate type="inclusive" normal="1988/1989">1988-1989</unitdate> (1 folder)</unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1988/1989">1988-1989</unitdate>
+                </unittitle>
+                <physdesc>
+                  <extent>1 folder</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -799,25 +804,45 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">5</container>
-                <unittitle><unitdate type="inclusive" normal="1995">1995</unitdate> (1 folder)</unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1995">1995</unitdate>
+                </unittitle>
+                <physdesc>
+                  <extent>1 folder</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">5</container>
-                <unittitle><unitdate type="inclusive" normal="1996">1996</unitdate> (1 folder)</unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1996">1996</unitdate>
+                </unittitle>
+                <physdesc>
+                  <extent>1 folder</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">5</container>
-                <unittitle><unitdate type="inclusive" normal="1997">1997</unitdate> (1 folder)</unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1997">1997</unitdate>
+                </unittitle>
+                <physdesc>
+                  <extent>1 folder</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">5</container>
-                <unittitle><unitdate type="inclusive" normal="2001">2001</unitdate> (1 folder)</unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="2001">2001</unitdate>
+                </unittitle>
+                <physdesc>
+                  <extent>1 folder</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>

--- a/Real_Masters_all/likertr.xml
+++ b/Real_Masters_all/likertr.xml
@@ -2494,13 +2494,19 @@ Rensis Likert Papers, Bentley Historical Library, University of Michigan</p>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">24</container>
-                <unittitle>Treasury Department Studies (2 binders)</unittitle>
+                <unittitle>Treasury Department Studies</unittitle>
+                <physdesc>
+                  <extent>2 binders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">25</container>
-                <unittitle>Treasury Department Studies (1 binder)</unittitle>
+                <unittitle>Treasury Department Studies</unittitle>
+                <physdesc>
+                  <extent>1 binder</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>
@@ -5183,7 +5189,10 @@ Rensis Likert Papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">12</container>
-              <unittitle>The Effect of Bombing on Health and Medical Care in Germany (1 volume and 1 folder)</unittitle>
+              <unittitle>The Effect of Bombing on Health and Medical Care in Germany</unittitle>
+              <physdesc>
+                <extent>1 volume and 1 folder</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/lindeman.xml
+++ b/Real_Masters_all/lindeman.xml
@@ -2799,7 +2799,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">8</container>
-              <unittitle>Michifish <unitdate type="inclusive" normal="1973">1973</unitdate> (2 tapes)</unittitle>
+              <unittitle>Michifish <unitdate type="inclusive" normal="1973">1973</unitdate></unittitle>
+              <physdesc>
+                <extent>2 tapes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/logcomp.xml
+++ b/Real_Masters_all/logcomp.xml
@@ -508,7 +508,10 @@ Logic of Computers Group (University of Michigan) Records, Bentley Historical Li
             <c04 level="file">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>"Chance, Cause, and Reason" (2-folders)</unittitle>
+                <unittitle>"Chance, Cause, and Reason"</unittitle>
+                <physdesc>
+                  <extent>2-folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/lovejoyp.xml
+++ b/Real_Masters_all/lovejoyp.xml
@@ -257,7 +257,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">4</container>
-                <unittitle>Correspondence between Lovejoy and editor of Country Gentleman (6 folders)</unittitle>
+                <unittitle>Correspondence between Lovejoy and editor of Country Gentleman</unittitle>
+                <physdesc>
+                  <extent>6 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/lsacoll.xml
+++ b/Real_Masters_all/lsacoll.xml
@@ -43098,7 +43098,10 @@ College of Literature, Science and the Arts (University of Michigan) Records, Be
           <c03 level="file">
             <did>
               <container type="box" label="Box">195</container>
-              <unittitle>Statistics <unitdate type="inclusive" normal="1963/1964">1963-1964</unitdate> (3 v.)</unittitle>
+              <unittitle>Statistics <unitdate type="inclusive" normal="1963/1964">1963-1964</unitdate></unittitle>
+              <physdesc>
+                <extent>3 v.</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -53229,7 +53232,10 @@ College of Literature, Science and the Arts (University of Michigan) Records, Be
             <c04 level="file">
               <did>
                 <container type="box" label="Box">262</container>
-                <unittitle>Faculty Code (1 folder and 1 notebook)</unittitle>
+                <unittitle>Faculty Code</unittitle>
+                <physdesc>
+                  <extent>1 folder and 1 notebook</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -96470,7 +96476,10 @@ College of Literature, Science and the Arts (University of Michigan) Records, Be
         <c02 level="file">
           <did>
             <container type="box" label="Box">65</container>
-            <unittitle>Minutes of LS&amp;A Administrative Board <unitdate type="inclusive" normal="1893/1922">1893-1922</unitdate> (4 v.)</unittitle>
+            <unittitle>Minutes of LS&amp;A Administrative Board <unitdate type="inclusive" normal="1893/1922">1893-1922</unitdate></unittitle>
+            <physdesc>
+              <extent>4 v.</extent>
+            </physdesc>
           </did>
         </c02>
       </c01>
@@ -96804,7 +96813,12 @@ College of Literature, Science and the Arts (University of Michigan) Records, Be
           <c03 level="file">
             <did>
               <container type="box" label="Box">303</container>
-              <unittitle><unitdate type="inclusive" normal="1988/1993">1988-1993</unitdate> (5 volumes.)</unittitle>
+              <unittitle>
+                <unitdate type="inclusive" normal="1988/1993">1988-1993</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>5 volumes.</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/lusksal.xml
+++ b/Real_Masters_all/lusksal.xml
@@ -147,7 +147,10 @@ Sally Lusk Papers, 1975-2001, Bentley Historical Library, University of Michigan
         <c02 level="file">
           <did>
             <container type="box" label="Box">1</container>
-            <unittitle>Noise Annoyance Among Factory and Construction Workers: Construct Development, March 1996(2 folders)</unittitle>
+            <unittitle>Noise Annoyance Among Factory and Construction Workers: Construct Development, March 1996</unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/macadamb.xml
+++ b/Real_Masters_all/macadamb.xml
@@ -989,7 +989,10 @@ Barbara MacAdam papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="item">
             <did>
               <container type="box" label="Box">7</container>
-              <unittitle>Symposium <unitdate type="inclusive" normal="1987/1988">1987-1988</unitdate> (2 folders, includes negatives)</unittitle>
+              <unittitle>Symposium <unitdate type="inclusive" normal="1987/1988">1987-1988</unitdate></unittitle>
+              <physdesc>
+                <extent>2 folders, includes negatives</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/mahperd.xml
+++ b/Real_Masters_all/mahperd.xml
@@ -2459,7 +2459,10 @@ Among the most notable is Michigan Exemplary Physical Education Programs Project
         <c02 level="file">
           <did>
             <container type="box" label="Box">11</container>
-            <unittitle>Michigan Exemplary Physical Education Programs Project <unitdate type="inclusive" normal="1989/1991">1989-1991</unitdate> (4 folders and 1 notebook)</unittitle>
+            <unittitle>Michigan Exemplary Physical Education Programs Project <unitdate type="inclusive" normal="1989/1991">1989-1991</unitdate></unittitle>
+            <physdesc>
+              <extent>4 folders and 1 notebook</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/marquaww.xml
+++ b/Real_Masters_all/marquaww.xml
@@ -1896,7 +1896,10 @@ Walter W. Marquardt papers, Bentley Historical Library, University of Michigan</
               <container type="box" label="Box">3</container>
               <container type="tray" label="Tray">5</container>
               <unitid>215-216</unitid>
-              <unittitle>Dog market, Bagnio (2 slides)</unittitle>
+              <unittitle>Dog market, Bagnio</unittitle>
+              <physdesc>
+                <extent>2 slides</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/massab.xml
+++ b/Real_Masters_all/massab.xml
@@ -3265,13 +3265,19 @@ courses Maassab taught in the Department of Epidemiology. are divided into six s
             <c04 level="file">
               <did>
                 <container type="box" label="Box">22</container>
-                <unittitle>AA/CR18, AA/CR24 and AA/CR26 <unitdate type="inclusive" normal="1974/1982">1974-1982</unitdate> (2 notebooks)</unittitle>
+                <unittitle>AA/CR18, AA/CR24 and AA/CR26 <unitdate type="inclusive" normal="1974/1982">1974-1982</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 notebooks</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">22</container>
-                <unittitle>AA/CR33-AA/CR36 <unitdate type="inclusive" normal="1977/1978">1977-1978</unitdate> (2 notebooks)</unittitle>
+                <unittitle>AA/CR33-AA/CR36 <unitdate type="inclusive" normal="1977/1978">1977-1978</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 notebooks</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/matthaei.xml
+++ b/Real_Masters_all/matthaei.xml
@@ -1783,7 +1783,10 @@ Matthaei Botanical Gardens (University of Michigan) records, Bentley Historical 
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">6</container>
-                  <unittitle>Species <unitdate type="inclusive" normal="1914/1927">1914-1927</unitdate> (13 folders, arranged alphabetically by plant name)</unittitle>
+                  <unittitle>Species <unitdate type="inclusive" normal="1914/1927">1914-1927</unitdate></unittitle>
+                  <physdesc>
+                    <extent>13 folders, arranged alphabetically by plant name</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>

--- a/Real_Masters_all/mccallaw.xml
+++ b/Real_Masters_all/mccallaw.xml
@@ -543,7 +543,10 @@ Almon Watson McCall papers, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unittitle>Grand Haven Harbor (2 folders and 1 volume)</unittitle>
+            <unittitle>Grand Haven Harbor</unittitle>
+            <physdesc>
+              <extent>2 folders and 1 volume</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/meamum.xml
+++ b/Real_Masters_all/meamum.xml
@@ -1792,7 +1792,10 @@ Department of Mechanical Engineering (University of Michigan) records, Bentley H
         <c02 level="file">
           <did>
             <container type="box" label="Box">15</container>
-            <unittitle>35 mm slides <unitdate type="inclusive">undated</unitdate> (24 containers and binder)</unittitle>
+            <unittitle>35 mm slides <unitdate type="inclusive">undated</unitdate></unittitle>
+            <physdesc>
+              <extent>24 containers and binder</extent>
+            </physdesc>
           </did>
         </c02>
       </c01>

--- a/Real_Masters_all/medrecs.xml
+++ b/Real_Masters_all/medrecs.xml
@@ -5218,7 +5218,10 @@ Middle English Dictionary records, Bentley Historical Library, University of Mic
             <c04 level="file">
               <did>
                 <container type="box" label="Box">73</container>
-                <unittitle>Text of Warner's edition of <title render="italic">Vsp.D.Hom</title>., ca. 1980s-1990s  (1 floppy disk)</unittitle>
+                <unittitle>Text of Warner's edition of <title render="italic">Vsp.D.Hom</title>., ca. 1980s-1990s</unittitle>
+                <physdesc>
+                  <extent>1 floppy disk</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/medschl.xml
+++ b/Real_Masters_all/medschl.xml
@@ -677,7 +677,10 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">3</container>
-                    <unittitle>Background (2 folder)</unittitle>
+                    <unittitle>Background</unittitle>
+                    <physdesc>
+                      <extent>2 folder</extent>
+                    </physdesc>
                   </did>
                 </c06>
               </c05>
@@ -2404,7 +2407,12 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">269</container>
-                  <unittitle><unitdate type="inclusive" normal="1990">1990</unitdate> (1 volume)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1990">1990</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>1 volume</extent>
+                  </physdesc>
                 </did>
                 <accessrestrict>
                   <p>[ER RESTRICTED until <date type="restriction" normal="2022-07-01">July 1, 2022</date>]</p>
@@ -2413,7 +2421,12 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">270</container>
-                  <unittitle><unitdate type="inclusive" normal="1991/1995">1991-1995</unitdate> (4 volumes and 1 folder)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1991/1995">1991-1995</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>4 volumes and 1 folder</extent>
+                  </physdesc>
                 </did>
                 <accessrestrict>
                   <p>[ER RESTRICTED until <date type="restriction" normal="2022-07-01">July 1, 2022</date>]</p>
@@ -4520,7 +4533,12 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">14</container>
-                <unittitle><unitdate type="inclusive" normal="1973">May-October 1973</unitdate> (1 volume)</unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1973">May-October 1973</unitdate>
+                </unittitle>
+                <physdesc>
+                  <extent>1 volume</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -17835,7 +17853,10 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">313</container>
-                    <unittitle>Institutional Self-Study Report <unitdate type="inclusive" normal="1990">1990</unitdate> (1 volume)</unittitle>
+                    <unittitle>Institutional Self-Study Report <unitdate type="inclusive" normal="1990">1990</unitdate></unittitle>
+                    <physdesc>
+                      <extent>1 volume</extent>
+                    </physdesc>
                   </did>
                   <accessrestrict>
                     <p>[ER RESTRICTED until <date type="restriction" normal="2022-07-01">July 1, 2022</date>]</p>
@@ -17856,7 +17877,10 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">313</container>
-                    <unittitle>Medical Education Data Base Section XI-A--Basic Science Departments <unitdate type="inclusive" normal="1990">1990</unitdate> (1 volume)</unittitle>
+                    <unittitle>Medical Education Data Base Section XI-A--Basic Science Departments <unitdate type="inclusive" normal="1990">1990</unitdate></unittitle>
+                    <physdesc>
+                      <extent>1 volume</extent>
+                    </physdesc>
                   </did>
                   <accessrestrict>
                     <p>[ER RESTRICTED until <date type="restriction" normal="2022-07-01">July 1, 2022</date>]</p>
@@ -17865,7 +17889,10 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">314</container>
-                    <unittitle>Medical Education Data Base Section XI-B--Clinical Science Departments <unitdate type="inclusive" normal="1990">1990</unitdate> (1 volume)</unittitle>
+                    <unittitle>Medical Education Data Base Section XI-B--Clinical Science Departments <unitdate type="inclusive" normal="1990">1990</unitdate></unittitle>
+                    <physdesc>
+                      <extent>1 volume</extent>
+                    </physdesc>
                   </did>
                   <accessrestrict>
                     <p>[ER RESTRICTED until <date type="restriction" normal="2022-07-01">July 1, 2022</date>]</p>
@@ -22100,7 +22127,12 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">121</container>
-                <unittitle><unitdate type="inclusive" normal="1929/1948">1929-1948</unitdate> (2 folders and 10 volumes)</unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1929/1948">1929-1948</unitdate>
+                </unittitle>
+                <physdesc>
+                  <extent>2 folders and 10 volumes</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -26427,7 +26459,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">320</container>
-                <unittitle>MI Provider Network (2 hanging file folders) <unitdate type="inclusive" normal="1993/1996">1993-1996</unitdate></unittitle>
+                <unittitle>MI Provider Network <unitdate type="inclusive" normal="1993/1996">1993-1996</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 hanging file folders</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2022-07-01">July 1, 2022</date>]</p>

--- a/Real_Masters_all/mershon.xml
+++ b/Real_Masters_all/mershon.xml
@@ -1308,7 +1308,10 @@
           <c03 level="file">
             <did>
               <container label="Oversize Folder" type="folder">Ac</container>
-              <unittitle>Receipts for July 4th celebration, 1895, Saginaw, Mich. (1 item)</unittitle>
+              <unittitle>Receipts for July 4th celebration, 1895, Saginaw, Mich.</unittitle>
+              <physdesc>
+                <extent>1 item</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/metcalfr.xml
+++ b/Real_Masters_all/metcalfr.xml
@@ -8670,7 +8670,10 @@ inch boards</physfacet>
           </c03>
           <c03 level="file">
             <did>
-              <unittitle>Metcalf Houses (11 boxes)</unittitle>
+              <unittitle>Metcalf Houses</unittitle>
+              <physdesc>
+                <extent>11 boxes</extent>
+              </physdesc>
             </did>
             <odd>
               <p>(These slides are also listed in the Project Files series)</p>

--- a/Real_Masters_all/mgleecl.xml
+++ b/Real_Masters_all/mgleecl.xml
@@ -846,7 +846,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">8</container>
-              <unittitle>Tour <unitdate type="inclusive" normal="1987">1987</unitdate> (9 envelopes)</unittitle>
+              <unittitle>Tour <unitdate type="inclusive" normal="1987">1987</unitdate></unittitle>
+              <physdesc>
+                <extent>9 envelopes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -2072,7 +2075,10 @@
               </c05>
               <c05 level="file">
                 <did>
-                  <unittitle>Speeches by Men's Glee Club members (3 files)</unittitle>
+                  <unittitle>Speeches by Men's Glee Club members</unittitle>
+                  <physdesc>
+                    <extent>3 files</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -2082,7 +2088,10 @@
               </c05>
               <c05 level="file">
                 <did>
-                  <unittitle>Vocal performance by the Men's Glee Club (4 files)</unittitle>
+                  <unittitle>Vocal performance by the Men's Glee Club</unittitle>
+                  <physdesc>
+                    <extent>4 files</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -2264,7 +2273,10 @@
               </c05>
               <c05 level="file">
                 <did>
-                  <unittitle>Mens' Glee Club performance at the Shanghai Oriental Art Center (6 files)</unittitle>
+                  <unittitle>Mens' Glee Club performance at the Shanghai Oriental Art Center</unittitle>
+                  <physdesc>
+                    <extent>6 files</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">

--- a/Real_Masters_all/miforens.xml
+++ b/Real_Masters_all/miforens.xml
@@ -9271,7 +9271,10 @@ Michigan Interscholastic Forensic Association records, Bentley Historical Librar
           <c03 level="file">
             <did>
               <container type="box" label="Box">50</container>
-              <unittitle>Class B Final <unitdate type="inclusive" normal="1986/1987">1986-1987</unitdate> (60 min, VHS videotape)</unittitle>
+              <unittitle>Class B Final <unitdate type="inclusive" normal="1986/1987">1986-1987</unitdate></unittitle>
+              <physdesc>
+                <extent>60 min, VHS videotape</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -9433,7 +9436,10 @@ Michigan Interscholastic Forensic Association records, Bentley Historical Librar
           <c03 level="file">
             <did>
               <container type="box" label="Box">50</container>
-              <unittitle>Debate Final Class C/D <unitdate type="inclusive" normal="1999/2000">1999-2000</unitdate> (2 tapes, VHS videotape)</unittitle>
+              <unittitle>Debate Final Class C/D <unitdate type="inclusive" normal="1999/2000">1999-2000</unitdate></unittitle>
+              <physdesc>
+                <extent>2 tapes, VHS videotape</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -9451,7 +9457,10 @@ Michigan Interscholastic Forensic Association records, Bentley Historical Librar
           <c03 level="file">
             <did>
               <container type="box" label="Box">50</container>
-              <unittitle>C/D Debate Finals <unitdate type="inclusive" normal="2000/2001">2000-2001</unitdate> (2 tapes, VHS videotape)</unittitle>
+              <unittitle>C/D Debate Finals <unitdate type="inclusive" normal="2000/2001">2000-2001</unitdate></unittitle>
+              <physdesc>
+                <extent>2 tapes, VHS videotape</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/milliken.xml
+++ b/Real_Masters_all/milliken.xml
@@ -8393,7 +8393,10 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">243</container>
-                    <unittitle>Health and Medical Affairs (1 folder)</unittitle>
+                    <unittitle>Health and Medical Affairs</unittitle>
+                    <physdesc>
+                      <extent>1 folder</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
@@ -8472,7 +8475,10 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">245</container>
-                    <unittitle>General (1 folder)</unittitle>
+                    <unittitle>General</unittitle>
+                    <physdesc>
+                      <extent>1 folder</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
@@ -8514,7 +8520,10 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">248</container>
-                    <unittitle>Insurance (1 folder)</unittitle>
+                    <unittitle>Insurance</unittitle>
+                    <physdesc>
+                      <extent>1 folder</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
@@ -8608,7 +8617,10 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">252</container>
-                    <unittitle>Pardons and Paroles (1 folder)</unittitle>
+                    <unittitle>Pardons and Paroles</unittitle>
+                    <physdesc>
+                      <extent>1 folder</extent>
+                    </physdesc>
                   </did>
                 </c06>
               </c05>
@@ -8698,7 +8710,10 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">255</container>
-                    <unittitle>General (1 folder)</unittitle>
+                    <unittitle>General</unittitle>
+                    <physdesc>
+                      <extent>1 folder</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
@@ -8713,7 +8728,10 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">257</container>
-                    <unittitle>General (1 folder)</unittitle>
+                    <unittitle>General</unittitle>
+                    <physdesc>
+                      <extent>1 folder</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
@@ -8734,7 +8752,10 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">258</container>
-                    <unittitle>Michigan Employment Securities Commission (1 folder)</unittitle>
+                    <unittitle>Michigan Employment Securities Commission</unittitle>
+                    <physdesc>
+                      <extent>1 folder</extent>
+                    </physdesc>
                   </did>
                 </c06>
               </c05>
@@ -8794,7 +8815,10 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">258</container>
-                    <unittitle>General (1 folder)</unittitle>
+                    <unittitle>General</unittitle>
+                    <physdesc>
+                      <extent>1 folder</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
@@ -8829,7 +8853,10 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">260</container>
-                    <unittitle>General (1 folder)</unittitle>
+                    <unittitle>General</unittitle>
+                    <physdesc>
+                      <extent>1 folder</extent>
+                    </physdesc>
                   </did>
                 </c06>
               </c05>
@@ -10548,7 +10575,10 @@
                   <c07 level="file">
                     <did>
                       <container type="box" label="Box">326</container>
-                      <unittitle>A-M (1 folder)</unittitle>
+                      <unittitle>A-M</unittitle>
+                      <physdesc>
+                        <extent>1 folder</extent>
+                      </physdesc>
                     </did>
                   </c07>
                   <c07 level="file">
@@ -49538,37 +49568,55 @@
                   <c07 level="file">
                     <did>
                       <container type="box" label="Box">806</container>
-                      <unittitle><unitdate type="inclusive" normal="1980">1980</unitdate> Winter, February 24-26 (3 folders, including Executive Committee Meeting)</unittitle>
+                      <unittitle><unitdate type="inclusive" normal="1980">1980</unitdate> Winter, February 24-26</unittitle>
+                      <physdesc>
+                        <extent>3 folders, including Executive Committee Meeting</extent>
+                      </physdesc>
                     </did>
                   </c07>
                   <c07 level="file">
                     <did>
                       <container type="box" label="Box">807</container>
-                      <unittitle><unitdate type="inclusive" normal="1980">1980</unitdate> Summer, August 3-5 (8 folders, including Executive Committee Meetings and Policy Research Board)</unittitle>
+                      <unittitle><unitdate type="inclusive" normal="1980">1980</unitdate> Summer, August 3-5</unittitle>
+                      <physdesc>
+                        <extent>8 folders, including Executive Committee Meetings and Policy Research Board</extent>
+                      </physdesc>
                     </did>
                   </c07>
                   <c07 level="file">
                     <did>
                       <container type="box" label="Box">807</container>
-                      <unittitle><unitdate type="inclusive" normal="1981">1981</unitdate> Winter, February 22-25 (6 folders, including Executive Committee Meetings and Policy Research Board)</unittitle>
+                      <unittitle><unitdate type="inclusive" normal="1981">1981</unitdate> Winter, February 22-25</unittitle>
+                      <physdesc>
+                        <extent>6 folders, including Executive Committee Meetings and Policy Research Board</extent>
+                      </physdesc>
                     </did>
                   </c07>
                   <c07 level="file">
                     <did>
                       <container type="box" label="Box">807</container>
-                      <unittitle><unitdate type="inclusive" normal="1981">1981</unitdate> Summer, August 9-11 (4 folders, including Executive Committee Meetings and Policy Research Board)</unittitle>
+                      <unittitle><unitdate type="inclusive" normal="1981">1981</unitdate> Summer, August 9-11</unittitle>
+                      <physdesc>
+                        <extent>4 folders, including Executive Committee Meetings and Policy Research Board</extent>
+                      </physdesc>
                     </did>
                   </c07>
                   <c07 level="file">
                     <did>
                       <container type="box" label="Box">807</container>
-                      <unittitle><unitdate type="inclusive" normal="1982">1982</unitdate> Winter, February 21-23 (4 folders, including Executive Committee Meetings and Policy Research Board)</unittitle>
+                      <unittitle><unitdate type="inclusive" normal="1982">1982</unitdate> Winter, February 21-23</unittitle>
+                      <physdesc>
+                        <extent>4 folders, including Executive Committee Meetings and Policy Research Board</extent>
+                      </physdesc>
                     </did>
                   </c07>
                   <c07 level="file">
                     <did>
                       <container type="box" label="Box">807</container>
-                      <unittitle><unitdate type="inclusive" normal="1982">1982</unitdate> Summer, August 8-10 (4 folders, including Executive Committee Meeting)</unittitle>
+                      <unittitle><unitdate type="inclusive" normal="1982">1982</unitdate> Summer, August 8-10</unittitle>
+                      <physdesc>
+                        <extent>4 folders, including Executive Committee Meeting</extent>
+                      </physdesc>
                     </did>
                   </c07>
                 </c06>

--- a/Real_Masters_all/mimedia.xml
+++ b/Real_Masters_all/mimedia.xml
@@ -3024,7 +3024,10 @@ Media Resources Center (University of Michigan) Records, Bentley Historical Libr
           <c03 level="file">
             <did>
               <container type="box" label="Box">25</container>
-              <unittitle>WPAG Scripts <unitdate type="inclusive" normal="1954/1956">1954-1956</unitdate> (8 v.)</unittitle>
+              <unittitle>WPAG Scripts <unitdate type="inclusive" normal="1954/1956">1954-1956</unitdate></unittitle>
+              <physdesc>
+                <extent>8 v.</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/miseagra.xml
+++ b/Real_Masters_all/miseagra.xml
@@ -2821,7 +2821,10 @@ Michigan Sea Grant Program records, Bentley Historical Library, University of Mi
           <c03 level="file">
             <did>
               <container type="box" label="Box">16</container>
-              <unittitle>The Sea Lamprey Story (2 cassettes)</unittitle>
+              <unittitle>The Sea Lamprey Story</unittitle>
+              <physdesc>
+                <extent>2 cassettes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/misynod.xml
+++ b/Real_Masters_all/misynod.xml
@@ -168,13 +168,19 @@
         <c02 level="file">
           <did>
             <container label="Box" type="box">1</container>
-            <unittitle>Minutes of Annual and Mid Winter Executive Meetings (27 folders) <unitdate type="inclusive" normal="1942/1968">1942-1968</unitdate></unittitle>
+            <unittitle>Minutes of Annual and Mid Winter Executive Meetings <unitdate type="inclusive" normal="1942/1968">1942-1968</unitdate></unittitle>
+            <physdesc>
+              <extent>27 folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">1</container>
-            <unittitle>Goals and Giving (14 folders) <unitdate type="inclusive" normal="1955/1968">1955-1968</unitdate></unittitle>
+            <unittitle>Goals and Giving <unitdate type="inclusive" normal="1955/1968">1955-1968</unitdate></unittitle>
+            <physdesc>
+              <extent>14 folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/munion.xml
+++ b/Real_Masters_all/munion.xml
@@ -263,7 +263,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">3</container>
-              <unittitle>Miscellaneous (1 folder)</unittitle>
+              <unittitle>Miscellaneous</unittitle>
+              <physdesc>
+                <extent>1 folder</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>
@@ -407,7 +410,12 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">7</container>
-                  <unittitle><unitdate type="inclusive" normal="1911/1926">1911-1926</unitdate> (1 vol. and 20 folders)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1911/1926">1911-1926</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>1 vol. and 20 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">

--- a/Real_Masters_all/muschba.xml
+++ b/Real_Masters_all/muschba.xml
@@ -16057,7 +16057,10 @@ YDA.1986.004.00674</unitid>
                 <did>
                   <container label="Box" type="box">A3</container>
                   <container label="Folder" type="folder">41-1</container>
-                  <unittitle>drawings (2 items) &amp; notes:</unittitle>
+                  <unittitle>drawings &amp; notes:</unittitle>
+                  <physdesc>
+                    <extent>2 items</extent>
+                  </physdesc>
                 </did>
                 <odd>
                   <p>(Folder 1)</p>
@@ -16070,7 +16073,10 @@ YDA.1986.004.00674</unitid>
                 <did>
                   <container label="Box" type="box">A3</container>
                   <container label="Folder" type="folder">41-2</container>
-                  <unittitle>drawings (7 items) &amp; notes:</unittitle>
+                  <unittitle>drawings &amp; notes:</unittitle>
+                  <physdesc>
+                    <extent>7 items</extent>
+                  </physdesc>
                 </did>
                 <odd>
                   <p>(Folder 2)</p>
@@ -16083,7 +16089,10 @@ YDA.1986.004.00674</unitid>
                 <did>
                   <container label="Box" type="box">A3</container>
                   <container label="Folder" type="folder">41-3</container>
-                  <unittitle>drawings (20 items) &amp; note:</unittitle>
+                  <unittitle>drawings &amp; note:</unittitle>
+                  <physdesc>
+                    <extent>20 items</extent>
+                  </physdesc>
                 </did>
                 <odd>
                   <p>(Folder 3)</p>
@@ -18926,7 +18935,10 @@ YDA.1986.004.00830</unitid>
                 <did>
                   <container type="box" label="Box">A4</container>
                   <container label="Folder" type="folder">43-4</container>
-                  <unittitle>archival: surveys, 2x3 photographs (8 items) and 6x8 photographs (4 items) of construction site, brochures, agenda, notes, envelopes, clippings.</unittitle>
+                  <unittitle>archival: surveys, 2x3 photographs and 6x8 photographs (4 items) of construction site, brochures, agenda, notes, envelopes, clippings.</unittitle>
+                  <physdesc>
+                    <extent>8 items</extent>
+                  </physdesc>
                 </did>
                 <odd>
                   <p>(Folder 2)</p>
@@ -35910,7 +35922,10 @@ YDA.1986.004.01776</unitid>
                 <did>
                   <container type="box" label="Box">A12</container>
                   <container label="Folder" type="folder">80-5</container>
-                  <unittitle>File # 79: prints, B&amp;W photographs (3 items) showing interior and exterior views.</unittitle>
+                  <unittitle>File # 79: prints, B&amp;W photographs showing interior and exterior views.</unittitle>
+                  <physdesc>
+                    <extent>3 items</extent>
+                  </physdesc>
                 </did>
                 <odd>
                   <p>(Folder 13)</p>
@@ -35933,7 +35948,10 @@ YDA.1986.004.01776</unitid>
                 <did>
                   <container type="box" label="Box">A12</container>
                   <container label="Folder" type="folder">80-7</container>
-                  <unittitle>archival: estimates, correspondence, statements, certificates, orders, photographs of beds (2 items).</unittitle>
+                  <unittitle>archival: estimates, correspondence, statements, certificates, orders, photographs of beds .</unittitle>
+                  <physdesc>
+                    <extent>2 items</extent>
+                  </physdesc>
                 </did>
                 <odd>
                   <p>(Folder 2)</p>
@@ -38313,7 +38331,10 @@ YDA.1986.004.01993</unitid>
                 <did>
                   <container type="box" label="Box">A14</container>
                   <container label="Folder" type="folder">83-11</container>
-                  <unittitle>prints, B&amp;W photographs (6 items) showing interior and exterior views of residence.</unittitle>
+                  <unittitle>prints, B&amp;W photographs showing interior and exterior views of residence.</unittitle>
+                  <physdesc>
+                    <extent>6 items</extent>
+                  </physdesc>
                 </did>
                 <odd>
                   <p>(Folder 14)</p>
@@ -40303,7 +40324,10 @@ YDA.1986.004.01993</unitid>
                 <did>
                   <container type="box" label="Box">A14</container>
                   <container label="Folder" type="folder">90-10</container>
-                  <unittitle>prints, 4x5 color transparencies (2 items) showing interior of residence, B&amp;W prints (4 items) showing interior of residence.</unittitle>
+                  <unittitle>prints, 4x5 color transparencies showing interior of residence, B&amp;W prints (4 items) showing interior of residence.</unittitle>
+                  <physdesc>
+                    <extent>2 items</extent>
+                  </physdesc>
                 </did>
                 <odd>
                   <p>(Folder 15)</p>

--- a/Real_Masters_all/muszool.xml
+++ b/Real_Masters_all/muszool.xml
@@ -1672,7 +1672,10 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">5</container>
-            <unittitle>Historical (2 folders) <unitdate type="inclusive" normal="1937/1993">1937-1993</unitdate></unittitle>
+            <unittitle>Historical <unitdate type="inclusive" normal="1937/1993">1937-1993</unitdate></unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/netzorgf.xml
+++ b/Real_Masters_all/netzorgf.xml
@@ -780,7 +780,10 @@ Netzorg family papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">7</container>
-              <unittitle>Scrapbooks <unitdate type="inclusive" normal="1957/1987">1957-1987</unitdate> (8 folders and 1 volume) See also Oversize</unittitle>
+              <unittitle>Scrapbooks <unitdate type="inclusive" normal="1957/1987">1957-1987</unitdate> See also Oversize</unittitle>
+              <physdesc>
+                <extent>8 folders and 1 volume</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -7031,7 +7034,10 @@ Netzorg family papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">35</container>
-              <unittitle>Photo albums <unitdate type="inclusive" normal="1935/1936">1935-1936</unitdate> (8 albums)</unittitle>
+              <unittitle>Photo albums <unitdate type="inclusive" normal="1935/1936">1935-1936</unitdate></unittitle>
+              <physdesc>
+                <extent>8 albums</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>
@@ -7179,7 +7185,10 @@ Netzorg family papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">35</container>
-              <unittitle>Morton J. Netzorg’s sketchbooks <unitdate type="inclusive" normal="1973/1986">1973-1986</unitdate> (5 albums)</unittitle>
+              <unittitle>Morton J. Netzorg’s sketchbooks <unitdate type="inclusive" normal="1973/1986">1973-1986</unitdate></unittitle>
+              <physdesc>
+                <extent>5 albums</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -7206,13 +7215,19 @@ Netzorg family papers, Bentley Historical Library, University of Michigan</p>
         <c02 level="file">
           <did>
             <container type="box" label="Box">36</container>
-            <unittitle>Morton J. Netzorg oral history (8 cassettes)</unittitle>
+            <unittitle>Morton J. Netzorg oral history</unittitle>
+            <physdesc>
+              <extent>8 cassettes</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">36</container>
-            <unittitle>Petra Netzog oral history (7 cassettes)</unittitle>
+            <unittitle>Petra Netzog oral history</unittitle>
+            <physdesc>
+              <extent>7 cassettes</extent>
+            </physdesc>
           </did>
         </c02>
       </c01>

--- a/Real_Masters_all/newsinfo.xml
+++ b/Real_Masters_all/newsinfo.xml
@@ -30379,7 +30379,10 @@ News and Information Services (University of Michigan) records, Bentley Historic
           <c03 level="file">
             <did>
               <container type="box" label="Box">165</container>
-              <unittitle>Physics, Department of (5 boxes)</unittitle>
+              <unittitle>Physics, Department of</unittitle>
+              <physdesc>
+                <extent>5 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -33999,7 +34002,10 @@ News and Information Services (University of Michigan) records, Bentley Historic
           <c03 level="file">
             <did>
               <container type="box" label="Box">50</container>
-              <unittitle>October (2 folders)</unittitle>
+              <unittitle>October</unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -35186,7 +35192,10 @@ News and Information Services (University of Michigan) records, Bentley Historic
           <c03 level="file">
             <did>
               <container type="box" label="Box">79</container>
-              <unittitle>Photographs (4 envelopes)</unittitle>
+              <unittitle>Photographs</unittitle>
+              <physdesc>
+                <extent>4 envelopes</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>
@@ -35216,7 +35225,10 @@ News and Information Services (University of Michigan) records, Bentley Historic
         <c02 level="file">
           <did>
             <container type="box" label="Box">35</container>
-            <unittitle>Audio-tapes of Information Service news briefs and "actualities" <unitdate type="inclusive" normal="1973/1975">1973-1975</unitdate> (15 reels)</unittitle>
+            <unittitle>Audio-tapes of Information Service news briefs and "actualities" <unitdate type="inclusive" normal="1973/1975">1973-1975</unitdate></unittitle>
+            <physdesc>
+              <extent>15 reels</extent>
+            </physdesc>
           </did>
           <odd>
             <p>(excerpts of newsmakers or events stories) with partial index</p>

--- a/Real_Masters_all/nisphoto.xml
+++ b/Real_Masters_all/nisphoto.xml
@@ -5412,7 +5412,10 @@ University of Michigan News and Information Services Photographs, Bentley Histor
       </c01>
       <c01 level="series">
         <did>
-          <unittitle>Series C <unitdate type="inclusive" normal="1961/1997">1961-1997</unitdate> (35mm negatives)</unittitle>
+          <unittitle>Series C <unitdate type="inclusive" normal="1961/1997">1961-1997</unitdate></unittitle>
+          <physdesc>
+            <extent>35mm negatives</extent>
+          </physdesc>
         </did>
         <scopecontent>
           <p>Series C (59 linear ft.; 1961-1997) consists of primarily black and white 35mm negatives, with occasional color negatives, many with contact sheets. The negatives are a identified by a job number and title and are numerically arranged in chronological order, starting in 1961 and running through 1984.</p>
@@ -8635,7 +8638,10 @@ University of Michigan News and Information Services Photographs, Bentley Histor
       </c01>
       <c01 level="series">
         <did>
-          <unittitle>Series F <unitdate type="inclusive" normal="1955/1965" certainty="approximate">circa 1955-1965</unitdate> (35 millimeter film containers (strip negatives)</unittitle>
+          <unittitle>Series F <unitdate type="inclusive" normal="1955/1965" certainty="approximate">circa 1955-1965</unitdate></unittitle>
+          <physdesc>
+            <extent>35 millimeter film containers (strip negatives</extent>
+          </physdesc>
         </did>
         <scopecontent>
           <p>SERIES F (4 linear ft.; ca. 1955-1965) is made up of film canisters filled with rolls of black and white 35mm negatives beginning about 1955 and running through the early 1960s. Broad ranges of subjects are documented, such as campus scenes, athletics, buildings, student activities, and events. The canisters are numbered and listed her in number order.</p>

--- a/Real_Masters_all/oethrel.xml
+++ b/Real_Masters_all/oethrel.xml
@@ -1845,7 +1845,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">12</container>
-                <unittitle>Record books <unitdate type="inclusive" normal="1955/1964">1955-1964</unitdate> (2 notebooks)</unittitle>
+                <unittitle>Record books <unitdate type="inclusive" normal="1955/1964">1955-1964</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 notebooks</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>
@@ -1856,7 +1859,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">12</container>
-                <unittitle>Record books <unitdate type="inclusive" normal="1956/1968">1956-1968</unitdate> (2 notebooks)</unittitle>
+                <unittitle>Record books <unitdate type="inclusive" normal="1956/1968">1956-1968</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 notebooks</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>

--- a/Real_Masters_all/ofarrell.xml
+++ b/Real_Masters_all/ofarrell.xml
@@ -281,7 +281,10 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">1</container>
-            <unittitle>Ah Quon McElrath Interview <unitdate type="inclusive" normal="1994">1994</unitdate> (2 audio cassettes)</unittitle>
+            <unittitle>Ah Quon McElrath Interview <unitdate type="inclusive" normal="1994">1994</unitdate></unittitle>
+            <physdesc>
+              <extent>2 audio cassettes</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/oksen.xml
+++ b/Real_Masters_all/oksen.xml
@@ -5304,13 +5304,19 @@ Michael Oksenberg papers, Bentley Historical Library, University of Michigan</p>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">44</container>
-                <unittitle>Correspondence and Memoranda <unitdate type="inclusive" normal="1980/1983">1980-1983</unitdate> (3 folders; 1 agenda book)</unittitle>
+                <unittitle>Correspondence and Memoranda <unitdate type="inclusive" normal="1980/1983">1980-1983</unitdate></unittitle>
+                <physdesc>
+                  <extent>3 folders; 1 agenda book</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">44</container>
-                <unittitle>Correspondence and Reports <unitdate type="inclusive" normal="1983/1989">1983-1989</unitdate> (3 folders; 1 agenda book)</unittitle>
+                <unittitle>Correspondence and Reports <unitdate type="inclusive" normal="1983/1989">1983-1989</unitdate></unittitle>
+                <physdesc>
+                  <extent>3 folders; 1 agenda book</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>
@@ -6978,7 +6984,10 @@ Michael Oksenberg papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">32</container>
-              <unittitle>Interviews by MO and others <unitdate type="inclusive" normal="1986">1986</unitdate> (3 binders)</unittitle>
+              <unittitle>Interviews by MO and others <unitdate type="inclusive" normal="1986">1986</unitdate></unittitle>
+              <physdesc>
+                <extent>3 binders</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>
@@ -7034,7 +7043,10 @@ Michael Oksenberg papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">33</container>
-              <unittitle>Interview Tapes, c. <unitdate type="inclusive" normal="1984/1986">1984-1986</unitdate> (21 audiocassettes and 3 microcassettes)</unittitle>
+              <unittitle>Interview Tapes, c. <unitdate type="inclusive" normal="1984/1986">1984-1986</unitdate></unittitle>
+              <physdesc>
+                <extent>21 audiocassettes and 3 microcassettes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -7211,13 +7223,19 @@ Michael Oksenberg papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">35</container>
-              <unittitle>Interviews with Oksenberg by M. Lampton about Carter Administration China Policy, transcripts and tapes, February and <unitdate type="inclusive" normal="1983-04">April 1983</unitdate> (8 audiocassettes)</unittitle>
+              <unittitle>Interviews with Oksenberg by M. Lampton about Carter Administration China Policy, transcripts and tapes, February and <unitdate type="inclusive" normal="1983-04">April 1983</unitdate></unittitle>
+              <physdesc>
+                <extent>8 audiocassettes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">35</container>
-              <unittitle>Interview with Oksenberg about Carter Administration China Policy, interviewer unknown <unitdate type="inclusive" normal="1982-05">May 1982</unitdate> (5 audiocassettes)</unittitle>
+              <unittitle>Interview with Oksenberg about Carter Administration China Policy, interviewer unknown <unitdate type="inclusive" normal="1982-05">May 1982</unitdate></unittitle>
+              <physdesc>
+                <extent>5 audiocassettes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -7229,7 +7247,10 @@ Michael Oksenberg papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">35</container>
-              <unittitle>Oksenberg Seminar on summer research <unitdate type="inclusive" normal="1981-10">October 1981</unitdate> (1 audiocassette)</unittitle>
+              <unittitle>Oksenberg Seminar on summer research <unitdate type="inclusive" normal="1981-10">October 1981</unitdate></unittitle>
+              <physdesc>
+                <extent>1 audiocassette</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/onspum.xml
+++ b/Real_Masters_all/onspum.xml
@@ -287,7 +287,10 @@ Office Of New Students Programs (University of Michigan) records, Bentley Histor
         <c02 level="file">
           <did>
             <container type="box" label="Box">1</container>
-            <unittitle>Diversity Training Manuals <unitdate type="inclusive" normal="1987/1989">1987-1989</unitdate> (3 expandable folders)</unittitle>
+            <unittitle>Diversity Training Manuals <unitdate type="inclusive" normal="1987/1989">1987-1989</unitdate></unittitle>
+            <physdesc>
+              <extent>3 expandable folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
@@ -299,7 +302,10 @@ Office Of New Students Programs (University of Michigan) records, Bentley Histor
         <c02 level="file">
           <did>
             <container type="box" label="Box">1</container>
-            <unittitle>Evaluations, cir <unitdate type="inclusive" normal="1987/1996" certainty="approximate">circa 1987-1996</unitdate> (2 expandable folders)</unittitle>
+            <unittitle>Evaluations, cir <unitdate type="inclusive" normal="1987/1996" certainty="approximate">circa 1987-1996</unitdate></unittitle>
+            <physdesc>
+              <extent>2 expandable folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/orgtrop.xml
+++ b/Real_Masters_all/orgtrop.xml
@@ -568,7 +568,10 @@ Organization for Tropical Studies records, Bentley Historical Library, Universit
         <c02 level="file">
           <did>
             <container type="box" label="Box">4</container>
-            <unittitle>General <unitdate type="inclusive" normal="1958/1968">1958-1968</unitdate> (4 bound volumes)</unittitle>
+            <unittitle>General <unitdate type="inclusive" normal="1958/1968">1958-1968</unitdate></unittitle>
+            <physdesc>
+              <extent>4 bound volumes</extent>
+            </physdesc>
           </did>
         </c02>
       </c01>

--- a/Real_Masters_all/osborncs.xml
+++ b/Real_Masters_all/osborncs.xml
@@ -1416,7 +1416,12 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">98</container>
-            <unittitle><unitdate type="inclusive" normal="1949">1949</unitdate> (1 folder)</unittitle>
+            <unittitle>
+              <unitdate type="inclusive" normal="1949">1949</unitdate>
+            </unittitle>
+            <physdesc>
+              <extent>1 folder</extent>
+            </physdesc>
           </did>
           <odd>
             <p>(later accession)</p>

--- a/Real_Masters_all/osherum.xml
+++ b/Real_Masters_all/osherum.xml
@@ -235,7 +235,10 @@ Osher Lifelong Learning Institute (University of Michigan) records, Bentley Hist
         <c02 level="file">
           <did>
             <container type="box" label="Box">1</container>
-            <unittitle>Committee meetings (5 photos)</unittitle>
+            <unittitle>Committee meetings</unittitle>
+            <physdesc>
+              <extent>5 photos</extent>
+            </physdesc>
           </did>
         </c02>
       </c01>

--- a/Real_Masters_all/ovpr.xml
+++ b/Real_Masters_all/ovpr.xml
@@ -41340,7 +41340,10 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">153</container>
-                  <unittitle>UM Faculty Assembly <unitdate type="inclusive">undated</unitdate> (2 audiotapes)</unittitle>
+                  <unittitle>UM Faculty Assembly <unitdate type="inclusive">undated</unitdate></unittitle>
+                  <physdesc>
+                    <extent>2 audiotapes</extent>
+                  </physdesc>
                 </did>
                 <odd>
                   <p>(accompanies one of the faculty meeting minutes below???)</p>
@@ -41375,7 +41378,10 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">153</container>
-                  <unittitle>Hearing on Research Policy Guidelines <unitdate type="inclusive" normal="1987-03">March 1987</unitdate> (1 audiotape)</unittitle>
+                  <unittitle>Hearing on Research Policy Guidelines <unitdate type="inclusive" normal="1987-03">March 1987</unitdate></unittitle>
+                  <physdesc>
+                    <extent>1 audiotape</extent>
+                  </physdesc>
                 </did>
                 <accessrestrict>
                   <p>[ER RESTRICTED until <date type="restriction" normal="2023-07-01">July 1, 2023</date>]</p>
@@ -41384,7 +41390,10 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">153</container>
-                  <unittitle>Regents Research Policy Revision: Discussion and Vote <unitdate type="inclusive" normal="1987-04">April 1987</unitdate> (1 audiotape)</unittitle>
+                  <unittitle>Regents Research Policy Revision: Discussion and Vote <unitdate type="inclusive" normal="1987-04">April 1987</unitdate></unittitle>
+                  <physdesc>
+                    <extent>1 audiotape</extent>
+                  </physdesc>
                 </did>
                 <accessrestrict>
                   <p>[ER RESTRICTED until <date type="restriction" normal="2023-07-01">July 1, 2023</date>]</p>
@@ -45174,7 +45183,10 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
           <c03 level="file">
             <did>
               <container type="box" label="Box">170</container>
-              <unittitle>BMC 1038 A-D The Future of Government/University Partnership (4 tape set)</unittitle>
+              <unittitle>BMC 1038 A-D The Future of Government/University Partnership</unittitle>
+              <physdesc>
+                <extent>4 tape set</extent>
+              </physdesc>
             </did>
             <odd>
               <p>(no. 45)</p>
@@ -45535,7 +45547,10 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
             <c04 level="file">
               <did>
                 <container type="box" label="Box">171</container>
-                <unittitle><unitdate type="inclusive" normal="1986/1987">1986-1987</unitdate> Proposals 1-22 (22 folders, by log number)</unittitle>
+                <unittitle><unitdate type="inclusive" normal="1986/1987">1986-1987</unitdate> Proposals 1-22</unittitle>
+                <physdesc>
+                  <extent>22 folders, by log number</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2023-07-01">July 1, 2023</date>]</p>
@@ -45544,7 +45559,10 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
             <c04 level="file">
               <did>
                 <container type="box" label="Box">172</container>
-                <unittitle><unitdate type="inclusive" normal="1986/1987">1986-1987</unitdate> Proposals 23-106 (84 folders, by log number)</unittitle>
+                <unittitle><unitdate type="inclusive" normal="1986/1987">1986-1987</unitdate> Proposals 23-106</unittitle>
+                <physdesc>
+                  <extent>84 folders, by log number</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2023-07-01">July 1, 2023</date>]</p>
@@ -45553,7 +45571,10 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
             <c04 level="file">
               <did>
                 <container type="box" label="Box">173</container>
-                <unittitle><unitdate type="inclusive" normal="1986/1987">1986-1987</unitdate> Proposals 107-146 (40 folders, by log number)</unittitle>
+                <unittitle><unitdate type="inclusive" normal="1986/1987">1986-1987</unitdate> Proposals 107-146</unittitle>
+                <physdesc>
+                  <extent>40 folders, by log number</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2023-07-01">July 1, 2023</date>]</p>
@@ -45562,7 +45583,10 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
             <c04 level="file">
               <did>
                 <container type="box" label="Box">173</container>
-                <unittitle><unitdate type="inclusive" normal="1987/1988">1987-1988</unitdate> Proposals 1-30 (30 folders, by log number)</unittitle>
+                <unittitle><unitdate type="inclusive" normal="1987/1988">1987-1988</unitdate> Proposals 1-30</unittitle>
+                <physdesc>
+                  <extent>30 folders, by log number</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2023-07-01">July 1, 2023</date>]</p>
@@ -45571,7 +45595,10 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
             <c04 level="file">
               <did>
                 <container type="box" label="Box">174</container>
-                <unittitle><unitdate type="inclusive" normal="1987/1988">1987-1988</unitdate> Proposals 31-43 (13 folders, by log number)</unittitle>
+                <unittitle><unitdate type="inclusive" normal="1987/1988">1987-1988</unitdate> Proposals 31-43</unittitle>
+                <physdesc>
+                  <extent>13 folders, by log number</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2023-07-01">July 1, 2023</date>]</p>
@@ -45580,7 +45607,10 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
             <c04 level="file">
               <did>
                 <container type="box" label="Box">174</container>
-                <unittitle><unitdate type="inclusive" normal="1988/1989">1988-1989</unitdate> Pre-Proposals 1-82 (82 folders, by log number)</unittitle>
+                <unittitle><unitdate type="inclusive" normal="1988/1989">1988-1989</unitdate> Pre-Proposals 1-82</unittitle>
+                <physdesc>
+                  <extent>82 folders, by log number</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2023-07-01">July 1, 2023</date>]</p>
@@ -45589,7 +45619,10 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
             <c04 level="file">
               <did>
                 <container type="box" label="Box">175</container>
-                <unittitle><unitdate type="inclusive" normal="1988/1989">1988-1989</unitdate> Pre-Proposals 83-105 (23 folders, by log number)</unittitle>
+                <unittitle><unitdate type="inclusive" normal="1988/1989">1988-1989</unitdate> Pre-Proposals 83-105</unittitle>
+                <physdesc>
+                  <extent>23 folders, by log number</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2023-07-01">July 1, 2023</date>]</p>
@@ -45687,7 +45720,10 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
             <c04 level="file">
               <did>
                 <container type="box" label="Box">177</container>
-                <unittitle><unitdate type="inclusive" normal="1988/1989">1988-1989</unitdate> Reviews of Final Proposals (24 folders for reviewers numbered 1-24)</unittitle>
+                <unittitle><unitdate type="inclusive" normal="1988/1989">1988-1989</unitdate> Reviews of Final Proposals</unittitle>
+                <physdesc>
+                  <extent>24 folders for reviewers numbered 1-24</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2023-07-01">July 1, 2023</date>]</p>

--- a/Real_Masters_all/parkin.xml
+++ b/Real_Masters_all/parkin.xml
@@ -1059,7 +1059,10 @@ William Charles Parkinson Papers, Bentley Historical Library, University of Mich
             <c04 level="file">
               <did>
                 <container type="box" label="Box">6</container>
-                <unittitle>Cyclotron <unitdate type="inclusive">undated</unitdate> (2 slides)</unittitle>
+                <unittitle>Cyclotron <unitdate type="inclusive">undated</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 slides</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -1071,7 +1074,10 @@ William Charles Parkinson Papers, Bentley Historical Library, University of Mich
             <c04 level="file">
               <did>
                 <container type="box" label="Box">6</container>
-                <unittitle>Equipment room/general assembly area for new cyclotron, North Campus <unitdate type="inclusive">undated</unitdate> (2 slides)</unittitle>
+                <unittitle>Equipment room/general assembly area for new cyclotron, North Campus <unitdate type="inclusive">undated</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 slides</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>
@@ -1299,7 +1305,10 @@ William Charles Parkinson Papers, Bentley Historical Library, University of Mich
             <c04 level="file">
               <did>
                 <container type="box" label="Box">6</container>
-                <unittitle>Cyclotron <unitdate type="inclusive">undated</unitdate> (3 slides)</unittitle>
+                <unittitle>Cyclotron <unitdate type="inclusive">undated</unitdate></unittitle>
+                <physdesc>
+                  <extent>3 slides</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/parsonsj.xml
+++ b/Real_Masters_all/parsonsj.xml
@@ -15590,19 +15590,28 @@ Jeffrey R. Parsons papers, Bentley Historical Library, University of Michigan</p
             <c04 level="file">
               <did>
                 <container type="box" label="Box">49</container>
-                <unittitle>Otomi Ethnography -- Mexico <unitdate type="inclusive" normal="1984">1984</unitdate> (2 notebooks) [includes tape transcriptions]</unittitle>
+                <unittitle>Otomi Ethnography -- Mexico <unitdate type="inclusive" normal="1984">1984</unitdate> [includes tape transcriptions]</unittitle>
+                <physdesc>
+                  <extent>2 notebooks</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">49</container>
-                <unittitle>Orizabita Fieldnotes -- Otomi Fieldwork <unitdate type="inclusive" normal="1983">1983</unitdate>, <unitdate type="inclusive" normal="1984">1984</unitdate> (2 notebooks)</unittitle>
+                <unittitle>Orizabita Fieldnotes -- Otomi Fieldwork <unitdate type="inclusive" normal="1983">1983</unitdate>, <unitdate type="inclusive" normal="1984">1984</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 notebooks</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">49</container>
-                <unittitle>Orizabita Fieldnotes <unitdate type="inclusive" normal="1986">1986</unitdate> (2 notebooks)</unittitle>
+                <unittitle>Orizabita Fieldnotes <unitdate type="inclusive" normal="1986">1986</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 notebooks</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -15620,7 +15629,10 @@ Jeffrey R. Parsons papers, Bentley Historical Library, University of Michigan</p
             <c04 level="file">
               <did>
                 <container type="box" label="Box">49</container>
-                <unittitle>Mexico <unitdate type="inclusive" normal="1987">1987</unitdate> (2 notebooks)</unittitle>
+                <unittitle>Mexico <unitdate type="inclusive" normal="1987">1987</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 notebooks</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -15632,13 +15644,19 @@ Jeffrey R. Parsons papers, Bentley Historical Library, University of Michigan</p
             <c04 level="file">
               <did>
                 <container type="box" label="Box">49</container>
-                <unittitle>Nexquipayac -- Field Notes <unitdate type="inclusive" normal="1988">1988</unitdate> (2 notebooks)</unittitle>
+                <unittitle>Nexquipayac -- Field Notes <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 notebooks</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">49</container>
-                <unittitle>Nexquipayac -- Field Notes <unitdate type="inclusive" normal="1988">1988</unitdate> (1 notebook)</unittitle>
+                <unittitle>Nexquipayac -- Field Notes <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
+                <physdesc>
+                  <extent>1 notebook</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -15656,7 +15674,10 @@ Jeffrey R. Parsons papers, Bentley Historical Library, University of Michigan</p
             <c04 level="file">
               <did>
                 <container type="box" label="Box">49</container>
-                <unittitle>Chimalhuacan Study <unitdate type="inclusive" normal="1992">1992</unitdate> (1 notebook)</unittitle>
+                <unittitle>Chimalhuacan Study <unitdate type="inclusive" normal="1992">1992</unitdate></unittitle>
+                <physdesc>
+                  <extent>1 notebook</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -15722,13 +15743,19 @@ Jeffrey R. Parsons papers, Bentley Historical Library, University of Michigan</p
             <c04 level="file">
               <did>
                 <container type="box" label="Box">49</container>
-                <unittitle>Mexico <unitdate type="inclusive" normal="1980">1980</unitdate>, <unitdate type="inclusive" normal="1981">1981</unitdate> Mexico <unitdate type="inclusive" normal="1981">1981</unitdate>, <unitdate type="inclusive" normal="1982">1982</unitdate> Misc Info <unitdate type="inclusive" normal="1983">1983</unitdate>, <unitdate type="inclusive" normal="1983">1983</unitdate> Photo Record (2 notebooks)</unittitle>
+                <unittitle>Mexico <unitdate type="inclusive" normal="1980">1980</unitdate>, <unitdate type="inclusive" normal="1981">1981</unitdate> Mexico <unitdate type="inclusive" normal="1981">1981</unitdate>, <unitdate type="inclusive" normal="1982">1982</unitdate> Misc Info <unitdate type="inclusive" normal="1983">1983</unitdate>, <unitdate type="inclusive" normal="1983">1983</unitdate> Photo Record</unittitle>
+                <physdesc>
+                  <extent>2 notebooks</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">50</container>
-                <unittitle>Photo Record Mexico <unitdate type="inclusive" normal="1982">1982</unitdate> Mexico <unitdate type="inclusive" normal="1984">1984</unitdate> &amp; <unitdate type="inclusive" normal="1986">1986</unitdate> (2 notebooks)</unittitle>
+                <unittitle>Photo Record Mexico <unitdate type="inclusive" normal="1982">1982</unitdate> Mexico <unitdate type="inclusive" normal="1984">1984</unitdate> &amp; <unitdate type="inclusive" normal="1986">1986</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 notebooks</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -20214,37 +20241,55 @@ Jeffrey R. Parsons papers, Bentley Historical Library, University of Michigan</p
             <c04 level="file">
               <did>
                 <container type="box" label="Box">52</container>
-                <unittitle>Parson-Andean Trip #1, 2 &amp; 3 <unitdate type="inclusive" normal="1966">1966</unitdate> (3 notebooks)</unittitle>
+                <unittitle>Parson-Andean Trip #1, 2 &amp; 3 <unitdate type="inclusive" normal="1966">1966</unitdate></unittitle>
+                <physdesc>
+                  <extent>3 notebooks</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">52</container>
-                <unittitle>Parsons-#1 Tarma <unitdate type="inclusive" normal="1975">1975</unitdate> #2 Peru <unitdate type="inclusive" normal="1975">1975</unitdate> #3 Jauja <unitdate type="inclusive" normal="1975">1975</unitdate> (3 notebooks)</unittitle>
+                <unittitle>Parsons-#1 Tarma <unitdate type="inclusive" normal="1975">1975</unitdate> #2 Peru <unitdate type="inclusive" normal="1975">1975</unitdate> #3 Jauja <unitdate type="inclusive" normal="1975">1975</unitdate></unittitle>
+                <physdesc>
+                  <extent>3 notebooks</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">52</container>
-                <unittitle>David Wilson #1 &amp; Charles Hastings <unitdate type="inclusive" normal="1975">1975</unitdate> Hastings #2 Tarma &amp; Jauja <unitdate type="inclusive" normal="1975">1975</unitdate> (2 notebooks)</unittitle>
+                <unittitle>David Wilson #1 &amp; Charles Hastings <unitdate type="inclusive" normal="1975">1975</unitdate> Hastings #2 Tarma &amp; Jauja <unitdate type="inclusive" normal="1975">1975</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 notebooks</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">52</container>
-                <unittitle>Parsons -- #1 &amp; 4 Jauja <unitdate type="inclusive" normal="1965">1965</unitdate> #2 Junin &amp; Jauja <unitdate type="inclusive" normal="1976">1976</unitdate> #3 Junin <unitdate type="inclusive" normal="1976">1976</unitdate> (3 notebooks)</unittitle>
+                <unittitle>Parsons -- #1 &amp; 4 Jauja <unitdate type="inclusive" normal="1965">1965</unitdate> #2 Junin &amp; Jauja <unitdate type="inclusive" normal="1976">1976</unitdate> #3 Junin <unitdate type="inclusive" normal="1976">1976</unitdate></unittitle>
+                <physdesc>
+                  <extent>3 notebooks</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">52</container>
-                <unittitle>Parsons -- Junin <unitdate type="inclusive" normal="1976">1976</unitdate> Alternate notebook; Peru <unitdate type="inclusive" normal="1975/1976">1975/76</unitdate> Records (2 notebooks)</unittitle>
+                <unittitle>Parsons -- Junin <unitdate type="inclusive" normal="1976">1976</unitdate> Alternate notebook; Peru <unitdate type="inclusive" normal="1975/1976">1975/76</unitdate> Records</unittitle>
+                <physdesc>
+                  <extent>2 notebooks</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">52</container>
-                <unittitle>Tugendrajch-Anschuetz-#1 Casaracra <unitdate type="inclusive" normal="1976">1976</unitdate> Junin <unitdate type="inclusive" normal="1976">1976</unitdate> Book2; Hastings Huasahuasi <unitdate type="inclusive" normal="1976">1976</unitdate> (3 notebooks)</unittitle>
+                <unittitle>Tugendrajch-Anschuetz-#1 Casaracra <unitdate type="inclusive" normal="1976">1976</unitdate> Junin <unitdate type="inclusive" normal="1976">1976</unitdate> Book2; Hastings Huasahuasi <unitdate type="inclusive" normal="1976">1976</unitdate></unittitle>
+                <physdesc>
+                  <extent>3 notebooks</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -20374,7 +20419,10 @@ Jeffrey R. Parsons papers, Bentley Historical Library, University of Michigan</p
         <c02 level="file">
           <did>
             <container type="box" label="Box">24</container>
-            <unittitle>Iceland <unitdate type="inclusive" normal="1986">1986</unitdate> (1 notebook)</unittitle>
+            <unittitle>Iceland <unitdate type="inclusive" normal="1986">1986</unitdate></unittitle>
+            <physdesc>
+              <extent>1 notebook</extent>
+            </physdesc>
           </did>
         </c02>
       </c01>
@@ -20903,7 +20951,10 @@ Jeffrey R. Parsons papers, Bentley Historical Library, University of Michigan</p
           </c03>
           <c03 level="file">
             <did>
-              <unittitle>Mexico <unitdate type="inclusive" normal="1972">1972</unitdate> (2 binders)</unittitle>
+              <unittitle>Mexico <unitdate type="inclusive" normal="1972">1972</unitdate></unittitle>
+              <physdesc>
+                <extent>2 binders</extent>
+              </physdesc>
             </did>
             <odd>
               <p>(Rolls 1-27; Rolls 28-53)</p>

--- a/Real_Masters_all/peo.xml
+++ b/Real_Masters_all/peo.xml
@@ -3537,7 +3537,10 @@ Programs for Educational Opportunity (University of Michigan) Records, Bentley H
           <c03 level="file">
             <did>
               <container type="box" label="Box">16</container>
-              <unittitle>FY <unitdate type="inclusive" normal="1987">1987</unitdate> (3 folders, 2 volumes)</unittitle>
+              <unittitle>FY <unitdate type="inclusive" normal="1987">1987</unitdate></unittitle>
+              <physdesc>
+                <extent>3 folders, 2 volumes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/personel.xml
+++ b/Real_Masters_all/personel.xml
@@ -5548,13 +5548,19 @@ Personnel Office (University of Michigan) Records, Bentley Historical Library, U
         <c02 level="file">
           <did>
             <container type="box" label="Box">36</container>
-            <unittitle>Revisions <unitdate type="inclusive" normal="1993">1993</unitdate> (7 folders, folders; 1-4 in Box 36)</unittitle>
+            <unittitle>Revisions <unitdate type="inclusive" normal="1993">1993</unitdate></unittitle>
+            <physdesc>
+              <extent>7 folders, folders; 1-4 in Box 36</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">37</container>
-            <unittitle>Revisions <unitdate type="inclusive" normal="1993">1993</unitdate> (7 folders, folders; 5-7 in Box 37)</unittitle>
+            <unittitle>Revisions <unitdate type="inclusive" normal="1993">1993</unitdate></unittitle>
+            <physdesc>
+              <extent>7 folders, folders; 5-7 in Box 37</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/photoser.xml
+++ b/Real_Masters_all/photoser.xml
@@ -1133,7 +1133,10 @@ Photo and Campus Services (University of Michigan), Bentley Historical Library, 
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unittitle>Photo Services Staff and Equipment <unitdate type="inclusive" normal="1960" certainty="approximate">circa 1960</unitdate> (2 images)</unittitle>
+            <unittitle>Photo Services Staff and Equipment <unitdate type="inclusive" normal="1960" certainty="approximate">circa 1960</unitdate></unittitle>
+            <physdesc>
+              <extent>2 images</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/physics.xml
+++ b/Real_Masters_all/physics.xml
@@ -3202,7 +3202,10 @@ Production</unittitle>
           <c03 level="file">
             <did>
               <container type="box" label="Box">16</container>
-              <unittitle>M. Perl <unitdate type="inclusive" normal="1991-04-11">April 11, 1991</unitdate> (2 tapes)</unittitle>
+              <unittitle>M. Perl <unitdate type="inclusive" normal="1991-04-11">April 11, 1991</unitdate></unittitle>
+              <physdesc>
+                <extent>2 tapes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/polisci.xml
+++ b/Real_Masters_all/polisci.xml
@@ -1425,7 +1425,10 @@ Department of Political Science (University of Michigan) records, Bentley Histor
           <c03 level="file">
             <did>
               <container type="box" label="Box">12</container>
-              <unittitle>Dictation of letters from Professor William B. Ballis to Professor Knott, Dean of LS&amp;A <unitdate type="inclusive" normal="1980" certainty="approximate">circa 1980</unitdate> (2 cassettes)</unittitle>
+              <unittitle>Dictation of letters from Professor William B. Ballis to Professor Knott, Dean of LS&amp;A <unitdate type="inclusive" normal="1980" certainty="approximate">circa 1980</unitdate></unittitle>
+              <physdesc>
+                <extent>2 cassettes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/postfam.xml
+++ b/Real_Masters_all/postfam.xml
@@ -1371,8 +1371,10 @@ v.)</unittitle>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">9</container>
-                <unittitle>Tributes (primarily typescripts of
-correspondence (3 v.)</unittitle>
+                <unittitle>Tributes (primarily typescripts of correspondence</unittitle>
+                <physdesc>
+                  <extent>3 v.</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -1487,7 +1489,10 @@ financial books <unitdate type="inclusive" normal="1912">1912</unitdate></unitti
             <c04 level="file">
               <did>
                 <container type="box" label="Box">46</container>
-                <unittitle>Ledgers and journal <unitdate type="inclusive" normal="1900/1906">1900-1906</unitdate> (5v.)</unittitle>
+                <unittitle>Ledgers and journal <unitdate type="inclusive" normal="1900/1906">1900-1906</unitdate></unittitle>
+                <physdesc>
+                  <extent>5v.</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/ppolicy.xml
+++ b/Real_Masters_all/ppolicy.xml
@@ -2600,7 +2600,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">15</container>
-                  <unittitle>October (2 folders)</unittitle>
+                  <unittitle>October</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
                 <accessrestrict>
                   <p>[ER RESTRICTED until <date type="restriction" normal="2022-07-01">July 1, 2022</date>]</p>

--- a/Real_Masters_all/prisoncr.xml
+++ b/Real_Masters_all/prisoncr.xml
@@ -1219,7 +1219,10 @@ Prison Creative Arts Project collection, Bentley Historical Library, University 
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unittitle>Newsletter <unitdate type="inclusive" normal="2010/2013">2010-2013</unitdate> (3 folders)</unittitle>
+            <unittitle>Newsletter <unitdate type="inclusive" normal="2010/2013">2010-2013</unitdate></unittitle>
+            <physdesc>
+              <extent>3 folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/rackhamg.xml
+++ b/Real_Masters_all/rackhamg.xml
@@ -1958,7 +1958,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">62</container>
-              <unittitle>Medicinal Chemistry <unitdate type="inclusive" normal="1967/1979">1967-1979</unitdate> (1 folder)</unittitle>
+              <unittitle>Medicinal Chemistry <unitdate type="inclusive" normal="1967/1979">1967-1979</unitdate></unittitle>
+              <physdesc>
+                <extent>1 folder</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -21925,7 +21928,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">100</container>
-              <unittitle>Masters of Management Program, Dearborn <unitdate type="inclusive" normal="1967/1980">1967-1980</unitdate> (1 notebook)</unittitle>
+              <unittitle>Masters of Management Program, Dearborn <unitdate type="inclusive" normal="1967/1980">1967-1980</unitdate></unittitle>
+              <physdesc>
+                <extent>1 notebook</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -21946,7 +21952,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">100</container>
-              <unittitle>Mathematics Department <unitdate type="inclusive" normal="1977/1978">1977-1978</unitdate> (2 folders, 1 notebook)</unittitle>
+              <unittitle>Mathematics Department <unitdate type="inclusive" normal="1977/1978">1977-1978</unitdate></unittitle>
+              <physdesc>
+                <extent>2 folders, 1 notebook</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -22252,7 +22261,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">102</container>
-              <unittitle>Philosophy <unitdate type="inclusive" normal="1989/1990">1989-1990</unitdate> (1 folder and 1 notebook)</unittitle>
+              <unittitle>Philosophy <unitdate type="inclusive" normal="1989/1990">1989-1990</unitdate></unittitle>
+              <physdesc>
+                <extent>1 folder and 1 notebook</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -22287,7 +22299,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">102</container>
-              <unittitle>Philosophy Department <unitdate type="inclusive" normal="1989/1990">1989-1990</unitdate> (1 folder and 1 notebook)</unittitle>
+              <unittitle>Philosophy Department <unitdate type="inclusive" normal="1989/1990">1989-1990</unitdate></unittitle>
+              <physdesc>
+                <extent>1 folder and 1 notebook</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -22496,7 +22511,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">104</container>
-              <unittitle>Religion Studies Program <unitdate type="inclusive" normal="1987/1989">1987-1989</unitdate> (1 folder and 1 notebook)</unittitle>
+              <unittitle>Religion Studies Program <unitdate type="inclusive" normal="1987/1989">1987-1989</unitdate></unittitle>
+              <physdesc>
+                <extent>1 folder and 1 notebook</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/regents.xml
+++ b/Real_Masters_all/regents.xml
@@ -272,7 +272,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">1</container>
-                <unittitle>Photostatic copy (1 v. oversize)</unittitle>
+                <unittitle>Photostatic copy</unittitle>
+                <physdesc>
+                  <extent>1 v. oversize</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -305,7 +308,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unittitle>Minutes, Regents Executive Committee <unitdate type="inclusive" normal="1845/1851">1845-1851</unitdate> (1 v.)</unittitle>
+              <unittitle>Minutes, Regents Executive Committee <unitdate type="inclusive" normal="1845/1851">1845-1851</unitdate></unittitle>
+              <physdesc>
+                <extent>1 v.</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -315,13 +321,23 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">1</container>
-                <unittitle><unitdate type="inclusive" normal="1837/1854">1837-1854</unitdate> (1 v. oversize)</unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1837/1854">1837-1854</unitdate>
+                </unittitle>
+                <physdesc>
+                  <extent>1 v. oversize</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">1</container>
-                <unittitle><unitdate type="inclusive" normal="1855/1870">1855-1870</unitdate> (1 v. oversize)</unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1855/1870">1855-1870</unitdate>
+                </unittitle>
+                <physdesc>
+                  <extent>1 v. oversize</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>

--- a/Real_Masters_all/riegled.xml
+++ b/Real_Masters_all/riegled.xml
@@ -3391,7 +3391,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">10</container>
-                  <unittitle>Poverty (4 folders)</unittitle>
+                  <unittitle>Poverty</unittitle>
+                  <physdesc>
+                    <extent>4 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -3803,7 +3806,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
             <c04 level="file">
               <did>
                 <container type="box" label="Box">13</container>
-                <unittitle>Federal spending (2 folders)</unittitle>
+                <unittitle>Federal spending</unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>
@@ -4717,7 +4723,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
             <c04 level="file">
               <did>
                 <container type="box" label="Box">19</container>
-                <unittitle>Banking, monetary policy, credit (2 folders)</unittitle>
+                <unittitle>Banking, monetary policy, credit</unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -4845,7 +4854,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
               </c05>
               <c05 level="file">
                 <did>
-                  <unittitle>Public service jobs, CETA, etc. (2 folders)</unittitle>
+                  <unittitle>Public service jobs, CETA, etc.</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
                 <c06 level="file">
                   <did>
@@ -6054,7 +6066,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">27</container>
-                  <unittitle>Financial(3 folders)</unittitle>
+                  <unittitle>Financial</unittitle>
+                  <physdesc>
+                    <extent>3 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -6253,7 +6268,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">29</container>
-                  <unittitle>General(4 folders)</unittitle>
+                  <unittitle>General</unittitle>
+                  <physdesc>
+                    <extent>4 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -21768,7 +21786,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">95</container>
-                  <unittitle>Budget resolution (4 folders)</unittitle>
+                  <unittitle>Budget resolution</unittitle>
+                  <physdesc>
+                    <extent>4 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -23330,7 +23351,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
             <c04 level="file">
               <did>
                 <container type="box" label="Box">103</container>
-                <unittitle>Revenue reconciliation proposal (4 folders)</unittitle>
+                <unittitle>Revenue reconciliation proposal</unittitle>
+                <physdesc>
+                  <extent>4 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -23621,13 +23645,19 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
             <c04 level="file">
               <did>
                 <container type="box" label="Box">104</container>
-                <unittitle>Tax documents (5 folders)</unittitle>
+                <unittitle>Tax documents</unittitle>
+                <physdesc>
+                  <extent>5 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">104</container>
-                <unittitle>Tax materials (4 folders)</unittitle>
+                <unittitle>Tax materials</unittitle>
+                <physdesc>
+                  <extent>4 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -24014,7 +24044,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
               </c05>
               <c05 level="file">
                 <did>
-                  <unittitle>Women (5 folders)</unittitle>
+                  <unittitle>Women</unittitle>
+                  <physdesc>
+                    <extent>5 folders</extent>
+                  </physdesc>
                 </did>
                 <c06 level="file">
                   <did>
@@ -24284,7 +24317,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
             <c04 level="file">
               <did>
                 <container type="box" label="Box">108</container>
-                <unittitle>Memos (4 folders)</unittitle>
+                <unittitle>Memos</unittitle>
+                <physdesc>
+                  <extent>4 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -24369,7 +24405,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">109</container>
-                  <unittitle>Correspondence (5 folders)</unittitle>
+                  <unittitle>Correspondence</unittitle>
+                  <physdesc>
+                    <extent>5 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -26539,7 +26578,12 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">120</container>
-                  <unittitle><unitdate type="inclusive" normal="1986">1986</unitdate> (5 folders)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1986">1986</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>5 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -26666,7 +26710,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
             <c04 level="file">
               <did>
                 <container type="box" label="Box">121</container>
-                <unittitle>Dioxin (5 folders)</unittitle>
+                <unittitle>Dioxin</unittitle>
+                <physdesc>
+                  <extent>5 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -27230,7 +27277,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
             <c04 level="file">
               <did>
                 <container type="box" label="Box">123</container>
-                <unittitle>Housing-Loose documents (4 folders)</unittitle>
+                <unittitle>Housing-Loose documents</unittitle>
+                <physdesc>
+                  <extent>4 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -27480,7 +27530,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
             <c04 level="file">
               <did>
                 <container type="box" label="Box">124</container>
-                <unittitle>Pokagon Potawatomi Band (4 folders)</unittitle>
+                <unittitle>Pokagon Potawatomi Band</unittitle>
+                <physdesc>
+                  <extent>4 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -27526,7 +27579,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">125</container>
-                  <unittitle>Closure (4 folders)</unittitle>
+                  <unittitle>Closure</unittitle>
+                  <physdesc>
+                    <extent>4 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -28546,7 +28602,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
             </c04>
             <c04 level="file">
               <did>
-                <unittitle>Memos (4 folders)</unittitle>
+                <unittitle>Memos</unittitle>
+                <physdesc>
+                  <extent>4 folders</extent>
+                </physdesc>
               </did>
               <c05 level="file">
                 <did>
@@ -33984,7 +34043,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">146</container>
-                  <unittitle>Hamtramck/Highland Park <unitdate type="inclusive" normal="1994">1994</unitdate> (4 folders)</unittitle>
+                  <unittitle>Hamtramck/Highland Park <unitdate type="inclusive" normal="1994">1994</unitdate></unittitle>
+                  <physdesc>
+                    <extent>4 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -34107,7 +34169,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">147</container>
-                  <unittitle>Project <unitdate type="inclusive" normal="1980">1980</unitdate> (4 folders)</unittitle>
+                  <unittitle>Project <unitdate type="inclusive" normal="1980">1980</unitdate></unittitle>
+                  <physdesc>
+                    <extent>4 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -35182,7 +35247,10 @@ Donald W. Riegle, Jr. papers, Bentley Historical Library, University of Michigan
             <c04 level="file">
               <did>
                 <container type="box" label="Box">153</container>
-                <unittitle>Flood insurance <unitdate type="inclusive" normal="1992">1992</unitdate> (4 folders)</unittitle>
+                <unittitle>Flood insurance <unitdate type="inclusive" normal="1992">1992</unitdate></unittitle>
+                <physdesc>
+                  <extent>4 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/romneyg.xml
+++ b/Real_Masters_all/romneyg.xml
@@ -28711,7 +28711,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">421</container>
-                  <unittitle>Tax Reform <unitdate type="inclusive" normal="1967">1967</unitdate> (1 expandable folder)</unittitle>
+                  <unittitle>Tax Reform <unitdate type="inclusive" normal="1967">1967</unitdate></unittitle>
+                  <physdesc>
+                    <extent>1 expandable folder</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -32815,7 +32818,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">8-P</container>
-              <unittitle>Legal matters (2 folders)</unittitle>
+              <unittitle>Legal matters</unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -40404,7 +40410,10 @@
         </scopecontent>
         <c02 level="series">
           <did>
-            <unittitle>Chronological Series I (7 inch tapes)</unittitle>
+            <unittitle>Chronological Series I</unittitle>
+            <physdesc>
+              <extent>7 inch tapes</extent>
+            </physdesc>
           </did>
           <c03 level="file">
             <did>
@@ -44013,9 +44022,12 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">371</container>
-                <unittitle>GR speech on Vietnam, University of Detroit, undated (3 tapes, tape 1 is missing)</unittitle>
+                <unittitle>GR speech on Vietnam, University of Detroit, undated</unittitle>
                 <physdesc>
                   <physfacet>7-1/2 ips</physfacet>
+                </physdesc>
+                <physdesc>
+                  <extent>3 tapes, tape 1 is missing</extent>
                 </physdesc>
               </did>
             </c04>
@@ -44169,7 +44181,10 @@
         </c02>
         <c02 level="series">
           <did>
-            <unittitle>Chronological Series II (5-inch tapes)</unittitle>
+            <unittitle>Chronological Series II</unittitle>
+            <physdesc>
+              <extent>5-inch tapes</extent>
+            </physdesc>
           </did>
           <c03 level="file">
             <did>
@@ -44936,7 +44951,10 @@
         </c02>
         <c02 level="series">
           <did>
-            <unittitle>Chronological Series III (3-inch tapes)</unittitle>
+            <unittitle>Chronological Series III</unittitle>
+            <physdesc>
+              <extent>3-inch tapes</extent>
+            </physdesc>
           </did>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/russlect.xml
+++ b/Real_Masters_all/russlect.xml
@@ -834,7 +834,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">2</container>
-              <unittitle>Henry Russel Lecture and Award Program <unitdate type="inclusive" normal="1997">1997</unitdate>, <unitdate type="inclusive" normal="1999/2002">1999-2002</unitdate> 2004-(2 folders)</unittitle>
+              <unittitle>Henry Russel Lecture and Award Program <unitdate type="inclusive" normal="1997">1997</unitdate>, <unitdate type="inclusive" normal="1999/2002">1999-2002</unitdate> 2004-</unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/satacad.xml
+++ b/Real_Masters_all/satacad.xml
@@ -446,7 +446,10 @@ William D. Ratcliff papers, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unittitle>Efficacy Detroit <unitdate type="inclusive" normal="1971/1972">1971-1972</unitdate>, <unitdate type="inclusive" normal="1986/1987">1986-1987</unitdate> (1 folder and 2 binders)</unittitle>
+            <unittitle>Efficacy Detroit <unitdate type="inclusive" normal="1971/1972">1971-1972</unitdate>, <unitdate type="inclusive" normal="1986/1987">1986-1987</unitdate></unittitle>
+            <physdesc>
+              <extent>1 folder and 2 binders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
@@ -618,7 +621,10 @@ William D. Ratcliff papers, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">4</container>
-            <unittitle>SAT/ACT workshop <unitdate type="inclusive" normal="1986">1986</unitdate>, <unitdate type="inclusive" normal="1988">1988</unitdate> (2 binders)</unittitle>
+            <unittitle>SAT/ACT workshop <unitdate type="inclusive" normal="1986">1986</unitdate>, <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
+            <physdesc>
+              <extent>2 binders</extent>
+            </physdesc>
           </did>
         </c02>
       </c01>
@@ -698,7 +704,10 @@ William D. Ratcliff papers, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">6</container>
-            <unittitle>Guidance counselor papers <unitdate type="inclusive" normal="1971/2003">1971-2003</unitdate> (3 folders and 1 binder)</unittitle>
+            <unittitle>Guidance counselor papers <unitdate type="inclusive" normal="1971/2003">1971-2003</unitdate></unittitle>
+            <physdesc>
+              <extent>3 folders and 1 binder</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
@@ -799,7 +808,10 @@ William D. Ratcliff papers, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">6</container>
-            <unittitle>Superintendent's Committee on African-American Achievement Initiatives <unitdate type="inclusive" normal="1997/1998">1997-1998</unitdate> (1 folder and 1 binder)</unittitle>
+            <unittitle>Superintendent's Committee on African-American Achievement Initiatives <unitdate type="inclusive" normal="1997/1998">1997-1998</unitdate></unittitle>
+            <physdesc>
+              <extent>1 folder and 1 binder</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/schneid.xml
+++ b/Real_Masters_all/schneid.xml
@@ -194,7 +194,10 @@ Richard Schneidewind papers, Bentley Historical Library, University of Michigan<
           </c03>
           <c03 level="file">
             <did>
-              <unittitle>Igorot Village exhibits <unitdate type="inclusive">undated</unitdate> (15 photographs on 2 pages)</unittitle>
+              <unittitle>Igorot Village exhibits <unitdate type="inclusive">undated</unitdate></unittitle>
+              <physdesc>
+                <extent>15 photographs on 2 pages</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/schofart.xml
+++ b/Real_Masters_all/schofart.xml
@@ -628,7 +628,12 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">3</container>
-              <unittitle><unitdate type="inclusive" normal="1978/1998">1978-1998</unitdate> (3 binders)</unittitle>
+              <unittitle>
+                <unitdate type="inclusive" normal="1978/1998">1978-1998</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>3 binders</extent>
+              </physdesc>
             </did>
             <accessrestrict>
               <p>[ER RESTRICTED until <date type="restriction" normal="2020-07-01">July 1, 2020</date>]</p>
@@ -656,7 +661,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">3</container>
-              <unittitle>Minutes <unitdate type="inclusive" normal="1974/1999">1974-1999</unitdate> (4 binders)</unittitle>
+              <unittitle>Minutes <unitdate type="inclusive" normal="1974/1999">1974-1999</unitdate></unittitle>
+              <physdesc>
+                <extent>4 binders</extent>
+              </physdesc>
             </did>
             <accessrestrict>
               <p>[ER RESTRICTED until <date type="restriction" normal="2020-07-01">July 1, 2020</date>]</p>

--- a/Real_Masters_all/schofed.xml
+++ b/Real_Masters_all/schofed.xml
@@ -6022,7 +6022,10 @@ School of Education (University of Michigan) Records, Bentley Historical Library
           <c03 level="file">
             <did>
               <container type="box" label="Box">32</container>
-              <unittitle>Bureau of School Services <unitdate type="inclusive" normal="1982">1982</unitdate> (3 folders, from SOE Review exhibits 130-132)</unittitle>
+              <unittitle>Bureau of School Services <unitdate type="inclusive" normal="1982">1982</unitdate></unittitle>
+              <physdesc>
+                <extent>3 folders, from SOE Review exhibits 130-132</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -11513,7 +11516,10 @@ School of Education (University of Michigan) Records, Bentley Historical Library
           <c03 level="file">
             <did>
               <container type="box" label="Box">19</container>
-              <unittitle>Evaluation and Planning Study <unitdate type="inclusive" normal="1975/1977">1975-1977</unitdate> (2 folders, university-wide study)</unittitle>
+              <unittitle>Evaluation and Planning Study <unitdate type="inclusive" normal="1975/1977">1975-1977</unitdate></unittitle>
+              <physdesc>
+                <extent>2 folders, university-wide study</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/sectryvp.xml
+++ b/Real_Masters_all/sectryvp.xml
@@ -2326,7 +2326,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">10</container>
-                <unittitle>Correspondence and Reports, <unitdate type="inclusive" normal="1972/1989">1972-1989</unitdate> (2 folders, includes CD)</unittitle>
+                <unittitle>Correspondence and Reports, <unitdate type="inclusive" normal="1972/1989">1972-1989</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 folders, includes CD</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date normal="2033-07-01" type="restrict">July 1, 2033</date>]</p>
@@ -3024,7 +3027,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">15</container>
-              <unittitle>President's Speeches, <unitdate type="inclusive" normal="1999/2006">1999-2006</unitdate> (2 folders, includes cassette tapes)</unittitle>
+              <unittitle>President's Speeches, <unitdate type="inclusive" normal="1999/2006">1999-2006</unitdate></unittitle>
+              <physdesc>
+                <extent>2 folders, includes cassette tapes</extent>
+              </physdesc>
             </did>
             <accessrestrict>
               <p>[ER RESTRICTED until <date normal="2033-07-01" type="restrict">July 1, 2033</date>]</p>

--- a/Real_Masters_all/sectyum.xml
+++ b/Real_Masters_all/sectyum.xml
@@ -286,7 +286,10 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">7</container>
-            <unittitle>Auditing Board proceedings <unitdate type="inclusive" normal="1909/1920">1909-1920</unitdate> (1 folder and 2 expandable folders)</unittitle>
+            <unittitle>Auditing Board proceedings <unitdate type="inclusive" normal="1909/1920">1909-1920</unitdate></unittitle>
+            <physdesc>
+              <extent>1 folder and 2 expandable folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/sharfman.xml
+++ b/Real_Masters_all/sharfman.xml
@@ -1537,7 +1537,10 @@ I. Leo Sharfman papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">5</container>
-              <unittitle>Vacation dispute, Detroit, Toledo and Ironton Railroad Co. <unitdate type="inclusive" normal="1944">1944</unitdate> (2 folders]</unittitle>
+              <unittitle>Vacation dispute, Detroit, Toledo and Ironton Railroad Co. <unitdate type="inclusive" normal="1944">1944</unitdate></unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/sincljl.xml
+++ b/Real_Masters_all/sincljl.xml
@@ -327,7 +327,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unittitle>Clippings, resumes, press releases(4 folders)</unittitle>
+              <unittitle>Clippings, resumes, press releases</unittitle>
+              <physdesc>
+                <extent>4 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -9282,7 +9285,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">63</container>
-                  <unittitle>John Sinclair <unitdate type="inclusive" normal="1979">1979</unitdate> (2 cassettes)</unittitle>
+                  <unittitle>John Sinclair <unitdate type="inclusive" normal="1979">1979</unitdate></unittitle>
+                  <physdesc>
+                    <extent>2 cassettes</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">

--- a/Real_Masters_all/sligh.xml
+++ b/Real_Masters_all/sligh.xml
@@ -2488,7 +2488,12 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">35</container>
-                <unittitle><unitdate type="inclusive" normal="1916">1916</unitdate> (2 books)</unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1916">1916</unitdate>
+                </unittitle>
+                <physdesc>
+                  <extent>2 books</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -2550,7 +2555,12 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">37</container>
-                <unittitle><unitdate type="inclusive" normal="1959">1959</unitdate> (2 binders)</unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1959">1959</unitdate>
+                </unittitle>
+                <physdesc>
+                  <extent>2 binders</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>

--- a/Real_Masters_all/smithglk.xml
+++ b/Real_Masters_all/smithglk.xml
@@ -4632,7 +4632,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">17</container>
-              <unittitle>Cross and the Flag subscriptions (2 folders)</unittitle>
+              <unittitle>Cross and the Flag subscriptions</unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -5457,7 +5460,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">21</container>
-              <unittitle>Memos: interoffice (5 folders)</unittitle>
+              <unittitle>Memos: interoffice</unittitle>
+              <physdesc>
+                <extent>5 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -6358,7 +6364,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">25</container>
-              <unittitle>Tracts (2 folders)</unittitle>
+              <unittitle>Tracts</unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -7557,7 +7566,10 @@
           <c03 level="file">
             <did>
               <container label="Box" type="box">32</container>
-              <unittitle>Memos (4 folders)</unittitle>
+              <unittitle>Memos</unittitle>
+              <physdesc>
+                <extent>4 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/snre.xml
+++ b/Real_Masters_all/snre.xml
@@ -2427,7 +2427,10 @@
               <c05 level="file">
                 <did>
                   <container type="folder" label="Oversize Folder">1</container>
-                  <unittitle>Ringwood Forest <unitdate type="inclusive" normal="1931">1931</unitdate>, <unitdate type="inclusive" normal="1953">1953</unitdate> (3 maps)</unittitle>
+                  <unittitle>Ringwood Forest <unitdate type="inclusive" normal="1931">1931</unitdate>, <unitdate type="inclusive" normal="1953">1953</unitdate></unittitle>
+                  <physdesc>
+                    <extent>3 maps</extent>
+                  </physdesc>
                 </did>
                 <accessrestrict>
                   <p>[ER RESTRICTED until <date type="restriction" normal="2032-07-01">July 1, 2032</date>]</p>
@@ -2436,7 +2439,10 @@
               <c05 level="file">
                 <did>
                   <container type="folder" label="Oversize Folder">1</container>
-                  <unittitle>Saginaw Forest <unitdate type="inclusive" normal="1932/1963">1932-1963</unitdate>, <unitdate type="inclusive">undated</unitdate> (9 maps)</unittitle>
+                  <unittitle>Saginaw Forest <unitdate type="inclusive" normal="1932/1963">1932-1963</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
+                  <physdesc>
+                    <extent>9 maps</extent>
+                  </physdesc>
                 </did>
                 <accessrestrict>
                   <p>[ER RESTRICTED until <date type="restriction" normal="2032-07-01">July 1, 2032</date>]</p>
@@ -2445,7 +2451,10 @@
               <c05 level="file">
                 <did>
                   <container type="folder" label="Oversize Folder">1</container>
-                  <unittitle>Stinchfield Woods <unitdate type="inclusive" normal="1936/1964">1936-1964</unitdate>, <unitdate type="inclusive">undated</unitdate> (14 maps)</unittitle>
+                  <unittitle>Stinchfield Woods <unitdate type="inclusive" normal="1936/1964">1936-1964</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
+                  <physdesc>
+                    <extent>14 maps</extent>
+                  </physdesc>
                 </did>
                 <accessrestrict>
                   <p>[ER RESTRICTED until <date type="restriction" normal="2032-07-01">July 1, 2032</date>]</p>
@@ -10830,7 +10839,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">50A</container>
-                  <unittitle>Duncan Bay (2 slides)</unittitle>
+                  <unittitle>Duncan Bay</unittitle>
+                  <physdesc>
+                    <extent>2 slides</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -11211,7 +11223,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">50C</container>
-                  <unittitle>Island Park (2 slides)</unittitle>
+                  <unittitle>Island Park</unittitle>
+                  <physdesc>
+                    <extent>2 slides</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -11268,7 +11283,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">50C</container>
-                  <unittitle>Tealdi Garden (6 slides)</unittitle>
+                  <unittitle>Tealdi Garden</unittitle>
+                  <physdesc>
+                    <extent>6 slides</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -12003,7 +12021,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">73</container>
-                <unittitle><unitdate type="inclusive" normal="1928">1928</unitdate> Forestry Sequences -- Saginaw Forest, Camp Filibert Roth (3 tapes)</unittitle>
+                <unittitle><unitdate type="inclusive" normal="1928">1928</unitdate> Forestry Sequences -- Saginaw Forest, Camp Filibert Roth</unittitle>
+                <physdesc>
+                  <extent>3 tapes</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -12092,7 +12113,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">74</container>
-                <unittitle>Camp Filibert Roth <unitdate type="inclusive">undated</unitdate> (2 reels)</unittitle>
+                <unittitle>Camp Filibert Roth <unitdate type="inclusive">undated</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 reels</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -12246,7 +12270,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">75</container>
-                  <unittitle>Miscellaneous <unitdate type="inclusive">undated</unitdate> (2 tapes)</unittitle>
+                  <unittitle>Miscellaneous <unitdate type="inclusive">undated</unitdate></unittitle>
+                  <physdesc>
+                    <extent>2 tapes</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -12258,7 +12285,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">75</container>
-                <unittitle>Bob Grese, Ken Polakowski, and Ian Grandison <unitdate type="inclusive">undated</unitdate> (3 tapes)</unittitle>
+                <unittitle>Bob Grese, Ken Polakowski, and Ian Grandison <unitdate type="inclusive">undated</unitdate></unittitle>
+                <physdesc>
+                  <extent>3 tapes</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>
@@ -12280,7 +12310,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">75</container>
-                <unittitle>General Program Information <unitdate type="inclusive">undated</unitdate> (3 tapes)</unittitle>
+                <unittitle>General Program Information <unitdate type="inclusive">undated</unitdate></unittitle>
+                <physdesc>
+                  <extent>3 tapes</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>

--- a/Real_Masters_all/solarcar.xml
+++ b/Real_Masters_all/solarcar.xml
@@ -2389,7 +2389,10 @@ Solar Car Team (University of Michigan) records, Bentley Historical Library, Uni
           <c03 level="file">
             <did>
               <container type="box" label="Box">13</container>
-              <unittitle>Chassis, 1996-1997(3 folders)</unittitle>
+              <unittitle>Chassis, 1996-1997</unittitle>
+              <physdesc>
+                <extent>3 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/sphpub.xml
+++ b/Real_Masters_all/sphpub.xml
@@ -454,7 +454,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">2</container>
-                <unittitle><unitdate type="inclusive" normal="1932/1941">1932-1941</unitdate> volumes 1-10 (2 bound volumes)</unittitle>
+                <unittitle><unitdate type="inclusive" normal="1932/1941">1932-1941</unitdate> volumes 1-10</unittitle>
+                <physdesc>
+                  <extent>2 bound volumes</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>

--- a/Real_Masters_all/sphum.xml
+++ b/Real_Masters_all/sphum.xml
@@ -5803,13 +5803,23 @@ Philip J. Deloria, December 2006.</p>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">45</container>
-                  <unittitle><unitdate type="inclusive" normal="1972">1972</unitdate> (2 folders including Fairlane Conference)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1972">1972</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 folders including Fairlane Conference</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">45</container>
-                  <unittitle><unitdate type="inclusive" normal="1973/1976">1973-1976</unitdate> (2 folders including Core Review)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1973/1976">1973-1976</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 folders including Core Review</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -6767,7 +6777,10 @@ Philip J. Deloria, December 2006.</p>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">89</container>
-                  <unittitle>Budget Meeting <unitdate type="inclusive" normal="1990-03-09">March 9, 1990</unitdate> (2 folders?)</unittitle>
+                  <unittitle>Budget Meeting <unitdate type="inclusive" normal="1990-03-09">March 9, 1990</unitdate></unittitle>
+                  <physdesc>
+                    <extent>2 folders?</extent>
+                  </physdesc>
                 </did>
                 <accessrestrict>
                   <p>[ER RESTRICTED until <date normal="2025-07-01">July 1, 2025</date>]</p>

--- a/Real_Masters_all/stephnsn.xml
+++ b/Real_Masters_all/stephnsn.xml
@@ -488,7 +488,10 @@ James E. Stephenson Papers
         <c02 level="file">
           <did>
             <container type="box" label="Box">4</container>
-            <unittitle>Human Rights Department (3 folders)</unittitle>
+            <unittitle>Human Rights Department</unittitle>
+            <physdesc>
+              <extent>3 folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/sunderer.xml
+++ b/Real_Masters_all/sunderer.xml
@@ -214,7 +214,12 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unittitle><unitdate type="inclusive" normal="1935">1935</unitdate> (3 expandable folders)</unittitle>
+              <unittitle>
+                <unitdate type="inclusive" normal="1935">1935</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>3 expandable folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -596,7 +601,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">4</container>
-              <unittitle>Survey Results <unitdate type="inclusive" normal="1941">1941</unitdate> (5 expandable folders)</unittitle>
+              <unittitle>Survey Results <unitdate type="inclusive" normal="1941">1941</unitdate></unittitle>
+              <physdesc>
+                <extent>5 expandable folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -810,7 +818,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">7</container>
-              <unittitle>History of English Reform (2 notebooks)</unittitle>
+              <unittitle>History of English Reform</unittitle>
+              <physdesc>
+                <extent>2 notebooks</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -895,7 +906,10 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">8</container>
-            <unittitle>Survey of American Bar Association (3 expandable folders)</unittitle>
+            <unittitle>Survey of American Bar Association</unittitle>
+            <physdesc>
+              <extent>3 expandable folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/suomicol.xml
+++ b/Real_Masters_all/suomicol.xml
@@ -6835,7 +6835,10 @@ Suomi College Finnish-American collection, Bentley Historical Library, Universit
           <c03 level="file">
             <did>
               <container type="reel" label="Roll">81</container>
-              <unittitle>Pastor's notebooks (2 items): Baptisms, Confirmations, Marriages, and Funerals</unittitle>
+              <unittitle>Pastor's notebooks : Baptisms, Confirmations, Marriages, and Funerals</unittitle>
+              <physdesc>
+                <extent>2 items</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/sweum.xml
+++ b/Real_Masters_all/sweum.xml
@@ -251,13 +251,19 @@ Society of Women Engineers, University of Michigan section records, Bentley Hist
           <c03 level="file">
             <did>
               <container type="box" label="Box">3</container>
-              <unittitle>Photo Album, date unknown (2 albums)</unittitle>
+              <unittitle>Photo Album, date unknown</unittitle>
+              <physdesc>
+                <extent>2 albums</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">3</container>
-              <unittitle>Photos, Summer Engineering Exploration <unitdate type="inclusive" normal="2003">2003</unitdate> (3 envelopes)</unittitle>
+              <unittitle>Photos, Summer Engineering Exploration <unitdate type="inclusive" normal="2003">2003</unitdate></unittitle>
+              <physdesc>
+                <extent>3 envelopes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/taubmans.xml
+++ b/Real_Masters_all/taubmans.xml
@@ -947,7 +947,10 @@ Samuel Taubman papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">6</container>
-              <unittitle>Shower door glass samples (2 envelopes)</unittitle>
+              <unittitle>Shower door glass samples</unittitle>
+              <physdesc>
+                <extent>2 envelopes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/tausigd.xml
+++ b/Real_Masters_all/tausigd.xml
@@ -203,7 +203,10 @@ Tau Sigma Delta. Alpha Chapter (University of Michigan) records, Bentley Histori
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unittitle>Reports <unitdate type="inclusive" normal="1958/1984">1958-1984</unitdate> (3 folders, includes two photographs.)</unittitle>
+            <unittitle>Reports <unitdate type="inclusive" normal="1958/1984">1958-1984</unitdate></unittitle>
+            <physdesc>
+              <extent>3 folders, includes two photographs.</extent>
+            </physdesc>
           </did>
         </c02>
       </c01>

--- a/Real_Masters_all/toyjim.xml
+++ b/Real_Masters_all/toyjim.xml
@@ -488,7 +488,10 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">6</container>
-            <unittitle>Log sheets of office activities (2 expandable folders)</unittitle>
+            <unittitle>Log sheets of office activities</unittitle>
+            <physdesc>
+              <extent>2 expandable folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">
@@ -2022,7 +2025,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">28</container>
-                  <unittitle><title render="italic">The Record</title>, <unitdate type="inclusive" normal="1974/2008">1974-2008</unitdate> (2 folders, scattered)</unittitle>
+                  <unittitle><title render="italic">The Record</title>, <unitdate type="inclusive" normal="1974/2008">1974-2008</unitdate></unittitle>
+                  <physdesc>
+                    <extent>2 folders, scattered</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -2376,7 +2382,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">14</container>
-              <unittitle>Collection of documents re gay liberation, etc. (1 expandable folder)</unittitle>
+              <unittitle>Collection of documents re gay liberation, etc.</unittitle>
+              <physdesc>
+                <extent>1 expandable folder</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/turcotte.xml
+++ b/Real_Masters_all/turcotte.xml
@@ -1176,7 +1176,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">6</container>
-                <unittitle>Surgery Staff Photographs, 1933/34-1936/37(4 items)</unittitle>
+                <unittitle>Surgery Staff Photographs, 1933/34-1936/37</unittitle>
+                <physdesc>
+                  <extent>4 items</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>

--- a/Real_Masters_all/turkusat.xml
+++ b/Real_Masters_all/turkusat.xml
@@ -12897,7 +12897,10 @@ Satakunta Region immigrant letters, Bentley Historical Library, University of Mi
           <c03 level="file">
             <did>
               <container type="reel" label="Roll">16</container>
-              <unittitle>from: Paavo Uusitalo. Calif. <unitdate type="inclusive" normal="1964">1964</unitdate> (2, items)</unittitle>
+              <unittitle>from: Paavo Uusitalo. Calif. <unitdate type="inclusive" normal="1964">1964</unitdate></unittitle>
+              <physdesc>
+                <extent>2, items</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>
@@ -17098,7 +17101,10 @@ Satakunta Region immigrant letters, Bentley Historical Library, University of Mi
           <c03 level="file">
             <did>
               <container type="reel" label="Roll">22</container>
-              <unittitle>from: Hilma Myllymaki. N.Y., N.J., Ont., 1915-1922(18 items)</unittitle>
+              <unittitle>from: Hilma Myllymaki. N.Y., N.J., Ont., 1915-1922</unittitle>
+              <physdesc>
+                <extent>18 items</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/turkvais.xml
+++ b/Real_Masters_all/turkvais.xml
@@ -3830,7 +3830,10 @@ thousands of letters written by Finnish emigrants from Varsinais-Suomi (Southwes
           <c03 level="file">
             <did>
               <container type="reel" label="Roll">7</container>
-              <unittitle>from: Walfrid Rosten. Minn. <unitdate type="inclusive" normal="1963">1963</unitdate> (11items)</unittitle>
+              <unittitle>from: Walfrid Rosten. Minn. <unitdate type="inclusive" normal="1963">1963</unitdate></unittitle>
+              <physdesc>
+                <extent>11items</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>

--- a/Real_Masters_all/udevent.xml
+++ b/Real_Masters_all/udevent.xml
@@ -2191,7 +2191,10 @@ University and Development Events (University of Michigan)Records, Bentley Histo
           <c03 level="file">
             <did>
               <container type="box" label="Box">14</container>
-              <unittitle>Winter Commencement, December 20 (2 file folders)</unittitle>
+              <unittitle>Winter Commencement, December 20</unittitle>
+              <physdesc>
+                <extent>2 file folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -2432,7 +2435,10 @@ University and Development Events (University of Michigan)Records, Bentley Histo
           <c03 level="file">
             <did>
               <container type="box" label="Box">11</container>
-              <unittitle>Board of Regents Meeting and President Lee Bollinger's first UM Press Conference <unitdate type="inclusive" normal="1996-11-12">November 12, 1996</unitdate> (2 tapes)</unittitle>
+              <unittitle>Board of Regents Meeting and President Lee Bollinger's first UM Press Conference <unitdate type="inclusive" normal="1996-11-12">November 12, 1996</unitdate></unittitle>
+              <physdesc>
+                <extent>2 tapes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -2450,7 +2456,12 @@ University and Development Events (University of Michigan)Records, Bentley Histo
             <c04 level="file">
               <did>
                 <container type="box" label="Box">11</container>
-                <unittitle><unitdate type="inclusive" normal="1994">Winter 1994</unitdate> (2 tapes)</unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1994">Winter 1994</unitdate>
+                </unittitle>
+                <physdesc>
+                  <extent>2 tapes</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>

--- a/Real_Masters_all/ulibrary.xml
+++ b/Real_Masters_all/ulibrary.xml
@@ -11437,7 +11437,12 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">25</container>
-                  <unittitle><unitdate type="inclusive" normal="1921/1922">1921-1922</unitdate> (2 folders')</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1921/1922">1921-1922</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 folders'</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -35185,7 +35190,12 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">78</container>
-                  <unittitle><unitdate type="inclusive" normal="1961/1962">1961-1962</unitdate> (1 folder and 2 v.)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1961/1962">1961-1962</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>1 folder and 2 v.</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -35203,7 +35213,12 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">79</container>
-                  <unittitle><unitdate type="inclusive" normal="1964/1965">1964-1965</unitdate> (2 folders and 5 v.)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1964/1965">1964-1965</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 folders and 5 v.</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -36663,7 +36678,10 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">86</container>
-                    <unittitle>National Survey (1 folder and 1 v.).</unittitle>
+                    <unittitle>National Survey .</unittitle>
+                    <physdesc>
+                      <extent>1 folder and 1 v.</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
@@ -36678,7 +36696,10 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">87</container>
-                    <unittitle>Anti-Pornography Groups (1 folder and 4 v.)</unittitle>
+                    <unittitle>Anti-Pornography Groups</unittitle>
+                    <physdesc>
+                      <extent>1 folder and 4 v.</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
@@ -36717,14 +36738,20 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">87</container>
-                    <unittitle>Miscellanea (2 folders and 1 v.)</unittitle>
+                    <unittitle>Miscellanea</unittitle>
+                    <physdesc>
+                      <extent>2 folders and 1 v.</extent>
+                    </physdesc>
                   </did>
                 </c06>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">88</container>
-                  <unittitle>Miscellaneous reports (2 folders and 2 v.)</unittitle>
+                  <unittitle>Miscellaneous reports</unittitle>
+                  <physdesc>
+                    <extent>2 folders and 2 v.</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -36794,14 +36821,20 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">89</container>
-                    <unittitle>Draft (2 folders and 1 v..)</unittitle>
+                    <unittitle>Draft</unittitle>
+                    <physdesc>
+                      <extent>2 folders and 1 v..</extent>
+                    </physdesc>
                   </did>
                 </c06>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">89</container>
-                  <unittitle>Charles H. Keating Report (3 v.)</unittitle>
+                  <unittitle>Charles H. Keating Report</unittitle>
+                  <physdesc>
+                    <extent>3 v.</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -44074,13 +44107,23 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">114</container>
-                  <unittitle><unitdate type="inclusive" normal="1967/1968">1967-1968</unitdate> (5 folders and 6 v.)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1967/1968">1967-1968</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>5 folders and 6 v.</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">114</container>
-                  <unittitle><unitdate type="inclusive" normal="1968/1969">1968-1969</unitdate> (2 folders and 2 v.)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1968/1969">1968-1969</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 folders and 2 v.</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -44097,13 +44140,23 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">115</container>
-                  <unittitle><unitdate type="inclusive" normal="1969/1970">1969-1970</unitdate> (3 v.)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1969/1970">1969-1970</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>3 v.</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">115</container>
-                  <unittitle><unitdate type="inclusive" normal="1970/1971">1970-1971</unitdate> (2 folders and 2 v.)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1970/1971">1970-1971</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 folders and 2 v.</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -45919,43 +45972,78 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">123</container>
-                  <unittitle><unitdate type="inclusive" normal="1962/1963">1962-1963</unitdate> (2 binders)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1962/1963">1962-1963</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 binders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">123</container>
-                  <unittitle><unitdate type="inclusive" normal="1963/1964">1963-1964</unitdate> (2 binders)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1963/1964">1963-1964</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 binders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">123</container>
-                  <unittitle><unitdate type="inclusive" normal="1964/1965">1964-1965</unitdate> (2 binders)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1964/1965">1964-1965</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 binders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">123</container>
-                  <unittitle><unitdate type="inclusive" normal="1965/1966">1965-1966</unitdate> (2 binders)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1965/1966">1965-1966</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 binders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">124</container>
-                  <unittitle><unitdate type="inclusive" normal="1966/1967">1966-1967</unitdate> (2 binders)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1966/1967">1966-1967</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 binders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">124</container>
-                  <unittitle><unitdate type="inclusive" normal="1967/1968">1967-1968</unitdate> (3 binders)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1967/1968">1967-1968</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>3 binders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">124</container>
-                  <unittitle><unitdate type="inclusive" normal="1968/1969">1968-1969</unitdate> (4 binders)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1968/1969">1968-1969</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>4 binders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -45973,25 +46061,45 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">125</container>
-                  <unittitle><unitdate type="inclusive" normal="1970/1971">1970-1971</unitdate> (5 binders)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1970/1971">1970-1971</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>5 binders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">125</container>
-                  <unittitle><unitdate type="inclusive" normal="1971/1972">1971-1972</unitdate> (4 binders)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1971/1972">1971-1972</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>4 binders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">125</container>
-                  <unittitle><unitdate type="inclusive" normal="1972/1973">1972-1973</unitdate> (6 binders)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1972/1973">1972-1973</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>6 binders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">125</container>
-                  <unittitle><unitdate type="inclusive" normal="1973/1974">1973-1974</unitdate> (3 binders)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1973/1974">1973-1974</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>3 binders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -46005,19 +46113,34 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">126</container>
-                  <unittitle><unitdate type="inclusive" normal="1974/1975">1974-1975</unitdate> (2 binders)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1974/1975">1974-1975</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 binders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">126</container>
-                  <unittitle><unitdate type="inclusive" normal="1975/1976">1975-1976</unitdate> (2 binders)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1975/1976">1975-1976</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 binders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">126</container>
-                  <unittitle><unitdate type="inclusive" normal="1976/1977">1976-1977</unitdate> (2 binders)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1976/1977">1976-1977</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 binders</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -56658,7 +56781,10 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
             <c04 level="file">
               <did>
                 <container type="box" label="Box">217</container>
-                <unittitle>Undergraduate Library Renovation <unitdate type="inclusive" normal="1987">1987</unitdate>, <unitdate type="inclusive" normal="1993">1993</unitdate> (1 folder, 1 volume)</unittitle>
+                <unittitle>Undergraduate Library Renovation <unitdate type="inclusive" normal="1987">1987</unitdate>, <unitdate type="inclusive" normal="1993">1993</unitdate></unittitle>
+                <physdesc>
+                  <extent>1 folder, 1 volume</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -82517,7 +82643,10 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
             <c04 level="file">
               <did>
                 <container type="box" label="Box">219</container>
-                <unittitle>General <unitdate type="inclusive" normal="1975/1978">1975-1978</unitdate> (3 expandable folders)</unittitle>
+                <unittitle>General <unitdate type="inclusive" normal="1975/1978">1975-1978</unitdate></unittitle>
+                <physdesc>
+                  <extent>3 expandable folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -82864,7 +82993,10 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
           <c03 level="file">
             <did>
               <container type="box" label="Box">231</container>
-              <unittitle>MIRLYN Training Guide (2 expandable folders) <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
+              <unittitle>MIRLYN Training Guide <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
+              <physdesc>
+                <extent>2 expandable folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/umdrama.xml
+++ b/Real_Masters_all/umdrama.xml
@@ -122,7 +122,10 @@ Drama Season (University of Michigan) records, Bentley Historical Library, Unive
         <c02 level="file">
           <did>
             <container type="box" label="Box">1</container>
-            <unittitle><unitdate type="inclusive" normal="1938/1942">1938-1942</unitdate>, <unitdate type="inclusive" normal="1949/1952">1949-1952</unitdate> (10 vol.)</unittitle>
+            <unittitle><unitdate type="inclusive" normal="1938/1942">1938-1942</unitdate>, <unitdate type="inclusive" normal="1949/1952">1949-1952</unitdate></unittitle>
+            <physdesc>
+              <extent>10 vol.</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/umhosp.xml
+++ b/Real_Masters_all/umhosp.xml
@@ -2838,7 +2838,12 @@ Hospitals (University of Michigan) records, Bentley Historical Library, Universi
             <c04 level="file">
               <did>
                 <container type="box" label="Box">58</container>
-                <unittitle><unitdate type="inclusive" normal="1983-11/1986-03" certainty="approximate">November 1983-March 1986</unitdate> (5 volumes and 10 folders)</unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1983-11/1986-03" certainty="approximate">November 1983-March 1986</unitdate>
+                </unittitle>
+                <physdesc>
+                  <extent>5 volumes and 10 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -2916,7 +2921,10 @@ Hospitals (University of Michigan) records, Bentley Historical Library, Universi
           <c03 level="file">
             <did>
               <container type="box" label="Box">132</container>
-              <unittitle>Director's Forum <unitdate type="inclusive" normal="1996/2004">1996-2004</unitdate> (39 video tapes) Zugich, John</unittitle>
+              <unittitle>Director's Forum <unitdate type="inclusive" normal="1996/2004">1996-2004</unitdate> Zugich, John</unittitle>
+              <physdesc>
+                <extent>39 video tapes</extent>
+              </physdesc>
             </did>
             <accessrestrict>
               <p>[ER RESTRICTED until <date type="restriction" normal="2028-07-01">July 1, 2028</date>]</p>
@@ -7624,7 +7632,10 @@ Hospitals (University of Michigan) records, Bentley Historical Library, Universi
           <c03 level="file">
             <did>
               <container type="box" label="Box">157</container>
-              <unittitle>Agendas and Minutes <unitdate type="inclusive" normal="1990">1990</unitdate> (1 binder)</unittitle>
+              <unittitle>Agendas and Minutes <unitdate type="inclusive" normal="1990">1990</unitdate></unittitle>
+              <physdesc>
+                <extent>1 binder</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -7696,7 +7707,10 @@ Hospitals (University of Michigan) records, Bentley Historical Library, Universi
           <c03 level="file">
             <did>
               <container type="box" label="Box">157</container>
-              <unittitle>Educational Videos (2 video tapes)</unittitle>
+              <unittitle>Educational Videos</unittitle>
+              <physdesc>
+                <extent>2 video tapes</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -7837,7 +7851,10 @@ Hospitals (University of Michigan) records, Bentley Historical Library, Universi
             <c04 level="file">
               <did>
                 <container type="box" label="Box">158</container>
-                <unittitle>Education Overview, volumes 1-2 and 4-5 (4 binders)</unittitle>
+                <unittitle>Education Overview, volumes 1-2 and 4-5</unittitle>
+                <physdesc>
+                  <extent>4 binders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -7868,7 +7885,10 @@ Hospitals (University of Michigan) records, Bentley Historical Library, Universi
           <c03 level="file">
             <did>
               <container type="box" label="Box">157</container>
-              <unittitle>Peritoneal Dialysis Training Program Manual (1 binder)</unittitle>
+              <unittitle>Peritoneal Dialysis Training Program Manual</unittitle>
+              <physdesc>
+                <extent>1 binder</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -7927,13 +7947,19 @@ Hospitals (University of Michigan) records, Bentley Historical Library, Universi
           <c03 level="file">
             <did>
               <container type="box" label="Box">157</container>
-              <unittitle>Resources Manual for Unit Shared Governance <unitdate type="inclusive" normal="1990">1990</unitdate> (1 binder)</unittitle>
+              <unittitle>Resources Manual for Unit Shared Governance <unitdate type="inclusive" normal="1990">1990</unitdate></unittitle>
+              <physdesc>
+                <extent>1 binder</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">157</container>
-              <unittitle>Retreat <unitdate type="inclusive" normal="1995">1995</unitdate> (1 binder)</unittitle>
+              <unittitle>Retreat <unitdate type="inclusive" normal="1995">1995</unitdate></unittitle>
+              <physdesc>
+                <extent>1 binder</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -7983,7 +8009,10 @@ Hospitals (University of Michigan) records, Bentley Historical Library, Universi
           <c03 level="file">
             <did>
               <container type="box" label="Box">136</container>
-              <unittitle>Continuing Care Committee (1 binder)</unittitle>
+              <unittitle>Continuing Care Committee</unittitle>
+              <physdesc>
+                <extent>1 binder</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -8067,7 +8096,10 @@ Hospitals (University of Michigan) records, Bentley Historical Library, Universi
           <c03 level="file">
             <did>
               <container type="box" label="Box">135</container>
-              <unittitle>Policy and Procedure Manual (1 binder)</unittitle>
+              <unittitle>Policy and Procedure Manual</unittitle>
+              <physdesc>
+                <extent>1 binder</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/umpresid.xml
+++ b/Real_Masters_all/umpresid.xml
@@ -44156,7 +44156,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">347</container>
-                <unittitle>Big Ten (1 expandable folder)</unittitle>
+                <unittitle>Big Ten</unittitle>
+                <physdesc>
+                  <extent>1 expandable folder</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[ER RESTRICTED unitl <date normal="2022-07-01">July 1, 2022</date>]</p>
@@ -46880,7 +46883,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">363</container>
-                <unittitle>General (3 folders; includes material on decommissioning the Ford Nuclear Reactor, and the annual report for the Michigan Memorial Phoenix Project)</unittitle>
+                <unittitle>General</unittitle>
+                <physdesc>
+                  <extent>3 folders; includes material on decommissioning the Ford Nuclear Reactor, and the annual report for the Michigan Memorial Phoenix Project</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date normal="2030-07-01" type="restriction">July 1, 2030</date>]</p>
@@ -49278,7 +49284,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">381</container>
-              <unittitle>International (4 folders; includes external review committee report on the Center for Japanese Studies)</unittitle>
+              <unittitle>International</unittitle>
+              <physdesc>
+                <extent>4 folders; includes external review committee report on the Center for Japanese Studies</extent>
+              </physdesc>
             </did>
             <accessrestrict>
               <p>[ER RESTRICTED until <date normal="2030-07-01" type="restriction">July 1, 2030</date>]</p>
@@ -59794,7 +59803,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">376</container>
-              <unittitle>Public Policy, Gerald R. Ford School of (2 folders; includes architectural proposals)</unittitle>
+              <unittitle>Public Policy, Gerald R. Ford School of</unittitle>
+              <physdesc>
+                <extent>2 folders; includes architectural proposals</extent>
+              </physdesc>
             </did>
             <accessrestrict>
               <p>[ER RESTRICTED until <date normal="2030-07-01" type="restriction">July 1, 2030</date>]</p>
@@ -64414,7 +64426,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">195</container>
-                  <unittitle>January (2 folders)</unittitle>
+                  <unittitle>January</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -64426,19 +64441,28 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">196</container>
-                  <unittitle>February (2 folders)</unittitle>
+                  <unittitle>February</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">196</container>
-                  <unittitle>March (2 folders)</unittitle>
+                  <unittitle>March</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">196</container>
-                  <unittitle>April (2 folders)</unittitle>
+                  <unittitle>April</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -64450,7 +64474,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">196</container>
-                  <unittitle>June (2 folders)</unittitle>
+                  <unittitle>June</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -64468,19 +64495,28 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">196</container>
-                  <unittitle>September (2 folders)</unittitle>
+                  <unittitle>September</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">197</container>
-                  <unittitle>October (3 folders)</unittitle>
+                  <unittitle>October</unittitle>
+                  <physdesc>
+                    <extent>3 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">197</container>
-                  <unittitle>November (2 folders)</unittitle>
+                  <unittitle>November</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -64511,7 +64547,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">197</container>
-                  <unittitle>February (2 folders)</unittitle>
+                  <unittitle>February</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -64523,7 +64562,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">197</container>
-                  <unittitle>March (2 folders)</unittitle>
+                  <unittitle>March</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -64547,7 +64589,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">198</container>
-                  <unittitle>July (2 folders)</unittitle>
+                  <unittitle>July</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -64559,13 +64604,19 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">198</container>
-                  <unittitle>October (2 folders)</unittitle>
+                  <unittitle>October</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">198</container>
-                  <unittitle>November (3 folders)</unittitle>
+                  <unittitle>November</unittitle>
+                  <physdesc>
+                    <extent>3 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -64596,7 +64647,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">199</container>
-                  <unittitle>March (2 folders)</unittitle>
+                  <unittitle>March</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -64614,25 +64668,37 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">199</container>
-                  <unittitle>June (2 folders)</unittitle>
+                  <unittitle>June</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">199</container>
-                  <unittitle>July (2 folders)</unittitle>
+                  <unittitle>July</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">200</container>
-                  <unittitle>September (2 folders)</unittitle>
+                  <unittitle>September</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">200</container>
-                  <unittitle>October (2 folders)</unittitle>
+                  <unittitle>October</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -64644,7 +64710,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">200</container>
-                  <unittitle>December (2 folders)</unittitle>
+                  <unittitle>December</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -64689,7 +64758,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">204</container>
-                <unittitle>Dedication <unitdate type="inclusive" normal="1986-06">June 1986</unitdate> (2 folders, 1 videotape)</unittitle>
+                <unittitle>Dedication <unitdate type="inclusive" normal="1986-06">June 1986</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 folders, 1 videotape</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -65177,7 +65249,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">210</container>
-                  <unittitle>January-December (12 folders)</unittitle>
+                  <unittitle>January-December</unittitle>
+                  <physdesc>
+                    <extent>12 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -65190,7 +65265,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">210</container>
-                  <unittitle>January-December (12 folders)</unittitle>
+                  <unittitle>January-December</unittitle>
+                  <physdesc>
+                    <extent>12 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -65203,13 +65281,19 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">210</container>
-                  <unittitle>January-August (8 folders)</unittitle>
+                  <unittitle>January-August</unittitle>
+                  <physdesc>
+                    <extent>8 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">211</container>
-                  <unittitle>September-December (4 folders)</unittitle>
+                  <unittitle>September-December</unittitle>
+                  <physdesc>
+                    <extent>4 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -65222,7 +65306,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">211</container>
-                  <unittitle>January-December (12 folders)</unittitle>
+                  <unittitle>January-December</unittitle>
+                  <physdesc>
+                    <extent>12 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -65235,7 +65322,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">211</container>
-                  <unittitle>January-December (12 folders)</unittitle>
+                  <unittitle>January-December</unittitle>
+                  <physdesc>
+                    <extent>12 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -65459,7 +65549,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">426</container>
-                <unittitle>Ca. <unitdate type="inclusive" normal="1985/1988">1985-1988</unitdate> (56 disks)</unittitle>
+                <unittitle>Ca. <unitdate type="inclusive" normal="1985/1988">1985-1988</unitdate></unittitle>
+                <physdesc>
+                  <extent>56 disks</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date normal="2030-07-01" type="restriction">July 1, 2030</date>]</p>
@@ -65613,13 +65706,19 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">227</container>
-                  <unittitle>January-September (18 folders)</unittitle>
+                  <unittitle>January-September</unittitle>
+                  <physdesc>
+                    <extent>18 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">228</container>
-                  <unittitle>October-December (6 folders)</unittitle>
+                  <unittitle>October-December</unittitle>
+                  <physdesc>
+                    <extent>6 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -65632,7 +65731,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">228</container>
-                  <unittitle>January-June (8 folders)</unittitle>
+                  <unittitle>January-June</unittitle>
+                  <physdesc>
+                    <extent>8 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -70452,7 +70554,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">442</container>
-                  <unittitle>September -- December (18 folders)</unittitle>
+                  <unittitle>September -- December</unittitle>
+                  <physdesc>
+                    <extent>18 folders</extent>
+                  </physdesc>
                 </did>
                 <accessrestrict>
                   <p>[ER RESTRICTED until <date normal="2030-07-01" type="restriction">July 1, 2030</date>]</p>
@@ -70469,7 +70574,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">443</container>
-                  <unittitle>January -- July (31 folders)</unittitle>
+                  <unittitle>January -- July</unittitle>
+                  <physdesc>
+                    <extent>31 folders</extent>
+                  </physdesc>
                 </did>
                 <accessrestrict>
                   <p>[ER RESTRICTED until <date normal="2030-07-01" type="restriction">July 1, 2030</date>]</p>
@@ -74015,7 +74123,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">343</container>
-                <unittitle>Back up copies of search documents on 3 ½" floppy disks (6 disks)</unittitle>
+                <unittitle>Back up copies of search documents on 3 ½" floppy disks</unittitle>
+                <physdesc>
+                  <extent>6 disks</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[PR RESTRICTED until July 1 <date type="restriction" normal="2028-07-01">2028</date>]</p>
@@ -76672,7 +76783,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">451</container>
-                  <unittitle>Disk -- Copies of Files from Provost Search (3 ½" floppy disk)</unittitle>
+                  <unittitle>Disk -- Copies of Files from Provost Search</unittitle>
+                  <physdesc>
+                    <extent>3 &amp;#189;" floppy disk</extent>
+                  </physdesc>
                 </did>
                 <accessrestrict>
                   <p>[PR RESTRICTED unitl <date type="restriction" normal="2031-07-01">2031</date>]</p>

--- a/Real_Masters_all/umspeech.xml
+++ b/Real_Masters_all/umspeech.xml
@@ -533,7 +533,10 @@ Dept. of Speech (University of Michigan) records,Bentley Historical Library, Uni
         <c02 level="file">
           <did>
             <container type="box" label="Box">27</container>
-            <unittitle>Notebooks (19 v.) containing clippings regarding theatre in Ann Arbor, including:</unittitle>
+            <unittitle>Notebooks containing clippings regarding theatre in Ann Arbor, including:</unittitle>
+            <physdesc>
+              <extent>19 v.</extent>
+            </physdesc>
           </did>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/umtreas.xml
+++ b/Real_Masters_all/umtreas.xml
@@ -307,7 +307,10 @@ Treasurer (University of Michigan) records, Bentley Historical Library, Universi
         </c02>
         <c02 level="subseries">
           <did>
-            <unittitle>Disbursements <unitdate type="inclusive" normal="1852/1858">1852-1858</unitdate>, <unitdate type="inclusive" normal="1879/1905">1879-1905</unitdate> (21 volumes.)</unittitle>
+            <unittitle>Disbursements <unitdate type="inclusive" normal="1852/1858">1852-1858</unitdate>, <unitdate type="inclusive" normal="1879/1905">1879-1905</unitdate></unittitle>
+            <physdesc>
+              <extent>21 volumes.</extent>
+            </physdesc>
           </did>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/umussoc.xml
+++ b/Real_Masters_all/umussoc.xml
@@ -3916,7 +3916,10 @@ University Musical Society (University of Michigan) Records, Bentley Historical 
           <c03 level="file">
             <did>
               <container type="box" label="Box">100</container>
-              <unittitle>Minutes <unitdate type="inclusive" normal="1881/1938">1881-1938</unitdate> (2 v.)</unittitle>
+              <unittitle>Minutes <unitdate type="inclusive" normal="1881/1938">1881-1938</unitdate></unittitle>
+              <physdesc>
+                <extent>2 v.</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -5392,7 +5395,10 @@ University Musical Society (University of Michigan) Records, Bentley Historical 
           <c03 level="file">
             <did>
               <container type="box" label="Box">109</container>
-              <unittitle><unitdate type="inclusive" normal="1973/1974">1973/74</unitdate> (2 folders),</unittitle>
+              <unittitle><unitdate type="inclusive" normal="1973/1974">1973/74</unitdate> ,</unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
             <odd>
               <p>(includes Bela Bartok, Jr., Gyorgy Sandor and Gail Rector, Leningrad Philharmonic and Choral Union)</p>
@@ -5407,7 +5413,10 @@ University Musical Society (University of Michigan) Records, Bentley Historical 
           <c03 level="file">
             <did>
               <container type="box" label="Box">110</container>
-              <unittitle><unitdate type="inclusive" normal="1974/1975">1974/75</unitdate> (2 folders),</unittitle>
+              <unittitle><unitdate type="inclusive" normal="1974/1975">1974/75</unitdate> ,</unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
             <odd>
               <p>(includes Msitislav Rostropovich and University Symphony, Seigi Ozawa and Donald Bryant(?))</p>
@@ -5422,7 +5431,10 @@ University Musical Society (University of Michigan) Records, Bentley Historical 
           <c03 level="file">
             <did>
               <container type="box" label="Box">110</container>
-              <unittitle><unitdate type="inclusive" normal="1975/1976">1975/76</unitdate> (2 folders), includes Yehudi Menuhin</unittitle>
+              <unittitle><unitdate type="inclusive" normal="1975/1976">1975/76</unitdate> , includes Yehudi Menuhin</unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -5448,7 +5460,10 @@ University Musical Society (University of Michigan) Records, Bentley Historical 
           <c03 level="file">
             <did>
               <container type="box" label="Box">110</container>
-              <unittitle><unitdate type="inclusive" normal="1977/1978">1977/78</unitdate> (2 folders),</unittitle>
+              <unittitle><unitdate type="inclusive" normal="1977/1978">1977/78</unitdate> ,</unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
             <odd>
               <p>(includes Robert Shaw, Vladimir Horowitz)</p>
@@ -7070,9 +7085,12 @@ University Musical Society (University of Michigan) Records, Bentley Historical 
           <c03 level="file">
             <did>
               <container type="box" label="Box">123</container>
-              <unittitle>Chicago Classical Oriental Ensemble <unitdate type="inclusive" normal="2008-02-08">February 8, 2008</unitdate> (3 tapes)</unittitle>
+              <unittitle>Chicago Classical Oriental Ensemble <unitdate type="inclusive" normal="2008-02-08">February 8, 2008</unitdate></unittitle>
               <physdesc>
                 <physfacet>DVCAM</physfacet>
+              </physdesc>
+              <physdesc>
+                <extent>3 tapes</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -7082,9 +7100,12 @@ University Musical Society (University of Michigan) Records, Bentley Historical 
           <c03 level="file">
             <did>
               <container type="box" label="Box">123</container>
-              <unittitle>Midnight's Children Events with Salman Rushdie <unitdate type="inclusive" normal="2003">2003</unitdate> (5 tapes)</unittitle>
+              <unittitle>Midnight's Children Events with Salman Rushdie <unitdate type="inclusive" normal="2003">2003</unitdate></unittitle>
               <physdesc>
                 <physfacet>DAT</physfacet>
+              </physdesc>
+              <physdesc>
+                <extent>5 tapes</extent>
               </physdesc>
             </did>
             <accessrestrict>

--- a/Real_Masters_all/unhealth.xml
+++ b/Real_Masters_all/unhealth.xml
@@ -463,7 +463,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">2</container>
-              <unittitle>Smoke-Free, 1989-1995(7 folders)</unittitle>
+              <unittitle>Smoke-Free, 1989-1995</unittitle>
+              <physdesc>
+                <extent>7 folders</extent>
+              </physdesc>
             </did>
           </c03>
         </c02>
@@ -1767,7 +1770,10 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">7</container>
-            <unittitle>Health Exam Sequence (42 mounted photos) <unitdate type="inclusive" normal="1961">1961</unitdate></unittitle>
+            <unittitle>Health Exam Sequence <unitdate type="inclusive" normal="1961">1961</unitdate></unittitle>
+            <physdesc>
+              <extent>42 mounted photos</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/vpaacent.xml
+++ b/Real_Masters_all/vpaacent.xml
@@ -38247,7 +38247,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">173</container>
-                <unittitle>Arms Control (2 folders)</unittitle>
+                <unittitle>Arms Control</unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -42036,7 +42039,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">208</container>
-                  <unittitle>Departmental Self Reviews (1 volume)</unittitle>
+                  <unittitle>Departmental Self Reviews</unittitle>
+                  <physdesc>
+                    <extent>1 volume</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -42556,7 +42562,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">212</container>
-                  <unittitle>Report from the Dean (1 volume)</unittitle>
+                  <unittitle>Report from the Dean</unittitle>
+                  <physdesc>
+                    <extent>1 volume</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -50567,7 +50576,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">268</container>
-                  <unittitle>Resources and Contacts (1 volume)</unittitle>
+                  <unittitle>Resources and Contacts</unittitle>
+                  <physdesc>
+                    <extent>1 volume</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -51970,7 +51982,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">275</container>
-                <unittitle>Protein Structure and Design Program/ Biophysics Research Division Strategic Retreat (1 folder and 2 volumes)</unittitle>
+                <unittitle>Protein Structure and Design Program/ Biophysics Research Division Strategic Retreat</unittitle>
+                <physdesc>
+                  <extent>1 folder and 2 volumes</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -52018,7 +52033,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">275</container>
-                  <unittitle>Computerization of Academic Records Project (1 folder and 6 volumes)</unittitle>
+                  <unittitle>Computerization of Academic Records Project</unittitle>
+                  <physdesc>
+                    <extent>1 folder and 6 volumes</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -52077,7 +52095,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">276</container>
-                <unittitle>Research Excellence Fund (1 folder and 1 volume)</unittitle>
+                <unittitle>Research Excellence Fund</unittitle>
+                <physdesc>
+                  <extent>1 folder and 1 volume</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -53181,7 +53202,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">280</container>
-                  <unittitle>Landscape Architecture Self-Evaluation Report (1 volume)</unittitle>
+                  <unittitle>Landscape Architecture Self-Evaluation Report</unittitle>
+                  <physdesc>
+                    <extent>1 volume</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>
@@ -61345,7 +61369,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">347</container>
-                <unittitle>Campaign Operations Group (1 folder and 2 books)</unittitle>
+                <unittitle>Campaign Operations Group</unittitle>
+                <physdesc>
+                  <extent>1 folder and 2 books</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/vpaastaf.xml
+++ b/Real_Masters_all/vpaastaf.xml
@@ -7770,7 +7770,10 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">45</container>
-                    <unittitle>Medical School (2 folders, includes Inteflex)</unittitle>
+                    <unittitle>Medical School</unittitle>
+                    <physdesc>
+                      <extent>2 folders, includes Inteflex</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
@@ -8876,7 +8879,10 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">50</container>
-                    <unittitle>Medical School (2 folders, includes Inteflex)</unittitle>
+                    <unittitle>Medical School</unittitle>
+                    <physdesc>
+                      <extent>2 folders, includes Inteflex</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
@@ -17682,7 +17688,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">75</container>
-                <unittitle>Counseling Review <unitdate type="inclusive" normal="1984/1985">1984-1985</unitdate> (1 folder, 1 volume)</unittitle>
+                <unittitle>Counseling Review <unitdate type="inclusive" normal="1984/1985">1984-1985</unitdate></unittitle>
+                <physdesc>
+                  <extent>1 folder, 1 volume</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -18542,7 +18551,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">85</container>
-                  <unittitle>Enrollment Planning <unitdate type="inclusive" normal="1981/1983">1981-1983</unitdate> (1 folder, 2 notebooks)</unittitle>
+                  <unittitle>Enrollment Planning <unitdate type="inclusive" normal="1981/1983">1981-1983</unitdate></unittitle>
+                  <physdesc>
+                    <extent>1 folder, 2 notebooks</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -18572,7 +18584,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">85</container>
-                  <unittitle>Graduate Employee Organization and Graduate Student Assistants <unitdate type="inclusive" normal="1982/1986">1982-1986</unitdate> (1 folder, 1 notebook)</unittitle>
+                  <unittitle>Graduate Employee Organization and Graduate Student Assistants <unitdate type="inclusive" normal="1982/1986">1982-1986</unitdate></unittitle>
+                  <physdesc>
+                    <extent>1 folder, 1 notebook</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -29117,7 +29132,10 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">220</container>
-                    <unittitle>General (2 folders and one volume)</unittitle>
+                    <unittitle>General</unittitle>
+                    <physdesc>
+                      <extent>2 folders and one volume</extent>
+                    </physdesc>
                   </did>
                 </c06>
                 <c06 level="file">
@@ -47427,7 +47445,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">115</container>
-              <unittitle>Nursing, School of (2 folders, includes Budget Conference)</unittitle>
+              <unittitle>Nursing, School of</unittitle>
+              <physdesc>
+                <extent>2 folders, includes Budget Conference</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -50078,7 +50099,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">358</container>
-              <unittitle>Sexual Harassment <unitdate type="inclusive" normal="1993/1994">1993-1994</unitdate> (2 folder)</unittitle>
+              <unittitle>Sexual Harassment <unitdate type="inclusive" normal="1993/1994">1993-1994</unitdate></unittitle>
+              <physdesc>
+                <extent>2 folder</extent>
+              </physdesc>
             </did>
             <accessrestrict>
               <p>[ER RESTRICTED until <date type="restriction" normal="2024-07-01">July 1, 2024</date>]</p>
@@ -59991,7 +60015,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">402</container>
-                  <unittitle>Resources (2 expandable files, the bulk is university publications explaining resources for victims)</unittitle>
+                  <unittitle>Resources</unittitle>
+                  <physdesc>
+                    <extent>2 expandable files, the bulk is university publications explaining resources for victims</extent>
+                  </physdesc>
                 </did>
                 <accessrestrict>
                   <p>[ER RESTRICTED until <date type="restriction" normal="2024-07-01">July 1, 2024</date>]</p>

--- a/Real_Masters_all/vpaasupp.xml
+++ b/Real_Masters_all/vpaasupp.xml
@@ -2133,7 +2133,10 @@ Vice President for Academic Affairs, Bentley Historical Library, University of M
           <c03 level="file">
             <did>
               <container type="box" label="Box">18</container>
-              <unittitle>Study Steering and Advisory Committee (5 folders) <unitdate type="inclusive" normal="1966/1968">1966-1968</unitdate></unittitle>
+              <unittitle>Study Steering and Advisory Committee <unitdate type="inclusive" normal="1966/1968">1966-1968</unitdate></unittitle>
+              <physdesc>
+                <extent>5 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/vpcfo.xml
+++ b/Real_Masters_all/vpcfo.xml
@@ -6107,13 +6107,19 @@ Vice President and Chief Financial Officer (University of Michigan) Records, Ben
             <c04 level="file">
               <did>
                 <container type="box" label="Box">90</container>
-                <unittitle>Financial Officers Subcommittee On Revenue Sharing <unitdate type="inclusive" normal="1989/1992">1989-1992</unitdate> (3 folders and 3 hanging files)</unittitle>
+                <unittitle>Financial Officers Subcommittee On Revenue Sharing <unitdate type="inclusive" normal="1989/1992">1989-1992</unitdate></unittitle>
+                <physdesc>
+                  <extent>3 folders and 3 hanging files</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">91</container>
-                <unittitle>Financial Officers Subcommittee On Revenue Sharing <unitdate type="inclusive" normal="1993/1994">1993-1994</unitdate> (3 hanging files)</unittitle>
+                <unittitle>Financial Officers Subcommittee On Revenue Sharing <unitdate type="inclusive" normal="1993/1994">1993-1994</unitdate></unittitle>
+                <physdesc>
+                  <extent>3 hanging files</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -12544,7 +12550,10 @@ Vice President and Chief Financial Officer (University of Michigan) Records, Ben
             <c04 level="file">
               <did>
                 <container type="box" label="Box">195</container>
-                <unittitle>Organization, 1992-2001(2 folders)</unittitle>
+                <unittitle>Organization, 1992-2001</unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2026-07-01">July 1, 2026</date>]</p>
@@ -13026,7 +13035,10 @@ Vice President and Chief Financial Officer (University of Michigan) Records, Ben
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">217</container>
-                  <unittitle>Life Sciences Institute, 1999-2002(2 folders)</unittitle>
+                  <unittitle>Life Sciences Institute, 1999-2002</unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
                 </did>
                 <accessrestrict>
                   <p>[ER RESTRICTED until <date type="restriction" normal="2028-07-01">July 1, 2028</date>]</p>
@@ -13191,7 +13203,10 @@ Vice President and Chief Financial Officer (University of Michigan) Records, Ben
             <c04 level="file">
               <did>
                 <container type="box" label="Box">219</container>
-                <unittitle>NCAA Steering Committee, 2003(2 folders)</unittitle>
+                <unittitle>NCAA Steering Committee, 2003</unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2028-07-01">July 1, 2028</date>]</p>
@@ -13329,7 +13344,10 @@ Vice President and Chief Financial Officer (University of Michigan) Records, Ben
             <c04 level="file">
               <did>
                 <container type="box" label="Box">222</container>
-                <unittitle>Budget, 2002-2003(2 folders)</unittitle>
+                <unittitle>Budget, 2002-2003</unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2028-07-01">July 1, 2028</date>]</p>
@@ -19463,7 +19481,10 @@ Vice President and Chief Financial Officer (University of Michigan) Records, Ben
             <c04 level="file">
               <did>
                 <container type="box" label="Box">226</container>
-                <unittitle>HRMS, 2005-(2 folders)</unittitle>
+                <unittitle>HRMS, 2005-</unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
               </did>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2028-07-01">July 1, 2028</date>]</p>

--- a/Real_Masters_all/vpcfopub.xml
+++ b/Real_Masters_all/vpcfopub.xml
@@ -906,25 +906,37 @@ Executive Vice-President and Chief Financial Officer (University of Michigan) pu
             <c04 level="file">
               <did>
                 <container type="box" label="Box">13</container>
-                <unittitle><title render="italic">1970-1971 Capital Outlay Budget Request including The Long-Range Needs for Five-Year Period 1970-1971 Through 1974-1975</title>, <unitdate type="inclusive" normal="1969">1969</unitdate> (2 volumes covering Ann Arbor, Flint, and Dearborn)</unittitle>
+                <unittitle><title render="italic">1970-1971 Capital Outlay Budget Request including The Long-Range Needs for Five-Year Period 1970-1971 Through 1974-1975</title>, <unitdate type="inclusive" normal="1969">1969</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 volumes covering Ann Arbor, Flint, and Dearborn</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">13</container>
-                <unittitle><title render="italic">1971-1972 Capital Outlay Budget Request...including The Long-Range Needs for Five-Year Period 1971-1972 Through 1975-1976</title>, <unitdate type="inclusive" normal="1970">1970</unitdate> (3 volumes covering Ann Arbor, Dearborn, and Flint)</unittitle>
+                <unittitle><title render="italic">1971-1972 Capital Outlay Budget Request...including The Long-Range Needs for Five-Year Period 1971-1972 Through 1975-1976</title>, <unitdate type="inclusive" normal="1970">1970</unitdate></unittitle>
+                <physdesc>
+                  <extent>3 volumes covering Ann Arbor, Dearborn, and Flint</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">13</container>
-                <unittitle><title render="italic">1972-1973 Capital Outlay Budget Request...including The Long-Range Needs for Five-Year Period 1972-1973 Through 1976-1977</title>, <unitdate type="inclusive" normal="1971">1971</unitdate> (4 volumes covering Ann Arbor, Dearborn, Flint, and the Medical Center)</unittitle>
+                <unittitle><title render="italic">1972-1973 Capital Outlay Budget Request...including The Long-Range Needs for Five-Year Period 1972-1973 Through 1976-1977</title>, <unitdate type="inclusive" normal="1971">1971</unitdate></unittitle>
+                <physdesc>
+                  <extent>4 volumes covering Ann Arbor, Dearborn, Flint, and the Medical Center</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">13</container>
-                <unittitle><title render="italic">1973-1974 Capital Outlay Budget Request...including The Long-Range Needs for Five-Year Period 1973-1974 Through 1977-1978</title>, <unitdate type="inclusive" normal="1972">1972</unitdate> (4 volumes)</unittitle>
+                <unittitle><title render="italic">1973-1974 Capital Outlay Budget Request...including The Long-Range Needs for Five-Year Period 1973-1974 Through 1977-1978</title>, <unitdate type="inclusive" normal="1972">1972</unitdate></unittitle>
+                <physdesc>
+                  <extent>4 volumes</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(covering Ann Arbor, Dearborn, Flint, and the Medical Center)</p>

--- a/Real_Masters_all/vpdev.xml
+++ b/Real_Masters_all/vpdev.xml
@@ -3934,13 +3934,19 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">13</container>
-                  <unittitle>General <unitdate type="inclusive" normal="1971/1980">1971-1980</unitdate> (1 folder)</unittitle>
+                  <unittitle>General <unitdate type="inclusive" normal="1971/1980">1971-1980</unitdate></unittitle>
+                  <physdesc>
+                    <extent>1 folder</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">14</container>
-                  <unittitle>General <unitdate type="inclusive" normal="1971/1980">1971-1980</unitdate> (1 folder)</unittitle>
+                  <unittitle>General <unitdate type="inclusive" normal="1971/1980">1971-1980</unitdate></unittitle>
+                  <physdesc>
+                    <extent>1 folder</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -5603,7 +5609,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">21</container>
-                  <unittitle>Speeches (3 audio tapes)</unittitle>
+                  <unittitle>Speeches</unittitle>
+                  <physdesc>
+                    <extent>3 audio tapes</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -5646,7 +5655,12 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">22</container>
-                  <unittitle><unitdate type="inclusive" normal="1972/1984">1972-1984</unitdate> (13 folders)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1972/1984">1972-1984</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>13 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
             </c04>

--- a/Real_Masters_all/vpgovrel.xml
+++ b/Real_Masters_all/vpgovrel.xml
@@ -4382,7 +4382,10 @@ Vice President for Government Relations (University of Michigan) records, Bentle
           <c03 level="file">
             <did>
               <container type="box" label="Box">28</container>
-              <unittitle>General <unitdate type="inclusive" normal="1968/1974">1968-1974</unitdate> (2 folders)</unittitle>
+              <unittitle>General <unitdate type="inclusive" normal="1968/1974">1968-1974</unitdate></unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/vpminaff.xml
+++ b/Real_Masters_all/vpminaff.xml
@@ -2347,7 +2347,12 @@ Vice Provost for Academic and Multicultural Affairs (University of Michigan)Reco
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">12</container>
-                  <unittitle><unitdate type="inclusive" normal="1987/1991">1987-1991</unitdate> (1 folder)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1987/1991">1987-1991</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>1 folder</extent>
+                  </physdesc>
                 </did>
                 <accessrestrict>
                   <p>[PR RESTRICTED until <date type="restriction" normal="2021-07-01">July 1, 2021</date>]</p>
@@ -2356,7 +2361,12 @@ Vice Provost for Academic and Multicultural Affairs (University of Michigan)Reco
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">12</container>
-                  <unittitle><unitdate type="inclusive" normal="1987/1991">1987-1991</unitdate> (1 folder)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1987/1991">1987-1991</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>1 folder</extent>
+                  </physdesc>
                 </did>
                 <accessrestrict>
                   <p>[PR RESTRICTED until <date type="restriction" normal="2021-07-01">July 1, 2021</date>]</p>
@@ -5131,7 +5141,10 @@ Vice Provost for Academic and Multicultural Affairs (University of Michigan)Reco
             <c04 level="file">
               <did>
                 <container type="box" label="Box">24</container>
-                <unittitle>General Files <unitdate type="inclusive" normal="1989/1992">1989-1992</unitdate> (3 folders)</unittitle>
+                <unittitle>General Files <unitdate type="inclusive" normal="1989/1992">1989-1992</unitdate></unittitle>
+                <physdesc>
+                  <extent>3 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -9061,7 +9074,10 @@ Vice Provost for Academic and Multicultural Affairs (University of Michigan)Reco
         <c02 level="file">
           <did>
             <container type="box" label="Box">19</container>
-            <unittitle>Director's Files (2 folders) <unitdate type="inclusive" normal="1992/1994">1992-1994</unitdate></unittitle>
+            <unittitle>Director's Files <unitdate type="inclusive" normal="1992/1994">1992-1994</unitdate></unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/vprpub.xml
+++ b/Real_Masters_all/vprpub.xml
@@ -147,7 +147,10 @@ Office of the Vice President for Research (University of Michigan) publications,
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unittitle><title render="italic">Report to the Regents</title>, <unitdate type="inclusive" normal="1992/1997">1992-1997</unitdate> (5 folders) </unittitle>
+              <unittitle><title render="italic">Report to the Regents</title>, <unitdate type="inclusive" normal="1992/1997">1992-1997</unitdate></unittitle>
+              <physdesc>
+                <extent>5 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/vpsaff.xml
+++ b/Real_Masters_all/vpsaff.xml
@@ -2344,7 +2344,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">9</container>
-              <unittitle>Recruitment and Placement <unitdate type="inclusive" normal="1968/1970">1968-1970</unitdate> (4 folders, photos)</unittitle>
+              <unittitle>Recruitment and Placement <unitdate type="inclusive" normal="1968/1970">1968-1970</unitdate></unittitle>
+              <physdesc>
+                <extent>4 folders, photos</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -4057,7 +4060,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">19</container>
-              <unittitle>Alcohol <unitdate type="inclusive" normal="1983/1986">1983-1986</unitdate> (2 folders)-See Also Counseling Services-Alcohol</unittitle>
+              <unittitle>Alcohol <unitdate type="inclusive" normal="1983/1986">1983-1986</unitdate> -See Also Counseling Services-Alcohol</unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">
@@ -4329,7 +4335,10 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">36</container>
-                  <unittitle>Police Report <unitdate type="inclusive" normal="1987">1987</unitdate> (1 folder)</unittitle>
+                  <unittitle>Police Report <unitdate type="inclusive" normal="1987">1987</unitdate></unittitle>
+                  <physdesc>
+                    <extent>1 folder</extent>
+                  </physdesc>
                 </did>
                 <accessrestrict>
                   <p>[SR RESTRICTED until July 1 <date type="inclusive" normal="2062">2062</date>]</p>
@@ -5687,13 +5696,23 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">24</container>
-                  <unittitle><unitdate type="inclusive" normal="1978/1989">1978-1989</unitdate> (1 folder)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1978/1989">1978-1989</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>1 folder</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">36</container>
-                  <unittitle><unitdate type="inclusive" normal="1978/1989">1978-1989</unitdate> (1 folder)</unittitle>
+                  <unittitle>
+                    <unitdate type="inclusive" normal="1978/1989">1978-1989</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>1 folder</extent>
+                  </physdesc>
                 </did>
                 <accessrestrict>
                   <p>[SR RESTRICTED until July 1 <date type="inclusive" normal="2064">2064</date>]</p>

--- a/Real_Masters_all/wallm60m.xml
+++ b/Real_Masters_all/wallm60m.xml
@@ -6708,7 +6708,10 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
             <c04 level="file">
               <did>
                 <container type="box" label="Box">29</container>
-                <unittitle>Background/Post-Show (2 folders; includes tape cassette)</unittitle>
+                <unittitle>Background/Post-Show</unittitle>
+                <physdesc>
+                  <extent>2 folders; includes tape cassette</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -13016,7 +13019,10 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
             <c04 level="file">
               <did>
                 <container type="box" label="Box">150</container>
-                <unittitle>"Poor Man's Atom Bomb" proposed story from B. Turpin (1 binder)</unittitle>
+                <unittitle>"Poor Man's Atom Bomb" proposed story from B. Turpin</unittitle>
+                <physdesc>
+                  <extent>1 binder</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -13034,13 +13040,19 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
             <c04 level="file">
               <did>
                 <container type="box" label="Box">150</container>
-                <unittitle>Louis Farrakhan transcripts <unitdate type="inclusive" normal="1996-04-02">April 2, 1996</unitdate> (1 binder)</unittitle>
+                <unittitle>Louis Farrakhan transcripts <unitdate type="inclusive" normal="1996-04-02">April 2, 1996</unitdate></unittitle>
+                <physdesc>
+                  <extent>1 binder</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">150</container>
-                <unittitle>Maxwell Air Force Base-Michael Beckelic <unitdate type="inclusive" normal="1997-10-27">October 27, 1997</unitdate> (1 binder)</unittitle>
+                <unittitle>Maxwell Air Force Base-Michael Beckelic <unitdate type="inclusive" normal="1997-10-27">October 27, 1997</unitdate></unittitle>
+                <physdesc>
+                  <extent>1 binder</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(re Air Force medical technician accused of poisoning newborn infants)</p>
@@ -13049,7 +13061,10 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
             <c04 level="file">
               <did>
                 <container type="box" label="Box">150</container>
-                <unittitle>Murder by the book <unitdate type="inclusive" normal="1997-03-02">March 2, 1997</unitdate> (2 binders and 1 folder)</unittitle>
+                <unittitle>Murder by the book <unitdate type="inclusive" normal="1997-03-02">March 2, 1997</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 binders and 1 folder</extent>
+                </physdesc>
               </did>
               <odd>
                 <p>(re how-to manual for a Hit Man)</p>
@@ -17211,7 +17226,10 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
             <c04 level="file">
               <did>
                 <container type="box" label="Box">65</container>
-                <unittitle>Primaries (2 folders and 8 briefing books)</unittitle>
+                <unittitle>Primaries</unittitle>
+                <physdesc>
+                  <extent>2 folders and 8 briefing books</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -17387,7 +17405,10 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
             <c04 level="file">
               <did>
                 <container type="box" label="Box">66</container>
-                <unittitle>Black September (2 folders)</unittitle>
+                <unittitle>Black September</unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -19056,7 +19077,10 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
             </c04>
             <c04 level="file">
               <did>
-                <unittitle>Speeches and Appearances (19 folders, arranged chronologically)</unittitle>
+                <unittitle>Speeches and Appearances</unittitle>
+                <physdesc>
+                  <extent>19 folders, arranged chronologically</extent>
+                </physdesc>
               </did>
               <c05 level="file">
                 <did>
@@ -19541,7 +19565,10 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
             </c04>
             <c04 level="file">
               <did>
-                <unittitle>Speeches and Appearances (11 folders, arranged chronologically)</unittitle>
+                <unittitle>Speeches and Appearances</unittitle>
+                <physdesc>
+                  <extent>11 folders, arranged chronologically</extent>
+                </physdesc>
               </did>
               <c05 level="file">
                 <did>
@@ -20054,7 +20081,10 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
             </c04>
             <c04 level="file">
               <did>
-                <unittitle>Speeches and Appearances (9 folders, arranged chronologically)</unittitle>
+                <unittitle>Speeches and Appearances</unittitle>
+                <physdesc>
+                  <extent>9 folders, arranged chronologically</extent>
+                </physdesc>
               </did>
               <c05 level="file">
                 <did>
@@ -20837,7 +20867,10 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
             </c04>
             <c04 level="file">
               <did>
-                <unittitle>Speeches and Appearances (16 folders, arranged chronologically)</unittitle>
+                <unittitle>Speeches and Appearances</unittitle>
+                <physdesc>
+                  <extent>16 folders, arranged chronologically</extent>
+                </physdesc>
               </did>
               <c05 level="file">
                 <did>
@@ -21057,7 +21090,10 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
             </c04>
             <c04 level="file">
               <did>
-                <unittitle>Speeches and Appearances (10 folders, arranged chronologically)</unittitle>
+                <unittitle>Speeches and Appearances</unittitle>
+                <physdesc>
+                  <extent>10 folders, arranged chronologically</extent>
+                </physdesc>
               </did>
               <c05 level="file">
                 <did>
@@ -21256,7 +21292,10 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
             </c04>
             <c04 level="file">
               <did>
-                <unittitle>Speeches and Appearances (7 folders, arranged chronologically)</unittitle>
+                <unittitle>Speeches and Appearances</unittitle>
+                <physdesc>
+                  <extent>7 folders, arranged chronologically</extent>
+                </physdesc>
               </did>
               <c05 level="file">
                 <did>
@@ -21497,7 +21536,10 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
             </c04>
             <c04 level="file">
               <did>
-                <unittitle>Speeches and Appearances (9 folders, arranged chronologically)</unittitle>
+                <unittitle>Speeches and Appearances</unittitle>
+                <physdesc>
+                  <extent>9 folders, arranged chronologically</extent>
+                </physdesc>
               </did>
               <c05 level="file">
                 <did>
@@ -21779,7 +21821,10 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
             </c04>
             <c04 level="file">
               <did>
-                <unittitle>Speeches and Appearances (8 folders, arranged chronologically)</unittitle>
+                <unittitle>Speeches and Appearances</unittitle>
+                <physdesc>
+                  <extent>8 folders, arranged chronologically</extent>
+                </physdesc>
               </did>
               <c05 level="file">
                 <did>
@@ -25474,7 +25519,10 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
             <c04 level="file">
               <did>
                 <container type="box" label="Box">96</container>
-                <unittitle>Bottom Line proposed interview program produced by Jan Helfeld <unitdate type="inclusive" normal="1992">1992</unitdate> (6 tapes)</unittitle>
+                <unittitle>Bottom Line proposed interview program produced by Jan Helfeld <unitdate type="inclusive" normal="1992">1992</unitdate></unittitle>
+                <physdesc>
+                  <extent>6 tapes</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -25776,7 +25824,10 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
             <c04 level="file">
               <did>
                 <container type="box" label="Box">97</container>
-                <unittitle><title render="italic">60 Minutes</title> segment "Melinda" <unitdate type="inclusive" normal="1990">1990</unitdate> (2 tapes)</unittitle>
+                <unittitle><title render="italic">60 Minutes</title> segment "Melinda" <unitdate type="inclusive" normal="1990">1990</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 tapes</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -25794,7 +25845,10 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
             <c04 level="file">
               <did>
                 <container type="box" label="Box">97</container>
-                <unittitle>Soros Foundation (2 tapes)</unittitle>
+                <unittitle>Soros Foundation</unittitle>
+                <physdesc>
+                  <extent>2 tapes</extent>
+                </physdesc>
               </did>
             </c04>
           </c03>
@@ -28524,7 +28578,10 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
         <c02 level="file">
           <did>
             <container type="box" label="Box">166</container>
-            <unittitle>Mitt Romney <unitdate type="inclusive" normal="2007">2007</unitdate> (4 binders and 2 folders)</unittitle>
+            <unittitle>Mitt Romney <unitdate type="inclusive" normal="2007">2007</unitdate></unittitle>
+            <physdesc>
+              <extent>4 binders and 2 folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/walterera.xml
+++ b/Real_Masters_all/walterera.xml
@@ -254,7 +254,10 @@ Erich A. Walter papers, Bentley Historical Library, University of Michigan</p>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">1</container>
-                <unittitle>Negatives <unitdate type="inclusive">undated</unitdate> (1 envelope, 1 folder)</unittitle>
+                <unittitle>Negatives <unitdate type="inclusive">undated</unitdate></unittitle>
+                <physdesc>
+                  <extent>1 envelope, 1 folder</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/wascohs.xml
+++ b/Real_Masters_all/wascohs.xml
@@ -1971,7 +1971,10 @@ Washtenaw County Historical Society records, Bentley Historical Library, Univers
       </c01>
       <c01 level="series">
         <did>
-          <unittitle>Glass slides (1 box; 53 slides)</unittitle>
+          <unittitle>Glass slides</unittitle>
+          <physdesc>
+            <extent>1 box; 53 slides</extent>
+          </physdesc>
         </did>
         <odd>
           <p>(the following identifications and descriptions were prepared by Lela Duff in 1956)</p>

--- a/Real_Masters_all/wellscar.xml
+++ b/Real_Masters_all/wellscar.xml
@@ -720,7 +720,10 @@ Carlton F. Wells papers, Bentley Historical Library, University of Michigan</p>
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unittitle>Trip to Turkey by Helen Wells <unitdate type="inclusive" normal="1927/1928">1927-1928</unitdate> (2 folders.)</unittitle>
+            <unittitle>Trip to Turkey by Helen Wells <unitdate type="inclusive" normal="1927/1928">1927-1928</unitdate></unittitle>
+            <physdesc>
+              <extent>2 folders.</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/whittfam.xml
+++ b/Real_Masters_all/whittfam.xml
@@ -849,9 +849,12 @@ Whittemore Family Papers
         </scopecontent>
         <c02 level="file">
           <did>
-            <unittitle>Letters of Temperance Mack, Almira Covey and Hyrum Smith <unitdate type="inclusive" normal="1835/1849">1835-1849</unitdate> (23 items in 2 folders)</unittitle>
+            <unittitle>Letters of Temperance Mack, Almira Covey and Hyrum Smith <unitdate type="inclusive" normal="1835/1849">1835-1849</unitdate></unittitle>
             <physdesc>
               <physfacet>photostatic copies</physfacet>
+            </physdesc>
+            <physdesc>
+              <extent>23 items in 2 folders</extent>
             </physdesc>
           </did>
           <odd>

--- a/Real_Masters_all/wineberg.xml
+++ b/Real_Masters_all/wineberg.xml
@@ -829,7 +829,10 @@ Susan Wineberg papers, Bentley Historical Library, University of Michigan</p>
         <c02 level="file">
           <did>
             <container type="box" label="Box">17</container>
-            <unittitle>Retreat <unitdate type="inclusive" normal="2004">2004</unitdate>, <unitdate type="inclusive" normal="2006/2007">2006-2007</unitdate> (3 folders)</unittitle>
+            <unittitle>Retreat <unitdate type="inclusive" normal="2004">2004</unitdate>, <unitdate type="inclusive" normal="2006/2007">2006-2007</unitdate></unittitle>
+            <physdesc>
+              <extent>3 folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/wleague.xml
+++ b/Real_Masters_all/wleague.xml
@@ -936,7 +936,12 @@ Women's League (University of Michigan) Records, Bentley Historical Library, Uni
           </c03>
           <c03 level="file">
             <did>
-              <unittitle><unitdate type="inclusive" normal="1952/1953">1952/53</unitdate> (4 volumes)</unittitle>
+              <unittitle>
+                <unitdate type="inclusive" normal="1952/1953">1952/53</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>4 volumes</extent>
+              </physdesc>
             </did>
             <c04 level="file">
               <did>
@@ -1674,7 +1679,10 @@ Women's League (University of Michigan) Records, Bentley Historical Library, Uni
           <c03 level="file">
             <did>
               <container type="box" label="Box">35</container>
-              <unittitle>Minutes, 1928-1965(14 folders)</unittitle>
+              <unittitle>Minutes, 1928-1965</unittitle>
+              <physdesc>
+                <extent>14 folders</extent>
+              </physdesc>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/wuom.xml
+++ b/Real_Masters_all/wuom.xml
@@ -276,7 +276,10 @@ WUOM Records, Bentley Historical Library, University of Michigan</p>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">1</container>
-                <unittitle>Radio Broadcasting Historical Material <unitdate type="inclusive" normal="1933/1949">1933-1949</unitdate> (2 binders)</unittitle>
+                <unittitle>Radio Broadcasting Historical Material <unitdate type="inclusive" normal="1933/1949">1933-1949</unitdate></unittitle>
+                <physdesc>
+                  <extent>2 binders</extent>
+                </physdesc>
               </did>
             </c04>
             <c04 level="file">
@@ -1729,7 +1732,10 @@ WUOM Records, Bentley Historical Library, University of Michigan</p>
               </did>
               <c05 level="file">
                 <did>
-                  <unittitle>"Festival of Song" (6 envelopes)</unittitle>
+                  <unittitle>"Festival of Song"</unittitle>
+                  <physdesc>
+                    <extent>6 envelopes</extent>
+                  </physdesc>
                 </did>
                 <c06 level="file">
                   <did>


### PR DESCRIPTION
Take 2! See earlier PR and related conversation here: #182 

This time the script also skips examples where the container tag's label attribute matched the found extent keyword, instead adding them to a list for later manual review.

Code workflow:
1. find all the unittitles whose parenthetical statements start with a number
2. if the contents of the parenthetical do not contain any of a set of extent keywords (like "folder" or "cassette"), then it does nothing
3. if the type attribute of the sibling `<container>` tag matches the found extent keyword, skip for manual review. There were ~20 of these.
4. if the unittitle's parent `<did>` tag already has an extent statement, it is skipped for manual review (I didn't want to overwrite anything or make duplicate information). There were only 4 or 5 of these.
5. assuming it passes the above tests, the parenthetical is removed from the unittitle, and inserted without parens into a new physdesc/extent statement in the unittitle's parent `<did>` tag

The script and input files can be found [here](https://github.com/walkerdb/bentley_code/tree/master/one-off%20scripts/unittitle_parentheticals)
