### PR TITLE
dao fixes based on results of adding dspace abstracts to ead

### DIFF
--- a/Real_Masters_all/compcent.xml
+++ b/Real_Masters_all/compcent.xml
@@ -5270,7 +5270,7 @@ Computing Center (University of Michigan) records, Bentley Historical Library, U
             <did>
               <physloc>Online</physloc>
               <unittitle>No. 480: Translation Day Character Code Changes on MTS <unitdate type="inclusive" normal="1988-02">February 1988</unitdate></unittitle>
-              <dao href="http://deepblue.lib.umich.edu/handle/2027.42/79603" show="new" actuate="onrequest">
+              <dao href="http://hdl.handle.net/2027.42/79603" show="new" actuate="onrequest">
                 <daodesc>
                   <p>[download file]</p>
                 </daodesc>
@@ -5281,7 +5281,7 @@ Computing Center (University of Michigan) records, Bentley Historical Library, U
             <did>
               <physloc>Online</physloc>
               <unittitle>No. 815: Using LaTeX on Michigan Terminal System <unitdate type="inclusive" normal="1988-08">August 1988</unitdate></unittitle>
-              <dao href="http://deepblue.lib.umich.edu/handle/2027.42/79604" show="new" actuate="onrequest">
+              <dao href="http://hdl.handle.net/2027.42/79604" show="new" actuate="onrequest">
                 <daodesc>
                   <p>[download file]</p>
                 </daodesc>

--- a/Real_Masters_all/compcent.xml
+++ b/Real_Masters_all/compcent.xml
@@ -5264,17 +5264,30 @@ Computing Center (University of Michigan) records, Bentley Historical Library, U
         </c02>
         <c02 level="file">
           <did>
-            <physloc>Online</physloc>
             <unittitle>Computing Center Memos <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
-            <physdesc>
-              <extent>2 files</extent>
-            </physdesc>
-            <dao href="http://hdl.handle.net/2027.42/79570" show="new" actuate="onrequest">
-              <daodesc>
-                <p>[download file]</p>
-              </daodesc>
-            </dao>
           </did>
+          <c03 level="file">
+            <did>
+              <physloc>Online</physloc>
+              <unittitle>No. 480: Translation Day Character Code Changes on MTS <unitdate type="inclusive" normal="1988-02">February 1988</unitdate></unittitle>
+              <dao href="http://deepblue.lib.umich.edu/handle/2027.42/79603" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download file]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc>Online</physloc>
+              <unittitle>No. 815: Using LaTeX on Michigan Terminal System <unitdate type="inclusive" normal="1988-08">August 1988</unitdate></unittitle>
+              <dao href="http://deepblue.lib.umich.edu/handle/2027.42/79604" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download file]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/compcent.xml
+++ b/Real_Masters_all/compcent.xml
@@ -5291,17 +5291,107 @@ Computing Center (University of Michigan) records, Bentley Historical Library, U
         </c02>
         <c02 level="file">
           <did>
-            <physloc>Online</physloc>
             <unittitle>Internal System Documentation <unitdate type="inclusive" normal="1978/1995">1978-1995</unitdate></unittitle>
-            <physdesc>
-              <extent>9 files</extent>
-            </physdesc>
-            <dao href="http://hdl.handle.net/2027.42/79570" show="new" actuate="onrequest">
-              <daodesc>
-                <p>[download file]</p>
-              </daodesc>
-            </dao>
           </did>
+          <c03 level="file">
+            <did>
+              <physloc>Online</physloc>
+              <unittitle>Disk Disaster Recovery <unitdate type="inclusive" normal="1987-04">April 1987</unitdate></unittitle>
+              <dao href="http://hdl.handle.net/2027.42/79618" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download file]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc>Online</physloc>
+              <unittitle>Lecture 1 <unitdate type="inclusive" normal="1978-05">May 1978</unitdate></unittitle>
+              <dao href="http://hdl.handle.net/2027.42/79606" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download file]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc>Online</physloc>
+              <unittitle>MTS D6.0 Disk Documentation <unitdate type="inclusive" normal="1987-04">April 1987</unitdate></unittitle>
+              <dao href="http://hdl.handle.net/2027.42/79607" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download file]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc>Online</physloc>
+              <unittitle>MTS Operators Manual <unitdate type="inclusive" normal="1995-02">February 1995</unitdate></unittitle>
+              <dao href="http://hdl.handle.net/2027.42/79628" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download file]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc>Online</physloc>
+              <unittitle>Resource Manager Operations Manual <unitdate type="inclusive" normal="1990-03">March 1990</unitdate></unittitle>
+              <dao href="http://hdl.handle.net/2027.42/79589" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download file]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc>Online</physloc>
+              <unittitle>University of Michigan Multiprogramming Supervisor (UMMPS) Supervisor Call Descriptions (MTS Distribution 6.0) <unitdate type="inclusive" normal="1987-11">November 1987</unitdate></unittitle>
+              <dao href="http://hdl.handle.net/2027.42/79584" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download file]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc>Online</physloc>
+              <unittitle>Volume 01: Michigan Termal System (Systems Edition) <unitdate type="inclusive" normal="1991-11">November 1991</unitdate></unittitle>
+              <dao href="http://hdl.handle.net/2027.42/79585" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download file]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc>Online</physloc>
+              <unittitle>Volume 03: Systems Subroutine Descriptions (Systems Edition) <unitdate type="inclusive" normal="1981-04">April 1981</unitdate></unittitle>
+              <dao href="http://hdl.handle.net/2027.42/79583" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download file]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc>Online</physloc>
+              <unittitle>Volume 99: Collected Materials <unitdate type="inclusive" normal="1978-06">June 1978</unitdate></unittitle>
+              <dao href="http://hdl.handle.net/2027.42/79596" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download file]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
         </c02>
         <c02 level="file">
           <did>
