### PR TITLE
subcontainer othertypes fix

### DIFF
--- a/Real_Masters_all/birkertg.xml
+++ b/Real_Masters_all/birkertg.xml
@@ -1703,7 +1703,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">1</container>
+                  <container type="othertype" label="Con.">Con. 1</container>
                   <unittitle>Lawrence Technological University Lecture <unitdate type="inclusive" normal="1965-02-06">February 6, 1965</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
@@ -1716,7 +1716,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">1</container>
+                  <container type="othertype" label="Con.">Con. 1</container>
                   <unittitle>University of Arkansas Lecture <unitdate type="inclusive" normal="1969-04-10/1969-04-11">April 10-11, 1969</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
@@ -1729,7 +1729,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">1</container>
+                  <container type="othertype" label="Con.">Con. 1</container>
                   <unittitle>University of Michigan Lecture <unitdate type="inclusive" normal="1970-02-26">February 26, 1970</unitdate></unittitle>
                 </did>
                 <odd>
@@ -1739,21 +1739,21 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">1</container>
+                  <container type="othertype" label="Con.">Con. 1</container>
                   <unittitle>University of Michigan Lecture-"Quo Vadis," <unitdate type="inclusive" normal="1974">1974</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">1</container>
+                  <container type="othertype" label="Con.">Con. 1</container>
                   <unittitle>IBM Southfield-Energy Seminar <unitdate type="inclusive" normal="1976-11">November 1976</unitdate> (side A)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">1</container>
+                  <container type="othertype" label="Con.">Con. 1</container>
                   <unittitle>University of Michigan Brown Bag Lecture <unitdate type="inclusive" normal="1976-10">October 1976</unitdate> (side B)</unittitle>
                 </did>
                 <odd>
@@ -1763,7 +1763,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">1</container>
+                  <container type="othertype" label="Con.">Con. 1</container>
                   <unittitle>New York Institute of Technology Lecture <unitdate type="inclusive" normal="1977-04-25">April 25, 1977</unitdate> (side A)</unittitle>
                 </did>
                 <odd>
@@ -1773,14 +1773,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">1</container>
+                  <container type="othertype" label="Con.">Con. 1</container>
                   <unittitle>WCAR Interview with Aurora Hendricks-IBM Southfield <unitdate type="inclusive" normal="1977">1977</unitdate> (side B)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">1</container>
+                  <container type="othertype" label="Con.">Con. 1</container>
                   <unittitle>University of Nebraska Lecture <unitdate type="inclusive" normal="1977-11-10">November 10, 1977</unitdate></unittitle>
                 </did>
                 <odd>
@@ -1790,49 +1790,49 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">1</container>
+                  <container type="othertype" label="Con.">Con. 1</container>
                   <unittitle>Civita Seminar/University of Michigan-"Visualize," <unitdate type="inclusive" normal="1977">1977</unitdate> (side A)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">1</container>
+                  <container type="othertype" label="Con.">Con. 1</container>
                   <unittitle>"Mind-Left Side, Right Side," <unitdate type="inclusive" normal="1977">1977</unitdate> (side B)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">1</container>
+                  <container type="othertype" label="Con.">Con. 1</container>
                   <unittitle>Monograph Dictation <unitdate type="inclusive" normal="1978" certainty="approximate">circa 1978</unitdate> (side A)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">1</container>
+                  <container type="othertype" label="Con.">Con. 1</container>
                   <unittitle>University of Michigan Seminar-"Mind" and "Methodology," <unitdate type="inclusive" normal="1978-01-15">January 15, 1978</unitdate> (side B)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">1</container>
+                  <container type="othertype" label="Con.">Con. 1</container>
                   <unittitle>Dictations of Letters <unitdate type="inclusive" normal="1978">1978</unitdate> (side A)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">1</container>
+                  <container type="othertype" label="Con.">Con. 1</container>
                   <unittitle>Columbia University Lecture <unitdate type="inclusive" normal="1978-03">March 1978</unitdate> (side B)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">1</container>
+                  <container type="othertype" label="Con.">Con. 1</container>
                   <unittitle>Autonomous University of Guadalajara Seminar <unitdate type="inclusive" normal="1979-02-19/1979-02-20">February 19-20, 1979</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
@@ -1845,7 +1845,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">1</container>
+                  <container type="othertype" label="Con.">Con. 1</container>
                   <unittitle>Autonomous University of Guadalajara Seminar-Questions and Answers <unitdate type="inclusive" normal="1979-02-22">February 22, 1979</unitdate></unittitle>
                 </did>
               </c05>
@@ -1859,7 +1859,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>Louisiana State University Lecture <unitdate type="inclusive" normal="1979-09-25">September 25, 1979</unitdate> (side A)</unittitle>
                 </did>
                 <odd>
@@ -1869,7 +1869,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>Association of Collegiate Schools of Architecture Lecture <unitdate type="inclusive" normal="1979-10-06">October 6, 1979</unitdate> (side B)</unittitle>
                 </did>
                 <odd>
@@ -1879,14 +1879,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>University of Michigan Faculty Design Meeting <unitdate type="inclusive" normal="1979-10-30">October 30, 1979</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>University of Michigan Seminar-"Knowing Yourself, Your Mind," <unitdate type="inclusive" normal="1980-09">September 1980</unitdate> (side A)</unittitle>
                 </did>
                 <odd>
@@ -1896,21 +1896,21 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>University of Michigan Seminar-"Second Part Mind, First Part Design Methodology," <unitdate type="inclusive" normal="1980-09">September 1980</unitdate> (side B)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>University of Michigan Design Methodology Seminar <unitdate type="inclusive" normal="1980">1980</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>University of Kentucky Lecture <unitdate type="inclusive" normal="1980-10-06">October 6, 1980</unitdate> (side A)</unittitle>
                 </did>
                 <odd>
@@ -1920,21 +1920,21 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>University of Michigan Design Seminar-"Conceptualization," <unitdate type="inclusive" normal="1980-11">November 1980</unitdate> (side B)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>University of Michigan Seminar <unitdate type="inclusive" normal="1980">1980</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>University of Michigan Brown Bag Lecture-"Design Methodology," <unitdate type="inclusive" normal="1981-02-09">February 9, 1981</unitdate></unittitle>
                 </did>
                 <odd>
@@ -1944,42 +1944,42 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>University of Michigan-Methodology I Seminar <unitdate type="inclusive" normal="1981-09">September 1981</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>University of Michigan-Methodology I Seminar <unitdate type="inclusive" normal="1981-09">September 1981</unitdate> (side A)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>University of Michigan-Methodology II Seminar <unitdate type="inclusive" normal="1981">1981</unitdate> (side B)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>University of Pennsylvania Lecture <unitdate type="inclusive" normal="1981-10-21">October 21, 1981</unitdate> (side A)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>T. Wolfe Seminar-"From Our House to Bauhaus," <unitdate type="inclusive" normal="1981" certainty="approximate">circa 1981</unitdate> (side B)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>Pratt Institute Lecture <unitdate type="inclusive" normal="1981-12-04">December 4, 1981</unitdate> (side A)</unittitle>
                 </did>
                 <odd>
@@ -1989,14 +1989,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>University of Detroit Lecture <unitdate type="inclusive" normal="1982-01-29">January 29, 1982</unitdate> (side B)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>University of Oklahoma Lecture <unitdate type="inclusive" normal="1982-04-06">April 6, 1982</unitdate> (side A)</unittitle>
                 </did>
                 <odd>
@@ -2006,14 +2006,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>Impromptu Lecture-Ann Arbor <unitdate type="inclusive" normal="1982-04-12">April 12, 1982</unitdate> (side B)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>Ball State University Lecture <unitdate type="inclusive" normal="1982-04-14">April 14, 1982</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2023,14 +2023,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>University of Michigan-First Day Remarks and Dictation of Letters, <unitdate type="inclusive" normal="1982">Fall 1982</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">2</container>
+                  <container type="othertype" label="Con.">Con. 2</container>
                   <unittitle>University of Michigan-Methodology Seminar <unitdate type="inclusive" normal="1982">1982</unitdate></unittitle>
                 </did>
               </c05>
@@ -2044,21 +2044,21 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">3</container>
+                  <container type="othertype" label="Con.">Con. 3</container>
                   <unittitle>University of Michigan Seminar-"You and Your Mind," <unitdate type="inclusive" normal="1982">1982</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">3</container>
+                  <container type="othertype" label="Con.">Con. 3</container>
                   <unittitle>University of Michigan ACSA Lecture <unitdate type="inclusive" normal="1982-10-21">October 21, 1982</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">3</container>
+                  <container type="othertype" label="Con.">Con. 3</container>
                   <unittitle>University of Michigan Seminar-"Metaphor, Symbolism and Color" (goes with lecture "Symbolism and Metaphor") <unitdate type="inclusive" normal="1982-11">November 1982</unitdate> (side A)</unittitle>
                 </did>
                 <odd>
@@ -2068,7 +2068,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">3</container>
+                  <container type="othertype" label="Con.">Con. 3</container>
                   <unittitle>Cranbrook School Lecture <unitdate type="inclusive" normal="1982-11-04">November 4, 1982</unitdate> (side B)</unittitle>
                 </did>
                 <odd>
@@ -2078,7 +2078,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">3</container>
+                  <container type="othertype" label="Con.">Con. 3</container>
                   <unittitle>Texas A &amp; M University Lecture <unitdate type="inclusive" normal="1982-11-18">November 18, 1982</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2088,7 +2088,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">3</container>
+                  <container type="othertype" label="Con.">Con. 3</container>
                   <unittitle>Charles Gandee Interview for <title render="italic">Architectural Record</title>, <unitdate type="inclusive" normal="1983-01-10">January 10, 1983</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2098,7 +2098,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">3</container>
+                  <container type="othertype" label="Con.">Con. 3</container>
                   <unittitle>Charles Mertz Interview-Detroit Heritage/Midwest <unitdate type="inclusive" normal="1983-01-11">January 11, 1983</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2112,7 +2112,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">3</container>
-                    <container type="othertype" label="Con.">3</container>
+                    <container type="othertype" label="Con.">Con. 3</container>
                     <unittitle>Lecture I <unitdate type="inclusive" normal="1983-01-24">January 24, 1983</unitdate></unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
@@ -2125,7 +2125,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">3</container>
-                    <container type="othertype" label="Con.">3</container>
+                    <container type="othertype" label="Con.">Con. 3</container>
                     <unittitle>Lecture II <unitdate type="inclusive" normal="1983-01-31">January 31, 1983</unitdate></unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
@@ -2138,7 +2138,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">3</container>
-                    <container type="othertype" label="Con.">3</container>
+                    <container type="othertype" label="Con.">Con. 3</container>
                     <unittitle>Lecture III-Metamorphosis Design Methodology (tape labeled "Design Metamorphosis 1959-Now") <unitdate type="inclusive" normal="1983-02-14">February 14, 1983</unitdate></unittitle>
                   </did>
                   <odd>
@@ -2148,7 +2148,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">3</container>
-                    <container type="othertype" label="Con.">3</container>
+                    <container type="othertype" label="Con.">Con. 3</container>
                     <unittitle>Seminar I-"You and Your Mind, Knowing Yourself" (tape labeled "Revised Plym Lecture I") <unitdate type="inclusive" normal="1983-02-18">February 18, 1983</unitdate></unittitle>
                   </did>
                   <odd>
@@ -2158,7 +2158,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">3</container>
-                    <container type="othertype" label="Con.">3</container>
+                    <container type="othertype" label="Con.">Con. 3</container>
                     <unittitle>Bob DeHaven's Theory Seminar <unitdate type="inclusive" normal="1983-04-19">April 19, 1983</unitdate></unittitle>
                   </did>
                   <odd>
@@ -2168,7 +2168,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">3</container>
-                    <container type="othertype" label="Con.">3</container>
+                    <container type="othertype" label="Con.">Con. 3</container>
                     <unittitle>Faculty Colloquium I <unitdate type="inclusive" normal="1983-01-26">January 26, 1983</unitdate></unittitle>
                   </did>
                   <odd>
@@ -2178,7 +2178,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">3</container>
-                    <container type="othertype" label="Con.">3</container>
+                    <container type="othertype" label="Con.">Con. 3</container>
                     <unittitle>Faculty Colloquium II <unitdate type="inclusive" normal="1983-02-15">February 15, 1983</unitdate></unittitle>
                   </did>
                   <odd>
@@ -2200,7 +2200,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">3</container>
-                    <container type="othertype" label="Con.">4</container>
+                    <container type="othertype" label="Con.">Con. 4</container>
                     <unittitle>Faculty Colloquium III <unitdate type="inclusive" normal="1983-03-15">March 15, 1983</unitdate></unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
@@ -2213,7 +2213,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">3</container>
-                    <container type="othertype" label="Con.">4</container>
+                    <container type="othertype" label="Con.">Con. 4</container>
                     <unittitle>Forum I <unitdate type="inclusive" normal="1983-02-09">February 9, 1983</unitdate></unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
@@ -2226,7 +2226,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">3</container>
-                    <container type="othertype" label="Con.">4</container>
+                    <container type="othertype" label="Con.">Con. 4</container>
                     <unittitle>Forum II <unitdate type="inclusive" normal="1983-02-23">February 23, 1983</unitdate></unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
@@ -2239,7 +2239,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">3</container>
-                    <container type="othertype" label="Con.">4</container>
+                    <container type="othertype" label="Con.">Con. 4</container>
                     <unittitle>Forum III (Paulsen-Creese) <unitdate type="inclusive" normal="1983-03-14">March 14, 1983</unitdate></unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
@@ -2252,7 +2252,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">3</container>
-                    <container type="othertype" label="Con.">4</container>
+                    <container type="othertype" label="Con.">Con. 4</container>
                     <unittitle>Forum IV <unitdate type="inclusive" normal="1983-04-13">April 13, 1983</unitdate></unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
@@ -2266,21 +2266,21 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">4</container>
+                  <container type="othertype" label="Con.">Con. 4</container>
                   <unittitle>Ball State University-Telecon "Lunchline," <unitdate type="inclusive" normal="1983-03-15">March 15, 1983</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">4</container>
+                  <container type="othertype" label="Con.">Con. 4</container>
                   <unittitle>Illinois Institute of Technology Lecture <unitdate type="inclusive" normal="1983-04-05">April 5, 1983</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">4</container>
+                  <container type="othertype" label="Con.">Con. 4</container>
                   <unittitle>The Smithsonian Institution Lecture <unitdate type="inclusive" normal="1983-04-26">April 26, 1983</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2290,7 +2290,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">4</container>
+                  <container type="othertype" label="Con.">Con. 4</container>
                   <unittitle>Iowa State University Lecture <unitdate type="inclusive" normal="1983-05-09">May 9, 1983</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2300,7 +2300,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">4</container>
+                  <container type="othertype" label="Con.">Con. 4</container>
                   <unittitle>Urban Center Books Lecture (Municipal Art Society of New York) <unitdate type="inclusive" normal="1983-06-01">June 1, 1983</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2317,42 +2317,42 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">5</container>
+                  <container type="othertype" label="Con.">Con. 5</container>
                   <unittitle>Pavia, Italy Lecture <unitdate type="inclusive" normal="1983-07-21">July 21, 1983</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">5</container>
+                  <container type="othertype" label="Con.">Con. 5</container>
                   <unittitle>Charles Merz Interview on Saarinen <unitdate type="inclusive" normal="1983-08">August 1983</unitdate> (side A)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">5</container>
+                  <container type="othertype" label="Con.">Con. 5</container>
                   <unittitle>Marsha Miro Interview-"Baldwin," for <title render="italic">Detroit Free Press</title>, <unitdate type="inclusive" normal="1983-08-29">August 29, 1983</unitdate> (side B)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">5</container>
+                  <container type="othertype" label="Con.">Con. 5</container>
                   <unittitle>University of Michigan-First Day Seminar, "Fading," <unitdate type="inclusive" normal="1983-09-12">September 12, 1983</unitdate> (side A)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">5</container>
+                  <container type="othertype" label="Con.">Con. 5</container>
                   <unittitle>University of Michigan-Student Seminar, "Methodology/Yourself," <unitdate type="inclusive" normal="1983-09-26">September 26, 1983</unitdate> (side B)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">5</container>
+                  <container type="othertype" label="Con.">Con. 5</container>
                   <unittitle>Iowa AIA Convention Speech <unitdate type="inclusive" normal="1983-09-14">September 14, 1983</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2365,14 +2365,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">5</container>
+                  <container type="othertype" label="Con.">Con. 5</container>
                   <unittitle>Louisiana State University Lecture <unitdate type="inclusive" normal="1983-11-29">November 29, 1983</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">5</container>
+                  <container type="othertype" label="Con.">Con. 5</container>
                   <unittitle>University of Michigan Lecture-"Next Architecture," <unitdate type="inclusive" normal="1984-02-13">February 13, 1984</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2382,7 +2382,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">5</container>
+                  <container type="othertype" label="Con.">Con. 5</container>
                   <unittitle>University of Michigan Lecture-"Next Architecture-You and Your Mind/Methodology," <unitdate type="inclusive" normal="1984-03-05">March 5, 1984</unitdate> (side A)</unittitle>
                 </did>
                 <odd>
