### PR TITLE
cleaning up a few container summaries

### DIFF
--- a/Real_Masters_all/chfundmi.xml
+++ b/Real_Masters_all/chfundmi.xml
@@ -46,7 +46,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">23 linear feet</extent>
-        <physfacet>24 boxes</physfacet>
+        <extent altrender="carrier">24 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4 oversize volumes</extent>

--- a/Real_Masters_all/chfundmi.xml
+++ b/Real_Masters_all/chfundmi.xml
@@ -46,7 +46,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">23 linear feet</extent>
-        <extent altrender="carrier">24 boxes</extent>
+        <extent altrender="carrier">(in 24 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4 oversize volumes</extent>

--- a/Real_Masters_all/claybour.xml
+++ b/Real_Masters_all/claybour.xml
@@ -47,7 +47,7 @@
       <physloc>Offsite storage in part; prior notification required for access to this portion</physloc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">5.5 linear feet</extent>
-        <physfacet>7 boxes</physfacet>
+        <extent altrender="carrier">(in 7 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/ferrydm.xml
+++ b/Real_Masters_all/ferrydm.xml
@@ -62,7 +62,7 @@
       <abstract>A pioneer Detroit, Michigan family, established the Ferry Seed Company and other business enterprises, active in civic and cultural affairs. Papers document the family and its business, cultural, political and philanthropic activities.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">23.5 linear feet</extent>
-        <physfacet>25 boxes</physfacet>
+        <extent altrender="carrier">(in 25 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 oversize volumes</extent>

--- a/Real_Masters_all/interloc.xml
+++ b/Real_Masters_all/interloc.xml
@@ -58,7 +58,7 @@
       </repository>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">86.4 linear feet</extent>
-        <physfacet>92 boxes</physfacet>
+        <extent altrender="carrier">(in 92 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">51 volumes</extent>

--- a/Real_Masters_all/kalmbach.xml
+++ b/Real_Masters_all/kalmbach.xml
@@ -47,7 +47,7 @@
       <abstract>Staff photographer for University of Michigan News and Information Services and contract photographer for the University of Michigan Athletic Department. Includes negatives and contact prints of game action photos of UM athletic competitions, 1978-2000 and some personal and family photos.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">27 linear feet</extent>
-        <physfacet>62 boxes</physfacet>
+        <extent altrender="carrier">(in 62 boxes)</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/kelseymu.xml
+++ b/Real_Masters_all/kelseymu.xml
@@ -51,7 +51,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">131.5 linear feet</extent>
-        <physfacet>244 boxes</physfacet>
+        <extent altrender="carrier">(in 244 boxes)</physfacet>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/macdnldk.xml
+++ b/Real_Masters_all/macdnldk.xml
@@ -42,7 +42,7 @@
       <abstract>Owner and operator of a network of Michigan radio stations, including WSAM in Saginaw, Michigan. Biographical files relating in part to his Ann Arbor and Saginaw, Michigan, civic activities; scrapbooks, advertisements and other materials relating to WSAM radio station; files detailing his involvement with the National Association of Broadcasters; scrapbooks documenting career activities, and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-        <physfacet>3 boxes</physfacet>
+        <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 oversize volumes</extent>

--- a/Real_Masters_all/mccreery.xml
+++ b/Real_Masters_all/mccreery.xml
@@ -62,7 +62,7 @@
       <abstract>The McCreery and Fenton families were prominent Genesee county, Michigan residents some of whose members distinguished themselves in local and state government, as soldiers during the Civil War, and in the United States diplomatic service. Papers include diaries, correspondence and other material relating to the Civil War, local and state politics and aspects of diplomatic service in Central and South America.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">12 linear feet</extent>
-        <physfacet>13 boxes</physfacet>
+        <extent altrender="carrier">(in 13 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/mhctopph.xml
+++ b/Real_Masters_all/mhctopph.xml
@@ -50,7 +50,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.5 linear feet</extent>
-        <physfacet>2 boxes</physfacet>
+        <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize boxes</extent>

--- a/Real_Masters_all/millardf.xml
+++ b/Real_Masters_all/millardf.xml
@@ -42,7 +42,7 @@
       <abstract>Republican attorney general of Michigan, 1951-1954, general counsel of the Department of the Army. World War I letters, papers detailing work as chairman of the committee on emerging problems of the Michigan Constitutional Convention; miscellaneous genealogical material, and diaries and memoranda books; scrapbooks concerning political career, especially his service as state attorney general; and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4 linear feet</extent>
-        <physfacet>6 boxes</physfacet>
+        <extent altrender="carrier">(in 6 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 oversize volumes</extent>

--- a/Real_Masters_all/mohr.xml
+++ b/Real_Masters_all/mohr.xml
@@ -71,9 +71,12 @@
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">85287
         Bj 2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
-      <physdesc altrender="whole">
-        <extent altrender="materialtype spaceoccupied">13 linear feet 1 oversize folder</extent>
-        <physfacet>14 boxes</physfacet>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">13 linear feet</extent>
+        <extent altrender="carrier">(in 14 boxes)</physfacet>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">1 oversize folder</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of

--- a/Real_Masters_all/pondfam.xml
+++ b/Real_Masters_all/pondfam.xml
@@ -46,7 +46,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">9.6 linear feet</extent>
-        <physfacet>13 boxes</physfacet>
+        <extent altrender="carrier">(in 13 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 oversize drawers</extent>

--- a/Real_Masters_all/ppolicy.xml
+++ b/Real_Masters_all/ppolicy.xml
@@ -62,7 +62,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">17 linear feet</extent>
-        <physfacet>18 Boxes</physfacet>
+        <extent altrender="carrier">(in 18 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3.97 GB</extent>

--- a/Real_Masters_all/sandersw.xml
+++ b/Real_Masters_all/sandersw.xml
@@ -43,7 +43,7 @@
       <abstract>Architect, professor of architecture at the University of Michigan. Biographical information; subject files relating to his professional activities, his involvement with the International Congress for Modern Architecture, his interest in architectural education, and his own design work; photographs and architectural drawings. The collection includes correspondence exchanged with Buckminster Fuller and Walter Gropius. There is also a letter from Lewis Mumford.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.3 linear feet</extent>
-        <physfacet>2 boxes</physfacet>
+        <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/sincljl.xml
+++ b/Real_Masters_all/sincljl.xml
@@ -70,7 +70,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">66.5 linear feet</extent>
-        <physfacet>82 boxes</physfacet>
+        <extent altrender="carrier">(in 82 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/weberw.xml
+++ b/Real_Masters_all/weberw.xml
@@ -58,7 +58,7 @@
       <abstract>Detroit, Michigan businessman and civic leader. Business correspondence relating to Weber's activities as a dealer in timber lands, his role as a member of the Art Commission in the development of Detroit, Michigan's Cultural Center, his involvement in the construction of the Detroit-Windsor bridge and tunnel and his activities during World War I; and correspondence and class notes of his sons, Harry B. and Erwin W. Weber, while attending University of Michigan; also photographs, including family portraits, aerial views of Windsor, Ontario, and Detroit, photographs of the construction of the Detroit-Windsor Tunnel and Ambassador Bridge, and glass negatives of family vacations in Upper Michigan, Ontario, and Quebec; and maps of land and timber holdings</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">28 linear feet</extent>
-        <physfacet>30 boxes</physfacet>
+        <extent altrender="carrier">(in 30 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">15 oversize volumes</extent>

--- a/Real_Masters_all/weissert.xml
+++ b/Real_Masters_all/weissert.xml
@@ -43,7 +43,7 @@
       <abstract>Journalist, historical researcher from Kalamazoo, Michigan; Correspondence, research articles and notes, and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3.3 linear feet</extent>
-        <physfacet>4 boxes</physfacet>
+        <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/wilkwarr.xml
+++ b/Real_Masters_all/wilkwarr.xml
@@ -47,7 +47,7 @@
       <abstract>Scrapbooks of Warren S. Wilkinson, member of the board of the Evening News Association, publisher of the <title render="italic">Detroit News</title>. Scrapbooks relate to the life and work of James E. Scripps, founder of the <title render="italic">Detroit News</title>, and to the struggle over the sale of the newspaper to Gannett Company in 1985.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
-        <physfacet>3 boxes</physfacet>
+        <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">5 oversize volumes</extent>


### PR DESCRIPTION
Fixing a few container summaries that got identified as physfacets.
