### PR TITLE
manual cleanup (extent number commas; eadid)

### DIFF
--- a/Real_Masters_all/archcoll.xml
+++ b/Real_Masters_all/archcoll.xml
@@ -16890,7 +16890,7 @@
           <did>
             <unittitle>Douglas Kelbaugh, (sent mail) <unitdate type="inclusive" normal="2003-11-18/2008-08-02">November 18, 2003-August 2, 2008</unitdate></unittitle>
             <physdesc>
-              <extent>1.8 GB; 22,438 files</extent>
+              <extent>1.8 GB; 22438 files</extent>
             </physdesc>
           </did>
           <accessrestrict>

--- a/Real_Masters_all/birkertg.xml
+++ b/Real_Masters_all/birkertg.xml
@@ -42,7 +42,7 @@
       </origination>
       <unittitle encodinganalog="245">Gunnar Birkerts papers <unitdate type="inclusive" encodinganalog="245$f" normal="1930/2002">1930-2002</unitdate></unittitle>
       <physdesc>
-        <extent encodinganalog="300">11 linear feet and 1,912 architectural drawings in 11 drawers</extent>
+        <extent encodinganalog="300">11 linear feet and 1912 architectural drawings in 11 drawers</extent>
       </physdesc>
       <abstract>Michigan-based architect, founder of Gunnar Birkerts and Associates, professor in the University of Michigan College of Architecture and Urban Planning. The collection is comprised of four series: Personal papers, Professional papers, Faculty papers, and Project files. Personal papers includes biographical information, family photographs, early architectural drawings, and course notebooks and project drawings completed while a student at the Technische Hochschule Stuttgart. Professional papers includes transcripts and notes of speeches, lectures and seminars (many of these are also available on audiotapes; some are available on videocassettes). Also included are correspondence, awards, travel diaries with conceptual drawings, newspaper and journal articles and photographs. Faculty papers include course and other materials relating to his career as professor at the University of Michigan College of Architecture and Urban Planning. Project files contains textual files, photographs, and conceptual drawings associated with 122 of the buildings and projects designed by Birkerts. Scanned images of some conceptual drawings are available on-line.</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">02103 Aa 2</unitid>

--- a/Real_Masters_all/blanfam.xml
+++ b/Real_Masters_all/blanfam.xml
@@ -39,7 +39,7 @@
       </origination>
       <unittitle encodinganalog="245">Blanchard Family Papers <unitdate type="inclusive" encodinganalog="245$f" normal="1835/2000" certainty="approximate">circa 1835-circa 2000</unitdate></unittitle>
       <physdesc>
-        <extent encodinganalog="300">49.5 linear feet (in 50 boxes) and 1,400 glass photographic plates (in 10 boxes)</extent>
+        <extent encodinganalog="300">49.5 linear feet (in 50 boxes) and 1400 glass photographic plates (in 10 boxes)</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">8868 Aa 2; UAm</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>

--- a/Real_Masters_all/cassidyj.xml
+++ b/Real_Masters_all/cassidyj.xml
@@ -43,7 +43,7 @@
       </origination>
       <unittitle encodinganalog="245">Jay Cassidy photograph collection <unitdate type="inclusive" encodinganalog="245$f" normal="1967/1970">1967-1970</unitdate></unittitle>
       <physdesc>
-        <extent encodinganalog="300">2.5 linear feet in 10 boxes, 4,882 digital images, and 1 oversize folder</extent>
+        <extent encodinganalog="300">2.5 linear feet in 10 boxes, 4882 digital images, and 1 oversize folder</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2011003 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
@@ -178,7 +178,7 @@ Jay Cassidy photograph collection, Bentley Historical Library, University of Mic
             <physloc>Online</physloc>
             <unittitle>Digital Images</unittitle>
             <physdesc>
-              <extent>4,882 items</extent>
+              <extent>4882 items</extent>
             </physdesc>
             <dao href="cassidyjaymd" show="new" actuate="onrequest">
               <daodesc>