@@ -2392,14 +2392,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">5</container>
+                  <container type="othertype" label="Con.">Con. 5</container>
                   <unittitle>Texas Tech University Lecture-"Next Architecture, My Work," <unitdate type="inclusive" normal="1984-04">April 1984</unitdate> (side B)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">5</container>
+                  <container type="othertype" label="Con.">Con. 5</container>
                   <unittitle>University of Idaho and Washington State University Seminars <unitdate type="inclusive" normal="1984-04-26">April 26, 1984</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2409,21 +2409,21 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">5</container>
+                  <container type="othertype" label="Con.">Con. 5</container>
                   <unittitle>Robert Benson's Class on Eero Saarinen <unitdate type="inclusive" normal="1984-05-07">May 7, 1984</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">5</container>
+                  <container type="othertype" label="Con.">Con. 5</container>
                   <unittitle>Birmingham-Bloomfield Art Association Lecture <unitdate type="inclusive" normal="1984-06-04">June 4, 1984</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">5</container>
+                  <container type="othertype" label="Con.">Con. 5</container>
                   <unittitle>Robert Benson Interview-Regarding Domino's Farms Master Plan <unitdate type="inclusive" normal="1984-06-20">June 20, 1984</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2433,21 +2433,21 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">5</container>
+                  <container type="othertype" label="Con.">Con. 5</container>
                   <unittitle>Robert Benson Interview-Domino's Farms <unitdate type="inclusive" normal="1984-09-01">September 1, 1984</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">5</container>
+                  <container type="othertype" label="Con.">Con. 5</container>
                   <unittitle>University of Michigan Seminar-"Design Methodology-Knowing Yourself," <unitdate type="inclusive" normal="1984-09-17">September 17, 1984</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">5</container>
+                  <container type="othertype" label="Con.">Con. 5</container>
                   <unittitle>University of Michigan-Monaghan Lecture <unitdate type="inclusive" normal="1984-10-01">October 1, 1984</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2457,7 +2457,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">5</container>
+                  <container type="othertype" label="Con.">Con. 5</container>
                   <unittitle>University of Michigan Alumni Meeting-"Objectives and Manifestations of the Domino's Farms Project," <unitdate type="inclusive" normal="1984-10-12">October 12, 1984</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2472,7 +2472,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">6</container>
+                  <container type="othertype" label="Con.">Con. 6</container>
                   <unittitle>Virginia Tech Lecture-"Departures," <unitdate type="inclusive" normal="1984-11-07">November 7, 1984</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2482,7 +2482,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">6</container>
+                  <container type="othertype" label="Con.">Con. 6</container>
                   <unittitle>University of Michigan-T. S. Monaghan Lecture-"Concepts and Manifestations," <unitdate type="inclusive" normal="1984-11-12">November 12, 1984</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2492,14 +2492,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">6</container>
+                  <container type="othertype" label="Con.">Con. 6</container>
                   <unittitle>"Thoughts to Kay Kaiser Regarding Writing," <unitdate type="inclusive" normal="1984">1984</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">6</container>
+                  <container type="othertype" label="Con.">Con. 6</container>
                   <unittitle>Andrews University Lecture <unitdate type="inclusive" normal="1985-04-18">April 18, 1985</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
@@ -2512,14 +2512,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">6</container>
+                  <container type="othertype" label="Con.">Con. 6</container>
                   <unittitle>Benson IV Interview <unitdate type="inclusive" normal="1985-08-19">August 19, 1985</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">6</container>
+                  <container type="othertype" label="Con.">Con. 6</container>
                   <unittitle>University of Michigan Lecture-"The Virtue of Individuality," <unitdate type="inclusive" normal="1985-09-23">September 23, 1985</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2529,42 +2529,42 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">6</container>
+                  <container type="othertype" label="Con.">Con. 6</container>
                   <unittitle>University of Cincinnati Lecture <unitdate type="inclusive" normal="1985-10-01">October 1, 1985</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">6</container>
+                  <container type="othertype" label="Con.">Con. 6</container>
                   <unittitle>Colorado Springs AIA Lecture <unitdate type="inclusive" normal="1985-10-10">October 10, 1985</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">6</container>
+                  <container type="othertype" label="Con.">Con. 6</container>
                   <unittitle>University of Michigan-Honors Studio Seminar-"Design Methodology I and II," <unitdate type="inclusive" normal="1985">1985</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">6</container>
+                  <container type="othertype" label="Con.">Con. 6</container>
                   <unittitle><title render="italic">Architecture and Urbanism</title> Essay-1500 words, <unitdate type="inclusive" normal="1985">1985</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">6</container>
+                  <container type="othertype" label="Con.">Con. 6</container>
                   <unittitle>Montana State University Lecture-"Virtue of Individuality," <unitdate type="inclusive" normal="1986-01-23">January 23, 1986</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">6</container>
+                  <container type="othertype" label="Con.">Con. 6</container>
                   <unittitle>University of Michigan-316 Studio Lecture <unitdate type="inclusive" normal="1986-03-04">March 4, 1986</unitdate> (side A)</unittitle>
                 </did>
                 <odd>
@@ -2574,21 +2574,21 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">6</container>
+                  <container type="othertype" label="Con.">Con. 6</container>
                   <unittitle>Saarinen Office History <unitdate type="inclusive" normal="1979">1979</unitdate> (side B)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">6</container>
+                  <container type="othertype" label="Con.">Con. 6</container>
                   <unittitle>University of Texas Lecture-"Virtue of Individuality," <unitdate type="inclusive" normal="1986-03-12">March 12, 1986</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">3</container>
-                  <container type="othertype" label="Con.">6</container>
+                  <container type="othertype" label="Con.">Con. 6</container>
                   <unittitle>University of Michigan Panel on "Yama"-G. Olving, K. Brown, W. Jarrett, G. Birkerts <unitdate type="inclusive" normal="1986-03-17">March 17, 1986</unitdate></unittitle>
                 </did>
               </c05>
@@ -2602,14 +2602,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">7</container>
+                  <container type="othertype" label="Con.">Con. 7</container>
                   <unittitle>Tamama Interview on Japan TV-Corning Museum of Glass <unitdate type="inclusive" normal="1986-03-25">March 25, 1986</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">7</container>
+                  <container type="othertype" label="Con.">Con. 7</container>
                   <unittitle>Ohio State University Lecture-"Virtue of Individuality," <unitdate type="inclusive" normal="1986-04-23">April 23, 1986</unitdate> (side A)</unittitle>
                 </did>
                 <odd>
@@ -2619,28 +2619,28 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">7</container>
+                  <container type="othertype" label="Con.">Con. 7</container>
                   <unittitle>Frank Lloyd Wright Symposium Press Conference with T. S. Monaghan and Professor Bruno Zevi <unitdate type="inclusive" normal="1986-04">April 1986</unitdate> (side B)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">7</container>
+                  <container type="othertype" label="Con.">Con. 7</container>
                   <unittitle>London Glass Conference-Lecture and Panel Discussion <unitdate type="inclusive" normal="1986-04">April 1986</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">7</container>
+                  <container type="othertype" label="Con.">Con. 7</container>
                   <unittitle>London Glass Conference-Sum-Up, with T. S. Buechner <unitdate type="inclusive" normal="1986-04">April 1986</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">7</container>
+                  <container type="othertype" label="Con.">Con. 7</container>
                   <unittitle>Diana Lennon Interview for <title render="italic">Detroit Free Press</title>, <unitdate type="inclusive" normal="1986-07-29">July 29, 1986</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2650,7 +2650,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">7</container>
+                  <container type="othertype" label="Con.">Con. 7</container>
                   <unittitle>Jim Schwartz Interview <unitdate type="inclusive" normal="1986-11-06">November 6, 1986</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2660,14 +2660,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">7</container>
+                  <container type="othertype" label="Con.">Con. 7</container>
                   <unittitle>Wisconsin AIA Lecture <unitdate type="inclusive" normal="1986-11-07">November 7, 1986</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">7</container>
+                  <container type="othertype" label="Con.">Con. 7</container>
                   <unittitle>Papal Visit Interviews-Channel 4, Rich Myke, Pontiac Silverdome <unitdate type="inclusive" normal="1987">1987</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2677,7 +2677,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">7</container>
+                  <container type="othertype" label="Con.">Con. 7</container>
                   <unittitle>Jim Schwartz Interview for <title render="italic">Engineering News Record</title>, <unitdate type="inclusive" normal="1987-01-06">January 6, 1987</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2687,7 +2687,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">7</container>
+                  <container type="othertype" label="Con.">Con. 7</container>
                   <unittitle>University of Michigan Symposium-"Architectural Library of the Future," <unitdate type="inclusive" normal="1987-01-23">January 23, 1987</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2697,28 +2697,28 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">7</container>
+                  <container type="othertype" label="Con.">Con. 7</container>
                   <unittitle>University of Michigan Brown Bag Lecture-"How to Get a Job," <unitdate type="inclusive" normal="1987-03-16">March 16, 1987</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">7</container>
+                  <container type="othertype" label="Con.">Con. 7</container>
                   <unittitle>University of Michigan Lecture by Vincent Scully on Frank Lloyd Wright <unitdate type="inclusive" normal="1987-04">April 1987</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">7</container>
+                  <container type="othertype" label="Con.">Con. 7</container>
                   <unittitle>University of Michigan Brown Bag Lecture-"Metaphor" Seminar <unitdate type="inclusive" normal="1987-04-29">April 29, 1987</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">7</container>
+                  <container type="othertype" label="Con.">Con. 7</container>
                   <unittitle>Ball State University College of Architecture &amp; Planning Summer Workshop, Columbus, Indiana-"Saarinen Legacy," <unitdate type="inclusive" normal="1987-06-02">June 2, 1987</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2728,7 +2728,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">7</container>
+                  <container type="othertype" label="Con.">Con. 7</container>
                   <unittitle>Ball State University College of Architecture &amp; Planning Summer Workshop, Columbus, Indiana-"Organic Architecture-The Steady Core of the Modern Movement," <unitdate type="inclusive" normal="1987-06-04">June 4, 1987</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2745,21 +2745,21 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">8</container>
+                  <container type="othertype" label="Con.">Con. 8</container>
                   <unittitle>State Capital Presentation, Lansing, Michigan <unitdate type="inclusive" normal="1987-06-18">June 18, 1987</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">8</container>
+                  <container type="othertype" label="Con.">Con. 8</container>
                   <unittitle>Gordon Bugbee Interview <unitdate type="inclusive" normal="1987-06">June 1987</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">8</container>
+                  <container type="othertype" label="Con.">Con. 8</container>
                   <unittitle>Bob Bauer Interview for <title render="italic">Michigan Alumnus</title>-"Creativity," <unitdate type="inclusive" normal="1987-09-30">September 30, 1987</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2769,7 +2769,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">8</container>
+                  <container type="othertype" label="Con.">Con. 8</container>
                   <unittitle>University of Michigan Lecture-"Continuity," <unitdate type="inclusive" normal="1987-10-07">October 7, 1987</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2779,7 +2779,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">8</container>
+                  <container type="othertype" label="Con.">Con. 8</container>
                   <unittitle>AIA Omaha Convention Panel Discussion: H. N. Jacobson, Gibbs, G. Birkerts, Rose <unitdate type="inclusive" normal="1987-10">October 1987</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
@@ -2789,14 +2789,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">8</container>
+                  <container type="othertype" label="Con.">Con. 8</container>
                   <unittitle>Ann Arbor Township Meeting-Domino's Tower <unitdate type="inclusive" normal="1987-10-11">October 11, 1987</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">8</container>
+                  <container type="othertype" label="Con.">Con. 8</container>
                   <unittitle>Ann Arbor AIA Meeting-Domino's Farms <unitdate type="inclusive" normal="1987-11-05">November 5, 1987</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2806,7 +2806,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">8</container>
+                  <container type="othertype" label="Con.">Con. 8</container>
                   <unittitle>The Smithsonian Institution Lecture-"Organic Core of the Modern Movement," <unitdate type="inclusive" normal="1987-11-16">November 16, 1987</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2816,7 +2816,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">8</container>
+                  <container type="othertype" label="Con.">Con. 8</container>
                   <unittitle>Kathy Blair Interview for <title render="italic">Ann Arbor News</title>, <unitdate type="inclusive" normal="1987-12-29">December 29, 1987</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
@@ -2829,21 +2829,21 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">8</container>
+                  <container type="othertype" label="Con.">Con. 8</container>
                   <unittitle>Interview with Student Jan Iversen-"How Gunnar Birkerts Approaches Structure," <unitdate type="inclusive" normal="1988-01-07">January 7, 1988</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">8</container>
+                  <container type="othertype" label="Con.">Con. 8</container>
                   <unittitle>"Creativity, Subconscious, etc," <unitdate type="inclusive" normal="1988-01-16">January 16, 1988</unitdate> (side A)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">8</container>
+                  <container type="othertype" label="Con.">Con. 8</container>
                   <unittitle>Yasser Mansour Interview <unitdate type="inclusive" normal="1988-01-16">January 16, 1988</unitdate> (side B)</unittitle>
                 </did>
                 <odd>
@@ -2853,7 +2853,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">8</container>
+                  <container type="othertype" label="Con.">Con. 8</container>
                   <unittitle>State Capital Restoration Master Plan Presentation, Lansing, Michigan-R. Frank and G. Birkerts <unitdate type="inclusive" normal="1988-02-02">February 2, 1988</unitdate> (tape dated January 2, 1988)</unittitle>
                 </did>
                 <odd>
@@ -2863,7 +2863,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">8</container>
+                  <container type="othertype" label="Con.">Con. 8</container>
                   <unittitle>University of Michigan Honors Studio-"You and Your Mind," <unitdate type="inclusive" normal="1988-10">October 1988</unitdate></unittitle>
                 </did>
               </c05>
@@ -2875,7 +2875,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">9</container>
+                  <container type="othertype" label="Con.">Con. 9</container>
                   <unittitle>Yasser Mansour Interview <unitdate type="inclusive" normal="1988-10-15">October 15, 1988</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2885,14 +2885,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">9</container>
+                  <container type="othertype" label="Con.">Con. 9</container>
                   <unittitle>Mississippi State University-Tele-Interview <unitdate type="inclusive" normal="1988-10-20">October 20, 1988</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">9</container>
+                  <container type="othertype" label="Con.">Con. 9</container>
                   <unittitle>Steelcase Lecture, Grand Rapids, Michigan-"Power of the Mind," <unitdate type="inclusive" normal="1988-11-15">November 15, 1988</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2905,14 +2905,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">9</container>
+                  <container type="othertype" label="Con.">Con. 9</container>
                   <unittitle>University of Michigan Lecture-"Concepts/Mind," <unitdate type="inclusive" normal="1988-11-16">November 16, 1988</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">9</container>
+                  <container type="othertype" label="Con.">Con. 9</container>
                   <unittitle>Yasser Mansour Interview <unitdate type="inclusive" normal="1988-12-31">December 31, 1988</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2922,14 +2922,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">9</container>
+                  <container type="othertype" label="Con.">Con. 9</container>
                   <unittitle>Tower News Announcement-WWJ Channel 4 <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">9</container>
+                  <container type="othertype" label="Con.">Con. 9</container>
                   <unittitle>University of Michigan Lecture-"The Organic Does Not Deconstruct," <unitdate type="inclusive" normal="1989-01-12">January 12, 1989</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2942,21 +2942,21 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">9</container>
+                  <container type="othertype" label="Con.">Con. 9</container>
                   <unittitle>Alberta Association of Architects Speech, Calgary <unitdate type="inclusive" normal="1989-04-08/1989-04-09">April 8-9, 1989</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">9</container>
+                  <container type="othertype" label="Con.">Con. 9</container>
                   <unittitle>Interview with Landon Walker and Bill Awddey, Metro/Jacksonville, Florida <unitdate type="inclusive" normal="1989-04-27">April 27, 1989</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">9</container>