@@ -5334,6 +5424,292 @@ Computing Center (University of Michigan) records, Bentley Historical Library, U
                 </daodesc>
               </dao>
             </did>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Second Edition Volume I <unitdate type="inclusive" normal="1967-12">December 1967</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79588" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Second Edition Volume II <unitdate type="inclusive" normal="1967-12">December 1967</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79587" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 01: The Michigan Terminal System <unitdate type="inclusive" normal="1991-11">November 1991</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79598" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 02: Public File Descriptions <unitdate type="inclusive" normal="1990-05">May 1990</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79612" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 02X: Obsolete Public File Descriptions <unitdate type="inclusive" normal="1987-01">January 1987</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79581" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 03: System Subroutine Descriptions <unitdate type="inclusive" normal="1989-09">September 1989</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79575" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 04: Terminals and Networks in MTS <unitdate type="inclusive" normal="1988-07">July 1988</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79592" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 05: System Services <unitdate type="inclusive" normal="1985-09">September 1985</unitdate></unittitle>
+                <dao href="" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 06: FORTRAN in MTS <unitdate type="inclusive" normal="1988-02">February 1988</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79601" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 07: PL/I in MTS <unitdate type="inclusive" normal="1985-09">September 1985</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79580" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 08: LISP and SLIP in MTS <unitdate type="inclusive" normal="1983-01">January 1983</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79591" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 09: SNOBOL4 in MTS <unitdate type="inclusive" normal="1983-01">January 1983</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79574" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 10: BASIC in MTS <unitdate type="inclusive" normal="1980-12">December 1980</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79608" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 11: Plot Description System <unitdate type="inclusive" normal="1985-04">April 1985</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79593" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 12: PIL/2 in MTS <unitdate type="inclusive" normal="1974-12">December 1974</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79630" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 13: Symbolic Debugging System <unitdate type="inclusive" normal="1985-09">September 1985</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79602" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 14: 360/370 Assemblers in MTS <unitdate type="inclusive" normal="1986-09">September 1986</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79622" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 15: FORMAT and TEXT360 <unitdate type="inclusive" normal="1988-03">March 1988</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79626" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 16: ALGOL in MTS <unitdate type="inclusive" normal="1980-09">September 1980</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79617" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 17: Integrated Graphics System <unitdate type="inclusive" normal="1984-09">September 1984</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79600" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 18: The MTS File Editor <unitdate type="inclusive" normal="1988-02">February 1988</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79613" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 19: Magnetic Tapes <unitdate type="inclusive" normal="1993-10">October 1993</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79582" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 20: Pascal in MTS <unitdate type="inclusive" normal="1989-01">January 1989</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79595" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 21: MTS Command Extensions and Macros <unitdate type="inclusive" normal="1991-04">April 1991</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79572" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 22: UTLisp in MTS <unitdate type="inclusive" normal="1988-05">May 1988</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79610" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>MTS Volume 23: Messaging and Conferencing in MTS <unitdate type="inclusive" normal="1991-02">February 1991</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79615" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
           </c03>
           <c03 level="file">
             <did>
@@ -5348,6 +5724,39 @@ Computing Center (University of Michigan) records, Bentley Historical Library, U
                 </daodesc>
               </dao>
             </did>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>Title <unitdate type="inclusive" normal="">Date</unitdate></unittitle>
+                <dao href="" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>Title <unitdate type="inclusive" normal="">Date</unitdate></unittitle>
+                <dao href="" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc>Online</physloc>
+                <unittitle>Title <unitdate type="inclusive" normal="">Date</unitdate></unittitle>
+                <dao href="" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download file]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/compcent.xml
+++ b/Real_Masters_all/compcent.xml
@@ -5415,14 +5415,6 @@ Computing Center (University of Michigan) records, Bentley Historical Library, U
             <did>
               <physloc>Online</physloc>
               <unittitle>MTS Volumes <unitdate type="inclusive" normal="1967/1993">1967-1993</unitdate></unittitle>
