### PR TITLE
changing Folders to Folder in container labels

### DIFF
--- a/Real_Masters_all/bourquin.xml
+++ b/Real_Masters_all/bourquin.xml
@@ -441,7 +441,7 @@
           <c03 level="file">
             <did>
               <container label="Drawer" type="map-case">88</container>
-              <container label="Folders" type="folder">10, 10-a</container>
+              <container label="Folder" type="folder">10, 10-a</container>
               <unittitle>Hillwood Subdivision <unitdate type="inclusive" normal="1953/1971">1953-1971 (scattered)</unitdate></unittitle>
             </did>
           </c03>

--- a/Real_Masters_all/gjelsnrh.xml
+++ b/Real_Masters_all/gjelsnrh.xml
@@ -122,7 +122,7 @@ Rudolph H. Gjelsness papers, Bentley Historical Library, University of Michigan<
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <container type="folder" label="Folders">1-4</container>
+              <container type="folder" label="Folder">1-4</container>
               <unittitle>
                 <unitdate type="inclusive">Undated</unitdate>
               </unittitle>
@@ -432,7 +432,7 @@ Rudolph H. Gjelsness papers, Bentley Historical Library, University of Michigan<
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <container type="folder" label="Folders">37-38</container>
+              <container type="folder" label="Folder">37-38</container>
               <unittitle>
                 <unitdate type="inclusive" normal="1916">1916</unitdate>
               </unittitle>
@@ -1516,7 +1516,7 @@ Rudolph H. Gjelsness papers, Bentley Historical Library, University of Michigan<
         <c02 level="file">
           <did>
             <container type="box" label="Box">4</container>
-            <container type="folder" label="Folders">46-47</container>
+            <container type="folder" label="Folder">46-47</container>
             <unittitle>Societies and Institutions</unittitle>
           </did>
         </c02>
@@ -1537,7 +1537,7 @@ Rudolph H. Gjelsness papers, Bentley Historical Library, University of Michigan<
         <c02 level="file">
           <did>
             <container type="box" label="Box">4</container>
-            <container type="folder" label="Folders">50-52</container>
+            <container type="folder" label="Folder">50-52</container>
             <unittitle>Transliteration</unittitle>
           </did>
         </c02>

--- a/Real_Masters_all/hubbardl.xml
+++ b/Real_Masters_all/hubbardl.xml
@@ -194,7 +194,7 @@ Lucius L. Hubbard Papers
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <container type="folder" label="Folders">1-11</container>
+            <container type="folder" label="Folder">1-11</container>
             <unittitle>
               <unitdate type="inclusive" normal="1929/1935">1929-1935</unitdate>
               <unitdate type="inclusive">undated</unitdate>
@@ -715,7 +715,7 @@ Lucius L. Hubbard Papers
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <container type="folder" label="Folders">41-45</container>
+            <container type="folder" label="Folder">41-45</container>
             <unittitle>Progress reports of Longyear and Hodge, Mining Engineers <unitdate type="inclusive" normal="1909-09/1911-01">September 1909-January 1911</unitdate></unittitle>
           </did>
         </c02>
@@ -778,7 +778,7 @@ Lucius L. Hubbard Papers
           <c03 level="item">
             <did>
               <container type="box" label="Box">3</container>
-              <container type="folder" label="Folders">50-51</container>
+              <container type="folder" label="Folder">50-51</container>
               <unittitle>Maps of the State of Maine</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
@@ -795,7 +795,7 @@ Lucius L. Hubbard Papers
           <c03 level="item">
             <did>
               <container type="box" label="Box">3</container>
-              <container type="folder" label="Folders">53-57</container>
+              <container type="folder" label="Folder">53-57</container>
               <unittitle>Miscellaneous manuscript maps, often not identified</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 folders</extent>
@@ -827,7 +827,7 @@ Lucius L. Hubbard Papers
         <c02 level="file">
           <did>
             <container type="box" label="Box">4</container>
-            <container type="folder" label="Folders">61-62</container>
+            <container type="folder" label="Folder">61-62</container>
             <unittitle>Reports and notes of the Seneca Copper Corporation <unitdate type="inclusive" normal="1920/1921">1920-1921</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 folders</extent>
@@ -857,7 +857,7 @@ Lucius L. Hubbard Papers
         <c02 level="file">
           <did>
             <container type="box" label="Box">4</container>
-            <container type="folder" label="Folders">67-71</container>
+            <container type="folder" label="Folder">67-71</container>
             <unittitle>Reports and notes of the Champion Copper Company <unitdate type="inclusive" normal="1900/1905">1900-1905</unitdate>, <unitdate type="inclusive" normal="1923" certainty="approximate">1923 undated</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">5 folders</extent>
@@ -867,7 +867,7 @@ Lucius L. Hubbard Papers
         <c02 level="file">
           <did>
             <container type="box" label="Box">4</container>
-            <container type="folder" label="Folders">72-73</container>
+            <container type="folder" label="Folder">72-73</container>
             <unittitle>General reports of the Copper Range Co. <unitdate type="inclusive" normal="1899/1903">1899-1903</unitdate></unittitle>
           </did>
         </c02>

--- a/Real_Masters_all/ztgergan.xml
+++ b/Real_Masters_all/ztgergan.xml
@@ -809,7 +809,7 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
           </c03>
           <c03 level="file">
             <did>
-              <container type="folder" label="Folders">16-17</container>
+              <container type="folder" label="Folder">16-17</container>
               <unittitle>Ann Arbor. Washtenaw County Building, Huron and Main Street <unitdate type="inclusive" normal="1953">1953</unitdate> (Job No. 775)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">58 drawings</extent>
@@ -827,7 +827,7 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
           </c03>
           <c03 level="file">
             <did>
-              <container type="folder" label="Folders">16-17</container>
+              <container type="folder" label="Folder">16-17</container>
               <unittitle>Ann Arbor. Washtenaw County Building (concessions area) <unitdate type="inclusive" normal="1955">1955</unitdate> (Job No. 775B)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 drawings</extent>


### PR DESCRIPTION
To cut down on some of the differences between container types and labels, I changed any instances of label="Folders" to label="Folder"

Before doing this, we already had hundreds of instances of folder ranges that had a label of Folder, not Folders, now we just have a few more, so this is not actually a significant change. Just thought I should point that out.