--- a/Real_Masters_all/duderst.xml
+++ b/Real_Masters_all/duderst.xml
@@ -78,7 +78,7 @@
       </origination>
       <unittitle encodinganalog="245">James J. Duderstadt Papers <unitdate encodinganalog="245$f" type="inclusive" normal="1963/1997">1963-1997</unitdate>, <unitdate encodinganalog="245 f" type="bulk" normal="1970/1996">1970-1996</unitdate></unittitle>
       <physdesc>
-        <extent encodinganalog="300">23.5 linear feet and 2,144 digital files (160.5 Mb)</extent>
+        <extent encodinganalog="300">23.5 linear feet and 2144 digital files (160.5 Mb)</extent>
       </physdesc>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">9811 Aa 2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
@@ -5793,7 +5793,7 @@
         <did>
           <unittitle>Digital Documents <unitdate type="inclusive" normal="1986/1997">1986-1997</unitdate></unittitle>
           <physdesc>
-            <extent>2,144 files (160.5 MB)</extent>
+            <extent>2144 files (160.5 MB)</extent>
           </physdesc>
         </did>
         <scopecontent>

--- a/Real_Masters_all/gbassoc.xml
+++ b/Real_Masters_all/gbassoc.xml
@@ -58,7 +58,7 @@
       </origination>
       <unittitle encodinganalog="245">Gunnar Birkerts and Associates records <unitdate type="inclusive" encodinganalog="245$f" normal="1960/2014">1960-2014</unitdate></unittitle>
       <physdesc>
-        <extent encodinganalog="300">87 linear feet of records and 10,000 drawings.</extent>
+        <extent encodinganalog="300">87 linear feet of records and 10000 drawings.</extent>
       </physdesc>
       <abstract>Architectural firm founded by Gunnar Birkerts, headquartered in Bloomfield Hills, Michigan. Textual records, architectural and engineering drawings and photographs document fourteen of the firm's major buildings including the Federal Reserve Building (Minneapolis, MN), Corning Glass Museum (Corning, NY) and the University of Michigan Law School Library Addition.</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">9915 Bb 2</unitid>

--- a/Real_Masters_all/geolsurv.xml
+++ b/Real_Masters_all/geolsurv.xml
@@ -43,7 +43,7 @@
       </origination>
       <unittitle encodinganalog="245">Topographic Quadrangle Maps <unitdate type="inclusive" encodinganalog="245$f" normal="1895/9999">1895-[ongoing]</unitdate></unittitle>
       <physdesc>
-        <extent encodinganalog="300">2,700 color maps (approximate)</extent>
+        <extent encodinganalog="300">2700 color maps (approximate)</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">M 4110 svar G4 [2010130]</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>

--- a/Real_Masters_all/gonzalesjess.xml
+++ b/Real_Masters_all/gonzalesjess.xml
@@ -3,7 +3,7 @@
 
   <eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
 
-    <eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::filename.xml//EN" encodinganalog="Identifier">
+    <eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::gonzalesjess.xml//EN" encodinganalog="Identifier">
       umich-bhl-2014079
     </eadid>
 

--- a/Real_Masters_all/jarocki.xml
+++ b/Real_Masters_all/jarocki.xml
@@ -42,7 +42,7 @@
       </origination>
       <unittitle encodinganalog="245">Walter Jarocki photographs <unitdate type="inclusive" encodinganalog="245$f" normal="1937">1937</unitdate>, <unitdate type="inclusive" encodinganalog="245$f" normal="1948">1948</unitdate>, <unitdate type="inclusive" encodinganalog="245$f" normal="1952/1959">1952-1959</unitdate>, <unitdate type="inclusive" encodinganalog="245$f" normal="1970/1989">1970s-early 1980s</unitdate></unittitle>
       <physdesc>
