### PR TITLE
Move problematic unitdate tags outside of unittitles

### DIFF
--- a/Real_Masters_all/osbornst.xml
+++ b/Real_Masters_all/osbornst.xml
@@ -2219,7 +2219,7 @@ Stellanova Osborn papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">34</container>
-              <unittitle>Interview with Stella Osborn <unitdate type="inclusive" normal="1981-12-31">December 31, 1981</unitdate> in which she discusses her public activities and tells how Chase Osborn brought Robert Frost to the University of Michigan in <unitdate type="inclusive" normal="1922">1922</unitdate></unittitle>
+              <unittitle>Interview with Stella Osborn <unitdate type="inclusive" normal="1981-12-31">December 31, 1981</unitdate> in which she discusses her public activities and tells how Chase Osborn brought Robert Frost to the University of Michigan in 1922</unittitle>
               <physdesc>
                 <physfacet>U-matic videocassette; color; ca. 20 minutes</physfacet>
               </physdesc>

--- a/Real_Masters_all/penningt.xml
+++ b/Real_Masters_all/penningt.xml
@@ -509,7 +509,7 @@ Jasper Green Pennington papers, Bentley Historical Library, University of Michig
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unittitle>D. Felix Lamond <unitdate type="inclusive" normal="1862/1937">1862-1937</unitdate> "A Musicians Musician" (Notes for an article), <unitdate type="inclusive" normal="1997">1997</unitdate></unittitle>
+            <unittitle>D. Felix Lamond 1862-1937, "A Musicians Musician" (Notes for an article), <unitdate type="inclusive" normal="1997">1997</unitdate></unittitle>
           </did>
         </c02>
       </c01>

--- a/Real_Masters_all/physiol.xml
+++ b/Real_Masters_all/physiol.xml
@@ -627,7 +627,7 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">3</container>
-                <unittitle>Groups <unitdate type="inclusive" normal="1897">1897</unitdate>, <unitdate type="inclusive" normal="1938/1958">1938-1958</unitdate>, <unitdate type="inclusive" normal="1964" certainty="approximate">circa 1964</unitdate> (includes some negatives)</unittitle>
+                <unittitle>Groups 1897, 1938-1958, <unitdate type="inclusive" normal="1964" certainty="approximate">circa 1964</unitdate> (includes some negatives)</unittitle>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/shengb.xml
+++ b/Real_Masters_all/shengb.xml
@@ -1903,7 +1903,7 @@ Bright Sheng Papers, Bentley Historical Library, University of Michigan</p>
               </did>
               <c05 level="file">
                 <did>
-                  <unittitle>H'un (Lacerations): In Memoriam <unitdate type="inclusive" normal="1966/1976">1966-1976</unitdate> (1988), <unitdate type="inclusive" normal="1989-10-31">October 31, 1989</unitdate></unittitle>
+                  <unittitle>H'un (Lacerations): In Memoriam 1966-1976 (1988), <unitdate type="inclusive" normal="1989-10-31">October 31, 1989</unitdate></unittitle>
                   <physdesc>
                     <physfacet>track 1, 22:16</physfacet>
                   </physdesc>

--- a/Real_Masters_all/ulibrary.xml
+++ b/Real_Masters_all/ulibrary.xml
@@ -83676,7 +83676,7 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
           <c03 level="file">
             <did>
               <container type="box" label="Box">249</container>
-              <unittitle>"The <unitdate type="inclusive" normal="1960/1969" certainty="approximate">1960s</unitdate> From Peaceful Protest to Guerrilla Warfare" Exhibition, <unitdate type="inclusive" normal="1993">1993</unitdate></unittitle>
+              <unittitle>"The 1960s From Peaceful Protest to Guerrilla Warfare" Exhibition, <unitdate type="inclusive" normal="1993">1993</unitdate></unittitle>
             </did>
             <accessrestrict>
               <p>[ER RESTRICTED until <date type="restriction" normal="2023-07-01">July 1, 2023</date>]</p>

--- a/Real_Masters_all/ummart.xml
+++ b/Real_Masters_all/ummart.xml
@@ -4117,7 +4117,7 @@ The records include correspondence, committee minutes, publicity material and ph
             <c04 level="file">
               <did>
                 <container type="box" label="Box">5</container>
-                <unittitle>"Memorabilia of the <unitdate type="inclusive" normal="1913">1913</unitdate> Armory Show," <unitdate type="inclusive" normal="1965-02-01/1965-02-22">February 1-22, 1965</unitdate></unittitle>
+                <unittitle>"Memorabilia of the 1913 Armory Show," <unitdate type="inclusive" normal="1965-02-01/1965-02-22">February 1-22, 1965</unitdate></unittitle>
               </did>
               <odd>
                 <p>(American Federation of Arts)</p>