-              <physdesc>
-                <extent>26 files</extent>
-              </physdesc>
-              <dao href="http://hdl.handle.net/2027.42/79570" show="new" actuate="onrequest">
-                <daodesc>
-                  <p>[download file]</p>
-                </daodesc>
-              </dao>
             </did>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/compcent.xml
+++ b/Real_Masters_all/compcent.xml
@@ -5497,7 +5497,7 @@ Computing Center (University of Michigan) records, Bentley Historical Library, U
               <did>
                 <physloc>Online</physloc>
                 <unittitle>MTS Volume 05: System Services <unitdate type="inclusive" normal="1985-09">September 1985</unitdate></unittitle>
-                <dao href="" show="new" actuate="onrequest">
+                <dao href="http://hdl.handle.net/2027.42/79597" show="new" actuate="onrequest">
                   <daodesc>
                     <p>[download file]</p>
                   </daodesc>
@@ -5705,22 +5705,13 @@ Computing Center (University of Michigan) records, Bentley Historical Library, U
           </c03>
           <c03 level="file">
             <did>
-              <physloc>Online</physloc>
               <unittitle>University of British Columbia Computing Centre (PLUS programming language and Command Language Parser) <unitdate type="inclusive" normal="1982/1987">1982-1987</unitdate></unittitle>
-              <physdesc>
-                <extent>3 files</extent>
-              </physdesc>
-              <dao href="http://hdl.handle.net/2027.42/79570" show="new" actuate="onrequest">
-                <daodesc>
-                  <p>[download file]</p>
-                </daodesc>
-              </dao>
             </did>
             <c04 level="file">
               <did>
                 <physloc>Online</physloc>
-                <unittitle>Title <unitdate type="inclusive" normal="">Date</unitdate></unittitle>
-                <dao href="" show="new" actuate="onrequest">
+                <unittitle>CLPARSER: A Command Language Parsing Facility <unitdate type="inclusive" normal="1982-11">November 1982</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79629" show="new" actuate="onrequest">
                   <daodesc>
                     <p>[download file]</p>
                   </daodesc>
@@ -5730,8 +5721,8 @@ Computing Center (University of Michigan) records, Bentley Historical Library, U
             <c04 level="file">
               <did>
                 <physloc>Online</physloc>
-                <unittitle>Title <unitdate type="inclusive" normal="">Date</unitdate></unittitle>
-                <dao href="" show="new" actuate="onrequest">
+                <unittitle>PLUS Source Library Definitions <unitdate type="inclusive" normal="1983-01">January 1983</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79577" show="new" actuate="onrequest">
                   <daodesc>
                     <p>[download file]</p>
                   </daodesc>
@@ -5741,8 +5732,8 @@ Computing Center (University of Michigan) records, Bentley Historical Library, U
             <c04 level="file">
               <did>
                 <physloc>Online</physloc>
-                <unittitle>Title <unitdate type="inclusive" normal="">Date</unitdate></unittitle>
-                <dao href="" show="new" actuate="onrequest">
+                <unittitle>PLUS: The Plus Programming Language <unitdate type="inclusive" normal="1987-10">October 1987</unitdate></unittitle>
+                <dao href="http://hdl.handle.net/2027.42/79616" show="new" actuate="onrequest">
                   <daodesc>
                     <p>[download file]</p>
                   </daodesc>
@@ -5753,17 +5744,107 @@ Computing Center (University of Michigan) records, Bentley Historical Library, U
         </c02>
         <c02 level="file">
           <did>
-            <physloc>Online</physloc>
             <unittitle>Reference Documents <unitdate type="inclusive" normal="1986/1995">1986-1995</unitdate></unittitle>
-            <physdesc>
-              <extent>9 files</extent>
-            </physdesc>
-            <dao href="http://hdl.handle.net/2027.42/79570" show="new" actuate="onrequest">
-              <daodesc>
-                <p>[download file]</p>
-              </daodesc>
-            </dao>
           </did>