-        <extent encodinganalog="300">2,265 negatives (approximate; in 3 boxes) and 2 prints (in oversize folder)</extent>
+        <extent encodinganalog="300">2265 negatives (approximate; in 3 boxes) and 2 prints (in oversize folder)</extent>
       </physdesc>
       <abstract>Hamtramck, Michigan, commercial photographer who took photographs for the city during the administration of Mayor Albert J. Zak in the 1950s. Photonegatives, mostly dated between 1952 and 1958, of public work projects (such as laying of sidewalks), ceremonial functions (such as Christmas displays on city streets), and some political activities. The collection also includes views of the city, its downtown area, residential streets and alleyways behind residences. There are two photographs of Frank Murphy (approximately 1937) and Harry Truman (approximately 1948) visiting Hamtramck. Also a smaller group of photonegatives from the 1970s-early 1980s depicting activities of mayor Robert W. Kozaren, his office, and Hamtramck's daily life.</abstract>
       <unitid encodinganalog="099" repositorycode="MiU-H" countrycode="us" type="call number">969 Aa 2; UAs</unitid>

--- a/Real_Masters_all/metcalfr.xml
+++ b/Real_Masters_all/metcalfr.xml
@@ -43,7 +43,7 @@
       </origination>
       <unittitle encodinganalog="245">Robert C. Metcalf papers <unitdate type="inclusive" encodinganalog="245$g" normal="1950/2008">1950-2008</unitdate>, <unitdate type="bulk" encodinganalog="245$g" normal="1950/1999">1950-1999</unitdate></unittitle>
       <physdesc>
-        <extent encodinganalog="300">12 linear feet and 4,372 drawings</extent>
+        <extent encodinganalog="300">12 linear feet and 4372 drawings</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2009179 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>

--- a/Real_Masters_all/mimedia.xml
+++ b/Real_Masters_all/mimedia.xml
@@ -3886,7 +3886,7 @@ Media Resources Center (University of Michigan) Records, Bentley Historical Libr
           <did>
             <unittitle>Television Programs</unittitle>
             <physdesc>
-              <extent>1,300 titles (approximate)</extent>
+              <extent>1300 titles (approximate)</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/oslerdav.xml
+++ b/Real_Masters_all/oslerdav.xml
@@ -47,7 +47,7 @@
       </origination>
       <unittitle encodinganalog="245">David W. Osler papers <unitdate type="inclusive" encodinganalog="245$f" normal="1956/2014">1956-2014</unitdate></unittitle>
       <physdesc>
-        <extent encodinganalog="300">1,960 architectural drawings, 1.3 linear feet of textual and photographic material (in 2 boxes)</extent>
+        <extent encodinganalog="300">1960 architectural drawings, 1.3 linear feet of textual and photographic material (in 2 boxes)</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2008176 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>

--- a/Real_Masters_all/penrod.xml
+++ b/Real_Masters_all/penrod.xml
@@ -43,7 +43,7 @@
       </origination>
       <unittitle encodinganalog="245">Penrod/Hiawatha Company postcard collection <unitdate type="inclusive" encodinganalog="245$f" normal="1950/2014">1950-2014</unitdate></unittitle>
       <physdesc>
-        <extent encodinganalog="300">8 postcard boxes (over 5,000 postcards) and 1.3 linear feet.</extent>
+        <extent encodinganalog="300">8 postcard boxes (over 5000 postcards) and 1.3 linear feet.</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">92456 Bb 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>

--- a/Real_Masters_all/solarcar.xml
+++ b/Real_Masters_all/solarcar.xml
@@ -43,7 +43,7 @@
       </origination>
       <unittitle encodinganalog="245">Solar Car Team (University of Michigan) records <unitdate type="inclusive" encodinganalog="245$f" normal="1985/2009">1985-2009</unitdate>, <unitdate type="bulk" encodinganalog="245$g" normal="1989/2003">1989-2003</unitdate></unittitle>
       <physdesc>
-        <extent encodinganalog="300">23 linear feet, 1 outsize scrapbook, and 94,104 digital records (4.06 GB 52.1 MB)</extent>
+        <extent encodinganalog="300">23 linear feet, 1 outsize scrapbook, and 94104 digital records (4.06 GB 52.1 MB)</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">921120 Bimu 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>


### PR DESCRIPTION
Aspace doesn't like commas in extent numbers, so I took them out.

Also replaced a placeholder eadid value in one of the new EADs