@@ -4798,7 +4798,7 @@ The records include correspondence, committee minutes, publicity material and ph
           <c03 level="file">
             <did>
               <container type="box" label="Box">6</container>
-              <unittitle>"American Representational Art of the <unitdate type="inclusive" normal="1920/1929" certainty="approximate">1920s</unitdate> and 1930s," <unitdate type="inclusive" normal="1970-03-01/1970-04-12">March 1-April 12, 1970</unitdate></unittitle>
+              <unittitle>"American Representational Art of the 1920s and 1930s," <unitdate type="inclusive" normal="1970-03-01/1970-04-12">March 1-April 12, 1970</unitdate></unittitle>
             </did>
           </c03>
           <c03 level="file">
@@ -5254,7 +5254,7 @@ The records include correspondence, committee minutes, publicity material and ph
           <c03 level="file">
             <did>
               <container type="box" label="Box">7</container>
-              <unittitle>"The Form of Cities in Perspective 500 B.C.-A.D. <unitdate type="inclusive" normal="2000">2000</unitdate> An Exhibition of Drawings by Charles A. Blessing," <unitdate type="inclusive" normal="1973-02-28/1973-03-25">February 28-March 25, 1973</unitdate></unittitle>
+              <unittitle>"The Form of Cities in Perspective 500 B.C.-A.D. 2000 An Exhibition of Drawings by Charles A. Blessing," <unitdate type="inclusive" normal="1973-02-28/1973-03-25">February 28-March 25, 1973</unitdate></unittitle>
             </did>
           </c03>
           <c03 level="file">
@@ -5384,7 +5384,7 @@ The records include correspondence, committee minutes, publicity material and ph
           <c03 level="file">
             <did>
               <container type="box" label="Box">7</container>
-              <unittitle>"A Director's Choice: <unitdate type="inclusive" normal="1946/1956">1946-1956</unitdate> Jean Paul Slusser," <unitdate type="inclusive" normal="1974-05-04/1974-05-27">May 4-27, 1974</unitdate></unittitle>
+              <unittitle>"A Director's Choice: 1946-1956 Jean Paul Slusser," <unitdate type="inclusive" normal="1974-05-04/1974-05-27">May 4-27, 1974</unitdate></unittitle>
             </did>
           </c03>
           <c03 level="file">
@@ -6596,7 +6596,7 @@ The records include correspondence, committee minutes, publicity material and ph
           <c03 level="file">
             <did>
               <container type="box" label="Box">9</container>
-              <unittitle>"The Federal Art Project: American Prints from the <unitdate type="inclusive" normal="1930/1939" certainty="approximate">1930s</unitdate> in the Collection of the University of Michigan Museum of Art," <unitdate type="inclusive" normal="1985-06-28/1985-08">June 28-August 1985</unitdate></unittitle>
+              <unittitle>"The Federal Art Project: American Prints from the 1930s in the Collection of the University of Michigan Museum of Art," <unitdate type="inclusive" normal="1985-06-28/1985-08">June 28-August 1985</unitdate></unittitle>
             </did>
           </c03>
           <c03 level="file">
@@ -7096,7 +7096,7 @@ The records include correspondence, committee minutes, publicity material and ph
           <c03 level="file">
             <did>
               <container type="box" label="Box">10</container>
-              <unittitle>"Art of the <unitdate type="inclusive" normal="1960/1969" certainty="approximate">1960s</unitdate> Part I and II," <unitdate type="inclusive" normal="1990-06-29/1990-08-05">June 29-August 5, 1990</unitdate> and August 10-[September 23], <unitdate type="inclusive" normal="1990">1990</unitdate></unittitle>
+              <unittitle>"Art of the 1960s Part I and II," <unitdate type="inclusive" normal="1990-06-29/1990-08-05">June 29-August 5, 1990</unitdate> and August 10-[September 23], <unitdate type="inclusive" normal="1990">1990</unitdate></unittitle>
             </did>
             <odd>
               <p>(in connection with History of Art 375: "Issues in American Art of the 1960s")</p>
@@ -8352,7 +8352,7 @@ The records include correspondence, committee minutes, publicity material and ph
           <c03 level="file">
             <did>
               <container type="box" label="Box">16</container>