+                  <container type="othertype" label="Con.">Con. 9</container>
                   <unittitle>University of Michigan John Dinkeloo Memorial Lecture-"The Virtue of Being Serious," <unitdate type="inclusive" normal="1990-03-01">March 1, 1990</unitdate> (tape dated, <unitdate type="inclusive" normal="1990-04-01">April 1, 1990</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2966,7 +2966,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">9</container>
+                  <container type="othertype" label="Con.">Con. 9</container>
                   <unittitle>Walker Art Center Lecture, Minneapolis, Minnesota-"Federal Reserve Bank Retrofit," <unitdate type="inclusive" normal="1990-07-18">July 18, 1990</unitdate></unittitle>
                 </did>
                 <odd>
@@ -2976,7 +2976,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">9</container>
+                  <container type="othertype" label="Con.">Con. 9</container>
                   <unittitle>Dayton AIA Speech-"Retrospective and Current," <unitdate type="inclusive" normal="1991-05-16">May 16, 1991</unitdate></unittitle>
                 </did>
               </c05>
@@ -2988,14 +2988,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">9</container>
+                  <container type="othertype" label="Con.">Con. 9</container>
                   <unittitle>University of Michigan Brown Bag Lecture <unitdate type="inclusive" normal="1991-10-18">October 18, 1991</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">9</container>
+                  <container type="othertype" label="Con.">Con. 9</container>
                   <unittitle>"Conversations Regarding the Future of Architecture" and "Frank Lloyd Wright," <unitdate>undated</unitdate></unittitle>
                 </did>
               </c05>
@@ -3013,7 +3013,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">4</container>
-                    <container type="othertype" label="Con.">10</container>
+                    <container type="othertype" label="Con.">Con. 10</container>
                     <unittitle>Lecture I <unitdate type="inclusive" normal="1990-10-31">October 31, 1990</unitdate></unittitle>
                   </did>
                   <odd>
@@ -3026,7 +3026,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">4</container>
-                    <container type="othertype" label="Con.">10</container>
+                    <container type="othertype" label="Con.">Con. 10</container>
                     <unittitle>Lecture II-"Organic Architecture," <unitdate type="inclusive" normal="1990-11-13">November 13, 1990</unitdate></unittitle>
                   </did>
                   <odd>
@@ -3036,7 +3036,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">4</container>
-                    <container type="othertype" label="Con.">10</container>
+                    <container type="othertype" label="Con.">Con. 10</container>
                     <unittitle>Elinor Weinel Seminar-"Nature of Imagination," and "Necessity for Design Process," <unitdate type="inclusive" normal="1990-10-16">October 16, 1990</unitdate></unittitle>
                   </did>
                   <odd>
@@ -3046,7 +3046,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">4</container>
-                    <container type="othertype" label="Con.">10</container>
+                    <container type="othertype" label="Con.">Con. 10</container>
                     <unittitle>Jim Kudrna Seminar-"Introduction to Education," <unitdate type="inclusive" normal="1990-10-16">October 16, 1990</unitdate></unittitle>
                   </did>
                   <odd>
@@ -3056,7 +3056,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">4</container>
-                    <container type="othertype" label="Con.">10</container>
+                    <container type="othertype" label="Con.">Con. 10</container>
                     <unittitle>Tom Brine Seminar-"Office Practice," <unitdate type="inclusive" normal="1990-10-16">October 16, 1990</unitdate></unittitle>
                   </did>
                   <odd>
@@ -3066,7 +3066,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">4</container>
-                    <container type="othertype" label="Con.">10</container>
+                    <container type="othertype" label="Con.">Con. 10</container>
                     <unittitle>Elinor Weinel Seminar-"The Act of Representation," <unitdate type="inclusive" normal="1990-10-30">October 30, 1990</unitdate></unittitle>
                   </did>
                   <odd>
@@ -3076,7 +3076,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">4</container>
-                    <container type="othertype" label="Con.">10</container>
+                    <container type="othertype" label="Con.">Con. 10</container>
                     <unittitle>Elinor Weinel Seminar-"Society and Self," <unitdate type="inclusive" normal="1990-11-05">November 5, 1990</unitdate></unittitle>
                   </did>
                   <odd>
@@ -3086,7 +3086,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">4</container>
-                    <container type="othertype" label="Con.">10</container>
+                    <container type="othertype" label="Con.">Con. 10</container>
                     <unittitle>Elinor Weinel Seminar-"Eero Saarinen Slide Show," <unitdate type="inclusive" normal="1990-11-05">November 5, 1990</unitdate></unittitle>
                   </did>
                   <odd>
@@ -3096,7 +3096,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">4</container>
-                    <container type="othertype" label="Con.">10</container>
+                    <container type="othertype" label="Con.">Con. 10</container>
                     <unittitle>Elinor Weinel Theory Seminar <unitdate type="inclusive" normal="1990-11-13">November 13, 1990</unitdate></unittitle>
                   </did>
                   <odd>
@@ -3106,7 +3106,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">4</container>
-                    <container type="othertype" label="Con.">10</container>
+                    <container type="othertype" label="Con.">Con. 10</container>
                     <unittitle>Jim Kudrna Theory Seminar <unitdate type="inclusive" normal="1990-11-13">November 13, 1990</unitdate></unittitle>
                   </did>
                   <odd>
@@ -3116,7 +3116,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">4</container>
-                    <container type="othertype" label="Con.">10</container>
+                    <container type="othertype" label="Con.">Con. 10</container>
                     <unittitle>Jim Kudrna Third Year Seminar <unitdate type="inclusive" normal="1990-11-15">November 15, 1990</unitdate></unittitle>
                   </did>
                   <odd>
@@ -3126,7 +3126,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">4</container>
-                    <container type="othertype" label="Con.">10</container>
+                    <container type="othertype" label="Con.">Con. 10</container>
                     <unittitle>Elinor Weinel Seminar-"Context, Site, etc," <unitdate type="inclusive" normal="1990-11-15">November 15, 1990</unitdate></unittitle>
                   </did>
                   <odd>
@@ -3139,7 +3139,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">4</container>
-                    <container type="othertype" label="Con.">10</container>
+                    <container type="othertype" label="Con.">Con. 10</container>
                     <unittitle>Elinor Weinel Seminar-"Means, Materials and Structure," <unitdate type="inclusive" normal="1990-12-05">December 5, 1990</unitdate></unittitle>
                   </did>
                   <odd>
@@ -3149,7 +3149,7 @@
                 <c06 level="file">
                   <did>
                     <container type="box" label="Box">4</container>
-                    <container type="othertype" label="Con.">10</container>
+                    <container type="othertype" label="Con.">Con. 10</container>
                     <unittitle>Elinor Weinel Seminar-"The Role of Critique," <unitdate type="inclusive" normal="1990-12-06">December 6, 1990</unitdate></unittitle>
                   </did>
                   <odd>
@@ -3160,7 +3160,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">10</container>
+                  <container type="othertype" label="Con.">Con. 10</container>
                   <unittitle>Tulsa AIA and Students-Lecture <unitdate type="inclusive" normal="1990-10-18">October 18, 1990</unitdate></unittitle>
                 </did>
               </c05>
@@ -3174,7 +3174,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">11</container>
+                  <container type="othertype" label="Con.">Con. 11</container>
                   <unittitle>University of Wisconsin Lecture, Milwaukee-"Polygonal/Underground," <unitdate type="inclusive" normal="1992-03-25">March 25, 1992</unitdate></unittitle>
                 </did>
                 <odd>
@@ -3184,14 +3184,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">11</container>
+                  <container type="othertype" label="Con.">Con. 11</container>
                   <unittitle>Wes Janz Interview-Saarinen <unitdate type="inclusive" normal="1992-07-22">July 22, 1992</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">11</container>
+                  <container type="othertype" label="Con.">Con. 11</container>
                   <unittitle>Reflective Studio Seminar <unitdate type="inclusive" normal="1993-03-13">March 13, 1993</unitdate></unittitle>
                 </did>
                 <odd>
@@ -3201,7 +3201,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">11</container>
+                  <container type="othertype" label="Con.">Con. 11</container>
                   <unittitle>Lawrence Technological University Lecture-"Expression," <unitdate type="inclusive" normal="1993-04-01">April 1, 1993</unitdate></unittitle>
                 </did>
                 <odd>
@@ -3211,7 +3211,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">11</container>
+                  <container type="othertype" label="Con.">Con. 11</container>
                   <unittitle>Los Angeles Lecture-"Process and Expression," <unitdate type="inclusive" normal="1993-05-21">May 21, 1993</unitdate></unittitle>
                 </did>
                 <odd>
@@ -3221,7 +3221,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">11</container>
+                  <container type="othertype" label="Con.">Con. 11</container>
                   <unittitle>University of Colorado and N. Colorado AIA Lecture <unitdate type="inclusive" normal="1993-10-15">October 15, 1993</unitdate></unittitle>
                 </did>
                 <odd>
@@ -3231,7 +3231,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">11</container>
+                  <container type="othertype" label="Con.">Con. 11</container>
                   <unittitle>Interview with Dr. George M. Goodwin-"Frank Lloyd Wright and Domino's Farms" <unitdate type="inclusive" normal="1993-12-16">December 16, 1993</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
@@ -3241,7 +3241,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">11</container>
+                  <container type="othertype" label="Con.">Con. 11</container>
                   <unittitle>Church of the Servant Dedication Lecture, Grand Rapids, Michigan <unitdate type="inclusive" normal="1994-02-13">February 13, 1994</unitdate></unittitle>
                 </did>
                 <odd>
@@ -3251,7 +3251,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">11</container>
+                  <container type="othertype" label="Con.">Con. 11</container>
                   <unittitle>Interview with Ted Sandstra for <title render="italic">Dialogue</title> (Calvin College Journal), <unitdate type="inclusive" normal="1994-03-14">March 14, 1994</unitdate></unittitle>
                 </did>
                 <odd>
@@ -3261,21 +3261,21 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">11</container>
+                  <container type="othertype" label="Con.">Con. 11</container>
                   <unittitle>Fiat/Torino Interview <unitdate type="inclusive" normal="1994-03-28">March 28, 1994</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">11</container>
+                  <container type="othertype" label="Con.">Con. 11</container>
                   <unittitle>Kemper Museum Opening, Kansas City <unitdate type="inclusive" normal="1994-09-26">September 26, 1994</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">11</container>
+                  <container type="othertype" label="Con.">Con. 11</container>
                   <unittitle>Milwaukee, Wisconsin Lecture-"Design Process . ," <unitdate type="inclusive" normal="1994-10-07">October 7, 1994</unitdate></unittitle>
                 </did>
                 <odd>
@@ -3293,14 +3293,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">12</container>
+                  <container type="othertype" label="Con.">Con. 12</container>
                   <unittitle>Michigan Tech. University Board of Control-9:30 AM Session <unitdate type="inclusive" normal="1994-11-18">November 18, 1994</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">12</container>
+                  <container type="othertype" label="Con.">Con. 12</container>
                   <unittitle>Bill Lacy Interview Regarding Purchase College, SUNY Master Plan <unitdate type="inclusive" normal="1996-06-19">June 19, 1996</unitdate></unittitle>
                 </did>
                 <odd>
@@ -3310,14 +3310,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">12</container>
+                  <container type="othertype" label="Con.">Con. 12</container>
                   <unittitle>Dunedin (NZ) Interview for <title render="italic">Otago Daily Times</title>, <unitdate type="inclusive" normal="1996-08-28">August 28, 1996</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">12</container>
+                  <container type="othertype" label="Con.">Con. 12</container>
                   <unittitle>New Zealand Institute of Architects Lecture, Dunedin, NZ <unitdate type="inclusive" normal="1996-08-29">August 29, 1996</unitdate></unittitle>
                 </did>
                 <odd>
@@ -3330,14 +3330,14 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">12</container>
+                  <container type="othertype" label="Con.">Con. 12</container>
                   <unittitle>Delft Underground Symposium <unitdate type="inclusive" normal="1997-03-17/1997-03-18">March 17-18, 1997</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">12</container>
+                  <container type="othertype" label="Con.">Con. 12</container>
                   <unittitle>Delft Underground Workshop <unitdate type="inclusive" normal="1997-03-19">March 19, 1997</unitdate></unittitle>
                 </did>
                 <odd>
@@ -3347,7 +3347,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">12</container>
+                  <container type="othertype" label="Con.">Con. 12</container>
                   <unittitle>Modena Speech <unitdate type="inclusive" normal="1997-09-19/1997-09-20">September 19-20, 1997</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
@@ -3360,28 +3360,28 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">12</container>
+                  <container type="othertype" label="Con.">Con. 12</container>
                   <unittitle>Columbus, Indiana Lecture-"You Are What You Have Been," <unitdate type="inclusive" normal="1998-01-11">January 11, 1998</unitdate></unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">12</container>
+                  <container type="othertype" label="Con.">Con. 12</container>
                   <unittitle>Columbus, Indiana Lecture <unitdate type="inclusive" normal="1998-01-11">January 11, 1998</unitdate> (side A)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">12</container>
+                  <container type="othertype" label="Con.">Con. 12</container>
                   <unittitle>Wes Roy Radio Interview and Cheryl Scott Interview for <title render="italic">The Republic</title>, <unitdate type="inclusive" normal="1998">1998</unitdate> (side B)</unittitle>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">12</container>
+                  <container type="othertype" label="Con.">Con. 12</container>
                   <unittitle>UIA/UNESCO Seminar at Cranbrook-"Lifelong Learning," <unitdate type="inclusive" normal="1998">1998</unitdate></unittitle>
                   <physdesc>
                     <physfacet>microcassette</physfacet>
@@ -3391,7 +3391,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">4</container>
-                  <container type="othertype" label="Con.">12</container>
+                  <container type="othertype" label="Con.">Con. 12</container>
                   <unittitle><genreform normal="Motion pictures">Filmstrip Tape</genreform>-"Welcome to the New Federal Reserve Bank," <unitdate>undated</unitdate></unittitle>
                 </did>
               </c05>

--- a/Real_Masters_all/cjsum.xml
+++ b/Real_Masters_all/cjsum.xml
@@ -2226,7 +2226,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">1</container>
+                  <container type="othertype" label="No.">No. 1</container>
                   <unitid>A</unitid>
                   <unittitle>Scenery, pretty; Obara Ike <unitdate type="inclusive" normal="1950-05">May 1950</unitdate></unittitle>
                 </did>
@@ -2234,7 +2234,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">1</container>
+                  <container type="othertype" label="No.">No. 1</container>
                   <unitid>B</unitid>
                   <unittitle>Scenery, Inland Sea, Tsu Kubo-gun, Shoson, Iwakwa Jinja dolmen <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -2247,7 +2247,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">1</container>
+                    <container type="othertype" label="No.">No. 1</container>
                     <unitid>Cl</unitid>
                     <unittitle>Hatake-Niiike <unitdate type="inclusive" normal="1951-06-27">June 27, 1951</unitdate></unittitle>
                   </did>
@@ -2255,7 +2255,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">1</container>
+                    <container type="othertype" label="No.">No. 1</container>
                     <unitid>C2</unitid>
                     <unittitle>Niiike-Path up hill, palms <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                   </did>
@@ -2263,7 +2263,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">1</container>
+                    <container type="othertype" label="No.">No. 1</container>
                     <unitid>C3</unitid>
                     <unittitle>Niiike-Hill dug back for more space <unitdate type="inclusive" normal="1951-08-01">August 1, 1951</unitdate></unittitle>
                   </did>
@@ -2271,7 +2271,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">1</container>
+                    <container type="othertype" label="No.">No. 1</container>
                     <unitid>C4</unitid>
                     <unittitle>Un-labeled; man in grain field</unittitle>
                   </did>
@@ -2280,7 +2280,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">1</container>
+                  <container type="othertype" label="No.">No. 1</container>
                   <unitid>D</unitid>
                   <unittitle>Transportation-Niiike, view of plain by Takeshi's house <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                 </did>
@@ -2288,7 +2288,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">1</container>
+                  <container type="othertype" label="No.">No. 1</container>
                   <unitid>E</unitid>
                   <unittitle>City streets and shops (not received)</unittitle>
                 </did>
@@ -2296,7 +2296,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">1</container>
+                  <container type="othertype" label="No.">No. 1</container>
                   <unitid>F</unitid>
                   <unittitle>Industry and Labor, Kibitsu-hiko shrine <unitdate type="inclusive" normal="1954-01">January 1954</unitdate></unittitle>
                 </did>
@@ -2304,7 +2304,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">1</container>
+                  <container type="othertype" label="No.">No. 1</container>
                   <unitid>G</unitid>
                   <unittitle>Re. center, Okayame (not received)</unittitle>
                 </did>
@@ -2312,7 +2312,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">1</container>
+                  <container type="othertype" label="No.">No. 1</container>
                   <unitid>H</unitid>
                   <unittitle>Animal care, Tsutsu farmer with plow and Korean ox. Old woman with sun hat <unitdate type="inclusive" normal="1950-08">August 1950</unitdate></unittitle>
                 </did>
@@ -2320,7 +2320,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">1</container>
+                  <container type="othertype" label="No.">No. 1</container>
                   <unitid>J</unitid>
                   <unittitle>Fertilizer, cultivation (not received)</unittitle>
                 </did>
@@ -2333,7 +2333,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">1</container>
+                    <container type="othertype" label="No.">No. 1</container>
                     <unitid>Kl</unitid>
                     <unittitle>Niiike-removing rice seedlings from seedbeds for transplanting <unitdate type="inclusive" normal="1950-06-23">June 23, 1950</unitdate></unittitle>
                   </did>
@@ -2341,7 +2341,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">1</container>
+                    <container type="othertype" label="No.">No. 1</container>
                     <unitid>K2</unitid>
                     <unittitle>Niiike paddy <unitdate type="inclusive" normal="1951-11-11">November 11, 1951</unitdate></unittitle>
                   </did>
@@ -2349,7 +2349,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>K3</unitid>
                     <unittitle>Niiike Beginning of rice Harvest <unitdate type="inclusive" normal="1950">1950</unitdate></unittitle>
                   </did>
@@ -2357,7 +2357,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>K4</unitid>
                     <unittitle>Okayema; Niiike-I-gusa and new rice, early <unitdate type="inclusive" normal="1950-06">June 1950</unitdate></unittitle>
                   </did>
@@ -2365,7 +2365,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>K5</unitid>
                     <unittitle>Niiike-cutting rice <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                   </did>
@@ -2373,7 +2373,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>K6</unitid>
                     <unittitle>Niiike-paddy, October. 8 <unitdate type="inclusive" normal="1951">1951</unitdate></unittitle>
                   </did>
@@ -2381,7 +2381,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>K7</unitid>
                     <unittitle>Niiike-paddy <unitdate type="inclusive" normal="1951-11-06">November 6, 1951</unitdate></unittitle>
                   </did>
@@ -2389,7 +2389,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>K8</unitid>
                     <unittitle>Niiike-paddy, rice transplanting, end of <unitdate type="inclusive" normal="1950-06">June 1950</unitdate></unittitle>
                   </did>
@@ -2398,7 +2398,7 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">2</container>
+                  <container type="othertype" label="No.">No. 2</container>
                   <unitid>L</unitid>
                   <unittitle>Wheat-ripening mug, above Kato Tadamatsu's house, Matsunagi <unitdate type="inclusive" normal="1951-06">June 1951</unitdate></unittitle>
                 </did>
@@ -2411,7 +2411,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>Ml</unitid>
                     <unittitle>Niiike-placing I-gusa on road <unitdate type="inclusive" normal="1951-07-20">July 20, 1951</unitdate></unittitle>
                   </did>
@@ -2419,7 +2419,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>M2</unitid>
                     <unittitle>Niiike-bunching and laying I-gusa on road <unitdate type="inclusive" normal="1951-07">July 1951</unitdate></unittitle>
                   </did>
@@ -2427,7 +2427,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>M3</unitid>
                     <unittitle>Niiike-bunching I-gusa <unitdate type="inclusive" normal="1951-07-20">July 20, 1951</unitdate></unittitle>
                   </did>
@@ -2435,7 +2435,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>M4</unitid>
                     <unittitle>Niiike-placing I-gusa on road, July 20, 195</unittitle>
                   </did>
@@ -2443,7 +2443,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>M5</unitid>
                     <unittitle>Niiike-bunching I-gusa <unitdate type="inclusive" normal="1951-07-24">July 24, 1951</unitdate></unittitle>
                   </did>
@@ -2451,7 +2451,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>M6</unitid>
                     <unittitle>Niiike cutting I-gusa <unitdate type="inclusive" normal="1951-07-24">July 24, 1951</unitdate></unittitle>
                   </did>
@@ -2459,7 +2459,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>M7</unitid>
                     <unittitle>Near Niiike-I-gusa on bicycle <unitdate type="inclusive" normal="1951-08-31">August 31, 1951</unitdate></unittitle>
                   </did>
@@ -2467,7 +2467,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>M8</unitid>
                     <unittitle>Niiike-placing I-gusa on road <unitdate type="inclusive" normal="1951-07-20">July 20, 1951</unitdate></unittitle>
                   </did>
@@ -2475,7 +2475,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>M9</unitid>
                     <unittitle>Niiike turning and drying I-gusa <unitdate type="inclusive" normal="1951-07-24">July 24, 1951</unitdate></unittitle>
                   </did>
@@ -2483,7 +2483,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>M10</unitid>
                     <unittitle>Niiike-starting to bunch and tie I-gusa <unitdate type="inclusive" normal="1951-07-24">July 24, 1951</unitdate></unittitle>
                   </did>
@@ -2491,7 +2491,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>M11</unitid>
                     <unittitle>Niiike-cutting to bunch and tie I-gusa, July 24, 195</unittitle>
                   </did>
@@ -2505,7 +2505,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>N1</unitid>
                     <unittitle>Niiike-Hatake <unitdate type="inclusive" normal="1951-10-08">October 8, 1951</unitdate></unittitle>
                   </did>
@@ -2513,7 +2513,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>N2</unitid>
                     <unittitle>Niiike-drying gourd in Sensei's yard <unitdate type="inclusive" normal="1951-08">August 1951</unitdate></unittitle>
                   </did>
@@ -2521,7 +2521,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>N3</unitid>
                     <unittitle>Niiike-Sensei in his dry field <unitdate type="inclusive" normal="1951-06-23">June 23, 1951</unitdate></unittitle>
                   </did>
@@ -2529,7 +2529,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>N4</unitid>
                     <unittitle>Niiike-Hatake <unitdate type="inclusive" normal="1951-09-20">September 20, 1951</unitdate></unittitle>
                   </did>
@@ -2537,7 +2537,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>N5</unitid>
                     <unittitle>Niiike-Hatake <unitdate type="inclusive" normal="1951-11-06">November 6, 1951</unitdate></unittitle>
                   </did>
@@ -2545,7 +2545,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>N6</unitid>
                     <unittitle>Niiike-Chicken-grass, sesame, children <unitdate type="inclusive" normal="1950-08-23">August 23, 1950</unitdate></unittitle>
                   </did>
@@ -2553,7 +2553,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>N7</unitid>
                     <unittitle>Niiike-Threshing naked barley <unitdate type="inclusive" normal="1950-05-29">May 29, 1950</unitdate></unittitle>
                   </did>
@@ -2561,7 +2561,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>N8</unitid>
                     <unittitle>Kawaoka-Natane mugi beyond <unitdate type="inclusive" normal="1951-05-25">May 25, 1951</unitdate></unittitle>
                   </did>
@@ -2569,7 +2569,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>N9</unitid>
                     <unittitle>-Niiike-Isamu's vegetable garden <unitdate type="inclusive" normal="1951-05-10">May 10, 1951</unitdate></unittitle>
                   </did>
@@ -2577,7 +2577,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>N10</unitid>
                     <unittitle>Sensei by neighbor's hemp <unitdate type="inclusive" normal="1951-06-23">June 23, 1951</unitdate></unittitle>
                   </did>
@@ -2591,7 +2591,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">2</container>
+                    <container type="othertype" label="No.">No. 2</container>
                     <unitid>P1</unitid>
                     <unittitle>Kamo-son, houses, strawshacks <unitdate type="inclusive" normal="1950-06-12">June 12, 1950</unitdate></unittitle>
                   </did>
@@ -2599,7 +2599,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>P2</unitid>
                     <unittitle>Niiike-scarecrow <unitdate type="inclusive" normal="1951-09-28">September 28, 1951</unitdate></unittitle>
                   </did>
@@ -2607,7 +2607,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>P3</unitid>
                     <unittitle>Niiike-Mugi beyond, Akashi Sendo, drying clay. <unitdate type="inclusive" normal="1951-05-11">May 11, 1951</unitdate></unittitle>
                   </did>
@@ -2621,7 +2621,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>Q1</unitid>
                     <unittitle>Hiroshima-oyster beds <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                   </did>
@@ -2629,7 +2629,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>Q2</unitid>
                     <unittitle>Takashima-(Okayama) Fisherman collecting seaweed from boat <unitdate type="inclusive" normal="1950-07">July 1950</unitdate></unittitle>
                   </did>
@@ -2643,7 +2643,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>R1</unitid>
                     <unittitle>Taisho pond <unitdate type="inclusive" normal="1951-08-23">August 23, 1951</unitdate></unittitle>
                   </did>
@@ -2651,7 +2651,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>R2</unitid>
                     <unittitle>Niiike-irrigation pond <unitdate type="inclusive" normal="1951-07-20">July 20, 1951</unitdate></unittitle>
                   </did>
@@ -2665,7 +2665,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>Tl</unitid>
                     <unittitle>Unidentified</unittitle>
                   </did>
@@ -2673,7 +2673,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>T2</unitid>
                     <unittitle>Arifuku Joshin in priest's funeral regalia <unitdate type="inclusive" normal="1951-06">June 1951</unitdate></unittitle>
                   </did>
@@ -2681,7 +2681,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>T3</unitid>
                     <unittitle>Children in road, Niiike <unitdate type="inclusive" normal="1950-08">August 1950</unitdate></unittitle>
                   </did>
@@ -2689,7 +2689,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>T4</unitid>
                     <unittitle>Pilgrim at Koboji <unitdate type="inclusive" normal="1950-05">May 1950</unitdate></unittitle>
                   </did>
@@ -2697,7 +2697,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>T5</unitid>
                     <unittitle>Woman in Lagitojin (winterwear) Mr. Koya winnowing <unitdate type="inclusive" normal="1950-08">August 1950</unitdate></unittitle>
                   </did>
@@ -2711,7 +2711,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>U1</unitid>
                     <unittitle>Niiike-new Neya, Nov</unittitle>
                   </did>
@@ -2719,7 +2719,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>U2</unitid>
                     <unittitle>Niiike-Sensei's shed, Persimmon Tree</unittitle>
                   </did>
@@ -2728,7 +2728,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">3</container>
+                  <container type="othertype" label="No.">No. 3</container>
                   <unitid>V</unitid>
                   <unittitle>Architecture-fine buildings, Mori Castle ruins on Hisashiyama <unitdate type="inclusive" normal="1950-08-23">August 23, 1950</unitdate></unittitle>
                 </did>
@@ -2741,7 +2741,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>W1</unitid>
                     <unittitle>Sensei's House-Niiike <unitdate type="inclusive" normal="1950-05">May 1950</unitdate></unittitle>
                   </did>
@@ -2749,7 +2749,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>W2</unitid>
                     <unittitle>Niiike-Takeshi's new house <unitdate type="inclusive" normal="1950-07">July 1950</unitdate></unittitle>
                   </did>
@@ -2757,7 +2757,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>W3</unitid>
                     <unittitle>Niiike-New Neya <unitdate type="inclusive" normal="1951-11-06">November 6, 1951</unitdate></unittitle>
                   </did>
@@ -2765,7 +2765,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>W4</unitid>
                     <unittitle>Niiike New house and black fence set in paddy scene <unitdate type="inclusive" normal="1950-07">July 1950</unitdate></unittitle>
                   </did>
@@ -2779,7 +2779,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>WA1</unitid>
                     <unittitle>Niiike-, Mayor H. Asae's new cow shed, an amateur construction, before thatching, walling <unitdate type="inclusive" normal="1950-03">March 1950</unitdate></unittitle>
                   </did>
@@ -2787,7 +2787,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>WA2</unitid>
                     <unittitle>Niiike-Rethatching I-Kokuji's house <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                   </did>
@@ -2795,7 +2795,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>WA3</unitid>
                     <unittitle>Niiike-yard of Tadashi's house <unitdate type="inclusive" normal="1950-07">July 1950</unitdate></unittitle>
                   </did>
@@ -2803,7 +2803,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>WA4</unitid>
                     <unittitle>Okayama-tile making, en route to Niiike <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                   </did>
@@ -2811,7 +2811,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>WA5</unitid>
                     <unittitle>Niiike-Hiroshi's new barn, foundation and lumber <unitdate type="inclusive" normal="1951-01">January 1951</unitdate></unittitle>
                   </did>
@@ -2819,7 +2819,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>WA6</unitid>
                     <unittitle>Niiike-New thatch roof, Shimobayashi <unitdate type="inclusive" normal="1950-09">September 1950</unitdate></unittitle>
                   </did>
@@ -2827,7 +2827,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>WA7</unitid>
                     <unittitle>Unidentified (thatcher?)</unittitle>
                   </did>
@@ -2835,7 +2835,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>WA8</unitid>
                     <unittitle>Niiike-new house <unitdate type="inclusive" normal="1951-07-20">July 20, 1951</unitdate></unittitle>
                   </did>
@@ -2843,7 +2843,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>WA9</unitid>
                     <unittitle>Niiike-barn and drying area <unitdate type="inclusive" normal="1950-06">June 1950</unitdate></unittitle>
                   </did>
@@ -2851,7 +2851,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>WA10</unitid>
                     <unittitle>Unidentified house under construction</unittitle>
                   </did>
@@ -2859,7 +2859,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>WA11</unitid>
                     <unittitle>Niijke--H. Tadashi's house <unitdate type="inclusive" normal="1950-07">July 1950</unitdate></unittitle>
                   </did>
@@ -2867,7 +2867,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">3</container>
+                    <container type="othertype" label="No.">No. 3</container>
                     <unitid>WA12</unitid>
                     <unittitle>Niiike-Hajime's front gate <unitdate type="inclusive" normal="1950-08">August 1950</unitdate></unittitle>
                   </did>
@@ -2876,7 +2876,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">4</container>
+                  <container type="othertype" label="No.">No. 4</container>
                   <unitid>X1</unitid>
                   <unittitle>Roadside shrine at K. <unitdate type="inclusive" normal="1950-11">November, 1950</unitdate></unittitle>
                 </did>
@@ -2884,7 +2884,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">4</container>
+                  <container type="othertype" label="No.">No. 4</container>
                   <unitid>X2</unitid>
                   <unittitle>Roadside shrine at K. <unitdate type="inclusive" normal="1950-11">November, 1950</unitdate></unittitle>
                 </did>
@@ -2892,7 +2892,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">4</container>
+                  <container type="othertype" label="No.">No. 4</container>
                   <unitid>Y1</unitid>
                   <unittitle>Buddhist priest (Aritaku Joshi) Matsunagi <unitdate type="inclusive" normal="1951-04">April 1951</unitdate></unittitle>
                 </did>
@@ -2900,7 +2900,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">4</container>
+                  <container type="othertype" label="No.">No. 4</container>
                   <unitid>Y2</unitid>
                   <unittitle>Kokubunji</unittitle>
                 </did>
@@ -2908,7 +2908,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">4</container>
+                  <container type="othertype" label="No.">No. 4</container>
                   <unitid>Y3</unitid>
                   <unittitle>Okayama-Kokubunji not far from Niiike <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -2921,7 +2921,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">4</container>
+                    <container type="othertype" label="No.">No. 4</container>
                     <unitid>ZE1</unitid>
                     <unittitle>Niiike-group of children my, Mayor's house <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                   </did>
@@ -2929,7 +2929,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">4</container>
+                    <container type="othertype" label="No.">No. 4</container>
                     <unitid>ZE2</unitid>
                     <unittitle>Okayama-looking NE from Sake Factory <unitdate type="inclusive" normal="1951-08-02">August 2, 1951</unitdate></unittitle>
                   </did>
@@ -2937,7 +2937,7 @@
                 <c06 level="item">
                   <did>
                     <container type="box" label="Box">16</container>
-                    <container type="othertype" label="No.">4</container>
+                    <container type="othertype" label="No.">No. 4</container>
                     <unitid>ZE3</unitid>
                     <unittitle>Kochi-ken-Makiyama river mura Odochi <unitdate type="inclusive" normal="1951-10-25">October 25, 1951</unitdate></unittitle>
                   </did>
@@ -2946,7 +2946,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">4</container>
+                  <container type="othertype" label="No.">No. 4</container>
                   <unitid>AF</unitid>
                   <unittitle>Festivals (not received)</unittitle>
                 </did>
@@ -2954,7 +2954,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">4</container>
+                  <container type="othertype" label="No.">No. 4</container>
                   <unitid>AFP</unitid>
                   <unittitle>Fall Festival Public Participants (not received)</unittitle>
                 </did>
@@ -2962,7 +2962,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">4</container>
+                  <container type="othertype" label="No.">No. 4</container>
                   <unitid>RE</unitid>
                   <unittitle>recreation (not received)</unittitle>
                 </did>
@@ -2970,7 +2970,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">5</container>
+                  <container type="othertype" label="No.">No. 5</container>
                   <unitid>AA1</unitid>
                   <unittitle>Ainu-Community /Piratori-son, Hokkaido <unitdate type="inclusive" normal="1951-03">March 1951</unitdate></unittitle>
                 </did>
@@ -2978,7 +2978,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">5</container>
+                  <container type="othertype" label="No.">No. 5</container>
                   <unitid>AA2</unitid>
                   <unittitle>Ainu-salt field <unitdate type="inclusive" normal="1951-02">February 1951</unitdate></unittitle>
                 </did>
@@ -2986,7 +2986,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">5</container>
+                  <container type="othertype" label="No.">No. 5</container>
                   <unitid>AA3</unitid>
                   <unittitle>Ainu-meat storage/cages at Museum of Ethnological Society of Hoya <unitdate type="inclusive" normal="1951-08">August 1951</unitdate></unittitle>
                 </did>
@@ -2994,7 +2994,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">5</container>
+                  <container type="othertype" label="No.">No. 5</container>
                   <unitid>AA4</unitid>
                   <unittitle>Mt. Fuji-from Hakone barrier at L. Hakone on Old Tokaido <unitdate type="inclusive" normal="1950-03">March 1950</unitdate></unittitle>
                 </did>
@@ -3002,7 +3002,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">5</container>
+                  <container type="othertype" label="No.">No. 5</container>
                   <unitid>AA5</unitid>
                   <unittitle>Mt. Fuji-from S. Side of Hakone Pass <unitdate type="inclusive" normal="1950-03">March 1950</unitdate></unittitle>
                 </did>
@@ -3010,7 +3010,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">5</container>
+                  <container type="othertype" label="No.">No. 5</container>
                   <unitid>AB1</unitid>
                   <unittitle>Mt. Fuji-view across water</unittitle>
                 </did>
@@ -3018,7 +3018,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">5</container>
+                  <container type="othertype" label="No.">No. 5</container>
                   <unitid>AB2</unitid>
                   <unittitle>Inland Sea-cruise <unitdate type="inclusive" normal="1950-05">May 1950</unitdate></unittitle>
                 </did>
@@ -3026,7 +3026,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">5</container>
+                  <container type="othertype" label="No.">No. 5</container>
                   <unitid>AB3</unitid>
                   <unittitle>Inland Sea-coast <unitdate type="inclusive" normal="1950-08">August 1950</unitdate></unittitle>
                 </did>
@@ -3034,7 +3034,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">5</container>
+                  <container type="othertype" label="No.">No. 5</container>
                   <unitid>AB4</unitid>
                   <unittitle>Inland Sea-valley off Inland Sea, E. Hiroshima Ken, [?] <unitdate type="inclusive" normal="1950-09">September 1950</unitdate></unittitle>
                 </did>
@@ -3042,7 +3042,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">5</container>
+                  <container type="othertype" label="No.">No. 5</container>
                   <unitid>AC1</unitid>
                   <unittitle>Inland Sea-tai fishing <unitdate type="inclusive" normal="1950-05">May 1950</unitdate></unittitle>
                 </did>
@@ -3050,7 +3050,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">5</container>
+                  <container type="othertype" label="No.">No. 5</container>
                   <unitid>AC2</unitid>
                   <unittitle>Inland Sea-view of hillside <unitdate type="inclusive" normal="1950-05">May 1950</unitdate></unittitle>
                 </did>
@@ -3058,7 +3058,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">5</container>
+                  <container type="othertype" label="No.">No. 5</container>
                   <unitid>AC3</unitid>
                   <unittitle>Higashi-mura-house of Fugimoto along path to Matsunagi <unitdate type="inclusive" normal="1951-08">August 1951</unitdate></unittitle>
                 </did>
@@ -3066,7 +3066,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">5</container>
+                  <container type="othertype" label="No.">No. 5</container>
                   <unitid>AD1</unitid>
                   <unittitle>Matsunagi-early morning roof scene <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                 </did>
@@ -3074,7 +3074,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">5</container>
+                  <container type="othertype" label="No.">No. 5</container>
                   <unitid>AD2</unitid>
                   <unittitle>Matsunagi-woman carrying tobacco</unittitle>
                 </did>
@@ -3082,7 +3082,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">5</container>
+                  <container type="othertype" label="No.">No. 5</container>
                   <unitid>AD3</unitid>
                   <unittitle>Matsunagi-roof and racks of drying rice</unittitle>
                 </did>
@@ -3090,7 +3090,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">5</container>
+                  <container type="othertype" label="No.">No. 5</container>
                   <unitid>AD4</unitid>
                   <unittitle>Matsunagi-slope cultivation</unittitle>
                 </did>
@@ -3098,7 +3098,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">5</container>
+                  <container type="othertype" label="No.">No. 5</container>
                   <unitid>AD5</unitid>
                   <unittitle>Matsunagi-elevated house sites against mountainside</unittitle>
                 </did>
@@ -3107,13 +3107,13 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">16</container>
-                <container type="othertype" label="No.">6</container>
+                <container type="othertype" label="No.">No. 6</container>
                 <unittitle>Kochi-Ken <unitdate type="inclusive" normal="1951-10-25/1951-10-26">October 25-26, 1951</unitdate></unittitle>
               </did>
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BA1</unitid>
                   <unittitle>Kochi-map legend <unitdate type="inclusive" normal="1951-10-25">October 25, 1951</unitdate></unittitle>
                 </did>
@@ -3121,7 +3121,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BA2</unitid>
                   <unittitle>Kochi-map</unittitle>
                 </did>
@@ -3129,7 +3129,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BA3</unitid>
                   <unittitle>Kochi-map low grade production after 5 regions. October 26,1951</unittitle>
                 </did>
@@ -3137,7 +3137,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BA4</unitid>
                   <unittitle>Kochi-city. Soil map legend, October 26,1951</unittitle>
                 </did>
@@ -3145,7 +3145,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BA5</unitid>
                   <unittitle>Kochi-city soil map, October 26,1951</unittitle>
                 </did>
@@ -3153,7 +3153,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BB1</unitid>
                   <unittitle>Kochi-plain-Eastern part legend, October 26,1951</unittitle>
                 </did>
@@ -3161,7 +3161,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BIJ 2</unitid>
                   <unittitle>Kochi-plain-Eastern part legend, map of, October 26,1951</unittitle>
                 </did>
@@ -3169,7 +3169,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BB3</unitid>
                   <unittitle>Kochi-Map legend. Low grade production after five regions, October 26,1951</unittitle>
                 </did>
@@ -3177,7 +3177,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BB4</unitid>
                   <unittitle>Kochi-plain "Bad environment for agriculture, October 26,1951</unittitle>
                 </did>
@@ -3185,7 +3185,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BB5</unitid>
                   <unittitle>Kochi-Ken. Cape Murato [?] <unitdate type="inclusive" normal="1951-10-26">October 26, 1951</unitdate></unittitle>
                 </did>
@@ -3193,7 +3193,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BC1</unitid>
                   <unittitle>Kochi-Ken. Cape Murato [?] <unitdate type="inclusive" normal="1951-10-26">October 26, 1951</unitdate></unittitle>
                 </did>
@@ -3201,7 +3201,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BC2</unitid>
                   <unittitle>Kochi-Ken. Cape Murato [?] <unitdate type="inclusive" normal="1951-10-26">October 26, 1951</unitdate></unittitle>
                 </did>
@@ -3209,7 +3209,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BC3</unitid>
                   <unittitle>Kochi-Ken. Cape Murato-Hano Town, Rocks showing level of sea 200 years ago, October 26,1951</unittitle>
                 </did>
@@ -3217,7 +3217,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BC4</unitid>
                   <unittitle>Kochi-Ken-Murator Saki town/Takaoko, tarred ropes</unittitle>
                 </did>
@@ -3225,7 +3225,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BC5</unitid>
                   <unittitle>Kochi-Ken-Murato Saki town-Takaoko, Sea Wall</unittitle>
                 </did>
@@ -3233,7 +3233,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BD1</unitid>
                   <unittitle>Kochi-Ken-Makiyamamura-trees cut this summer, map</unittitle>
                 </did>
@@ -3241,7 +3241,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BD2</unitid>
                   <unittitle>Kochi-Ken-Makiyamamura-trees cut this summer, map</unittitle>
                 </did>
@@ -3249,7 +3249,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BD3</unitid>
                   <unittitle>Kochi-Ken-Makiyamamura-trees cut this summer (sugi-10 years old)</unittitle>
                 </did>
@@ -3257,7 +3257,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">6</container>
+                  <container type="othertype" label="No.">No. 6</container>
                   <unitid>BD4</unitid>
                   <unittitle>Kochi-Ken-Monabe River Valley-W Daicho-mura/Kumigun/Nagano Aza <unitdate type="inclusive" normal="1951-10-25">October 25, 1951</unitdate></unittitle>
                 </did>
@@ -3265,7 +3265,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">7</container>
+                  <container type="othertype" label="No.">No. 7</container>
                   <unitid>CA1</unitid>
                   <unittitle>Kochi-Kera Aza, Keru St. SW, 2 rice crops, <unitdate type="inclusive" normal="1951">October 25 1951</unitdate></unittitle>
                 </did>
@@ -3273,7 +3273,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">7</container>
+                  <container type="othertype" label="No.">No. 7</container>
                   <unitid>CA2</unitid>
                   <unittitle>Kochi-Kera Aza, Keru St. NE, 1 rice crops (Straw in bkgd.), <unitdate type="inclusive" normal="1951">October 25 1951</unitdate></unittitle>
                 </did>
@@ -3281,7 +3281,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">7</container>
+                  <container type="othertype" label="No.">No. 7</container>
                   <unitid>CA3</unitid>
                   <unittitle>Kochi-Tei Harbor, October 26</unittitle>
                 </did>
@@ -3289,7 +3289,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">7</container>
+                  <container type="othertype" label="No.">No. 7</container>
                   <unitid>CA4</unitid>
                   <unittitle>Kochi-Near Tei Harbor, burnt &amp; green bamboo, October 26</unittitle>
                 </did>
@@ -3297,7 +3297,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">7</container>
+                  <container type="othertype" label="No.">No. 7</container>
                   <unitid>CA5</unitid>
                   <unittitle>Kochi-Birafu Machi/Shimoneji Aza Narus Slopes, October 25</unittitle>
                 </did>
@@ -3305,7 +3305,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">7</container>
+                  <container type="othertype" label="No.">No. 7</container>
                   <unitid>CB1</unitid>
                   <unittitle>Kochi-Karyoso. Nahari machi basket for carrying live Ponito bait, October 26</unittitle>
                 </did>
@@ -3313,7 +3313,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">7</container>
+                  <container type="othertype" label="No.">No. 7</container>
                   <unitid>CB2</unitid>
                   <unittitle>Kochi-Yamada machi from Kagami bridge, October 25</unittitle>
                 </did>
@@ -3326,7 +3326,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">7</container>
+                  <container type="othertype" label="No.">No. 7</container>
                   <unitid>CC1</unitid>
                   <unittitle>Kokubunji, September 24</unittitle>
                 </did>
@@ -3334,7 +3334,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">7</container>
+                  <container type="othertype" label="No.">No. 7</container>
                   <unitid>CC2</unitid>
                   <unittitle>Kokubunj-Misu Village, Nov 25</unittitle>
                 </did>
@@ -3342,7 +3342,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">7</container>
+                  <container type="othertype" label="No.">No. 7</container>
                   <unitid>CD1</unitid>
                   <unittitle>Kokubunji-dances, September 24</unittitle>
                 </did>
@@ -3350,7 +3350,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">7</container>
+                  <container type="othertype" label="No.">No. 7</container>
                   <unitid>CD2</unitid>
                   <unittitle>Kokubunji-dances, September 24</unittitle>
                 </did>
@@ -3358,7 +3358,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">7</container>
+                  <container type="othertype" label="No.">No. 7</container>
                   <unitid>CD3</unitid>
                   <unittitle>Kokubunji-dances, September 24</unittitle>
                 </did>
@@ -3366,7 +3366,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">7</container>
+                  <container type="othertype" label="No.">No. 7</container>
                   <unitid>CD4</unitid>
                   <unittitle>Kokubunji-dances, September 24</unittitle>
                 </did>
@@ -3374,7 +3374,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">7</container>
+                  <container type="othertype" label="No.">No. 7</container>
                   <unitid>CD5</unitid>
                   <unittitle>Kokubunji-dances, September 24</unittitle>
                 </did>
@@ -3390,7 +3390,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DA1</unitid>
                   <unittitle>Niiike-east from hill <unitdate type="inclusive" normal="1951-11-22">November 22, 1951</unitdate></unittitle>
                 </did>
@@ -3398,7 +3398,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DA2</unitid>
                   <unittitle>Niiike east from hill <unitdate type="inclusive" normal="1951-11-06">November 6, 1951</unitdate></unittitle>
                 </did>
@@ -3406,7 +3406,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DA3</unitid>
                   <unittitle>Oukaido-Kasu kabe town <unitdate type="inclusive" normal="1951-12-08">December 8, 1951</unitdate></unittitle>
                 </did>
@@ -3414,7 +3414,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DA4</unitid>
                   <unittitle>Niiike-Datake <unitdate type="inclusive" normal="1951-11-22">November 22, 1951</unitdate></unittitle>
                 </did>
@@ -3422,7 +3422,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DA5</unitid>
                   <unittitle>Niiike-Datake <unitdate type="inclusive" normal="1951-11-22">November 22, 1951</unitdate></unittitle>
                 </did>
@@ -3430,7 +3430,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DB1</unitid>
                   <unittitle>Niiike-paddy, November 6</unittitle>
                 </did>
@@ -3438,7 +3438,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DB2</unitid>
                   <unittitle>Niiike-paddy, November 11</unittitle>
                 </did>
@@ -3446,7 +3446,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DB3</unitid>
                   <unittitle>Niiike-Spring plowing for rice seed bed-with con <unitdate type="inclusive" normal="1950-05">May 1950</unitdate></unittitle>
                 </did>
@@ -3454,7 +3454,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DB4</unitid>
                   <unittitle>Niiike-beginning to gather I-guga [?] bunching and tying <unitdate type="inclusive" normal="1951-07-24">July 24, 1951</unitdate></unittitle>
                 </did>
@@ -3462,7 +3462,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DB5</unitid>
                   <unittitle>Niiike-Eyre, Dr. Hall, &amp; informant <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -3470,7 +3470,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DC1</unitid>
                   <unittitle>Niiike-drying magi [?] <unitdate type="inclusive" normal="1951-06-11">June 11, 1951</unitdate></unittitle>
                 </did>
@@ -3478,7 +3478,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DC2</unitid>
                   <unittitle>Niiike--New Neya [?] <unitdate type="inclusive" normal="1951-11-22">November 22, 1951</unitdate></unittitle>
                 </did>
@@ -3486,7 +3486,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DC3</unitid>
                   <unittitle>Niiike-drying rice at Niiike <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                 </did>
@@ -3494,7 +3494,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DC4</unitid>
                   <unittitle>Niiike-Hiroshi's new barn-mid-point in construction <unitdate type="inclusive" normal="1951-01">January 1951</unitdate></unittitle>
                 </did>
@@ -3502,7 +3502,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DC5</unitid>
                   <unittitle>Niiike pre-harvest shot-Daikon, bamboo <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                 </did>
@@ -3510,7 +3510,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DD1</unitid>
                   <unittitle>Niiike-rice harvest-general shot <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                 </did>
@@ -3518,7 +3518,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DD2</unitid>
                   <unittitle>Niiike-fire tower- <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -3526,7 +3526,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DD3</unitid>
                   <unittitle>Niiike-house roof detail <unitdate type="inclusive" normal="1951-02">February 1951</unitdate></unittitle>
                 </did>
@@ -3534,7 +3534,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DD4</unitid>
                   <unittitle>Niiike-cemetery and Einoike <unitdate type="inclusive" normal="1951-01">January 1951</unitdate></unittitle>
                 </did>
@@ -3542,7 +3542,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">8</container>
+                  <container type="othertype" label="No.">No. 8</container>
                   <unitid>DD5</unitid>
                   <unittitle>Niiike-beginning of harvest-General Hain <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                 </did>
@@ -3550,7 +3550,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>EA1</unitid>
                   <unittitle>Niiike-spring harvest scene <unitdate type="inclusive" normal="1950-01-12">January 12, 1950</unitdate></unittitle>
                 </did>
@@ -3558,7 +3558,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>EA2</unitid>
                   <unittitle>Niiike-Hatake <unitdate type="inclusive" normal="1951-07-20">July 20, 1951</unitdate></unittitle>
                 </did>
@@ -3566,7 +3566,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>EA3</unitid>
                   <unittitle>Niiike-rear (North) side of Kenshiros unfinished house <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -3574,7 +3574,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>EA4</unitid>
                   <unittitle>Niiike-I. Ishita cleaning ditch-sugar cane, taro, kampyo <unitdate type="inclusive" normal="1950-08-23">August 23, 1950</unitdate></unittitle>
                 </did>
@@ -3582,7 +3582,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>EA5</unitid>
                   <unittitle>Okayama-cemetery along road to Niiike <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -3590,7 +3590,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>EB1</unitid>
                   <unittitle>Niiike-Abac-san with flowers in front of his house <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -3598,7 +3598,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>EB2</unitid>
                   <unittitle>Niiike-from Oyama <unitdate type="inclusive" normal="1951-08-23">August 23, 1951</unitdate></unittitle>
                 </did>
@@ -3606,7 +3606,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>EB3</unitid>
                   <unittitle>Niiike-paddy fields <unitdate type="inclusive" normal="1951-06-23">June 23, 1951</unitdate></unittitle>
                 </did>
@@ -3614,7 +3614,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>EB4</unitid>
                   <unittitle>Niiike-paddy <unitdate type="inclusive" normal="1951-06-11">June 11, 1951</unitdate></unittitle>
                 </did>
@@ -3622,7 +3622,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>EB5</unitid>
                   <unittitle>Niiike-paddy-mugi <unitdate type="inclusive" normal="1951-04-16">April 16, 1951</unitdate></unittitle>
                 </did>
@@ -3630,7 +3630,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>EC1</unitid>
                   <unittitle>Niiike-dry field <unitdate type="inclusive" normal="1951-04-16">April 16, 1951</unitdate></unittitle>
                 </did>
@@ -3638,7 +3638,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>EC2</unitid>
                   <unittitle>Niiike-paddy-mugi <unitdate type="inclusive" normal="1951-05-11">May 11, 1951</unitdate></unittitle>
                 </did>
@@ -3646,7 +3646,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>EC3</unitid>
                   <unittitle>Niiike-dry fields <unitdate type="inclusive" normal="1951-05-11">May 11, 1951</unitdate></unittitle>
                 </did>
@@ -3654,7 +3654,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>EC4</unitid>
                   <unittitle>Niiike-paddy-mugi <unitdate type="inclusive" normal="1951-05-21">May 21, 1951</unitdate></unittitle>
                 </did>
@@ -3662,7 +3662,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>EC5</unitid>
                   <unittitle>Niiike-dry field <unitdate type="inclusive" normal="1951-05-21">May 21, 1951</unitdate></unittitle>
                 </did>
@@ -3670,7 +3670,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>ED1</unitid>
                   <unittitle>Niiike-paddy-mugi <unitdate type="inclusive" normal="1951-05-31">May 31, 1951</unitdate></unittitle>
                 </did>
@@ -3678,7 +3678,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>ED2</unitid>
                   <unittitle>Niiike-paddy-mugi <unitdate type="inclusive" normal="1951-06-11">June 11, 1951</unitdate></unittitle>
                 </did>
@@ -3686,7 +3686,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>ED3</unitid>
                   <unittitle>Niiike-dry fields <unitdate type="inclusive" normal="1951-05-31">May 31, 1951</unitdate></unittitle>
                 </did>
@@ -3694,7 +3694,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>ED4</unitid>
                   <unittitle>Niiike-paddy <unitdate type="inclusive" normal="1951-06-11">June 11, 1951</unitdate></unittitle>
                 </did>
@@ -3702,7 +3702,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">9</container>
+                  <container type="othertype" label="No.">No. 9</container>
                   <unitid>ED5</unitid>
                   <unittitle>Niiike-hatake <unitdate type="inclusive" normal="1951-06-23">June 23, 1951</unitdate></unittitle>
                 </did>
@@ -3710,7 +3710,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">10</container>
+                  <container type="othertype" label="No.">No. 10</container>
                   <unitid>FA1</unitid>
                   <unittitle>Niiike-paddy <unitdate type="inclusive" normal="1951-06-23">June 23, 1951</unitdate></unittitle>
                 </did>
@@ -3718,7 +3718,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">10</container>
+                  <container type="othertype" label="No.">No. 10</container>
                   <unitid>FA2</unitid>
                   <unittitle>Niiike-paddy <unitdate type="inclusive" normal="1951-07-24">July 24, 1951</unitdate></unittitle>
                 </did>
@@ -3726,7 +3726,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">10</container>
+                  <container type="othertype" label="No.">No. 10</container>
                   <unitid>FA3</unitid>
                   <unittitle>Niiike-paddy <unitdate type="inclusive" normal="1951-07-20">July 20, 1951</unitdate></unittitle>
                 </did>
@@ -3734,7 +3734,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">10</container>
+                  <container type="othertype" label="No.">No. 10</container>
                   <unitid>FA4</unitid>
                   <unittitle>Niiike-hatake <unitdate type="inclusive" normal="1951-07-20">July 20, 1951</unitdate></unittitle>
                 </did>
@@ -3742,7 +3742,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">10</container>
+                  <container type="othertype" label="No.">No. 10</container>
                   <unitid>FA5</unitid>
                   <unittitle>Niiike-hatake <unitdate type="inclusive" normal="1951-07-24">July 24, 1951</unitdate></unittitle>
                 </did>
@@ -3750,7 +3750,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">10</container>
+                  <container type="othertype" label="No.">No. 10</container>
                   <unitid>FB1</unitid>
                   <unittitle>Niiike-paddy <unitdate type="inclusive" normal="1951-08-01">August 1, 1951</unitdate></unittitle>
                 </did>
@@ -3758,7 +3758,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">10</container>
+                  <container type="othertype" label="No.">No. 10</container>
                   <unitid>FB2</unitid>
                   <unittitle>Niiike-hatake, <unitdate type="inclusive" normal="1951">August 1 1951</unitdate></unittitle>
                 </did>
@@ -3766,7 +3766,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">10</container>
+                  <container type="othertype" label="No.">No. 10</container>
                   <unitid>FB3</unitid>
                   <unittitle>Niiike-hatake, <unitdate type="inclusive" normal="1951">August 13 1951</unitdate></unittitle>
                 </did>
@@ -3774,7 +3774,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">10</container>
+                  <container type="othertype" label="No.">No. 10</container>
                   <unitid>FB4</unitid>
                   <unittitle>Niiike-paddy, <unitdate type="inclusive" normal="1951">August 13 1951</unitdate></unittitle>
                 </did>
@@ -3782,7 +3782,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">10</container>
+                  <container type="othertype" label="No.">No. 10</container>
                   <unitid>FB5</unitid>
                   <unittitle>Niiike-hatake, <unitdate type="inclusive" normal="1951">August 21 1951</unitdate></unittitle>
                 </did>
@@ -3790,7 +3790,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">10</container>
+                  <container type="othertype" label="No.">No. 10</container>
                   <unitid>FC1</unitid>
                   <unittitle>Niiike-hatake, <unitdate type="inclusive" normal="1951">August 21 1951</unitdate></unittitle>
                 </did>
@@ -3798,7 +3798,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">10</container>
+                  <container type="othertype" label="No.">No. 10</container>
                   <unitid>FC2</unitid>
                   <unittitle>Niiike-hatake, <unitdate type="inclusive" normal="1951">August 21 1951</unitdate></unittitle>
                 </did>
@@ -3806,7 +3806,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">10</container>
+                  <container type="othertype" label="No.">No. 10</container>
                   <unitid>FC3</unitid>
                   <unittitle>Niiike-hatake, <unitdate type="inclusive" normal="1951">August 21 1951</unitdate></unittitle>
                 </did>
@@ -3814,7 +3814,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">10</container>
+                  <container type="othertype" label="No.">No. 10</container>
                   <unitid>FC4</unitid>
                   <unittitle>Niiike-hatake, <unitdate type="inclusive" normal="1951">August 21 1951</unitdate></unittitle>
                 </did>
@@ -3822,7 +3822,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">10</container>
+                  <container type="othertype" label="No.">No. 10</container>
                   <unitid>FC5</unitid>
                   <unittitle>Niiike-hatake, <unitdate type="inclusive" normal="1951">August 21 1951</unitdate></unittitle>
                 </did>
@@ -3830,7 +3830,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">10</container>
+                  <container type="othertype" label="No.">No. 10</container>
                   <unitid>FC1</unitid>
                   <unittitle>Niiike-hatake, <unitdate type="inclusive" normal="1951">August 21 1951</unitdate></unittitle>
                 </did>
@@ -3838,7 +3838,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">10</container>
+                  <container type="othertype" label="No.">No. 10</container>
                   <unitid>FD1-5</unitid>
                   <unittitle>Niiike-hatake, <unitdate type="inclusive" normal="1951">August 21 1951</unitdate></unittitle>
                 </did>
@@ -3846,7 +3846,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GA1</unitid>
                   <unittitle>Niiike-Hatake <unitdate type="inclusive" normal="1951-09-28">September 28, 1951</unitdate></unittitle>
                 </did>
@@ -3854,7 +3854,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GA2</unitid>
                   <unittitle>Niiike-New Neya <unitdate type="inclusive" normal="1951-09-28">September 28, 1951</unitdate></unittitle>
                 </did>
@@ -3862,7 +3862,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GA3</unitid>
                   <unittitle>Niiike-paddy <unitdate type="inclusive" normal="1951-10-18">October 18, 1951</unitdate></unittitle>
                 </did>
@@ -3870,7 +3870,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GA4</unitid>
                   <unittitle>Niiike-New Neya <unitdate type="inclusive" normal="1951-10-18">October 18, 1951</unitdate></unittitle>
                 </did>
@@ -3878,7 +3878,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GA5</unitid>
                   <unittitle>Niiike-Hatake <unitdate type="inclusive" normal="1951-10-18">October 18, 1951</unitdate></unittitle>
                 </did>
@@ -3886,7 +3886,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GB1</unitid>
                   <unittitle>Niiike-east from hill <unitdate type="inclusive" normal="1951-10-18">October 18, 1951</unitdate></unittitle>
                 </did>
@@ -3894,7 +3894,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GB2</unitid>
                   <unittitle>Niiike-hatake <unitdate type="inclusive" normal="1951-11-06">November 6, 1951</unitdate></unittitle>
                 </did>
@@ -3902,7 +3902,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GB3</unitid>
                   <unittitle>Niiike-paddy <unitdate type="inclusive" normal="1951-11-22">November 22, 1951</unitdate></unittitle>
                 </did>
@@ -3910,7 +3910,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GB4</unitid>
                   <unittitle>Niiike-mugi <unitdate type="inclusive" normal="1951-05-11">May 11, 1951</unitdate></unittitle>
                 </did>
@@ -3918,7 +3918,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GB5</unitid>
                   <unittitle>Niiike-dry field <unitdate type="inclusive" normal="1951-05-21">May 21, 1951</unitdate></unittitle>
                 </did>
@@ -3926,7 +3926,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GC1</unitid>
                   <unittitle>Niiike-dry fields <unitdate type="inclusive" normal="1951-05-21">May 21, 1951</unitdate></unittitle>
                 </did>
@@ -3934,7 +3934,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GC2</unitid>
                   <unittitle>Niiike-paddy-mugi <unitdate type="inclusive" normal="1951-05-21">May 21, 1951</unitdate></unittitle>
                 </did>
@@ -3942,7 +3942,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GC3</unitid>
                   <unittitle>Niiike-Hatake-dry fields <unitdate type="inclusive" normal="1951-05-31">May 31, 1951</unitdate></unittitle>
                 </did>
@@ -3950,7 +3950,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GC4</unitid>
                   <unittitle>Niiike-dry field- <unitdate type="inclusive" normal="1951-05-21">May 21, 1951</unitdate></unittitle>
                 </did>
@@ -3958,7 +3958,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GC5</unitid>
                   <unittitle>Niiike-dry fields <unitdate type="inclusive" normal="1951-06-11">June 11, 1951</unitdate></unittitle>
                 </did>
@@ -3966,7 +3966,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GD1</unitid>
                   <unittitle>Niiike-dry fields <unitdate type="inclusive" normal="1951-06-11">June 11, 1951</unitdate></unittitle>
                 </did>
@@ -3974,7 +3974,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GD2</unitid>
                   <unittitle>Niiike-Hatake-dry fields <unitdate type="inclusive" normal="1951-06-23">June 23, 1951</unitdate></unittitle>
                 </did>
@@ -3982,7 +3982,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GD3</unitid>
                   <unittitle>Niiike-dry field <unitdate type="inclusive" normal="1951-06-11">June 11, 1951</unitdate></unittitle>
                 </did>
@@ -3990,7 +3990,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GD4</unitid>
                   <unittitle>Niiike-paddy <unitdate type="inclusive" normal="1951-06-20">June 20, 1951</unitdate></unittitle>
                 </did>
@@ -3998,7 +3998,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">11</container>
+                  <container type="othertype" label="No.">No. 11</container>
                   <unitid>GD5</unitid>
                   <unittitle>Niiike-Hatake <unitdate type="inclusive" normal="1951-06-24">June 24, 1951</unitdate></unittitle>
                 </did>
@@ -4006,7 +4006,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HB1</unitid>
                   <unittitle>Niiike-Hatake <unitdate type="inclusive" normal="1951-08-21">August 21, 1951</unitdate></unittitle>
                 </did>
@@ -4014,7 +4014,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HA2</unitid>
                   <unittitle>Niiike-paddy <unitdate type="inclusive" normal="1951-08-23">August 23, 1951</unitdate></unittitle>
                 </did>
@@ -4022,7 +4022,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HA3</unitid>
                   <unittitle>Niiike-paddy <unitdate type="inclusive" normal="1951-08-23">August 23, 1951</unitdate></unittitle>
                 </did>
@@ -4030,7 +4030,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HA4</unitid>
                   <unittitle>Niiike-paddy <unitdate type="inclusive" normal="1951-08-17">August 17, 1951</unitdate></unittitle>
                 </did>
@@ -4038,7 +4038,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HA52</unitid>
                   <unittitle>Niiike-paddy <unitdate type="inclusive" normal="1951-08-21">August 21, 1951</unitdate></unittitle>
                 </did>
@@ -4046,7 +4046,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HB1</unitid>
                   <unittitle>Niiike-paddy <unitdate type="inclusive" normal="1951-08-23">August 23, 1951</unitdate></unittitle>
                 </did>
@@ -4054,7 +4054,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HB2</unitid>
                   <unittitle>Niiike-paddy, <unitdate type="inclusive" normal="1951-08-14">September August 14, 1951</unitdate></unittitle>
                 </did>
@@ -4062,7 +4062,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HB3</unitid>
                   <unittitle>Niiike-Hatake <unitdate type="inclusive" normal="1951-09-14">September 14, 1951</unitdate></unittitle>
                 </did>
@@ -4070,7 +4070,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HB4</unitid>
                   <unittitle>Niiike-drying day, New Neya-seed bed, mug, beyond <unitdate type="inclusive" normal="1951-05-11">May 11, 1951</unitdate></unittitle>
                 </did>
@@ -4078,7 +4078,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HB5</unitid>
                   <unittitle>Niiike-Rice seedlings-New Neya <unitdate type="inclusive" normal="1951-05-21">May 21, 1951</unitdate></unittitle>
                 </did>
@@ -4086,7 +4086,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HC1</unitid>
                   <unittitle>Niiike-rice seedlings in front of New Neya <unitdate type="inclusive" normal="1951-06-11">June 11, 1951</unitdate></unittitle>
                 </did>
@@ -4094,7 +4094,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HC2</unitid>
                   <unittitle>Niiike-paddy-New Neya <unitdate type="inclusive" normal="1951-06-23">June 23, 1951</unitdate></unittitle>
                 </did>
@@ -4102,7 +4102,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HC3</unitid>
                   <unittitle>Niiike-paddy-New Neya <unitdate type="inclusive" normal="1951-07-07/1951-07-20">July 7-20, 1951</unitdate></unittitle>
                 </did>
@@ -4110,7 +4110,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HC4</unitid>
                   <unittitle>Niiike-paddy by New Neya <unitdate type="inclusive" normal="1951-08-24">August 24, 1951</unitdate></unittitle>
                 </did>
@@ -4118,7 +4118,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HC5</unitid>
                   <unittitle>Niiike-New Neya <unitdate type="inclusive" normal="1951-08-01">August 1, 1951</unitdate></unittitle>
                 </did>
@@ -4126,7 +4126,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HD1</unitid>
                   <unittitle>Niiike-New Neya <unitdate type="inclusive" normal="1951-08-13">August 13, 1951</unitdate></unittitle>
                 </did>
@@ -4134,7 +4134,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HD2</unitid>
                   <unittitle>Niiike-New Neya <unitdate type="inclusive" normal="1951-08-23">August 23, 1951</unitdate></unittitle>
                 </did>
@@ -4142,7 +4142,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HD3</unitid>
                   <unittitle>Niiike-New Neya, <unitdate type="inclusive" normal="1951">August 13 1951</unitdate></unittitle>
                 </did>
@@ -4150,7 +4150,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HD4</unitid>
                   <unittitle>Niiike-from hill <unitdate type="inclusive" normal="1951-08-31">August 31, 1951</unitdate></unittitle>
                 </did>
@@ -4158,7 +4158,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">12</container>
+                  <container type="othertype" label="No.">No. 12</container>
                   <unitid>HD5</unitid>
                   <unittitle>Niiike-from hill <unitdate type="inclusive" normal="1951-09-24">September 24, 1951</unitdate></unittitle>
                 </did>
@@ -4166,7 +4166,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">13</container>
+                  <container type="othertype" label="No.">No. 13</container>
                   <unitid>IA1</unitid>
                   <unittitle>Niiike-gathering dried I-gusa <unitdate type="inclusive" normal="1951-07-24">July 24, 1951</unitdate></unittitle>
                 </did>
@@ -4174,7 +4174,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">13</container>
+                  <container type="othertype" label="No.">No. 13</container>
                   <unitid>IA2</unitid>
                   <unittitle>Niiike-shaking short stems out of cut I-gusa <unitdate type="inclusive" normal="1951">1951</unitdate></unittitle>
                 </did>
@@ -4182,7 +4182,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">13</container>
+                  <container type="othertype" label="No.">No. 13</container>
                   <unitid>IA3</unitid>
                   <unittitle>Niiike-turning I-gusa over <unitdate type="inclusive" normal="1951-07-24">July 24, 1951</unitdate></unittitle>
                 </did>
@@ -4190,7 +4190,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">13</container>
+                  <container type="othertype" label="No.">No. 13</container>
                   <unitid>IA4</unitid>
                   <unittitle>Niiike-I-gusa drying on road to Niiike <unitdate type="inclusive" normal="1951-07-24">July 24, 1951</unitdate></unittitle>
                 </did>
@@ -4198,7 +4198,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">13</container>
+                  <container type="othertype" label="No.">No. 13</container>
                   <unitid>IA5</unitid>
                   <unittitle>turning I-gusa over <unitdate type="inclusive" normal="1951-07-24">July 24, 1951</unitdate></unittitle>
                 </did>
@@ -4206,7 +4206,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">13</container>
+                  <container type="othertype" label="No.">No. 13</container>
                   <unitid>IB1</unitid>
                   <unittitle>Niiike-close up of I-gusa <unitdate type="inclusive" normal="1951-05-11">May 11, 1951</unitdate></unittitle>
                 </did>
@@ -4214,7 +4214,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">13</container>
+                  <container type="othertype" label="No.">No. 13</container>
                   <unitid>IB2</unitid>
                   <unittitle>Niiike-shaking I-gusa for short stems and tying I-gusa <unitdate type="inclusive" normal="1951-07-24">July 24, 1951</unitdate></unittitle>
                 </did>
@@ -4222,7 +4222,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">13</container>
+                  <container type="othertype" label="No.">No. 13</container>
                   <unitid>IB3</unitid>
                   <unittitle>Niiike-shaking and tying I-gusa <unitdate type="inclusive" normal="1951-07-24">July 24, 1951</unitdate></unittitle>
                 </did>
@@ -4230,7 +4230,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">13</container>
+                  <container type="othertype" label="No.">No. 13</container>
                   <unitid>IB4</unitid>
                   <unittitle>Niiike-tied bundles of dried I-gusa <unitdate type="inclusive" normal="1951-07-24">July 24, 1951</unitdate></unittitle>
                 </did>
@@ -4238,7 +4238,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">13</container>
+                  <container type="othertype" label="No.">No. 13</container>
                   <unitid>IB5</unitid>
                   <unittitle>Niiike-turning I-gusa over <unitdate type="inclusive" normal="1951">1951</unitdate></unittitle>
                 </did>
@@ -4246,7 +4246,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">13</container>
+                  <container type="othertype" label="No.">No. 13</container>
                   <unitid>IC1</unitid>
                   <unittitle>Niiike-clay-water for dipping I-gusa <unitdate type="inclusive" normal="1951-07-20">July 20, 1951</unitdate></unittitle>
                 </did>
@@ -4254,7 +4254,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">13</container>
+                  <container type="othertype" label="No.">No. 13</container>
                   <unitid>IC2</unitid>
                   <unittitle>Niiike-Masao Hiramatsu wearing Tatami <unitdate type="inclusive" normal="1951-08-21">August 21, 1951</unitdate></unittitle>
                 </did>
@@ -4262,7 +4262,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">13</container>
+                  <container type="othertype" label="No.">No. 13</container>
                   <unitid>IC3</unitid>
                   <unittitle>Niiike-Hatake <unitdate type="inclusive" normal="1951-08-01">August 1, 1951</unitdate></unittitle>
                 </did>
@@ -4270,7 +4270,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">13</container>
+                  <container type="othertype" label="No.">No. 13</container>
                   <unitid>IC4</unitid>
                   <unittitle>Niiike-dry fields <unitdate type="inclusive" normal="1951-05-11">May 11, 1951</unitdate></unittitle>
                 </did>
@@ -4278,7 +4278,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">13</container>
+                  <container type="othertype" label="No.">No. 13</container>
                   <unitid>IC5</unitid>
                   <unittitle>Niiike-paddy <unitdate type="inclusive" normal="1951-09-14">September 14, 1951</unitdate></unittitle>
                 </did>
@@ -4291,7 +4291,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">14</container>
+                  <container type="othertype" label="No.">No. 14</container>
                   <unitid>JA1</unitid>
                   <unittitle>Nikkokaido <unitdate type="inclusive" normal="1951-12-11">December 11, 1951</unitdate></unittitle>
                 </did>
@@ -4299,7 +4299,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">14</container>
+                  <container type="othertype" label="No.">No. 14</container>
                   <unitid>JA2</unitid>
                   <unittitle>Nikkokaido <unitdate type="inclusive" normal="1951-12-11">December 11, 1951</unitdate></unittitle>
                 </did>
@@ -4307,7 +4307,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">14</container>
+                  <container type="othertype" label="No.">No. 14</container>
                   <unitid>JA3</unitid>
                   <unittitle>Nikkokaido <unitdate type="inclusive" normal="1951-12-11">December 11, 1951</unitdate></unittitle>
                 </did>
@@ -4315,7 +4315,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">14</container>
+                  <container type="othertype" label="No.">No. 14</container>
                   <unitid>JA4</unitid>
                   <unittitle>Nikkokaido-Iuraichi size of log-Noh for scale <unitdate type="inclusive" normal="1951-12-11">December 11, 1951</unitdate></unittitle>
                 </did>
@@ -4323,7 +4323,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">14</container>
+                  <container type="othertype" label="No.">No. 14</container>
                   <unitid>JA5</unitid>
                   <unittitle>Nikkokaido-Iuraichi size of log-Noh for scale <unitdate type="inclusive" normal="1951-12-11">December 11, 1951</unitdate></unittitle>
                 </did>
@@ -4331,7 +4331,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">14</container>
+                  <container type="othertype" label="No.">No. 14</container>
                   <unitid>JB1</unitid>
                   <unittitle>Nikkokaido-Iuraichi size of log-Noh for scale <unitdate type="inclusive" normal="1951-12-11">December 11, 1951</unitdate></unittitle>
                 </did>
@@ -4339,7 +4339,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">14</container>
+                  <container type="othertype" label="No.">No. 14</container>
                   <unitid>JB2</unitid>
                   <unittitle>Nikkokaido-, Marugame (Shikoku)-tori pattern, November 24</unittitle>
                 </did>
@@ -4347,7 +4347,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">14</container>
+                  <container type="othertype" label="No.">No. 14</container>
                   <unitid>JB3</unitid>
                   <unittitle>Nikkokaido-, Marugame (Shikoku)-tori pattern-south <unitdate type="inclusive" normal="1951-11-24">November 24, 1951</unitdate></unittitle>
                 </did>
@@ -4360,7 +4360,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">14</container>
+                  <container type="othertype" label="No.">No. 14</container>
                   <unitid>JB4</unitid>
                   <unittitle>Oukaido-20 miles north of Tokyo <unitdate type="inclusive" normal="1951-12-08">December 8, 1951</unitdate></unittitle>
                 </did>
@@ -4368,7 +4368,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">14</container>
+                  <container type="othertype" label="No.">No. 14</container>
                   <unitid>JB5</unitid>
                   <unittitle>Oukaido-20 miles north of Tokyo <unitdate type="inclusive" normal="1951-12-08">December 8, 1951</unitdate></unittitle>
                 </did>
@@ -4376,7 +4376,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">14</container>
+                  <container type="othertype" label="No.">No. 14</container>
                   <unitid>JC1</unitid>
                   <unittitle>Oukaido-near Kamitakamo village <unitdate type="inclusive" normal="1951-12-08">December 8, 1951</unitdate></unittitle>
                 </did>
@@ -4384,7 +4384,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">14</container>
+                  <container type="othertype" label="No.">No. 14</container>
                   <unitid>JC2</unitid>
                   <unittitle>Oukaido-near Kamitakamo village <unitdate type="inclusive" normal="1951-12-08">December 8, 1951</unitdate></unittitle>
                 </did>
@@ -4392,7 +4392,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">14</container>
+                  <container type="othertype" label="No.">No. 14</container>
                   <unitid>JC3</unitid>
                   <unittitle>Oukaido-near Kamitakamo village <unitdate type="inclusive" normal="1951-12-08">December 8, 1951</unitdate></unittitle>
                 </did>
@@ -4400,7 +4400,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">14</container>
+                  <container type="othertype" label="No.">No. 14</container>
                   <unitid>JC4</unitid>
                   <unittitle>Oukaido-Kasukabe town <unitdate type="inclusive" normal="1951-12-08">December 8, 1951</unitdate></unittitle>
                 </did>
@@ -4408,7 +4408,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">14</container>
+                  <container type="othertype" label="No.">No. 14</container>
                   <unitid>JC5</unitid>
                   <unittitle>Oukaido-Kasukabe town <unitdate type="inclusive" normal="1951-12-08">December 8, 1951</unitdate></unittitle>
                 </did>
@@ -4416,7 +4416,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">14</container>
+                  <container type="othertype" label="No.">No. 14</container>
                   <unitid>JD1</unitid>
                   <unittitle>Oukaido-Noga Village <unitdate type="inclusive" normal="1951-12-01">December 1, 1951</unitdate></unittitle>
                 </did>
@@ -4429,7 +4429,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KA1</unitid>
                   <unittitle>Orayama-skyline in twilight <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                 </did>
@@ -4437,7 +4437,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KA2</unitid>
                   <unittitle>Orayama-looking NW from fire tower, August 2</unittitle>
                 </did>
@@ -4445,7 +4445,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KA3</unitid>
                   <unittitle>Orayama-near Kurashiki city-Mani Shopping St. <unitdate type="inclusive" normal="1950-08">August 1950</unitdate></unittitle>
                 </did>
@@ -4453,7 +4453,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KA4</unitid>
                   <unittitle>Orayama-near Kurashiki city-Mani Shopping St. <unitdate type="inclusive" normal="1950-08">August 1950</unitdate></unittitle>
                 </did>
@@ -4461,7 +4461,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KA5</unitid>
                   <unittitle>Orayama-Oku-gun, Owari-Kadota Shell mound <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -4469,7 +4469,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KB1</unitid>
                   <unittitle>Orayama-Waterwheel <unitdate type="inclusive" normal="1950-05">May 1950</unitdate></unittitle>
                 </did>
@@ -4477,7 +4477,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KB2</unitid>
                   <unittitle>Orayama-Shimotsui rest hotel <unitdate type="inclusive" normal="1950-05">May 1950</unitdate></unittitle>
                 </did>
@@ -4485,7 +4485,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KB3</unitid>
                   <unittitle>Orayama-Vakake <unitdate type="inclusive" normal="1950-05">May 1950</unitdate></unittitle>
                 </did>
@@ -4493,7 +4493,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KB4</unitid>
                   <unittitle>Orayama-Yoshii River, April. <unitdate type="inclusive" normal="1950">1950</unitdate></unittitle>
                 </did>
@@ -4501,7 +4501,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KB5</unitid>
                   <unittitle>Orayama-Thmashima <unitdate type="inclusive" normal="1950-03">March 1950</unitdate></unittitle>
                 </did>
@@ -4509,7 +4509,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KC1</unitid>
                   <unittitle>Orayama-near Okutsu hot springs <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -4517,7 +4517,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KC2</unitid>
                   <unittitle>Orayama-Kurashiki, Ohara's mansion <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -4525,7 +4525,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KC3</unitid>
                   <unittitle>Orayama-near Kurashiki, grass mats drying <unitdate type="inclusive" normal="1950-05">May 1950</unitdate></unittitle>
                 </did>
@@ -4533,7 +4533,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KC4</unitid>
                   <unittitle>Orayama-Inland Sea near Shimotisui <unitdate type="inclusive" normal="1950-03">March 1950</unitdate></unittitle>
                 </did>
@@ -4541,7 +4541,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KC5</unitid>
                   <unittitle>Orayama-terraces on slope near Shkuma <unitdate type="inclusive" normal="1950-03">March 1950</unitdate></unittitle>
                 </did>
@@ -4549,7 +4549,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KD1</unitid>
                   <unittitle>Orayama-Smoldering charcoal-burning bus, August 27</unittitle>
                 </did>
@@ -4557,7 +4557,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KD2</unitid>
                   <unittitle>Orayama-Takamatsu Elem.-school children <unitdate type="inclusive" normal="1950-10">October 1950</unitdate></unittitle>
                 </did>
@@ -4565,7 +4565,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KD3</unitid>
                   <unittitle>Orayama-Chinomiya-fire brigade <unitdate type="inclusive" normal="1950-03">March 1950</unitdate></unittitle>
                 </did>
@@ -4573,7 +4573,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KD4</unitid>
                   <unittitle>Orayama-Minamigata <unitdate type="inclusive" normal="1950-03">March 1950</unitdate></unittitle>
                 </did>
@@ -4581,7 +4581,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">15</container>
+                  <container type="othertype" label="No.">No. 15</container>
                   <unitid>KD5</unitid>
                   <unittitle>Orayama-Asahi Press Bldg. <unitdate type="inclusive" normal="1950-08-10">August 10, 1950</unitdate></unittitle>
                 </did>
@@ -4594,7 +4594,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>LA1</unitid>
                   <unittitle>Okayama City-Musician Cart <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -4602,7 +4602,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>LA2</unitid>
                   <unittitle>Okayama City-Koboji (temple)--festival <unitdate type="inclusive" normal="1950-05">May 1950</unitdate></unittitle>
                 </did>
@@ -4610,7 +4610,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>LA3</unitid>
                   <unittitle>Okayama City-Tamashima-head priest of Ensuji <unitdate type="inclusive" normal="1950-03">March 1950</unitdate></unittitle>
                 </did>
@@ -4618,7 +4618,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>LA4</unitid>
                   <unittitle>Okayama City-Juio-sam. by his work of art <unitdate type="inclusive" normal="1951-08-26">August 26, 1951</unitdate></unittitle>
                 </did>
@@ -4626,7 +4626,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>LA5</unitid>
                   <unittitle>Okayama City-Tamashima, Entsugi (temple) <unitdate type="inclusive" normal="1950-03">March 1950</unitdate></unittitle>
                 </did>
@@ -4634,7 +4634,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>LB1</unitid>
                   <unittitle>Okayama City-Sogenji (Zin temple) <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                 </did>
@@ -4642,7 +4642,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>LB2</unitid>
                   <unittitle>Staff at Center for J. Studies <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                 </did>
@@ -4650,7 +4650,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>LB3</unitid>
                   <unittitle>Okayama-Yokake honjin (fendal inn) <unitdate type="inclusive" normal="1950-05">May 1950</unitdate></unittitle>
                 </did>
@@ -4658,7 +4658,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>LB4</unitid>
                   <unittitle>Okayama City-Takashima-charring bottom of fishing boat <unitdate type="inclusive" normal="1950-07">July 1950</unitdate></unittitle>
                 </did>
@@ -4671,7 +4671,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>MA1</unitid>
                   <unittitle>Tokyo-Imperial Palace plaza-Dai Ichi Bldg. <unitdate type="inclusive" normal="1951-03">March 1951</unitdate></unittitle>
                 </did>
@@ -4679,7 +4679,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>MA2</unitid>
                   <unittitle>Tokyo-Imperial Palace plaza-bridge <unitdate type="inclusive" normal="1951-03">March 1951</unitdate></unittitle>
                 </did>
@@ -4687,7 +4687,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>MA3</unitid>
                   <unittitle>Tokyo-Binzo-street scene <unitdate type="inclusive" normal="1951-08">August 1951</unitdate></unittitle>
                 </did>
@@ -4695,7 +4695,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>MA4</unitid>
                   <unittitle>Tokyo-Shimbachi <unitdate type="inclusive" normal="1951-08">August 1951</unitdate></unittitle>
                 </did>
@@ -4703,7 +4703,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>MA5</unitid>
                   <unittitle>Tokyo-Akabusa-big movie house <unitdate type="inclusive" normal="1951-08">August 1951</unitdate></unittitle>
                 </did>
@@ -4711,7 +4711,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>MB1</unitid>
                   <unittitle>Tokyo-Hibuya Park <unitdate type="inclusive" normal="1951-03">March 1951</unitdate></unittitle>
                 </did>
@@ -4719,7 +4719,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>MB2</unitid>
                   <unittitle>Tokyo-Imperial Hotel <unitdate type="inclusive" normal="1951-03">March, 1951</unitdate></unittitle>
                 </did>
@@ -4727,7 +4727,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>MB3</unitid>
                   <unittitle>Tokyo-Binza-new building <unitdate type="inclusive" normal="1951-08">August 1951</unitdate></unittitle>
                 </did>
@@ -4740,7 +4740,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>MC1</unitid>
                   <unittitle>Kyoto-festival at Hietian Shrine <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -4748,7 +4748,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>MC2</unitid>
                   <unittitle>Kyoto-street scene <unitdate type="inclusive" normal="1951-06">June 1951</unitdate></unittitle>
                 </did>
@@ -4756,7 +4756,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">16</container>
+                  <container type="othertype" label="No.">No. 16</container>
                   <unitid>MC3</unitid>
                   <unittitle>Kyoto-festival at Hietian Shrine <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -4765,13 +4765,13 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">16</container>
-                <container type="othertype" label="No.">18</container>
+                <container type="othertype" label="No.">No. 18</container>
                 <unittitle>Miscellaneous</unittitle>
               </did>
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>NA1</unitid>
                   <unittitle>Hishashiyama-Mori Castle ruins <unitdate type="inclusive" normal="1951-08-23">August 23, 1951</unitdate></unittitle>
                 </did>
@@ -4779,7 +4779,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>NA2</unitid>
                   <unittitle>, Marugama-Shikoku-tori pattern-south <unitdate type="inclusive" normal="1951-11-24">November 24, 1951</unitdate></unittitle>
                 </did>
@@ -4787,7 +4787,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>NA3</unitid>
                   <unittitle>Kamakura-Daibutsu <unitdate type="inclusive" normal="1951-08">August 1951</unitdate></unittitle>
                 </did>
@@ -4795,7 +4795,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>NA4</unitid>
                   <unittitle>Shimotsui-resort hotel <unitdate type="inclusive" normal="1951-08">August 1951</unitdate></unittitle>
                 </did>
@@ -4803,7 +4803,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>NA5</unitid>
                   <unittitle>Nara-Todaijo kondo <unitdate type="inclusive" normal="1950-10">October 1950</unitdate></unittitle>
                 </did>
@@ -4811,7 +4811,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>NB1</unitid>
                   <unittitle>Soja-cho-priest &amp; Mr. Taniguchi before temple's pagoda <unitdate type="inclusive" normal="1951-08">August 1951</unitdate></unittitle>
                 </did>
@@ -4819,7 +4819,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>NB2</unitid>
                   <unittitle>Kyoto-Heian-style cart in Jidai Matsuri <unitdate type="inclusive" normal="1950-10">October 1950</unitdate></unittitle>
                 </did>
@@ -4827,7 +4827,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>NB3</unitid>
                   <unittitle>Kamakura-main gate, Hachiman Shrine <unitdate type="inclusive" normal="1951-08">August 1951</unitdate></unittitle>
                 </did>
@@ -4835,7 +4835,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>NB4</unitid>
                   <unittitle>Kyoto-court of Heian Jingu <unitdate type="inclusive" normal="1950-10">October 1950</unitdate></unittitle>
                 </did>
@@ -4843,7 +4843,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>NB5</unitid>
                   <unittitle>Koboji <unitdate type="inclusive" normal="1950-10">October 1950</unitdate></unittitle>
                 </did>
@@ -4851,7 +4851,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>NC1</unitid>
                   <unittitle>Kojima-shi Shrine, Hachiman <unitdate type="inclusive" normal="1950-10">October 1950</unitdate></unittitle>
                 </did>
@@ -4859,7 +4859,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>NC2</unitid>
                   <unittitle>-Kamakura-Daibutsu <unitdate type="inclusive" normal="1950-03">March 1950</unitdate></unittitle>
                 </did>
@@ -4867,7 +4867,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>NC3</unitid>
                   <unittitle>Toru-approach to Toshogu <unitdate type="inclusive" normal="1950-08">August 1950</unitdate></unittitle>
                 </did>
@@ -4875,7 +4875,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>NC4</unitid>
                   <unittitle>Tsukubo, Shoson <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -4883,7 +4883,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>NC5</unitid>
                   <unittitle>-Hiramatsu Sensei <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -4891,7 +4891,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>ND1</unitid>
                   <unittitle>Hakata-semi-commercial bion festival, July 1-14 <unitdate type="inclusive" normal="1950">1950</unitdate></unittitle>
                 </did>
@@ -4899,7 +4899,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>ND2</unitid>
                   <unittitle>Osarva Castle <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -4907,7 +4907,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>ND3</unitid>
                   <unittitle>Kihara granddaughters in No costume <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -4915,7 +4915,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>ND4</unitid>
                   <unittitle>Tainarsu-lighting in grave plot, 1st night of Bion festival</unittitle>
                 </did>
@@ -4923,7 +4923,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">18</container>
+                  <container type="othertype" label="No.">No. 18</container>
                   <unitid>ND5</unitid>
                   <unittitle>ceremonial objects on shelves</unittitle>
                 </did>
@@ -4931,7 +4931,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>OA1</unitid>
                   <unittitle>Beardsley as samurai <unitdate type="inclusive" normal="1950-05">May 1950</unitdate></unittitle>
                 </did>
@@ -4939,7 +4939,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>OA2</unitid>
                   <unittitle>Amano kashidate-bridge <unitdate type="inclusive" normal="1951-06">June 1951</unitdate></unittitle>
                 </did>
@@ -4947,7 +4947,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>OA3</unitid>
                   <unittitle>Harjo-chi-salt field along coast <unitdate type="inclusive" normal="1951-08">August 1951</unitdate></unittitle>
                 </did>
@@ -4955,7 +4955,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>OA4</unitid>
                   <unittitle>Hashirijina-drying shrimp nets <unitdate type="inclusive" normal="1950-08">August 1950</unitdate></unittitle>
                 </did>
@@ -4963,7 +4963,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>OA5</unitid>
                   <unittitle>Ikura-political campaign speech by Station <unitdate type="inclusive" normal="1951-04">April 1951</unitdate></unittitle>
                 </did>
@@ -4971,7 +4971,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>OB1</unitid>
                   <unittitle>Enoshina-causeway <unitdate type="inclusive" normal="1951-08">August 1951</unitdate></unittitle>
                 </did>
@@ -4979,7 +4979,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>OB2</unitid>
                   <unittitle>Kamakura-Prof. Beardsley, Hall, Coheste &amp; wife <unitdate type="inclusive" normal="1950-03">March 1950</unitdate></unittitle>
                 </did>
@@ -4987,7 +4987,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>OB3</unitid>
                   <unittitle>Tamatsukuri-Chorakuen Inn bath house <unitdate type="inclusive" normal="1951-06">June 1951</unitdate></unittitle>
                 </did>
@@ -4995,7 +4995,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>OB4</unitid>
                   <unittitle>Sanindo-Naoe-paddy <unitdate type="inclusive" normal="1951-06">June 1951</unitdate></unittitle>
                 </did>
@@ -5003,7 +5003,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>OB5</unitid>
                   <unittitle>Ohishima boats in cove <unitdate type="inclusive" normal="1950-08">August 1950</unitdate></unittitle>
                 </did>
@@ -5011,7 +5011,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>OC1</unitid>
                   <unittitle>Shimobayashi-approach with lotus pond <unitdate type="inclusive" normal="1950-09">September 1950</unitdate></unittitle>
                 </did>
@@ -5019,7 +5019,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>OC2</unitid>
                   <unittitle>Minamikan-garden, Matsue, Shinane key <unitdate type="inclusive" normal="1950-08">August 1950</unitdate></unittitle>
                 </did>
@@ -5027,7 +5027,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>OC3</unitid>
                   <unittitle>Karsura garden-teahouse <unitdate type="inclusive" normal="1950-08">August 1950</unitdate></unittitle>
                 </did>
@@ -5035,7 +5035,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>OC4</unitid>
                   <unittitle>Unzen-hotsprings <unitdate type="inclusive" normal="1950-12">December 1950</unitdate></unittitle>
                 </did>
@@ -5043,7 +5043,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>OC5</unitid>
                   <unittitle>Senzoker-hanging noodles to dry by rack <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                 </did>
@@ -5051,7 +5051,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>OD1</unitid>
                   <unittitle>Kamahura-Great Buddna <unitdate type="inclusive" normal="1951-08">August 1951</unitdate></unittitle>
                 </did>
@@ -5059,7 +5059,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>CD2</unitid>
                   <unittitle>Sanatzn-cherry blossoms <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -5067,7 +5067,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>OD3</unitid>
                   <unittitle>Ikura-from plateau <unitdate type="inclusive" normal="1951-04">April 1951</unitdate></unittitle>
                 </did>
@@ -5075,7 +5075,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>OD4</unitid>
                   <unittitle>Tsutsu-Ogi Ryuho (priest), Sudo Seitaro (kuzo) at hotel</unittitle>
                 </did>
@@ -5083,7 +5083,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">19</container>
+                  <container type="othertype" label="No.">No. 19</container>
                   <unitid>CD5</unitid>
                   <unittitle>Cryptomeair Avenue leading fun Toshogu-to Futa-arasan, Jinsa <unitdate type="inclusive" normal="1950-08">August 1950</unitdate></unittitle>
                 </did>
@@ -5091,7 +5091,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PA</unitid>
                   <unittitle>Kamo-son, <unitdate type="inclusive" normal="1950">July 5 1950</unitdate></unittitle>
                 </did>
@@ -5099,7 +5099,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PA2</unitid>
                   <unittitle>Takahashi River from K. <unitdate type="inclusive" normal="1950-03">March 1950</unitdate></unittitle>
                 </did>
@@ -5107,7 +5107,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PA3</unitid>
                   <unittitle>Kamakura, Hachiman-gu entrance <unitdate type="inclusive" normal="1950-03">March 1950</unitdate></unittitle>
                 </did>
@@ -5115,7 +5115,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PA4</unitid>
                   <unittitle>Kasuga no Miya Nara <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -5123,7 +5123,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PA5</unitid>
                   <unittitle>Shurakuen at Shimatsu <unitdate type="inclusive" normal="1950-03">March 1950</unitdate></unittitle>
                 </did>
@@ -5131,7 +5131,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PB1</unitid>
                   <unittitle>Kibitsu-Jinja <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                 </did>
@@ -5139,7 +5139,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PB2</unitid>
                   <unittitle>Kurashiki-Shrine <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -5147,7 +5147,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PB3</unitid>
                   <unittitle>Sea of Japan <unitdate type="inclusive" normal="1950-08">August 1950</unitdate></unittitle>
                 </did>
@@ -5155,7 +5155,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PB4</unitid>
                   <unittitle>Mihajima <unitdate type="inclusive" normal="1950-05">May 1950</unitdate></unittitle>
                 </did>
@@ -5163,7 +5163,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PB5</unitid>
                   <unittitle>Lake Hakone, or Takaido Rd., Mach <unitdate type="inclusive" normal="1950">1950</unitdate></unittitle>
                 </did>
@@ -5171,7 +5171,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PC1</unitid>
                   <unittitle>S.S. Gen. Gordon, mid-Pacific Sunset, view to east <unitdate type="inclusive" normal="1950-03">March 1950</unitdate></unittitle>
                 </did>
@@ -5179,7 +5179,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PC2</unitid>
                   <unittitle>Koshin-san view. Valley of Ashimori River <unitdate type="inclusive" normal="1950-06">June 1950</unitdate></unittitle>
                 </did>
@@ -5187,7 +5187,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PC3</unitid>
                   <unittitle>Fukuoka-Matsuri palaguin tying up traffic <unitdate type="inclusive" normal="1950-07">July 1950</unitdate></unittitle>
                 </did>
@@ -5195,7 +5195,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PC4</unitid>
                   <unittitle>Naked festival participants <unitdate type="inclusive" normal="1951-02">February 1951</unitdate></unittitle>
                 </did>
@@ -5203,7 +5203,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PC5</unitid>
                   <unittitle>-Kojima-shi Street procession <unitdate type="inclusive" normal="1950-10">October 1950</unitdate></unittitle>
                 </did>
@@ -5211,7 +5211,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PD1</unitid>
                   <unittitle>morning view from our window <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                 </did>
@@ -5219,7 +5219,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PD2</unitid>
                   <unittitle>Kochi-point at Karsurahama <unitdate type="inclusive" normal="1950-10">October 1950</unitdate></unittitle>
                 </did>
@@ -5227,7 +5227,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PD3</unitid>
                   <unittitle>Kibitsu procession <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                 </did>
@@ -5235,7 +5235,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PD4</unitid>
                   <unittitle>Sakadzu-flower viewing <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -5243,7 +5243,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">20</container>
+                  <container type="othertype" label="No.">No. 20</container>
                   <unitid>PD5</unitid>
                   <unittitle>Shimobayashi-togarashi drying <unitdate type="inclusive" normal="1950-09">September 1950</unitdate></unittitle>
                 </did>
@@ -5251,7 +5251,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">21</container>
+                  <container type="othertype" label="No.">No. 21</container>
                   <unitid>QA1</unitid>
                   <unittitle>Hashihama-Shikoku coast from island <unitdate type="inclusive" normal="1950-05">May 1950</unitdate></unittitle>
                 </did>
@@ -5259,7 +5259,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">21</container>
+                  <container type="othertype" label="No.">No. 21</container>
                   <unitid>QA2</unitid>
                   <unittitle>Shimotsu-center's fishing trip <unitdate type="inclusive" normal="1950-07">July 1950</unitdate></unittitle>
                 </did>
@@ -5267,7 +5267,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">21</container>
+                  <container type="othertype" label="No.">No. 21</container>
                   <unitid>QA3</unitid>
                   <unittitle>Takahashi River-falls <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                 </did>
@@ -5275,7 +5275,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">21</container>
+                  <container type="othertype" label="No.">No. 21</container>
                   <unitid>QA4</unitid>
                   <unittitle>Palace Garden, Katsura detached from <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -5283,7 +5283,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">21</container>
+                  <container type="othertype" label="No.">No. 21</container>
                   <unitid>QA5</unitid>
                   <unittitle>Kochi-point at Katsurahama <unitdate type="inclusive" normal="1950-10">October 1950</unitdate></unittitle>
                 </did>
@@ -5291,7 +5291,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">21</container>
+                  <container type="othertype" label="No.">No. 21</container>
                   <unitid>QB1</unitid>
                   <unittitle>Kojima-Shi. Hama-Kampyot fish drying <unitdate type="inclusive" normal="1950-08">August 1950</unitdate></unittitle>
                 </did>
@@ -5299,7 +5299,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">21</container>
+                  <container type="othertype" label="No.">No. 21</container>
                   <unitid>QB2</unitid>
                   <unittitle>Horen-peasant house <unitdate type="inclusive" normal="1950-09">September 1950</unitdate></unittitle>
                 </did>
@@ -5307,7 +5307,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">21</container>
+                  <container type="othertype" label="No.">No. 21</container>
                   <unitid>QB3</unitid>
                   <unittitle>Tsushima-Magere-woman diver <unitdate type="inclusive" normal="1950-08">August 1950</unitdate></unittitle>
                 </did>
@@ -5315,7 +5315,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">21</container>
+                  <container type="othertype" label="No.">No. 21</container>
                   <unitid>QB4</unitid>
                   <unittitle>Nara Todarji-Honden <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -5323,7 +5323,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">21</container>
+                  <container type="othertype" label="No.">No. 21</container>
                   <unitid>QB5</unitid>
                   <unittitle>Kamakura-Daibutsu <unitdate type="inclusive" normal="1950-03">March 1950</unitdate></unittitle>
                 </did>
@@ -5331,7 +5331,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">21</container>
+                  <container type="othertype" label="No.">No. 21</container>
                   <unitid>QC1</unitid>
                   <unittitle>Miyajima <unitdate type="inclusive" normal="1950-05">May 1950</unitdate></unittitle>
                 </did>
@@ -5339,7 +5339,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">21</container>
+                  <container type="othertype" label="No.">No. 21</container>
                   <unitid>QC2</unitid>
                   <unittitle>Miyajimaen route to <unitdate type="inclusive" normal="1950-05">May 1950</unitdate></unittitle>
                 </did>
@@ -5347,7 +5347,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">21</container>
+                  <container type="othertype" label="No.">No. 21</container>
                   <unitid>QC3</unitid>
                   <unittitle>our apt. at K(amakura?) <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                 </did>
@@ -5355,7 +5355,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">21</container>
+                  <container type="othertype" label="No.">No. 21</container>
                   <unitid>QC4</unitid>
                   <unittitle>drying willet and kura at K(amakura?) <unitdate type="inclusive" normal="1950-11">November 1950</unitdate></unittitle>
                 </did>
@@ -5363,7 +5363,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">21</container>
+                  <container type="othertype" label="No.">No. 21</container>
                   <unitid>QC5</unitid>
                   <unittitle>Nara Park-Kasuga no-Miza Temple <unitdate type="inclusive" normal="1950-04">April 1950</unitdate></unittitle>
                 </did>
@@ -5371,7 +5371,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">21</container>
+                  <container type="othertype" label="No.">No. 21</container>
                   <unitid>QD1</unitid>
                   <unittitle>Fishing boats at (blank) <unitdate type="inclusive" normal="1950-08">August 1950</unitdate></unittitle>
                 </did>
@@ -5379,7 +5379,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">22</container>
+                  <container type="othertype" label="No.">No. 22</container>
                   <unitid>RA1-5</unitid>
                   <unittitle>Miscellaneous Unidentified slides of Japan</unittitle>
                 </did>
@@ -5387,7 +5387,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">22</container>
+                  <container type="othertype" label="No.">No. 22</container>
                   <unitid>RB1-5</unitid>
                   <unittitle>Miscellaneous Unidentified slides of Japan</unittitle>
                 </did>
@@ -5395,7 +5395,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">22</container>
+                  <container type="othertype" label="No.">No. 22</container>
                   <unitid>RC1-5</unitid>
                   <unittitle>Miscellaneous Unidentified slides of Japan</unittitle>
                 </did>
@@ -5403,7 +5403,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">22</container>
+                  <container type="othertype" label="No.">No. 22</container>
                   <unitid>RD1-2</unitid>
                   <unittitle>Miscellaneous Unidentified slides of Japan</unittitle>
                 </did>
@@ -5411,7 +5411,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">23</container>
+                  <container type="othertype" label="No.">No. 23</container>
                   <unitid>SAl-5</unitid>
                   <unittitle>Unidentified slides of Korea</unittitle>
                 </did>
@@ -5419,7 +5419,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">23</container>
+                  <container type="othertype" label="No.">No. 23</container>
                   <unitid>SB1-5</unitid>
                   <unittitle>Unidentified slides of Korea</unittitle>
                 </did>
@@ -5427,7 +5427,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">23</container>
+                  <container type="othertype" label="No.">No. 23</container>
                   <unitid>SC1-5</unitid>
                   <unittitle>Unidentified slides of Korea</unittitle>
                 </did>
@@ -5435,7 +5435,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">24</container>
+                  <container type="othertype" label="No.">No. 24</container>
                   <unitid>TA1-5</unitid>
                   <unittitle>Unidentified slides of Korea</unittitle>
                 </did>
@@ -5443,7 +5443,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">24</container>
+                  <container type="othertype" label="No.">No. 24</container>
                   <unitid>TB1-5</unitid>
                   <unittitle>Unidentified slides of Korea</unittitle>
                 </did>
@@ -5451,7 +5451,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">24</container>
+                  <container type="othertype" label="No.">No. 24</container>
                   <unitid>TC1-5</unitid>
                   <unittitle>Unidentified slides of Korea</unittitle>
                 </did>
@@ -5459,7 +5459,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">24</container>
+                  <container type="othertype" label="No.">No. 24</container>
                   <unitid>TD1-5</unitid>
                   <unittitle>Unidentified slides of Korea</unittitle>
                 </did>
@@ -5467,7 +5467,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">25</container>
+                  <container type="othertype" label="No.">No. 25</container>
                   <unitid>UAl-5</unitid>
                   <unittitle>unidentified slides</unittitle>
                 </did>
@@ -5475,7 +5475,7 @@
               <c05 level="item">
                 <did>
                   <container type="box" label="Box">16</container>
-                  <container type="othertype" label="No.">25</container>
+                  <container type="othertype" label="No.">No. 25</container>
                   <unitid>UB1-2</unitid>
                   <unittitle>unidentified slides</unittitle>
                 </did>


### PR DESCRIPTION
You can't see it because the files are too big, but this takes care of adding the container label to the container text for subcontainers of type "othertype"

As an example,

<container type="othertype" label="Con.">1</container>

is now...

<container type="othertype" label="Con.">Con. 1</container>