+		  <c03 level="file">
+		    <did>
+			  <physloc>Online</physloc>
+			  <unittitle>BITNET on Michigan Terminal System <unitdate type="inclusive" normal="1990-09">September 1990</unitdate></unittitle>
+			  <dao href="http://hdl.handle.net/2027.42/79579" show="new" actuate="onrequest">
+			    <daodesc>
+				  <p>[download file]</p>
+				</daodesc>
+			  </dao>
+			</did>
+		  </c03>
+		  <c03 level="file">
+		    <did>
+			  <physloc>Online</physloc>
+			  <unittitle>C89 S/370 compiler <unitdate type="inclusive" normal="1992-10">October 1992</unitdate></unittitle>
+			  <dao href="http://hdl.handle.net/2027.42/79609" show="new" actuate="onrequest">
+			    <daodesc>
+				  <p>[download file]</p>
+				</daodesc>
+			  </dao>
+			</did>
+		  </c03>
+		  <c03 level="file">
+		    <did>
+			  <physloc>Online</physloc>
+			  <unittitle>Computer Conferencing Guidelines <unitdate type="inclusive" normal="1989-10">October 1989</unitdate></unittitle>
+			  <dao href="http://hdl.handle.net/2027.42/79625" show="new" actuate="onrequest">
+			    <daodesc>
+				  <p>[download file]</p>
+				</daodesc>
+			  </dao>
+			</did>
+		  </c03>
+		  <c03 level="file">
+		    <did>
+			  <physloc>Online</physloc>
+			  <unittitle>Confer and Michigan Terminal System Help <unitdate type="inclusive" normal="1989-10">October 1989</unitdate></unittitle>
+			  <dao href="http://hdl.handle.net/2027.42/79573" show="new" actuate="onrequest">
+			    <daodesc>
+				  <p>[download file]</p>
+				</daodesc>
+			  </dao>
+			</did>
+		  </c03>
+		  <c03 level="file">
+		    <did>
+			  <physloc>Online</physloc>
+			  <unittitle>Guidelines for Effective Conferencing for Organizers <unitdate type="inclusive" normal="1989-10">October 1989</unitdate></unittitle>
+			  <dao href="http://hdl.handle.net/2027.42/79627" show="new" actuate="onrequest">
+			    <daodesc>
+				  <p>[download file]</p>
+				</daodesc>
+			  </dao>
+			</did>
+		  </c03>
+		  <c03 level="file">
+		    <did>
+			  <physloc>Online</physloc>
+			  <unittitle>Guidelines for Effective Conferencing for Participants <unitdate type="inclusive" normal="1989-10">October 1989</unitdate></unittitle>
+			  <dao href="http://hdl.handle.net/2027.42/79624" show="new" actuate="onrequest">
+			    <daodesc>
+				  <p>[download file]</p>
+				</daodesc>
+			  </dao>
+			</did>
+		  </c03>
+		  <c03 level="file">
+		    <did>
+			  <physloc>Online</physloc>
+			  <unittitle>Information Technology Division Publications <unitdate type="inclusive" normal="1995-11">November 1995</unitdate></unittitle>
+			  <dao href="http://hdl.handle.net/2027.42/79611" show="new" actuate="onrequest">
+			    <daodesc>
+				  <p>[download file]</p>
+				</daodesc>
+			  </dao>
+			</did>
+		  </c03>
+		  <c03 level="file">
+		    <did>
+			  <physloc>Online</physloc>
+			  <unittitle>TEXTFORM Reference Manual <unitdate type="inclusive" normal="1986-01">January 1986</unitdate></unittitle>
+			  <dao href="http://hdl.handle.net/2027.42/79578" show="new" actuate="onrequest">
+			    <daodesc>
+				  <p>[download file]</p>
+				</daodesc>
+			  </dao>
+			</did>
+		  </c03>
+		  <c03 level="file">
+		    <did>
+			  <physloc>Online</physloc>
+			  <unittitle>The Resource Manager <unitdate type="inclusive" normal="1991-11">November 1991</unitdate></unittitle>
+			  <dao href="http://hdl.handle.net/2027.42/79623" show="new" actuate="onrequest">
+			    <daodesc>
+				  <p>[download file]</p>
+				</daodesc>
+			  </dao>
+			</did>
+		  </c03>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/mcook.xml
+++ b/Real_Masters_all/mcook.xml
@@ -38,7 +38,7 @@
       </origination>
       <unittitle encodinganalog="245">Martha Cook Building (University of Michigan) records <unitdate type="inclusive" encodinganalog="245$f" normal="1967">Summer 1967</unitdate></unittitle>
       <physdesc>
-        <extent encodinganalog="300">7,25 linear ft. and 1 outsize box.</extent>
+        <extent encodinganalog="300">7.25 linear ft. and 1 outsize box.</extent>
       </physdesc>
       <unitid encodinganalog="099" repositorycode="MiU-H" countrycode="us" type="call number">Bimu F17 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>


### PR DESCRIPTION
Running the script that adds abstracts from DSpace to our EADs revealed that there are some daos that point to the collection in DSpace, not any individual item, and have things like a physfacet of 3, or 9, or 26 files with no actual links to the files. 

I split those up into individual components and added links to the actual items, not the collection as a whole. 

Also I changed an extent that had a comma when it should have had a period. 