-              <unittitle>"Amish Quilts <unitdate type="inclusive" normal="1880/1940">1880-1940</unitdate> from the Collection of Faith and Stephen Brown," <unitdate type="inclusive" normal="2000-07-08/2000-09-10">July 8-September 10, 2000</unitdate></unittitle>
+              <unittitle>"Amish Quilts 1880-1940 from the Collection of Faith and Stephen Brown," <unitdate type="inclusive" normal="2000-07-08/2000-09-10">July 8-September 10, 2000</unitdate></unittitle>
             </did>
             <odd>
               <p>(includes label copy)</p>

--- a/Real_Masters_all/umpresid.xml
+++ b/Real_Masters_all/umpresid.xml
@@ -62544,7 +62544,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">113</container>
-                  <unittitle>"The Age/Rank Composition of the University of Michigan Faculty to <unitdate type="inclusive" normal="1995">1995</unitdate> A Simulation Study," <unitdate type="inclusive" normal="1975">1975</unitdate></unittitle>
+                  <unittitle>"The Age/Rank Composition of the University of Michigan Faculty to 1995 A Simulation Study," <unitdate type="inclusive" normal="1975">1975</unitdate></unittitle>
                 </did>
               </c05>
             </c04>

--- a/Real_Masters_all/upclansi.xml
+++ b/Real_Masters_all/upclansi.xml
@@ -454,7 +454,7 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unittitle>History <unitdate type="inclusive" normal="1920">1920</unitdate> and background information, <unitdate type="inclusive" normal="1960">1960</unitdate></unittitle>
+            <unittitle>History 1920 and background information, <unitdate type="inclusive" normal="1960">1960</unitdate></unittitle>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/vargasg.xml
+++ b/Real_Masters_all/vargasg.xml
@@ -359,7 +359,7 @@ George Vargas papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unittitle>New Deal: Government Art of the <unitdate type="inclusive" normal="1930/1939" certainty="approximate">1930s</unitdate>, <unitdate type="inclusive" normal="1940/1949" certainty="approximate">1940s</unitdate> Pontiac Art Center, Michigan, <unitdate type="inclusive" normal="1989-03-04/1989-04-14">March 4-April 14, 1989</unitdate></unittitle>
+              <unittitle>New Deal: Government Art of the 1930s, 1940s Pontiac Art Center, Michigan, <unitdate type="inclusive" normal="1989-03-04/1989-04-14">March 4-April 14, 1989</unitdate></unittitle>
             </did>
             <odd>
               <p>(see also "Art Show Posters, etc." under "Original Artwork")</p>
@@ -962,7 +962,7 @@ George Vargas papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">2</container>
-              <unittitle>"An Era of Uncertainty: The Formation and Growth of Mexicano Communities in Michigan <unitdate type="inclusive" normal="1936/1964">1936-1964</unitdate>" by Dennis Valdez, <unitdate type="inclusive" normal="1981-11-14">November 14, 1981</unitdate></unittitle>
+              <unittitle>"An Era of Uncertainty: The Formation and Growth of Mexicano Communities in Michigan 1936-1964" by Dennis Valdez, <unitdate type="inclusive" normal="1981-11-14">November 14, 1981</unitdate></unittitle>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/vpdev.xml
+++ b/Real_Masters_all/vpdev.xml
@@ -12370,7 +12370,7 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">48</container>
-                <unittitle>University Relations in the <unitdate type="inclusive" normal="1980/1989" certainty="approximate">1980s</unitdate> A Planning Document, <unitdate type="inclusive" normal="1992-02">February 1992</unitdate></unittitle>
+                <unittitle>University Relations in the 1980s A Planning Document, <unitdate type="inclusive" normal="1992-02">February 1992</unitdate></unittitle>
               </did>
             </c04>
           </c03>

--- a/Real_Masters_all/wallm60m.xml
+++ b/Real_Masters_all/wallm60m.xml
@@ -8604,7 +8604,7 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
           </c03>
           <c03 level="file">
             <did>
-              <unittitle>"Women in Combat?" (the controversy over whether the <unitdate type="inclusive" normal="1948">1948</unitdate> law preventing women from taking part in direct combat should be overturned), <unitdate type="inclusive" normal="1989-01-01">January 1, 1989</unitdate></unittitle>
+              <unittitle>"Women in Combat?" (the controversy over whether the 1948 law preventing women from taking part in direct combat should be overturned), <unitdate type="inclusive" normal="1989-01-01">January 1, 1989</unitdate></unittitle>
             </did>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/wascohs.xml
+++ b/Real_Masters_all/wascohs.xml
@@ -2022,13 +2022,13 @@ Washtenaw County Historical Society records, Bentley Historical Library, Univers
           <c03 level="file">
             <did>
               <container type="box" label="Box">6</container>
-              <unittitle>7. Washtenaw Hotel, Broadway, built <unitdate type="inclusive" normal="1831">1831</unitdate> or 1832. Supposedly the finest hotel between Detroit and Jackson; condemned in <unitdate type="inclusive" normal="1921">1921</unitdate></unittitle>
+              <unittitle>7. Washtenaw Hotel, Broadway, built 1831 or 1832. Supposedly the finest hotel between Detroit and Jackson; condemned in 1921</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">6</container>
-              <unittitle>8. Unity Block, SW corner Ann and Fifth Avenue. The First Methodist Church built <unitdate type="inclusive" normal="1831/1832">1831-1832</unitdate> sold to Unitarians who worshipped there from <unitdate type="inclusive" normal="1867">1867</unitdate> to 1882. Torn down ca. 1930.</unittitle>
+              <unittitle>8. Unity Block, SW corner Ann and Fifth Avenue. The First Methodist Church built 1831-1832 sold to Unitarians who worshipped there from 1867 to 1882. Torn down ca. 1930.</unittitle>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/wuom.xml
+++ b/Real_Masters_all/wuom.xml
@@ -2508,7 +2508,7 @@ WUOM Records, Bentley Historical Library, University of Michigan</p>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">18</container>
-                  <unittitle>Program #5: The Anthracite Coal Strike of <unitdate type="inclusive" normal="1902">1902</unitdate> broadcast <unitdate type="inclusive" normal="1965-02-10">February 10, 1965</unitdate></unittitle>
+                  <unittitle>Program #5: The Anthracite Coal Strike of 1902 broadcast <unitdate type="inclusive" normal="1965-02-10">February 10, 1965</unitdate></unittitle>
                   <unitid>[R45A]</unitid>
                 </did>
               </c05>
@@ -2618,21 +2618,21 @@ WUOM Records, Bentley Historical Library, University of Michigan</p>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">18</container>
-                  <unittitle>Program #21: The <unitdate type="inclusive" normal="1930/1939" certainty="approximate">1930s</unitdate> pt. 1., broadcast June 1. <unitdate type="inclusive" normal="1965">1965</unitdate></unittitle>
+                  <unittitle>Program #21: The 1930s pt. 1., broadcast June 1. <unitdate type="inclusive" normal="1965">1965</unitdate></unittitle>
                   <unitid>[R53A]</unitid>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">18</container>
-                  <unittitle>Program #22: The <unitdate type="inclusive" normal="1930/1939" certainty="approximate">1930s</unitdate> pt. 2., broadcast June 8. <unitdate type="inclusive" normal="1965">1965</unitdate></unittitle>
+                  <unittitle>Program #22: The 1930s pt. 2., broadcast June 8. <unitdate type="inclusive" normal="1965">1965</unitdate></unittitle>
                   <unitid>[R53A]</unitid>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">18</container>
-                  <unittitle>Program #23: The <unitdate type="inclusive" normal="1930/1939" certainty="approximate">1930s</unitdate> pt. 3., broadcast <unitdate type="inclusive" normal="1965-06-15">June 15, 1965</unitdate></unittitle>
+                  <unittitle>Program #23: The 1930s pt. 3., broadcast <unitdate type="inclusive" normal="1965-06-15">June 15, 1965</unitdate></unittitle>
                   <unitid>[R54A]</unitid>
                 </did>
               </c05>


### PR DESCRIPTION
A significant refinement on #177

The intention of this pull is to mitigate potential problems with ASpace mangling resource titles when it automatically pulls unitdates out of unittitles. The script used to make the changes does the following:
1. if a unittitle contains multiple unitdates, and those dates only appear at the end of the unittitle, separated solely by commas and/or "and"s, then those unitdates are removed and appended after the unittitle, and the tail end of the unittitle is cleaned to remove trailing punctuation.
2. if a unittitle contains multiple unitdates, with significant text between them, and if the disparity between those dates or date ranges is less than 10 years, then the unitdate _tags_ are removed, leaving their text, and the original tags are appended after the unittitle
3. if the unittitle passes the above test, except that the date disparity is greater than 10 years, its location and content was recorded and set aside for manual review (this is meant to get around the issue with some dates actually being part of proper nouns).

If the above operations left the unittitle completely empty, it was deleted entirely.

Additionally, when pulling out unitdates to append after the unittitle, duplicate dates were removed (as in, if there were two "1950"s, only one was appended after the unittitle)

code and tests can be found [here](https://github.com/walkerdb/bentley_code/tree/master/one-off%20scripts/unitdates_in_unittitles)

Let me know if anything seems off!
