### PR TITLE
Combine lone container summaries with extent they came from

### DIFF
--- a/Real_Masters_all/aathrift.xml
+++ b/Real_Masters_all/aathrift.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">87477 Bk 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Philanthropic organization established to aid the needy through the resale of merchandise. Minutes of board and general meetings, financial records, constitution and by-laws, history, and photographs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/aathrift.xml
+++ b/Real_Masters_all/aathrift.xml
@@ -43,8 +43,6 @@
       <abstract>Philanthropic organization established to aid the needy through the resale of merchandise. Minutes of board and general meetings, financial records, constitution and by-laws, history, and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/aitonasp.xml
+++ b/Real_Masters_all/aitonasp.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">[7219] DA 2; A311; P186</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Professor of Latin American history at the University of Michigan. Reprints of journal articles and other writings.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.3 linear feet</extent>
         <extent altrender="carrier">(in 1 box)</extent>
       </physdesc>

--- a/Real_Masters_all/aitonasp.xml
+++ b/Real_Masters_all/aitonasp.xml
@@ -43,8 +43,6 @@
       <abstract>Professor of Latin American history at the University of Michigan. Reprints of journal articles and other writings.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 1 box)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/aprillth.xml
+++ b/Real_Masters_all/aprillth.xml
@@ -47,8 +47,6 @@
       <abstract>Lifelong member of Zion Lutheran Church, Ann Arbor, Michigan, Aprill served for several years in the 1990s as a member of the Church’s Executive Board. Papers include files relating to the history of Zion Lutheran Church, including a conflict within the church in the mid-1990s.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/aprillth.xml
+++ b/Real_Masters_all/aprillth.xml
@@ -45,7 +45,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2008065 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Lifelong member of Zion Lutheran Church, Ann Arbor, Michigan, Aprill served for several years in the 1990s as a member of the Church’s Executive Board. Papers include files relating to the history of Zion Lutheran Church, including a conflict within the church in the mid-1990s.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/armstron.xml
+++ b/Real_Masters_all/armstron.xml
@@ -43,8 +43,6 @@
       <abstract>Hillsdale, Michigan, Singer Sewing Machine Company representative in central China, 1911-1917; wife, Elsa F. Armstrong of Northfield, Minnesota, Evangelical Lutheran missionary in China, 1911-1917. Correspondence between Arthur and Elsa Armstrong, Elsa Armstrong's family, and other missionaries, concerning life in China; also photographs and Arthur and Elsa Armstrong's reminiscences of China.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/armstron.xml
+++ b/Real_Masters_all/armstron.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">854 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Hillsdale, Michigan, Singer Sewing Machine Company representative in central China, 1911-1917; wife, Elsa F. Armstrong of Northfield, Minnesota, Evangelical Lutheran missionary in China, 1911-1917. Correspondence between Arthur and Elsa Armstrong, Elsa Armstrong's family, and other missionaries, concerning life in China; also photographs and Arthur and Elsa Armstrong's reminiscences of China.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/bachbarb.xml
+++ b/Real_Masters_all/bachbarb.xml
@@ -43,8 +43,6 @@
       <abstract>Barbara Bach first worked as a Boston area schoolteacher and creator of television documentaries. After receiving a Master's degree in Education in 1969, she became an Ann Arbor, Mich. businesswoman, networking facilitator, fundraiser, and lifelong educator/mentor to individuals and organizations. The collection includes business records, association newsletters, campaign literature, photographs, and correspondence representing her multiple careers as an entrepreneur, legislative aide, community activist, and executive director in a policy environment promoting economic development in Michigan.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">9.3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 10 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/bachbarb.xml
+++ b/Real_Masters_all/bachbarb.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2013048 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Barbara Bach first worked as a Boston area schoolteacher and creator of television documentaries. After receiving a Master's degree in Education in 1969, she became an Ann Arbor, Mich. businesswoman, networking facilitator, fundraiser, and lifelong educator/mentor to individuals and organizations. The collection includes business records, association newsletters, campaign literature, photographs, and correspondence representing her multiple careers as an entrepreneur, legislative aide, community activist, and executive director in a policy environment promoting economic development in Michigan.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">9.3 linear feet</extent>
         <extent altrender="carrier">(in 10 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/barretta.xml
+++ b/Real_Masters_all/barretta.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">9766 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Physician, early specialist in the treatment of mental illness; correspondence; topical files; lectures and publications; casework; and photographs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/barretta.xml
+++ b/Real_Masters_all/barretta.xml
@@ -43,8 +43,6 @@
       <abstract>Physician, early specialist in the treatment of mental illness; correspondence; topical files; lectures and publications; casework; and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/beardsly.xml
+++ b/Real_Masters_all/beardsly.xml
@@ -49,8 +49,6 @@
       </note>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">5.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 6 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/beardsly.xml
+++ b/Real_Masters_all/beardsly.xml
@@ -47,7 +47,7 @@
       <note>
         <p><emph>Sponsor:</emph> This finding aid is a product of a project supported by a grant awarded to the Bentley Historical Library and University of Michigan Museum of Anthropology in 2002 by the Division of Preservation and Access of the National Endowment for the Humanities, an independent federal agency.</p>
       </note>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">5.5 linear feet</extent>
         <extent altrender="carrier">(in 6 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/beekman.xml
+++ b/Real_Masters_all/beekman.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2011041 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Collection of correspondence, records of committees and organizations, legislation drafts, and research material on the subject of Special Education programs and services, created and used by Lynwood Beekman in his law practice and in drafting of the Michigan Special Education legislation.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">9.25 linear feet</extent>
         <extent altrender="carrier">(in 10 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/beekman.xml
+++ b/Real_Masters_all/beekman.xml
@@ -43,8 +43,6 @@
       <abstract>Collection of correspondence, records of committees and organizations, legislation drafts, and research material on the subject of Special Education programs and services, created and used by Lynwood Beekman in his law practice and in drafting of the Michigan Special Education legislation.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">9.25 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 10 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/beggvic.xml
+++ b/Real_Masters_all/beggvic.xml
@@ -47,8 +47,6 @@
       <abstract>Collection of records, correspondence, memoranda, issued official statements, and architectural drawings of The Muslim Unity Center of Bloomfield Hills, Michigan, the Council of Islamic Organizations of Michigan and other Islamic organizations in Michigan and the U.S.; correspondence and memoranda, statements and articles written by and about interfaith organizations and projects in Michigan; also correspondence, conference presentations, speeches, and newspaper articles written by and about Victor Begg; reports and articles about Muslim communities in Michigan and in the U.S., politics in the Middle East, interfaith dialogue, and terrorism.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.6 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/beggvic.xml
+++ b/Real_Masters_all/beggvic.xml
@@ -45,7 +45,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2011075 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Collection of records, correspondence, memoranda, issued official statements, and architectural drawings of The Muslim Unity Center of Bloomfield Hills, Michigan, the Council of Islamic Organizations of Michigan and other Islamic organizations in Michigan and the U.S.; correspondence and memoranda, statements and articles written by and about interfaith organizations and projects in Michigan; also correspondence, conference presentations, speeches, and newspaper articles written by and about Victor Begg; reports and articles about Muslim communities in Michigan and in the U.S., politics in the Middle East, interfaith dialogue, and terrorism.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.6 linear feet</extent>
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/bethelro.xml
+++ b/Real_Masters_all/bethelro.xml
@@ -58,8 +58,6 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">10 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 11 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">

--- a/Real_Masters_all/bethisraelcong.xml
+++ b/Real_Masters_all/bethisraelcong.xml
@@ -58,7 +58,7 @@ Beth Israel Congregation Jewish Life in Ann Arbor Oral History Project records
 
  
 </unittitle>
-      <physdesc>
+      <physdesc altrender="whole">
         <extent encodinganalog="300">
 0.2 linear feet and 7.48 GB (online) 
 </extent>

--- a/Real_Masters_all/bonistee.xml
+++ b/Real_Masters_all/bonistee.xml
@@ -52,7 +52,7 @@
       <abstract>Ann Arbor, Michigan, attorney, Republican regent of the University of Michigan. Correspondence and other materials relating to state and local Republican party affairs, particularly the election of 1944 and the Constitutional Convention, 1961-1962; organizational files, primarily concerning activities with the Rotary Club, the Free and Accepted Order of Masons, the National Music Camp at Interlochen, the American Bar Association, the First Presbyterian Church of Ann Arbor, the Historical Society of Michigan, Cleary College, Dickinson College in Carlisle, Pennsylvania, and the Wayne State University Board of Governors; and photographs.</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">85518 Aa 2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">13 linear feet</extent>
         <extent altrender="carrier">(in 14 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/bonistee.xml
+++ b/Real_Masters_all/bonistee.xml
@@ -54,8 +54,6 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">13 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 14 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/bratere.xml
+++ b/Real_Masters_all/bratere.xml
@@ -47,8 +47,6 @@
       <abstract>Member of the Michigan State Senate, House of Representatives, Ann Arbor City Council, and Mayor of Ann Arbor; records include handwritten notes on policy issues, collected research materials, and news clippings related to Brater’s service as a member of the Michigan State Senate and House of Representatives.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">19.75 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 20 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">

--- a/Real_Masters_all/brewerdwight.xml
+++ b/Real_Masters_all/brewerdwight.xml
@@ -61,7 +61,7 @@ Dwight J. Brewer papers
 1862-1865
 </unitdate>
 </unittitle>
-      <physdesc>
+      <physdesc altrender="whole">
         <extent encodinganalog="300">
 0.3 linear feet and 393.3 MB (online)
 </extent>
@@ -148,7 +148,7 @@ Dwight J. Brewer, Bentley Historical Library, University of Michigan</p>
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Correspondence, <unitdate type="inclusive" normal="1862/1865">1862-1865</unitdate> </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>18 folders</extent>
             </physdesc>
           </did>

--- a/Real_Masters_all/brownhen.xml
+++ b/Real_Masters_all/brownhen.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">85956 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Historian and manuscript curator; collected historical materials and various activities files.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/brownhen.xml
+++ b/Real_Masters_all/brownhen.xml
@@ -43,8 +43,6 @@
       <abstract>Historian and manuscript curator; collected historical materials and various activities files.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/brownjam.xml
+++ b/Real_Masters_all/brownjam.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">8574 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Papers of the Rev. James A. Brown, Michigan Methodist minister, and his wife Winifred Croel Brown. Correspondence, diaries, sermons, photographs and other materials relating in part to their pastorate in Elsie, Michigan, life during the depression; include comments on farming conditions, politics, and the effects of prohibition.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3.5 linear feet</extent>
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/brownjam.xml
+++ b/Real_Masters_all/brownjam.xml
@@ -43,8 +43,6 @@
       <abstract>Papers of the Rev. James A. Brown, Michigan Methodist minister, and his wife Winifred Croel Brown. Correspondence, diaries, sermons, photographs and other materials relating in part to their pastorate in Elsie, Michigan, life during the depression; include comments on farming conditions, politics, and the effects of prohibition.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/burrowsf.xml
+++ b/Real_Masters_all/burrowsf.xml
@@ -40,7 +40,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">85895 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Burrows-Avery-Smith families of New York, Connecticut, and Michigan. Correspondence and business papers of Lorenzo Burrows, New York Congressman, 1849-1853; George L. Burrows, Saginaw, Michigan, banker and speculator; material concerning the Whig Party and New York state politics, 1848-1860. Correspondents include: Millard Fillmore, Washington Hunt, and John Young.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">6 linear feet</extent>
         <extent altrender="carrier">(in 7 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/burrowsf.xml
+++ b/Real_Masters_all/burrowsf.xml
@@ -42,8 +42,6 @@
       <abstract>Burrows-Avery-Smith families of New York, Connecticut, and Michigan. Correspondence and business papers of Lorenzo Burrows, New York Congressman, 1849-1853; George L. Burrows, Saginaw, Michigan, banker and speculator; material concerning the Whig Party and New York state politics, 1848-1860. Correspondents include: Millard Fillmore, Washington Hunt, and John Young.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">6 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 7 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/butterfi.xml
+++ b/Real_Masters_all/butterfi.xml
@@ -57,8 +57,6 @@
       </note>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">10 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 11 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">

--- a/Real_Masters_all/campbelj.xml
+++ b/Real_Masters_all/campbelj.xml
@@ -50,8 +50,6 @@
       <abstract>University of Michigan professor of law, Detroit, Michigan, attorney, Michigan Supreme Court justice. Family correspondence, journal of trip to Sandusky, Ohio, in 1844, and lecture materials; also papers of Valeria Campbell, corresponding secretary of the Soldiers' Aid Society of Detroit, U. S. Sanitary Commission, concerning the society, the Detroit Soldiers' Home, and other relief agencies; and University student letters, 1872-1876, of Henry M. Campbell.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4.2 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 5 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">

--- a/Real_Masters_all/ccmich.xml
+++ b/Real_Masters_all/ccmich.xml
@@ -50,8 +50,6 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">16.75 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 17 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/ccmich.xml
+++ b/Real_Masters_all/ccmich.xml
@@ -48,7 +48,7 @@
       <abstract>Record group consists of Administration, Office Reference, and Reforms subgroups; files relate to lobbying efforts on behalf of campaign reform, ethics in politics, lobbying reform.</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">90125 Bm 2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">16.75 linear feet</extent>
         <extent altrender="carrier">(in 17 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/cew.xml
+++ b/Real_Masters_all/cew.xml
@@ -40,7 +40,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">8740 Bimu C484 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Minutes, correspondence, audiovisual materials, and other records documenting the founding, public programs, research projects, day-to-day administrative activities, and individual staff members of the University of Michigan's Center for the Education of Women.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">42 linear feet</extent>
         <extent altrender="carrier">(in 43 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/cew.xml
+++ b/Real_Masters_all/cew.xml
@@ -42,8 +42,6 @@
       <abstract>Minutes, correspondence, audiovisual materials, and other records documenting the founding, public programs, research projects, day-to-day administrative activities, and individual staff members of the University of Michigan's Center for the Education of Women.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">42 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 43 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/cewpub.xml
+++ b/Real_Masters_all/cewpub.xml
@@ -46,7 +46,7 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Center for the Education of Women publications
 include miscellaneous bibliographies, brochures, calendars, flyers, journals, and proceedings. Also includes newsletters such as <title render="italic">Cornerstone</title> and <title render="italic">Newsletter: Center for Continuing Education of Women</title>; reports documenting the history of CEW such as Center for the Education of Women: 30 Year Anniversary Report, 1964-1994 and publications describing CEW library holdings and materials from the Women in Science Program.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/cewpub.xml
+++ b/Real_Masters_all/cewpub.xml
@@ -48,8 +48,6 @@
 include miscellaneous bibliographies, brochures, calendars, flyers, journals, and proceedings. Also includes newsletters such as <title render="italic">Cornerstone</title> and <title render="italic">Newsletter: Center for Continuing Education of Women</title>; reports documenting the history of CEW such as Center for the Education of Women: 30 Year Anniversary Report, 1964-1994 and publications describing CEW library holdings and materials from the Women in Science Program.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/chapinrd.xml
+++ b/Real_Masters_all/chapinrd.xml
@@ -62,8 +62,6 @@
       <abstract>Lansing, Michigan businessman, founder of the Hudson Motor car Company, Secretary of Commerce in the Hoover Administration, leader of the "good roads movement" and the Lincoln Highway Association. Collection includes correspondence, speeches, business papers, clippings and scrapbooks and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">32 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 33 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">

--- a/Real_Masters_all/charnetski.xml
+++ b/Real_Masters_all/charnetski.xml
@@ -43,8 +43,6 @@
       <abstract>Papers of Clark J. Charnetski (1942- ), a physicist who specialized in holographic research and development at Conductron Corporation in Ann Arbor, Mich., where he was the Associate Research Physicist and Chief Holographer. This collection contains materials relating to the administrative background of Conductron Corporation, materials relating to holography in Michigan collected by Charnetski, papers and presentations given by Charnetski and Conductron Corporation, notes, drawings, information relating to patents of Charnetski and others at Conductron, as well as detailed papers regarding the projects that Charnetski conducted while at Conductron.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3.1 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/charnetski.xml
+++ b/Real_Masters_all/charnetski.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2014075 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Papers of Clark J. Charnetski (1942- ), a physicist who specialized in holographic research and development at Conductron Corporation in Ann Arbor, Mich., where he was the Associate Research Physicist and Chief Holographer. This collection contains materials relating to the administrative background of Conductron Corporation, materials relating to holography in Michigan collected by Charnetski, papers and presentations given by Charnetski and Conductron Corporation, notes, drawings, information relating to patents of Charnetski and others at Conductron, as well as detailed papers regarding the projects that Charnetski conducted while at Conductron.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3.1 linear feet</extent>
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/chavisj.xml
+++ b/Real_Masters_all/chavisj.xml
@@ -43,8 +43,6 @@
       <abstract>Historian and administrator at University of Michigan and Tuskegee Institute. Minutes, reports and correspondence relating primarily to enrollment of black students at University of Michigan, including material concerning his work with the Steering Committee for the Development of Academic Opportunities, the Opportunity Award Program, and the Exchange Program with Tuskegee Institute.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.25 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/chavisj.xml
+++ b/Real_Masters_all/chavisj.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">851047 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Historian and administrator at University of Michigan and Tuskegee Institute. Minutes, reports and correspondence relating primarily to enrollment of black students at University of Michigan, including material concerning his work with the Steering Committee for the Development of Academic Opportunities, the Opportunity Award Program, and the Exchange Program with Tuskegee Institute.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.25 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/chgdshep.xml
+++ b/Real_Masters_all/chgdshep.xml
@@ -40,7 +40,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">06112 Ba 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Church of the Good Shepherd (Episcopal) in Dearborn Heights, Michigan was established in 1954. In 1990, the church building was sold; and in 1998, the congregation officially disbanded. The records include a complete register of church vital records, parochial reports, and annual reports.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3.3 linear feet</extent>
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/chgdshep.xml
+++ b/Real_Masters_all/chgdshep.xml
@@ -42,8 +42,6 @@
       <abstract>Church of the Good Shepherd (Episcopal) in Dearborn Heights, Michigan was established in 1954. In 1990, the church building was sold; and in 1998, the congregation officially disbanded. The records include a complete register of church vital records, parochial reports, and annual reports.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3.3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/civileng.xml
+++ b/Real_Masters_all/civileng.xml
@@ -289,7 +289,7 @@ Department of Civil and Environmental Engineering (University of Michigan) recor
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>Reports of Department Chairs, <unitdate type="inclusive" normal="1999/2000">1999-2000</unitdate> </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>2 folders</extent>
             </physdesc>
           </did>
@@ -521,7 +521,7 @@ Department of Civil and Environmental Engineering (University of Michigan) recor
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>Department Correspondence, <unitdate type="inclusive" normal="1987/1992">1987-1992</unitdate> </unittitle>
-              <physdesc>
+              <physdesc altrender="whole">
                 <extent>2 folders</extent>
               </physdesc>
             </did>
@@ -552,7 +552,7 @@ Department of Civil and Environmental Engineering (University of Michigan) recor
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>Executive Committee </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>2 folders</extent>
             </physdesc>
           </did>
@@ -564,7 +564,7 @@ Department of Civil and Environmental Engineering (University of Michigan) recor
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Faculty Meeting Minutes, <unitdate type="inclusive" normal="1985">1985</unitdate>, <unitdate type="inclusive" normal="1989/1996">1989-1996</unitdate>, <unitdate type="inclusive" normal="1998">1998</unitdate>, <unitdate type="inclusive" normal="2000/2001">2000-2001</unitdate> </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>9 folders</extent>
             </physdesc>
           </did>
@@ -603,7 +603,7 @@ Department of Civil and Environmental Engineering (University of Michigan) recor
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Rules of the Faculty Minutes, <unitdate type="inclusive" normal="1963/1984">1963-1984</unitdate> </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>3 folders</extent>
             </physdesc>
           </did>
@@ -633,7 +633,7 @@ Department of Civil and Environmental Engineering (University of Michigan) recor
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Search for Department Chair, <unitdate type="inclusive" normal="1984">1984</unitdate>, <unitdate type="inclusive" normal="1999">1999</unitdate> </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>2 folders</extent>
             </physdesc>
           </did>
@@ -653,7 +653,7 @@ Department of Civil and Environmental Engineering (University of Michigan) recor
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Academic Budget, <unitdate type="inclusive" normal="1941/1947">1941-1947</unitdate>, <unitdate type="inclusive" normal="1949/1951">1949-1951</unitdate> </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>2 folders</extent>
             </physdesc>
           </did>
@@ -703,7 +703,7 @@ Department of Civil and Environmental Engineering (University of Michigan) recor
           <did>
             <container type="box" label="Box">5</container>
             <unittitle>Correspondence, <unitdate type="inclusive" normal="1993/1994">1993-1994</unitdate> </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>2 folders</extent>
             </physdesc>
           </did>

--- a/Real_Masters_all/cjsumpub.xml
+++ b/Real_Masters_all/cjsumpub.xml
@@ -52,7 +52,7 @@
       <abstract>Interdisciplinary, area studies center at the University of Michigan. Publications include brochures and pamphlets, calendars, catalogs of center publications, flyers, newsletters, posters, press releases, bulletins and course catalogs, lectures, manuals, programs, and reports. Also contains bulletin from summer session. There are also programs which describe the U.S.- Japan Automotive Industry Conference. Also includes a monograph from the Series Michigan Papers in Japanese Studies</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">9748 Bimu C170 2 UBImul C170</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/cjsumpub.xml
+++ b/Real_Masters_all/cjsumpub.xml
@@ -54,8 +54,6 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/communic.xml
+++ b/Real_Masters_all/communic.xml
@@ -45,7 +45,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">87124 Bimu C26 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Formerly called the Department of Journalism; includes administrative files, records of sponsored workshops, conferences, and lectures; faculty personnel files; and records of internship programs, including reports from students interning at local Michigan newspapers.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">9.3 linear feet</extent>
         <extent altrender="carrier">(in 10 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/communic.xml
+++ b/Real_Masters_all/communic.xml
@@ -47,8 +47,6 @@
       <abstract>Formerly called the Department of Journalism; includes administrative files, records of sponsored workshops, conferences, and lectures; faculty personnel files; and records of internship programs, including reports from students interning at local Michigan newspapers.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">9.3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 10 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/conger.xml
+++ b/Real_Masters_all/conger.xml
@@ -42,8 +42,6 @@
       <abstract>The Lucile B. Conger Alumnae Chapter was established in 1947 as an offshoot of the Junior Michigan Alumnae Group. The Conger Chapter provides financial support and mentorship to women attending the University of Michigan through annual fundraising and social events. Materials include officer records, newsletters, membership directories, and scrapbooks.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/conger.xml
+++ b/Real_Masters_all/conger.xml
@@ -40,7 +40,7 @@
       <unitid encodinganalog="099" repositorycode="MiU-H" countrycode="us" type="call number">04138 Bimu H6 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>The Lucile B. Conger Alumnae Chapter was established in 1947 as an offshoot of the Junior Michigan Alumnae Group. The Conger Chapter provides financial support and mentorship to women attending the University of Michigan through annual fundraising and social events. Materials include officer records, newsletters, membership directories, and scrapbooks.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/coolmary.xml
+++ b/Real_Masters_all/coolmary.xml
@@ -43,8 +43,6 @@
       <abstract>Assistant to the director of the Hopwood Awards program at the University of Michigan; correspondence relating in part to her research into the life and career of American admiral and explorer, Charles Wilkes.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/coolmary.xml
+++ b/Real_Masters_all/coolmary.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">85169 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Assistant to the director of the Hopwood Awards program at the University of Michigan; correspondence relating in part to her research into the life and career of American admiral and explorer, Charles Wilkes.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.5 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/coonsdh.xml
+++ b/Real_Masters_all/coonsdh.xml
@@ -43,8 +43,6 @@
       <abstract>Gerontologist at the Institute of Gerontology of the University of Michigan, specializing in Alzheimer's Disease and the training and education of people working with the elderly. Professional papers, including correspondence, subject files, papers and reports, and files relating to workshops and symposia attended; Alzheimer's Disease research files; photographs; and other audio-visual materials.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/coonsdh.xml
+++ b/Real_Masters_all/coonsdh.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">90138 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Gerontologist at the Institute of Gerontology of the University of Michigan, specializing in Alzheimer's Disease and the training and education of people working with the elderly. Professional papers, including correspondence, subject files, papers and reports, and files relating to workshops and symposia attended; Alzheimer's Disease research files; photographs; and other audio-visual materials.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/culvermm.xml
+++ b/Real_Masters_all/culvermm.xml
@@ -43,8 +43,6 @@
       <abstract>Papers of Washtenaw County, Mich. architectural historian and preservation activist Mary M. Culver. Collection includes records of Washtenaw County, Mich. historic preservation organizations, Culver's research files and presentations, and images of Michigan historic buildings.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2.3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/culvermm.xml
+++ b/Real_Masters_all/culvermm.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2014064 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Papers of Washtenaw County, Mich. architectural historian and preservation activist Mary M. Culver. Collection includes records of Washtenaw County, Mich. historic preservation organizations, Culver's research files and presentations, and images of Michigan historic buildings.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.3 linear feet</extent>
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/currtop.xml
+++ b/Real_Masters_all/currtop.xml
@@ -45,7 +45,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">90126 Bk 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Constitution and bylaws, correspondence, minutes, photographs, and programs; minutes describe presentation by Raoul Wallenberg about Sweden and Swedish architecture.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/currtop.xml
+++ b/Real_Masters_all/currtop.xml
@@ -47,8 +47,6 @@
       <abstract>Constitution and bylaws, correspondence, minutes, photographs, and programs; minutes describe presentation by Raoul Wallenberg about Sweden and Swedish architecture.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/cwuchel.xml
+++ b/Real_Masters_all/cwuchel.xml
@@ -43,8 +43,6 @@
       <abstract>Records of Chelsea, Michigan chapter of Church Women United, an interdenominational church women's organization. Minutes of meetings, reports, memoranda, scrapbooks, and collected printed materials relating to activities and interests.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.65 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/cwuchel.xml
+++ b/Real_Masters_all/cwuchel.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2014054 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Records of Chelsea, Michigan chapter of Church Women United, an interdenominational church women's organization. Minutes of meetings, reports, memoranda, scrapbooks, and collected printed materials relating to activities and interests.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.65 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/davisannb.xml
+++ b/Real_Masters_all/davisannb.xml
@@ -61,7 +61,7 @@ Ann B. Davis papers
 1956-2010
 </unitdate>
 </unittitle>
-      <physdesc>
+      <physdesc altrender="whole">
         <extent encodinganalog="300">
 3.5 linear feet, 1 oversize volume and 15 GB (online)
 
@@ -493,7 +493,7 @@ The collection is arranged into five series: Personal Files, Professional Files,
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Alice's Brady Bunch Cookbook, <unitdate type="inclusive" normal="1994">1994</unitdate> </unittitle>
-              <physdesc>
+              <physdesc altrender="whole">
                 <extent>2 folders</extent>
               </physdesc>
             </did>
@@ -544,7 +544,7 @@ The collection is arranged into five series: Personal Files, Professional Files,
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Photographs </unittitle>
-              <physdesc>
+              <physdesc altrender="whole">
                 <extent>3 folders</extent>
               </physdesc>
             </did>
@@ -578,7 +578,7 @@ The collection is arranged into five series: Personal Files, Professional Files,
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Myrnalene, <unitdate type="inclusive" normal="1961">1961</unitdate> </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>2 folders</extent>
             </physdesc>
           </did>
@@ -679,7 +679,7 @@ The collection is arranged into five series: Personal Files, Professional Files,
               <unittitle>
                 <unitdate type="inclusive" normal="1993/1996">1993-1996</unitdate>
               </unittitle>
-              <physdesc>
+              <physdesc altrender="whole">
                 <extent>2 folders</extent>
               </physdesc>
             </did>
@@ -707,7 +707,7 @@ The collection is arranged into five series: Personal Files, Professional Files,
               <unittitle>
                 <unitdate type="inclusive" normal="2006/2007">2006-2007</unitdate>
               </unittitle>
-              <physdesc>
+              <physdesc altrender="whole">
                 <extent>4 folders</extent>
               </physdesc>
             </did>
@@ -767,7 +767,7 @@ The collection is arranged into five series: Personal Files, Professional Files,
             <did>
               <physloc>Online </physloc>
               <unittitle>Granny's Dinner Playhouse, Dallas, Texas, <unitdate type="inclusive" normal="1975">1975</unitdate> </unittitle>
-              <physdesc>
+              <physdesc altrender="whole">
                 <extent>2 folders</extent>
               </physdesc>
             </did>
@@ -889,7 +889,7 @@ The collection is arranged into five series: Personal Files, Professional Files,
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Friend's Pictures </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>2 folders</extent>
             </physdesc>
           </did>
@@ -898,7 +898,7 @@ The collection is arranged into five series: Personal Files, Professional Files,
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Italy, <unitdate type="inclusive">October-November, 1971</unitdate> </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>6 folders</extent>
             </physdesc>
           </did>
@@ -916,7 +916,7 @@ The collection is arranged into five series: Personal Files, Professional Files,
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Miscellaneous Photographs </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>3 folders</extent>
             </physdesc>
           </did>
@@ -931,7 +931,7 @@ The collection is arranged into five series: Personal Files, Professional Files,
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Photo Albums, <unitdate type="inclusive" normal="1960/1979" certainty="approximate">1960s-1970s</unitdate> </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>2 folders</extent>
             </physdesc>
           </did>
@@ -952,7 +952,7 @@ The collection is arranged into five series: Personal Files, Professional Files,
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Thailand, <unitdate type="inclusive">September, 1967</unitdate> </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>2 folders</extent>
             </physdesc>
           </did>
@@ -961,7 +961,7 @@ The collection is arranged into five series: Personal Files, Professional Files,
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Vietnam, <unitdate type="inclusive">September, 1967</unitdate> </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>2 folders</extent>
             </physdesc>
           </did>
@@ -970,7 +970,7 @@ The collection is arranged into five series: Personal Files, Professional Files,
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Color Slides, circa <unitdate type="inclusive" normal="1971/1976">1971-1976</unitdate> </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>2 folders and 10 slides boxes</extent>
             </physdesc>
           </did>

--- a/Real_Masters_all/davislor.xml
+++ b/Real_Masters_all/davislor.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">851220 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Washtenaw County, Michigan minister, local historian and public official; correspondence, sermons, and collected papers relating to the history of Ann Arbor and Washtenaw County, Michigan.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.6 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/davislor.xml
+++ b/Real_Masters_all/davislor.xml
@@ -43,8 +43,6 @@
       <abstract>Washtenaw County, Michigan minister, local historian and public official; correspondence, sermons, and collected papers relating to the history of Ann Arbor and Washtenaw County, Michigan.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.6 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/denbleyk.xml
+++ b/Real_Masters_all/denbleyk.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">851056 Aa 2; UAx</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Paulus den Bleyker family of Kalamazoo, Michigan. Papers of Paulus den Bleyker, his son John, John's wife, Anna Balch den Bleyker, and other family members relating to family and business affairs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">9 linear feet</extent>
         <extent altrender="carrier">(in 10 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/denbleyk.xml
+++ b/Real_Masters_all/denbleyk.xml
@@ -43,8 +43,6 @@
       <abstract>Paulus den Bleyker family of Kalamazoo, Michigan. Papers of Paulus den Bleyker, his son John, John's wife, Anna Balch den Bleyker, and other family members relating to family and business affairs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">9 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 10 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/detroitnews.xml
+++ b/Real_Masters_all/detroitnews.xml
@@ -60,7 +60,7 @@ Detroit News records
 1912-1982
 </unitdate>
 </unittitle>
-      <physdesc>
+      <physdesc altrender="whole">
         <extent encodinganalog="300">
 164.5 linear feet (in 180 boxes) and 33.4 GB (online)
 </extent>
@@ -203,7 +203,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Building Excavation for New Press Room-Exterior Views of Finished Structure, <unitdate type="inclusive" normal="1929">1929</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-2" show="new" actuate="onrequest">
@@ -217,7 +217,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Craftsmanship-Toys, <unitdate type="inclusive" normal="1935">1935</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>5 negatives</extent>
                 </physdesc>
                 <dao href="2014153-3" show="new" actuate="onrequest">
@@ -253,7 +253,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Experience Column-Carillon, <unitdate type="inclusive" normal="1939">1939</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-6" show="new" actuate="onrequest">
@@ -267,7 +267,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Fair and Square Club-Trophy, <unitdate type="inclusive" normal="1934/1935">1934-1935</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-7" show="new" actuate="onrequest">
@@ -281,7 +281,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Green, Jerry (Jerome)-Detroit News Emp. Editorial-Sports, <unitdate type="inclusive" normal="1966/1984">1966-1984</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>17 negatives</extent>
                 </physdesc>
               </did>
@@ -290,7 +290,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Halloween Scenes-Ann Seiter as a Witch, <unitdate type="inclusive" normal="1958">1958</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-9" show="new" actuate="onrequest">
@@ -321,7 +321,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Medal of Valour for Police, <unitdate type="inclusive" normal="1928">1928</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-12" show="new" actuate="onrequest">
@@ -368,7 +368,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Radio-Equipment-Ultra High Frequency Converter Designed and Built by A. B. Allen <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-16" show="new" actuate="onrequest">
@@ -393,7 +393,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Radio-Microphone, <unitdate type="inclusive" normal="1932/1937">1932-1937</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>9 negatives</extent>
                 </physdesc>
                 <dao href="2014153-18" show="new" actuate="onrequest">
@@ -407,7 +407,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Radio-Mobile Unit #1-Pack Set-Equipment, <unitdate type="inclusive" normal="1937">1937</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>7 negatives</extent>
                 </physdesc>
                 <dao href="2014153-19" show="new" actuate="onrequest">
@@ -432,7 +432,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Radio-Programs-"Smoothies"-Gail Abbey, Jack Hill, Georgia Leath, Bobette Hall, <unitdate type="inclusive" normal="1935">1935</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>5 negatives</extent>
                 </physdesc>
                 <dao href="2014153-21" show="new" actuate="onrequest">
@@ -446,7 +446,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Radio-Short Wave Adapter-Equipment, <unitdate type="inclusive" normal="1935/1936">1935-1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-22" show="new" actuate="onrequest">
@@ -474,7 +474,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Radio-Staff-Elwood Ryan, Kurt Schmeissen, Louis Cohen, and Lillian Dixon <unitdate type="inclusive" normal="1937">1937</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-24" show="new" actuate="onrequest">
@@ -513,7 +513,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Schools-Classroom Scenes, <unitdate type="inclusive" normal="1938/1959">1938-1959</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>9 negatives</extent>
                 </physdesc>
                 <dao href="2014153-27" show="new" actuate="onrequest">
@@ -527,7 +527,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Schools-Classroom Scenes-Doty School, Monteith School, Hubert School, <unitdate type="inclusive" normal="1934/1958">1934-1958</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>5 negatives</extent>
                 </physdesc>
                 <dao href="2014153-28" show="new" actuate="onrequest">
@@ -550,7 +550,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Spelling Bee-Contestants, <unitdate type="inclusive" normal="1933/1934">1933-1934</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-30" show="new" actuate="onrequest">
@@ -589,7 +589,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Television-Equipment-Antenna on Penobscot Building, <unitdate type="inclusive" normal="1949/1950">1949-1950</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>6 negatives</extent>
                 </physdesc>
                 <dao href="2014153-33" show="new" actuate="onrequest">
@@ -603,7 +603,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Television-Tower-Construction, <unitdate type="inclusive" normal="1954">1954</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>10 negatives</extent>
                 </physdesc>
               </did>
@@ -612,7 +612,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Travel Show-Crowds, <unitdate type="inclusive" normal="1950">1950</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-35" show="new" actuate="onrequest">
@@ -626,7 +626,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Warehouse-Lombardo 10/18/1949-Roto 11/20/1949-Photos from Bridge, <unitdate type="inclusive" normal="1949">1949</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>6 negatives</extent>
                 </physdesc>
                 <dao href="2014153-36" show="new" actuate="onrequest">
@@ -640,7 +640,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Advertising-Detroit News Lettering on Downtown Detroit, <unitdate type="inclusive" normal="1932">1932</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>5 negatives</extent>
                 </physdesc>
                 <dao href="2014153-37" show="new" actuate="onrequest">
@@ -654,7 +654,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Advertising-Detroit News Sign, <unitdate type="inclusive" normal="1932">1932</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>6 negatives</extent>
                 </physdesc>
                 <dao href="2014153-38" show="new" actuate="onrequest">
@@ -690,7 +690,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Branch Offices-General Motors Building, <unitdate type="inclusive" normal="1929">1929</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-41" show="new" actuate="onrequest">
@@ -704,7 +704,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Bread Contest, <unitdate type="inclusive" normal="1922">1922</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>7 negatives</extent>
                 </physdesc>
                 <dao href="2014153-42" show="new" actuate="onrequest">
@@ -732,7 +732,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Carriers, <unitdate type="inclusive" normal="1929">1929</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>20 negatives</extent>
                 </physdesc>
                 <dao href="2014153-44" show="new" actuate="onrequest">
@@ -757,7 +757,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Chorus, <unitdate type="inclusive" normal="1928">1928</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-46" show="new" actuate="onrequest">
@@ -771,7 +771,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Circulation Department Staff, <unitdate type="inclusive" normal="1930">1930</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-47" show="new" actuate="onrequest">
@@ -785,7 +785,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Cooking School-Crowd-Auditorium, <unitdate type="inclusive" normal="1932">1932</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-48" show="new" actuate="onrequest">
@@ -799,7 +799,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Cooking School-Crowd in Auditorium, <unitdate type="inclusive" normal="1933">1933</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-49" show="new" actuate="onrequest">
@@ -835,7 +835,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Craftsmanship-Interior View of Workshop, <unitdate type="inclusive" normal="1935">1935</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>11 negatives</extent>
                 </physdesc>
                 <dao href="2014153-52" show="new" actuate="onrequest">
@@ -849,7 +849,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Delivery Services-Trucks, <unitdate type="inclusive" normal="1929">1929</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>6 negatives</extent>
                 </physdesc>
                 <dao href="2014153-53" show="new" actuate="onrequest">
@@ -863,7 +863,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Dock, Detroit River, between 1st &amp; 2nd Avenues, <unitdate type="inclusive" normal="1926">1926</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-54" show="new" actuate="onrequest">
@@ -877,7 +877,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Employees-Department Heads, <unitdate type="inclusive" normal="1938">1938</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>5 negatives</extent>
                 </physdesc>
                 <dao href="2014153-55" show="new" actuate="onrequest">
@@ -891,7 +891,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Employees-Dinner for "Key Men", <unitdate type="inclusive" normal="1939">1939</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-56" show="new" actuate="onrequest">
@@ -916,7 +916,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Exterior-Lafayette Entrance View Taken from Second and Lafayette, <unitdate type="inclusive" normal="1928/1933">1928-1933</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>5 negatives</extent>
                 </physdesc>
               </did>
@@ -928,7 +928,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Exterior-Radio Tower, <unitdate type="inclusive" normal="1932">1932</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
               </did>
@@ -943,7 +943,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Exterior-Views Showing News, <unitdate type="inclusive" normal="1926/1940">1926-1940</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>10 negatives</extent>
                 </physdesc>
               </did>
@@ -952,7 +952,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Exterior-Views of Side Facing Fort Street, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
               </did>
@@ -964,7 +964,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Exterior-Warehouse, <unitdate type="inclusive" normal="1931">1931</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
               </did>
@@ -973,7 +973,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Art Department-New Addition, <unitdate type="inclusive" normal="1940">1940</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
               </did>
@@ -988,7 +988,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Advertising Room, <unitdate type="inclusive" normal="1931/1935">1931-1935</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>7 negatives</extent>
                 </physdesc>
               </did>
@@ -997,7 +997,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Nancy Brown's Office-Fourth Floor, <unitdate type="inclusive" normal="1939">1939</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
               </did>
@@ -1012,7 +1012,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Composing Room, <unitdate type="inclusive" normal="1931/1938">1931-1938</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>6 negatives</extent>
                 </physdesc>
               </did>
@@ -1048,7 +1048,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Library, <unitdate type="inclusive" normal="1931">1931</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
               </did>
@@ -1057,7 +1057,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Mailing Room, <unitdate type="inclusive" normal="1923">1923</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>9 negatives</extent>
                 </physdesc>
               </did>
@@ -1066,7 +1066,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Photographers' Studio, <unitdate type="inclusive" normal="1929">1929</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>5 negatives</extent>
                 </physdesc>
               </did>
@@ -1075,7 +1075,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior Views-Photographer's Studio, <unitdate type="inclusive" normal="1933">1933</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>4 negatives</extent>
                 </physdesc>
               </did>
@@ -1084,7 +1084,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Photographic Department, <unitdate type="inclusive" normal="1931/1939">1931-1939</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>24 negatives</extent>
                 </physdesc>
               </did>
@@ -1093,7 +1093,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Press Room-Showing Roto Presses, <unitdate type="inclusive" normal="1932">1932</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>7 negatives</extent>
                 </physdesc>
               </did>
@@ -1102,7 +1102,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Press Room-Views of Presses and Pressmen, <unitdate type="inclusive" normal="1927/1938">1927-1938</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>30 negatives</extent>
                 </physdesc>
               </did>
@@ -1111,7 +1111,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Press Room, Electrical Controls, Board for Presses, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>4 negatives</extent>
                 </physdesc>
               </did>
@@ -1120,7 +1120,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Reference Department, <unitdate type="inclusive" normal="1930/1939">1930-1939</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>10 negatives</extent>
                 </physdesc>
               </did>
@@ -1129,7 +1129,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Stereotype Room, <unitdate type="inclusive" normal="1938">1938</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
               </did>
@@ -1162,7 +1162,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-"Women's Department"-First Floor, <unitdate type="inclusive" normal="1928/1934">1928-1934</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
               </did>
@@ -1171,7 +1171,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>Old Building-Interior-Cranbrook Press-Owned by George Gough Booth, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-88" show="new" actuate="onrequest">
@@ -1196,7 +1196,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Photo Show-Cedar Pointe, <unitdate type="inclusive" normal="1931">1931</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-90" show="new" actuate="onrequest">
@@ -1210,7 +1210,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Photo Show-General Motors Building, <unitdate type="inclusive" normal="1931">1931</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>28 negatives</extent>
                 </physdesc>
                 <dao href="2014153-91" show="new" actuate="onrequest">
@@ -1235,7 +1235,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Radio-Birthday Party-10th Anniversary, <unitdate type="inclusive" normal="1930">1930</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>5 negatives</extent>
                 </physdesc>
                 <dao href="2014153-93" show="new" actuate="onrequest">
@@ -1293,7 +1293,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Radio-Entertainers-Frank and Ernest, <unitdate type="inclusive" normal="1931">1931</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-98" show="new" actuate="onrequest">
@@ -1329,7 +1329,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Radio-Orchestra, <unitdate type="inclusive" normal="1930/1933">1930-1933</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>10 negatives</extent>
                 </physdesc>
                 <dao href="2014153-101" show="new" actuate="onrequest">
@@ -1343,7 +1343,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Radio-Orchestra, <unitdate type="inclusive" normal="1932">1932</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>5 negatives</extent>
                 </physdesc>
                 <dao href="2014153-102" show="new" actuate="onrequest">
@@ -1368,7 +1368,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Radio-Orchestra and String Quartet, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>7 negatives</extent>
                 </physdesc>
                 <dao href="2014153-104" show="new" actuate="onrequest">
@@ -1393,7 +1393,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Radio-Players-Rita Alcock and William Morrison, <unitdate type="inclusive" normal="1933">1933</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-106" show="new" actuate="onrequest">
@@ -1407,7 +1407,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Radio-Players-Cadillac-Herbert Labadie, <unitdate type="inclusive" normal="1931">1931</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-107" show="new" actuate="onrequest">
@@ -1421,7 +1421,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Radio-Players-Plays, <unitdate type="inclusive" normal="1931">1931</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>8 negatives</extent>
                 </physdesc>
                 <dao href="2014153-108" show="new" actuate="onrequest">
@@ -1446,7 +1446,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Radio-Players-Dr. B.D. Welling and Glendora Forshee, <unitdate type="inclusive" normal="1933">1933</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-110" show="new" actuate="onrequest">
@@ -1482,7 +1482,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Short Wave-W8XWJ-Lobby, <unitdate type="inclusive" normal="1938/1940">1938-1940</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
               </did>
@@ -1491,7 +1491,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Short Wave Station-W8XWJ-Equipment in Penobscot Building, <unitdate type="inclusive" normal="1936/1938">1936-1938</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>11 negatives</extent>
                 </physdesc>
               </did>
@@ -1506,7 +1506,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Construction-Series "B", <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>8 negatives</extent>
                 </physdesc>
               </did>
@@ -1515,7 +1515,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Construction-Series "C", <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>8 negatives</extent>
                 </physdesc>
               </did>
@@ -1524,7 +1524,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Construction-Series "E", <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>9 negatives</extent>
                 </physdesc>
               </did>
@@ -1533,7 +1533,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Construction-Series "F", <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
               </did>
@@ -1548,7 +1548,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Equipment, <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>4 negatives</extent>
                 </physdesc>
               </did>
@@ -1557,7 +1557,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Exterior View, <unitdate type="inclusive" normal="1936/1941">1936-1941</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>12 negatives</extent>
                 </physdesc>
               </did>
@@ -1572,7 +1572,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Exterior-Sculpture on East and West Side of Entrance, <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
               </did>
@@ -1581,7 +1581,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Interior-Air Conditioning System, <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
               </did>
@@ -1596,7 +1596,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Interior-Auditorium Studio and Orchestra, <unitdate type="inclusive" normal="1936/1939">1936-1939</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>5 negatives</extent>
                 </physdesc>
               </did>
@@ -1611,7 +1611,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Interior-Control Room, <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
               </did>
@@ -1620,7 +1620,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Interior-Lobby-Main Lobby, <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
               </did>
@@ -1635,7 +1635,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Interior-News Room, <unitdate type="inclusive" normal="1938">1938</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
               </did>
@@ -1656,7 +1656,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Interior-Studios A, B, C, and D, <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>10 negatives</extent>
                 </physdesc>
               </did>
@@ -1665,7 +1665,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-Old-Equipment, <unitdate type="inclusive" normal="1922/1931">1922-1931</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>19 negatives</extent>
                 </physdesc>
               </did>
@@ -1677,7 +1677,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-Old-Equipment-Transmitter and Control Room, <unitdate type="inclusive" normal="1921/1930">1921-1930</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>15 negatives</extent>
                 </physdesc>
               </did>
@@ -1698,7 +1698,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Tower-New-On New Transmitting Station, Meyers and Eight Mile Road, <unitdate type="inclusive" normal="1935">1935</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>8 negatives</extent>
                 </physdesc>
               </did>
@@ -1713,7 +1713,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Transmitter-New-Building-Exterior, <unitdate type="inclusive" normal="1936/1941">1936-1941</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>14 negatives</extent>
                 </physdesc>
               </did>
@@ -1740,7 +1740,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Transmitter-New-Equipment-Scripps Motor, <unitdate type="inclusive" normal="1937">1937</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
               </did>
@@ -1761,7 +1761,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">4</container>
                 <unittitle>Radio-Transmitter-New-Interior-Control Room, <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
               </did>
@@ -1770,7 +1770,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">4</container>
                 <unittitle>Radio-Transmitter-New-Interior-Caretaker's Apartment, <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>5 negatives</extent>
                 </physdesc>
               </did>
@@ -1785,7 +1785,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">4</container>
                 <unittitle>Radio-Transmitter-New-Interior-Control Room, <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
               </did>
@@ -1800,7 +1800,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">4</container>
                 <unittitle>Radio-Transmitter-New-Interior-Hall and Staircase-New Transmitting Station, <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
               </did>
@@ -1809,7 +1809,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">4</container>
                 <unittitle>Radio-Transmitter-New-Interior-Lobby-Showing Mural, <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
               </did>
@@ -1818,7 +1818,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">4</container>
                 <unittitle>Radio-Transmitter-New-Interior-Murals, <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
               </did>
@@ -1833,7 +1833,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">4</container>
                 <unittitle>Radio-Transmitter-New-Interior-Operators Bunks, <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
               </did>
@@ -1848,7 +1848,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Rotogravure Sections-Retouching, <unitdate type="inclusive" normal="1929">1929</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-160" show="new" actuate="onrequest">
@@ -1862,7 +1862,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Spelling Bee, <unitdate type="inclusive" normal="1929">1929</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-161" show="new" actuate="onrequest">
@@ -1876,7 +1876,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Spelling Bee-Coliseum Scenes, <unitdate type="inclusive" normal="1930">1930</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>6 negatives</extent>
                 </physdesc>
                 <dao href="2014153-162" show="new" actuate="onrequest">
@@ -1890,7 +1890,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">4</container>
                 <unittitle>Spelling Bee-Coliseum Scenes, <unitdate type="inclusive" normal="1932">1932</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>5 negatives</extent>
                 </physdesc>
               </did>
@@ -1899,7 +1899,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">4</container>
                 <unittitle>Spelling Bee-Coliseum Scenes, <unitdate type="inclusive" normal="1933">1933</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
               </did>
@@ -1920,7 +1920,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">4</container>
                 <unittitle>Spelling Bee-Coliseum Scenes, <unitdate type="inclusive" normal="1937">1937</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>5 negatives</extent>
                 </physdesc>
               </did>
@@ -1929,7 +1929,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <container type="box" label="Box">4</container>
                 <unittitle>Spelling Bee-Coliseum Scenes, <unitdate type="inclusive" normal="1938">1938</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
               </did>
@@ -1938,7 +1938,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Spelling Bee-Group Photo of Contestants, <unitdate type="inclusive" normal="1930">1930</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-169" show="new" actuate="onrequest">
@@ -1952,7 +1952,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Spelling Bee-Group Photo of Contestants, <unitdate type="inclusive" normal="1932">1932</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-170" show="new" actuate="onrequest">
@@ -1977,7 +1977,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Spelling Contest, <unitdate type="inclusive" normal="1927">1927</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-172" show="new" actuate="onrequest">
@@ -1991,7 +1991,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Spelling Contest, <unitdate type="inclusive" normal="1928">1928</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-173" show="new" actuate="onrequest">
@@ -2005,7 +2005,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Spelling Contest-Vivian Bremer-Winner, <unitdate type="inclusive" normal="1926">1926</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-174" show="new" actuate="onrequest">
@@ -2019,7 +2019,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Spelling Contest-Dorothy Karrick-Winner, <unitdate type="inclusive" normal="1925">1925</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>9 negatives</extent>
                 </physdesc>
                 <dao href="2014153-175" show="new" actuate="onrequest">
@@ -2036,7 +2036,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Spelling Contest-Justine Pearsall-Winner, <unitdate type="inclusive" normal="1922">1922</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>16 negatives</extent>
                 </physdesc>
                 <dao href="2014153-176" show="new" actuate="onrequest">
@@ -2050,7 +2050,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Young Writers' Club, <unitdate type="inclusive" normal="1928">1928</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>7 negatives</extent>
                 </physdesc>
                 <dao href="2014153-177" show="new" actuate="onrequest">
@@ -2105,7 +2105,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Barbecue-Parade, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-181" show="new" actuate="onrequest">
@@ -2119,7 +2119,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Barbecue-Mr. George Booth with: Mr. Scott, Mr. George Miller, Mr. M. Bingay, Mr. William Scripps. Mr. Scripps also with Wife and Mother, <unitdate type="inclusive" normal="1923">1923</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-182" show="new" actuate="onrequest">
@@ -2133,7 +2133,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Barbecue-Trip to Grove for Lunch, Meat Roasting Spits, Guests as Tables, Spectators Watching Games-50th Anniversary at Scripps Farm, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-183" show="new" actuate="onrequest">
@@ -2158,7 +2158,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Building Excavation for New Press Room, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-185" show="new" actuate="onrequest">
@@ -2172,7 +2172,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Detroit Riding and Hunt Club-Horses in Paddock, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-186" show="new" actuate="onrequest">
@@ -2186,7 +2186,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Dock, Detroit River, between First and Second Avenues, <unitdate type="inclusive" normal="1926">1926</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-187" show="new" actuate="onrequest">
@@ -2200,7 +2200,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Fish Sale, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-188" show="new" actuate="onrequest">
@@ -2225,7 +2225,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Parades-Beer Parade, <unitdate type="inclusive" normal="1932">1932</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-190" show="new" actuate="onrequest">
@@ -2239,7 +2239,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Radio-Short Wave Station-Antenna on Penobscot Building Tower, <unitdate type="inclusive" normal="1936">1936</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-191" show="new" actuate="onrequest">
@@ -2253,7 +2253,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Radio-Towers-Birds on Tower, <unitdate type="inclusive" normal="1933">1933</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-192" show="new" actuate="onrequest">
@@ -2267,7 +2267,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Rolls of Paper Unloaded from Truck in Warehouse, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-193" show="new" actuate="onrequest">
@@ -2317,7 +2317,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Cigar Factory-Women Making Cigars, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-197" show="new" actuate="onrequest">
@@ -2342,7 +2342,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Fish Campaign, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>7 negatives</extent>
                 </physdesc>
                 <dao href="2014153-199" show="new" actuate="onrequest">
@@ -2370,7 +2370,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>New Building-Construction, <unitdate type="inclusive" normal="1915/1916">1915-1916</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>8 negatives</extent>
                 </physdesc>
                 <dao href="2014153-200" show="new" actuate="onrequest">
@@ -2384,7 +2384,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>New Building-Excavation, <unitdate type="inclusive" normal="1915">1915</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>7 negatives 1 of 7</extent>
                 </physdesc>
                 <dao href="2014153-201" show="new" actuate="onrequest">
@@ -2398,7 +2398,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>New Building-Excavation, <unitdate type="inclusive" normal="1915">1915</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>7 negatives, 2-7 of 7</extent>
                 </physdesc>
                 <dao href="2014153-201" show="new" actuate="onrequest">
@@ -2423,7 +2423,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>New Building-Exterior-Decorated for 32nd Division Reunion, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>5 negatives</extent>
                 </physdesc>
                 <dao href="2014153-203" show="new" actuate="onrequest">
@@ -2437,7 +2437,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>New Building-Exterior-Lafayette Entrance View Taken from Second and Lafayette, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-58" show="new" actuate="onrequest">
@@ -2476,7 +2476,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>New Building-Exterior-Views of Side Facing Fort Street, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>6 negatives, 1-2 of 6 </extent>
                 </physdesc>
                 <dao href="2014153-62" show="new" actuate="onrequest">
@@ -2493,7 +2493,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>New Building-Exterior-Views of Side Facing Fort Street, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>6 negatives,3-6 of 6</extent>
                 </physdesc>
                 <dao href="2014153-62" show="new" actuate="onrequest">
@@ -2510,7 +2510,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Art Room (Former One on Third Floor)-Mural Decorations, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>6 negatives</extent>
                 </physdesc>
                 <dao href="2014153-206" show="new" actuate="onrequest">
@@ -2524,7 +2524,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Composing Room, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-69" show="new" actuate="onrequest">
@@ -2541,7 +2541,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Dark Room, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>7 negatives</extent>
                 </physdesc>
                 <dao href="2014153-207" show="new" actuate="onrequest">
@@ -2577,7 +2577,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Lobby-Second Floor, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-210" show="new" actuate="onrequest">
@@ -2591,7 +2591,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Mailing Room, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>5 negatives</extent>
                 </physdesc>
                 <dao href="2014153-211" show="new" actuate="onrequest">
@@ -2605,7 +2605,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Press Room-New Presses, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-212" show="new" actuate="onrequest">
@@ -2619,7 +2619,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Stereotype Room, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-83" show="new" actuate="onrequest">
@@ -2636,7 +2636,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Storage Room for Paper, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-84" show="new" actuate="onrequest">
@@ -2653,7 +2653,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Old Building-Exterior-Delivery Trucks Lined up Outside Old Building, <unitdate type="inclusive" normal="1912">1912</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-213" show="new" actuate="onrequest">
@@ -2667,7 +2667,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Old Building-Exterior-Views of Building on Shelby and Larned, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-214" show="new" actuate="onrequest">
@@ -2681,7 +2681,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Old Building-Interior-Advertising Department-Business Office, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-215" show="new" actuate="onrequest">
@@ -2695,7 +2695,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Old Building-Interior-Art Room, <unitdate type="inclusive" normal="1912">1912</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-216" show="new" actuate="onrequest">
@@ -2709,7 +2709,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Old Building-Interior-Composing Room-Stereotype Room, <unitdate type="inclusive" normal="1912">1912</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>9 negatives</extent>
                 </physdesc>
                 <dao href="2014153-217" show="new" actuate="onrequest">
@@ -2745,7 +2745,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Old Building-Interior-Photographers' Room, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-220" show="new" actuate="onrequest">
@@ -2759,7 +2759,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Old Building-Interior-Press Room, <unitdate type="inclusive" normal="1910/1912">1910-1912</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-221" show="new" actuate="onrequest">
@@ -2820,7 +2820,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Young Writers' Club, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-177" show="new" actuate="onrequest">
@@ -2848,7 +2848,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Art Department-Kraemer's Corner, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-226" show="new" actuate="onrequest">
@@ -2879,7 +2879,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Bindery, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-228" show="new" actuate="onrequest">
@@ -2910,7 +2910,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Building Exterior, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-230" show="new" actuate="onrequest">
@@ -3117,7 +3117,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Hospital, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-248" show="new" actuate="onrequest">
@@ -3145,7 +3145,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Ink Tank Truck, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-250" show="new" actuate="onrequest">
@@ -3181,7 +3181,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Library-New Building, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives,1-2 of 3</extent>
                 </physdesc>
                 <dao href="2014153-253" show="new" actuate="onrequest">
@@ -3195,7 +3195,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Library-New Building, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 negatives, 3 of 3</extent>
                 </physdesc>
                 <dao href="2014153-253" show="new" actuate="onrequest">
@@ -4305,7 +4305,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Windows, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-353" show="new" actuate="onrequest">
@@ -4319,7 +4319,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Windows, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-354" show="new" actuate="onrequest">
@@ -4626,7 +4626,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Roto, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-380" show="new" actuate="onrequest">

--- a/Real_Masters_all/donahuew.xml
+++ b/Real_Masters_all/donahuew.xml
@@ -52,7 +52,7 @@
       <abstract>Gerontologist, faculty member at the University of Michigan, first with the Bureau of Psychological Services, later with the Institute for Human Adjustment, and as co-director of its successor unit, the Institute of Gerontology. Files detailing her participation at various meetings and conferences, her other professional activities and affiliations, research projects files, University of Michigan administrative and teaching materials, and videotapes of presentations at 1979 conference, "White House Conferences as Agents of Social Change", also photographs.</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">87399 Aa 2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">26 linear feet</extent>
         <extent altrender="carrier">(in 27 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/donahuew.xml
+++ b/Real_Masters_all/donahuew.xml
@@ -54,8 +54,6 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">26 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 27 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/dudleyam.xml
+++ b/Real_Masters_all/dudleyam.xml
@@ -43,8 +43,6 @@
       <abstract>Electrical engineer; professional papers relating to his career at Westinghouse.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.6 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/dudleyam.xml
+++ b/Real_Masters_all/dudleyam.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2009005 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Electrical engineer; professional papers relating to his career at Westinghouse.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.6 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/durbanl.xml
+++ b/Real_Masters_all/durbanl.xml
@@ -6625,7 +6625,7 @@
           <did>
             <container type="box" label="Box">73</container>
             <unittitle>Detroit Mayor Cavanagh speaking on WJLB program, "Crime Problem in Detroit" <unitdate type="inclusive" normal="1967-05-17">May 17, 1967</unitdate></unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>00:28:08 min.</extent>
             </physdesc>
           </did>
@@ -6634,7 +6634,7 @@
           <did>
             <container type="box" label="Box">73-5</container>
             <unittitle>Francis A. Kornegay interview with June White <unitdate type="inclusive" normal="1967-10-08">October 8, 1967</unitdate></unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>30 min.</extent>
             </physdesc>
           </did>
@@ -6772,7 +6772,7 @@
           <did>
             <container type="box" label="Box">73-18</container>
             <unittitle><unitdate type="inclusive">Undated</unitdate> in two parts</unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>2 tapes</extent>
             </physdesc>
           </did>
@@ -6841,7 +6841,7 @@
           <did>
             <container type="box" label="Box">73-26</container>
             <unittitle>Unidentified</unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>2 tapes</extent>
             </physdesc>
           </did>

--- a/Real_Masters_all/eskimo.xml
+++ b/Real_Masters_all/eskimo.xml
@@ -46,8 +46,6 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/eskimo.xml
+++ b/Real_Masters_all/eskimo.xml
@@ -44,7 +44,7 @@
       <abstract>Agency established by Eugene Power to provide market for Inuit art, also gallery for Inuit art. Correspondence, scrapbooks, and office files detailing the company's activities.</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">861010 Bp 2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/festing.xml
+++ b/Real_Masters_all/festing.xml
@@ -44,7 +44,7 @@
       <abstract>Social psychologist, specialist in the theory of cognitive dissonance, with interest in the fields of visual perception, archaeology and pre-historic social organization. Papers, primarily from his years at Stanford University, include correspondence, speeches, unpublished articles, reports, some research material and files relating to various professional organizations and meetings.</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">90165 Aa 2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3.5 linear feet</extent>
         <extent altrender="carrier">(in 5 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/festing.xml
+++ b/Real_Masters_all/festing.xml
@@ -46,8 +46,6 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 5 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/fullerel.xml
+++ b/Real_Masters_all/fullerel.xml
@@ -50,8 +50,6 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">240 glass negatives (approximate</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">

--- a/Real_Masters_all/fultond.xml
+++ b/Real_Masters_all/fultond.xml
@@ -51,8 +51,6 @@
       <abstract>Outdoor writer and photographer for The Ann Arbor News, advocate of environment issues, author of local interest and music review columns; articles written and photographs taken by Fulton, personal correspondence and documentation of awards received.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">13.3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 15 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/fultond.xml
+++ b/Real_Masters_all/fultond.xml
@@ -49,7 +49,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2008089 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Outdoor writer and photographer for The Ann Arbor News, advocate of environment issues, author of local interest and music review columns; articles written and photographs taken by Fulton, personal correspondence and documentation of awards received.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">13.3 linear feet</extent>
         <extent altrender="carrier">(in 15 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/galbraij.xml
+++ b/Real_Masters_all/galbraij.xml
@@ -49,8 +49,6 @@
 The D. James Galbraith Photographic Collection is significant for its extensive photographic evidence of rural Michigan, particularly its emphasis on families, communities, and local institutions such as churches and schools. The collection is useful as a visual representation of late twentieth-century Michigan, capturing a wide array of social and cultural activities that highlight the daily experiences of Michigan residents.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">16 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 10 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">

--- a/Real_Masters_all/goldbergst.xml
+++ b/Real_Masters_all/goldbergst.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2013098 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Papers of Stanley B. Goldberg, president of the Wayne County, Mich., chapter of Mothers Against Drunk Driving. Collection includes correspondence, newspaper clippings, and videotapes.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.5 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/goldbergst.xml
+++ b/Real_Masters_all/goldbergst.xml
@@ -43,8 +43,6 @@
       <abstract>Papers of Stanley B. Goldberg, president of the Wayne County, Mich., chapter of Mothers Against Drunk Driving. Collection includes correspondence, newspaper clippings, and videotapes.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/goldmane.xml
+++ b/Real_Masters_all/goldmane.xml
@@ -52,7 +52,7 @@
       <abstract>Edwin Franko Goldman (1878-1956) was an American composer and conductor for military bands. Collection, assembled by Goldman, of autographs, letters, photographs, and musical scores of many musical celebrities from his lifetime and before.</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">9560 Aa 2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/goldmane.xml
+++ b/Real_Masters_all/goldmane.xml
@@ -54,8 +54,6 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/gossette.xml
+++ b/Real_Masters_all/gossette.xml
@@ -43,8 +43,6 @@
       <abstract>Volunteer in local and national community and professional organizations and resident of Bloomfield Hills, Michigan from 1947-1981; records include photographs, correspondence, articles, newspaper clippings, and notes related to Gossett’s personal life and volunteer activities.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2.6 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/gossette.xml
+++ b/Real_Masters_all/gossette.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2009186 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Volunteer in local and national community and professional organizations and resident of Bloomfield Hills, Michigan from 1947-1981; records include photographs, correspondence, articles, newspaper clippings, and notes related to Gossett’s personal life and volunteer activities.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.6 linear feet</extent>
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/grahamwd.xml
+++ b/Real_Masters_all/grahamwd.xml
@@ -59,7 +59,7 @@ Walter D. Graham scrapbooks and photo album
 </unitdate>
 
 </unittitle>
-      <physdesc>
+      <physdesc altrender="whole">
         <extent encodinganalog="300">
 1 scrapbook, 2 photo albums, 1 reel microfilm
 </extent>

--- a/Real_Masters_all/greenman.xml
+++ b/Real_Masters_all/greenman.xml
@@ -47,7 +47,7 @@
       <note>
         <p><emph>Sponsor:</emph> This finding aid is a product of a project supported by a grant awarded to the Bentley Historical Library and University of Michigan Museum of Anthropology in 2002 by the Division of Preservation and Access of the National Endowment for the Humanities, an independent federal agency.</p>
       </note>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">7 linear feet</extent>
         <extent altrender="carrier">(in 8 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/greenman.xml
+++ b/Real_Masters_all/greenman.xml
@@ -49,8 +49,6 @@
       </note>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 8 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/grimmjoe.xml
+++ b/Real_Masters_all/grimmjoe.xml
@@ -43,8 +43,6 @@
       <abstract>University of Michigan student photographer for the Michiganensian; photographs of images used in the yearbook.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.6 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/grimmjoe.xml
+++ b/Real_Masters_all/grimmjoe.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">92777 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>University of Michigan student photographer for the Michiganensian; photographs of images used in the yearbook.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.6 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/hilbish.xml
+++ b/Real_Masters_all/hilbish.xml
@@ -45,7 +45,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2009139 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Professor at the University of Michigan (1965-1988). Director of Choirs, and respected conductor of choral music, well-known for his extensive repertoire and new interpretations of 20th century choral music. The collection includes photographs, video, press clippings, writings, correspondence, and programs documenting Hilbish's work as an instructor and conductor from 1948 to 2004.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/hilbish.xml
+++ b/Real_Masters_all/hilbish.xml
@@ -47,8 +47,6 @@
       <abstract>Professor at the University of Michigan (1965-1988). Director of Choirs, and respected conductor of choral music, well-known for his extensive repertoire and new interpretations of 20th century choral music. The collection includes photographs, video, press clippings, writings, correspondence, and programs documenting Hilbish's work as an instructor and conductor from 1948 to 2004.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/holljeep.xml
+++ b/Real_Masters_all/holljeep.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2009082 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Hugh "Jeep" Holland was the founder of the A-Square Record label in Ann Arbor in 1967, and consequently became an integral part of the southeast Michigan music scene in the late 1960s and early 1970s. The collection documents, in papers, photographs and sound recordings, Jeep’s personal life, interests, and career.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">12 linear feet</extent>
         <extent altrender="carrier">(in 13 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/holljeep.xml
+++ b/Real_Masters_all/holljeep.xml
@@ -43,8 +43,6 @@
       <abstract>Hugh "Jeep" Holland was the founder of the A-Square Record label in Ann Arbor in 1967, and consequently became an integral part of the southeast Michigan music scene in the late 1960s and early 1970s. The collection documents, in papers, photographs and sound recordings, Jeep’s personal life, interests, and career.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">12 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 13 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/intermed.xml
+++ b/Real_Masters_all/intermed.xml
@@ -45,7 +45,7 @@
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
         <extptr href="bhladd" show="embed" actuate="onload"/>
       </repository>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">27.3 linear feet</extent>
         <extent altrender="carrier">(in 28 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/intermed.xml
+++ b/Real_Masters_all/intermed.xml
@@ -47,8 +47,6 @@
       </repository>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">27.3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 28 boxes)</extent>
       </physdesc>
       <physloc>Portions located in offsite storage; prior notification required for access.</physloc>

--- a/Real_Masters_all/ioepub.xml
+++ b/Real_Masters_all/ioepub.xml
@@ -510,7 +510,7 @@ Department of Industrial and Operations Engineering (University of Michigan) rec
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Chronological Files, <unitdate type="inclusive" normal="1978/1993">1978-1993</unitdate> </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>7 folders</extent>
             </physdesc>
           </did>
@@ -529,7 +529,7 @@ Department of Industrial and Operations Engineering (University of Michigan) rec
                 <unittitle>
                   <unitdate type="inclusive" normal="1974/1976">1974-1976</unitdate>
                 </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>2 folders</extent>
                 </physdesc>
               </did>
@@ -540,7 +540,7 @@ Department of Industrial and Operations Engineering (University of Michigan) rec
                 <unittitle>
                   <unitdate type="inclusive" normal="1974/1976">1974-1976</unitdate>
                 </unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent>3 folders</extent>
                 </physdesc>
               </did>
@@ -558,7 +558,7 @@ Department of Industrial and Operations Engineering (University of Michigan) rec
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Financial Aid Committee, <unitdate type="inclusive" normal="1974/1976">1974-1976</unitdate> </unittitle>
-              <physdesc>
+              <physdesc altrender="whole">
                 <extent>3 folders</extent>
               </physdesc>
             </did>
@@ -567,7 +567,7 @@ Department of Industrial and Operations Engineering (University of Michigan) rec
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Admissions, Financial Aid, and Graduate Programs, <unitdate type="inclusive" normal="1976/1979">1976-1979</unitdate> </unittitle>
-              <physdesc>
+              <physdesc altrender="whole">
                 <extent>3 folders</extent>
               </physdesc>
             </did>
@@ -576,7 +576,7 @@ Department of Industrial and Operations Engineering (University of Michigan) rec
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Ph.D. Committee, <unitdate type="inclusive" normal="1972">1972</unitdate> and <unitdate type="inclusive" normal="1974">1974</unitdate> </unittitle>
-              <physdesc>
+              <physdesc altrender="whole">
                 <extent>3 folders</extent>
               </physdesc>
             </did>
@@ -591,7 +591,7 @@ Department of Industrial and Operations Engineering (University of Michigan) rec
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Steering Review, <unitdate type="inclusive" normal="1968/1981">1968-1981</unitdate> </unittitle>
-              <physdesc>
+              <physdesc altrender="whole">
                 <extent>26 folders</extent>
               </physdesc>
             </did>

--- a/Real_Masters_all/irwinfam.xml
+++ b/Real_Masters_all/irwinfam.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">87341 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>James and Sybil (Hunter) Irwin were early setters of Washtenaw County, Michigan. Their two sons, John E. and (James) Leman Irwin, fought in the Civil War as volunteer members of the 20th Michigan Infantry. Correspondence, diaries, and ledgers from these and other branches of the family are preserved in the Irwin family papers.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">6.3 linear feet</extent>
         <extent altrender="carrier">(in 8 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/irwinfam.xml
+++ b/Real_Masters_all/irwinfam.xml
@@ -43,8 +43,6 @@
       <abstract>James and Sybil (Hunter) Irwin were early setters of Washtenaw County, Michigan. Their two sons, John E. and (James) Leman Irwin, fought in the Civil War as volunteer members of the 20th Michigan Infantry. Correspondence, diaries, and ledgers from these and other branches of the family are preserved in the Irwin family papers.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">6.3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 8 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/jarocki.xml
+++ b/Real_Masters_all/jarocki.xml
@@ -46,8 +46,6 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2265 negatives (approximate</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">

--- a/Real_Masters_all/johnstondona.xml
+++ b/Real_Masters_all/johnstondona.xml
@@ -61,7 +61,7 @@ Donald A. Johnston papers
 1989-2012
 </unitdate>
 </unittitle>
-      <physdesc>
+      <physdesc altrender="whole">
         <extent encodinganalog="300">
 13.5 linear feet
 </extent>

--- a/Real_Masters_all/joneslv.xml
+++ b/Real_Masters_all/joneslv.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2014073 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>LaVerne Jones was an employee of the Michigan Bell Telephone Company. The materials include board of directors minutes, correspondence, publications, reports, maps, and photographs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.4 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/joneslv.xml
+++ b/Real_Masters_all/joneslv.xml
@@ -43,8 +43,6 @@
       <abstract>LaVerne Jones was an employee of the Michigan Bell Telephone Company. The materials include board of directors minutes, correspondence, publications, reports, maps, and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.4 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/katzdl.xml
+++ b/Real_Masters_all/katzdl.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">90133 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Professor of chemical engineering at the University of Michigan. Tapes and transcript of tapes of oral interviews with Donald Katz talking about his life and professional activities; reprints of his writings; files relating to his Ann Arbor Council of Churches activities; and files of his investigation of the Port Huron Water Tunnel explosion, 1971.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/katzdl.xml
+++ b/Real_Masters_all/katzdl.xml
@@ -43,8 +43,6 @@
       <abstract>Professor of chemical engineering at the University of Michigan. Tapes and transcript of tapes of oral interviews with Donald Katz talking about his life and professional activities; reprints of his writings; files relating to his Ann Arbor Council of Churches activities; and files of his investigation of the Port Huron Water Tunnel explosion, 1971.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/kelloggj.xml
+++ b/Real_Masters_all/kelloggj.xml
@@ -54,8 +54,6 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English; some documents in French and German.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">19.3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 21 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">

--- a/Real_Masters_all/kermanc.xml
+++ b/Real_Masters_all/kermanc.xml
@@ -45,7 +45,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">0424 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Biographer of Kenneth E. Boulding. Collected information about life and career of Kenneth E. Boulding; tapes and transcripts of interviews with Kenneth E. Boulding and his family and associates; copies of Boulding articles; and photographs used in the biography.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.3 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/kermanc.xml
+++ b/Real_Masters_all/kermanc.xml
@@ -47,8 +47,6 @@
       <abstract>Biographer of Kenneth E. Boulding. Collected information about life and career of Kenneth E. Boulding; tapes and transcripts of interviews with Kenneth E. Boulding and his family and associates; copies of Boulding articles; and photographs used in the biography.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/kleinera.xml
+++ b/Real_Masters_all/kleinera.xml
@@ -47,8 +47,6 @@
       <physloc>offsite storage; prior notification required for access</physloc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">15.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 16 boxes)</extent>
       </physdesc>
       <repository encodinganalog="852">

--- a/Real_Masters_all/kleinera.xml
+++ b/Real_Masters_all/kleinera.xml
@@ -45,7 +45,7 @@
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">85263 Aa 2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physloc>offsite storage; prior notification required for access</physloc>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">15.5 linear feet</extent>
         <extent altrender="carrier">(in 16 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/ladlitcl.xml
+++ b/Real_Masters_all/ladlitcl.xml
@@ -46,8 +46,6 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">6 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 7 boxes)</extent>
       </physdesc>
       <repository encodinganalog="852">

--- a/Real_Masters_all/ladlitcl.xml
+++ b/Real_Masters_all/ladlitcl.xml
@@ -44,7 +44,7 @@
       <abstract>Minutes of meetings, scrapbooks, financial records, reports, and other papers; and photographs.</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">86323 Bj 2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">6 linear feet</extent>
         <extent altrender="carrier">(in 7 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/lanecw.xml
+++ b/Real_Masters_all/lanecw.xml
@@ -47,8 +47,6 @@
       <abstract>Architect based in Ann Arbor, Michigan. Project files relate to work with George Brigham and his system of constructing prefabricated homes, 1944-1947; files relating to design and construction of Huron High School in Ann Arbor; other projects concern design of mobile home parks and other Michigan school buildings.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 6 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">

--- a/Real_Masters_all/larsonct.xml
+++ b/Real_Masters_all/larsonct.xml
@@ -46,8 +46,6 @@
       <abstract>Professor of architecture at the University of Michigan. The series in the collection are: Architectural Research, 1932-1983; College of Architecture and Urban Planning, 1967-1985; Correspondence, 1962-1972; Development Index, 1947-1984; and Published Materials, 1930-1982.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 5 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/larsonct.xml
+++ b/Real_Masters_all/larsonct.xml
@@ -44,7 +44,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">9438 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Professor of architecture at the University of Michigan. The series in the collection are: Architectural Research, 1932-1983; College of Architecture and Urban Planning, 1967-1985; Correspondence, 1962-1972; Development Index, 1947-1984; and Published Materials, 1930-1982.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">4 linear feet</extent>
         <extent altrender="carrier">(in 5 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/lased.xml
+++ b/Real_Masters_all/lased.xml
@@ -62,8 +62,6 @@
       <abstract>Latino social service organization active in southwest Detroit, Michigan; records, primarily assembled by board member Lucy Gajec, include administrative files, correspondence, and publicity material</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.5 linear foot</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/lased.xml
+++ b/Real_Masters_all/lased.xml
@@ -60,7 +60,7 @@
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">9816-Bd 2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <abstract>Latino social service organization active in southwest Detroit, Michigan; records, primarily assembled by board member Lucy Gajec, include administrative files, correspondence, and publicity material</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.5 linear foot</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/lgbtum.xml
+++ b/Real_Masters_all/lgbtum.xml
@@ -1156,7 +1156,7 @@
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>Clippings </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>2 folders</extent>
             </physdesc>
           </did>
@@ -1260,7 +1260,7 @@
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>Personal papers </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>4 folders</extent>
             </physdesc>
           </did>
@@ -1281,7 +1281,7 @@
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>Publications </unittitle>
-            <physdesc>
+            <physdesc altrender="whole">
               <extent>2 folders</extent>
             </physdesc>
           </did>

--- a/Real_Masters_all/lombardw.xml
+++ b/Real_Masters_all/lombardw.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">85811 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Professor of physiology at the University of Michigan; correspondence, speeches, and other materials concerning U-M Medical School activities, the Ann Arbor Red Cross, the Ann Arbor Art Association, and Lombard’s interest in art and etching.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/lombardw.xml
+++ b/Real_Masters_all/lombardw.xml
@@ -43,8 +43,6 @@
       <abstract>Professor of physiology at the University of Michigan; correspondence, speeches, and other materials concerning U-M Medical School activities, the Ann Arbor Red Cross, the Ann Arbor Art Association, and Lombard’s interest in art and etching.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/lwvgp.xml
+++ b/Real_Masters_all/lwvgp.xml
@@ -43,8 +43,6 @@
       <abstract>Records of the League of Women Voters Grosse Pointe, Mich. chapter includes administrative, annual meetings and issues materials, and publications.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2.3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/lwvgp.xml
+++ b/Real_Masters_all/lwvgp.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2013057 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Records of the League of Women Voters Grosse Pointe, Mich. chapter includes administrative, annual meetings and issues materials, and publications.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.3 linear feet</extent>
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/madd.xml
+++ b/Real_Masters_all/madd.xml
@@ -44,7 +44,7 @@
       <unitid encodinganalog="099" repositorycode="MiU-H" countrycode="us" type="call number">8926 Bk 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Records of the MADD's state coordinating council, files from the various county chapters, bulletins from the national headquarters of MADD, and programs and clippings describing state activities; also videotapes relating to the work of the organization, and audio-tapes promoting the organization and its aims.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">9 linear feet</extent>
         <extent altrender="carrier">(in 10 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/madd.xml
+++ b/Real_Masters_all/madd.xml
@@ -46,8 +46,6 @@
       <abstract>Records of the MADD's state coordinating council, files from the various county chapters, bulletins from the national headquarters of MADD, and programs and clippings describing state activities; also videotapes relating to the work of the organization, and audio-tapes promoting the organization and its aims.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">9 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 10 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/masonst.xml
+++ b/Real_Masters_all/masonst.xml
@@ -40,7 +40,7 @@
       <unitid encodinganalog="099" repositorycode="MiU-H" countrycode="us" type="call number">851813 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>First governor of Michigan; correspondence, drafts of letters to Andrew Jackson and to Secretary of State John Forsyth; draft of his inaugural address, 1838 and of other messages to the Legislature; topics covered include the Toledo War and the dispute arising from his appointment as Secretary of the Michigan Territory.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.6 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/masonst.xml
+++ b/Real_Masters_all/masonst.xml
@@ -42,8 +42,6 @@
       <abstract>First governor of Michigan; correspondence, drafts of letters to Andrew Jackson and to Secretary of State John Forsyth; draft of his inaugural address, 1838 and of other messages to the Legislature; topics covered include the Toledo War and the dispute arising from his appointment as Secretary of the Michigan Territory.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.6 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/mattern.xml
+++ b/Real_Masters_all/mattern.xml
@@ -43,8 +43,6 @@
       <abstract>Professor of music education at University of Michigan. Correspondence relating to his work in music education; also programs relating to music education, particularly the Summer Conference on Music Education; and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 5 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/mattern.xml
+++ b/Real_Masters_all/mattern.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">851840 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Professor of music education at University of Michigan. Correspondence relating to his work in music education; also programs relating to music education, particularly the Summer Conference on Music Education; and photographs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3.5 linear feet</extent>
         <extent altrender="carrier">(in 5 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/mccauley.xml
+++ b/Real_Masters_all/mccauley.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">89498 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Newsletters and minutes of executive committee of the Dav-Joy-Lin-Dex Community Council; newsletters of area block clubs; files relating to her community and organizational involvement; published materials; and photographs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/mccauley.xml
+++ b/Real_Masters_all/mccauley.xml
@@ -43,8 +43,6 @@
       <abstract>Newsletters and minutes of executive committee of the Dav-Joy-Lin-Dex Community Council; newsletters of area block clubs; files relating to her community and organizational involvement; published materials; and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/mcintirs.xml
+++ b/Real_Masters_all/mcintirs.xml
@@ -42,8 +42,6 @@
       <abstract>Michigan State Police officer, later mayor of Mackinac Island, Michigan, and owner of the Iroquois Hotel on Mackinac Island. Scattered correspondence and miscellanea; largely photographs, prints, and slides, some of which had been collected by S. Alicia Poole, of views of Mackinac Island, the Straits of Mackinac, and Great Lakes ships and passenger ferries; also personal photographs relating in part to his association with Michigan governor G. Mennen Williams and his Michigan State Police activities.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/mcintirs.xml
+++ b/Real_Masters_all/mcintirs.xml
@@ -40,7 +40,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">89509 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Michigan State Police officer, later mayor of Mackinac Island, Michigan, and owner of the Iroquois Hotel on Mackinac Island. Scattered correspondence and miscellanea; largely photographs, prints, and slides, some of which had been collected by S. Alicia Poole, of views of Mackinac Island, the Straits of Mackinac, and Great Lakes ships and passenger ferries; also personal photographs relating in part to his association with Michigan governor G. Mennen Williams and his Michigan State Police activities.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/mcnamedh.xml
+++ b/Real_Masters_all/mcnamedh.xml
@@ -43,8 +43,6 @@
       <abstract>Papers of Edward H. McNamara (1926-2006), Democratic southeastern Michigan politician, served as Wayne county executive (1987-2002), Mayor of Livonia (1970-1986), and Livonia city councilman (1962-1968). The collection includes newspaper clippings, biographical materials, miscellaneous from his political career, and visual materials.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/mcnamedh.xml
+++ b/Real_Masters_all/mcnamedh.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">0790 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Papers of Edward H. McNamara (1926-2006), Democratic southeastern Michigan politician, served as Wayne county executive (1987-2002), Mayor of Livonia (1970-1986), and Livonia city councilman (1962-1968). The collection includes newspaper clippings, biographical materials, miscellaneous from his political career, and visual materials.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/mcook.xml
+++ b/Real_Masters_all/mcook.xml
@@ -1162,8 +1162,6 @@ Martha Cook Building (University of Michigan) Records, Bentley Historical Librar
             <unittitle>Negatives <unitdate type="inclusive" normal="1965-10">October 1965</unitdate></unittitle>
             <physdesc altrender="part">
               <extent altrender="materialtype spaceoccupied">109 negatives</extent>
-            </physdesc>
-            <physdesc altrender="part">
               <extent altrender="carrier">(in 20 strips, of furnishings and architecture; people)</extent>
             </physdesc>
             <physdesc altrender="part">

--- a/Real_Masters_all/mcrrc.xml
+++ b/Real_Masters_all/mcrrc.xml
@@ -45,7 +45,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">87354 Bb 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Letter books, 1883-1921, of company president and general manager (outgoing only); administrative records, including contracts, financial papers, and miscellanea; manuscript and printed agreements between MCR and other railway lines; volumes of letters received, 1846 and 1860 (fragmentary); time books, 1853-1872, detailing hours and wages on the Detroit-Chicago section of the railroad; and miscellaneous scattered correspondence of Alpheus Felch, James F. Joy, and William Woodbridge.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">25.3 linear feet</extent>
         <extent altrender="carrier">(in 26 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/mcrrc.xml
+++ b/Real_Masters_all/mcrrc.xml
@@ -47,8 +47,6 @@
       <abstract>Letter books, 1883-1921, of company president and general manager (outgoing only); administrative records, including contracts, financial papers, and miscellanea; manuscript and printed agreements between MCR and other railway lines; volumes of letters received, 1846 and 1860 (fragmentary); time books, 1853-1872, detailing hours and wages on the Detroit-Chicago section of the railroad; and miscellaneous scattered correspondence of Alpheus Felch, James F. Joy, and William Woodbridge.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">25.3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 26 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/methaa.xml
+++ b/Real_Masters_all/methaa.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">86971 Ba 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Methodist church established in Ann Arbor, Michigan in 1827; proceedings and minutes of various church boards and committees; baptism and marriage records, topical files relating to church activities and personalities; and photographs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">5.5 linear feet</extent>
         <extent altrender="carrier">(in 7 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/methaa.xml
+++ b/Real_Masters_all/methaa.xml
@@ -43,8 +43,6 @@
       <abstract>Methodist church established in Ann Arbor, Michigan in 1827; proceedings and minutes of various church boards and committees; baptism and marriage records, topical files relating to church activities and personalities; and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">5.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 7 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/microbio.xml
+++ b/Real_Masters_all/microbio.xml
@@ -48,7 +48,7 @@
       <unitid encodinganalog="099" repositorycode="MiU-H" countrycode="us" type="call number">87146 Bimu C46 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Collected historical information, including record of faculty research, 1890-1970, history of the department, and faculty bibliography; and correspondence and memoranda of chairmen, Walter J. Nungester and Frederick C. Neidhardt; also administrative files concerning faculty activities, fellowships, research projects, and student affairs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/microbio.xml
+++ b/Real_Masters_all/microbio.xml
@@ -50,8 +50,6 @@
       <abstract>Collected historical information, including record of faculty research, 1890-1970, history of the department, and faculty bibliography; and correspondence and memoranda of chairmen, Walter J. Nungester and Frederick C. Neidhardt; also administrative files concerning faculty activities, fellowships, research projects, and student affairs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/migardcl.xml
+++ b/Real_Masters_all/migardcl.xml
@@ -47,8 +47,6 @@
       <abstract>The Michigan Garden Clubs was formed in 1931 as an organization of separate Michigan gardening groups. The record group includes administrative and historical files, activities files, awards, correspondence, yearbooks, and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7.3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 8 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/migardcl.xml
+++ b/Real_Masters_all/migardcl.xml
@@ -45,7 +45,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">07101 Bn 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>The Michigan Garden Clubs was formed in 1931 as an organization of separate Michigan gardening groups. The record group includes administrative and historical files, activities files, awards, correspondence, yearbooks, and photographs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">7.3 linear feet</extent>
         <extent altrender="carrier">(in 8 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/millswl.xml
+++ b/Real_Masters_all/millswl.xml
@@ -42,8 +42,6 @@
       <abstract>Dearborn, Michigan newspaper publisher; candidate for mayor of Dearborn in 1957. Papers relating to the Dearborn Independent newspaper; collected materials detailing the career of Dearborn mayor Orville Hubbard; campaign files documenting Mills' unsuccessful bid to unseat Hubbard in 1957; and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/millswl.xml
+++ b/Real_Masters_all/millswl.xml
@@ -40,7 +40,7 @@
       <unitid encodinganalog="099" repositorycode="MiU-H" countrycode="us" type="call number">89506 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Dearborn, Michigan newspaper publisher; candidate for mayor of Dearborn in 1957. Papers relating to the Dearborn Independent newspaper; collected materials detailing the career of Dearborn mayor Orville Hubbard; campaign files documenting Mills' unsuccessful bid to unseat Hubbard in 1957; and photographs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.3 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/morrisseylew.xml
+++ b/Real_Masters_all/morrisseylew.xml
@@ -67,7 +67,7 @@ Lewis A. Morrissey papers
 1994-2003
 </unitdate>
 </unittitle>
-      <physdesc>
+      <physdesc altrender="whole">
         <extent encodinganalog="300">
 1 linear foot
 </extent>

--- a/Real_Masters_all/mtheater.xml
+++ b/Real_Masters_all/mtheater.xml
@@ -45,7 +45,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2011096 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Michigan Theater Foundation was formed in 1979 when it purchased the Michigan Theater in Ann Arbor, Mich., a historic landmark built in 1928 and restored by the fundrasing efforts of the Foundation. The record group comprises administrative records, including files of the Executive Director, Board of Trustees and administrative committees; grant proposals, materials related to fundraising, theater restoration, renovation, and membership campaigns; descriptions of programs, series, and individual events taken place at the theater; publicity photographs, audio- and video (VHS) recordings, and outsize posters and calendars of events.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">4.5 linear feet</extent>
         <extent altrender="carrier">(in 6 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/mtheater.xml
+++ b/Real_Masters_all/mtheater.xml
@@ -47,8 +47,6 @@
       <abstract>Michigan Theater Foundation was formed in 1979 when it purchased the Michigan Theater in Ann Arbor, Mich., a historic landmark built in 1928 and restored by the fundrasing efforts of the Foundation. The record group comprises administrative records, including files of the Executive Director, Board of Trustees and administrative committees; grant proposals, materials related to fundraising, theater restoration, renovation, and membership campaigns; descriptions of programs, series, and individual events taken place at the theater; publicity photographs, audio- and video (VHS) recordings, and outsize posters and calendars of events.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 6 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/muncyr.xml
+++ b/Real_Masters_all/muncyr.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">85535 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Socialist Labor Party member, later member of the League for Socialist Reconstruction. Correspondence, campaign files, audio-tapes, and other materials largely concerning his work with the State Central Committee of the Socialist Labor Party and Socialist Reconstruction, 1928-1992; and collected family materials including letters and memoirs of Levi Muncy, soldier during the Civil War; also photographs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">15.5 linear feet</extent>
         <extent altrender="carrier">(in 16 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/muncyr.xml
+++ b/Real_Masters_all/muncyr.xml
@@ -43,8 +43,6 @@
       <abstract>Socialist Labor Party member, later member of the League for Socialist Reconstruction. Correspondence, campaign files, audio-tapes, and other materials largely concerning his work with the State Central Committee of the Socialist Labor Party and Socialist Reconstruction, 1928-1992; and collected family materials including letters and memoirs of Levi Muncy, soldier during the Civil War; also photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">15.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 16 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/nursescc.xml
+++ b/Real_Masters_all/nursescc.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">90148 Bf 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Professional nursing association chapter established in 1982. Subject files relating to chapter activities; include chapter board and committee files.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/nursescc.xml
+++ b/Real_Masters_all/nursescc.xml
@@ -43,8 +43,6 @@
       <abstract>Professional nursing association chapter established in 1982. Subject files relating to chapter activities; include chapter board and committee files.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/obgynum.xml
+++ b/Real_Masters_all/obgynum.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">921084 Bimu C500 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Records include registers; annual reports; administrative files; departmental minutes; admissions books containing details on admission, births, treatment, and disposition of patients; and photographs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">6.5 linear feet</extent>
         <extent altrender="carrier">(in 8 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/obgynum.xml
+++ b/Real_Masters_all/obgynum.xml
@@ -43,8 +43,6 @@
       <abstract>Records include registers; annual reports; administrative files; departmental minutes; admissions books containing details on admission, births, treatment, and disposition of patients; and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">6.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 8 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/ouradnik.xml
+++ b/Real_Masters_all/ouradnik.xml
@@ -47,8 +47,6 @@
       <abstract>Official photographer for the University Players (formerly Play Production) at the University of Michigan starting in 1928; photographic negatives of cast (in costume) from various student productions.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">420 negatives (approximate</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/ouradnik.xml
+++ b/Real_Masters_all/ouradnik.xml
@@ -45,7 +45,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">92661 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Official photographer for the University Players (formerly Play Production) at the University of Michigan starting in 1928; photographic negatives of cast (in costume) from various student productions.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">420 negatives (approximate</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/pacoszch.xml
+++ b/Real_Masters_all/pacoszch.xml
@@ -49,7 +49,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2009116 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Widely published American Polish poet whose life is at the heart of her poetry; diaries and publications.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">7 linear feet</extent>
         <extent altrender="carrier">(in 7 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/pacoszch.xml
+++ b/Real_Masters_all/pacoszch.xml
@@ -51,8 +51,6 @@
       <abstract>Widely published American Polish poet whose life is at the heart of her poetry; diaries and publications.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 7 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/pattersf.xml
+++ b/Real_Masters_all/pattersf.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">852119 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>New York State and Ann Arbor, Michigan family; family correspondence, business papers, student notebooks, photograph albums.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/pattersf.xml
+++ b/Real_Masters_all/pattersf.xml
@@ -43,8 +43,6 @@
       <abstract>New York State and Ann Arbor, Michigan family; family correspondence, business papers, student notebooks, photograph albums.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/peacewrk.xml
+++ b/Real_Masters_all/peacewrk.xml
@@ -47,8 +47,6 @@
       <abstract>Michigan Peaceworks (MPW) was an Ann Arbor based grassroots organization dedicated to peace, social justice, and human rights that was founded in 2001 following the September 11th attacks. The collection includes material related to their public events and outreach activities in Ann Arbor. These events and activities are well represented in posters, fliers, and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 6 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/peacewrk.xml
+++ b/Real_Masters_all/peacewrk.xml
@@ -45,7 +45,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2010096 Bj 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Michigan Peaceworks (MPW) was an Ann Arbor based grassroots organization dedicated to peace, social justice, and human rights that was founded in 2001 following the September 11th attacks. The collection includes material related to their public events and outreach activities in Ann Arbor. These events and activities are well represented in posters, fliers, and photographs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">4.5 linear feet</extent>
         <extent altrender="carrier">(in 6 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/pharmpub.xml
+++ b/Real_Masters_all/pharmpub.xml
@@ -58,8 +58,6 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2.8 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">

--- a/Real_Masters_all/photoser.xml
+++ b/Real_Masters_all/photoser.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">94135 Bimu 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>The University of Michigan Photo and Campus Services is a comprehensive photographic unit established to meet the needs of the schools, colleges, departments, and other units within the university as well as individuals within the university community. In existence since 1948, the unit officially became part of News and Information Services in 1997. Services include photographic reproduction and studio and location photography.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.25 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/photoser.xml
+++ b/Real_Masters_all/photoser.xml
@@ -43,8 +43,6 @@
       <abstract>The University of Michigan Photo and Campus Services is a comprehensive photographic unit established to meet the needs of the schools, colleges, departments, and other units within the university as well as individuals within the university community. In existence since 1948, the unit officially became part of News and Information Services in 1997. Services include photographic reproduction and studio and location photography.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.25 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/pinkush.xml
+++ b/Real_Masters_all/pinkush.xml
@@ -51,8 +51,6 @@
       <abstract>Hermann Pinkus and Hilde Hensel Pinkus were German immigrants who worked as dermatologists and allergists in the greater Detroit area. The collection includes records from the Detroit Dermatological Society and material related to the Pinkus’s participation in professional societies and their research interests, including thorium X and amino acids.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 5 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">

--- a/Real_Masters_all/pontaul.xml
+++ b/Real_Masters_all/pontaul.xml
@@ -40,7 +40,7 @@
       <unitid encodinganalog="099" repositorycode="MiU-H" countrycode="us" type="call number">9144 Bd 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Pontiac, Michigan, chapter of the National Urban League. The record group includes scattered minutes and annual reports, clippings and scrapbooks, publications, subject files relating to chapter activities, and photographs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.7 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/pontaul.xml
+++ b/Real_Masters_all/pontaul.xml
@@ -42,8 +42,6 @@
       <abstract>Pontiac, Michigan, chapter of the National Urban League. The record group includes scattered minutes and annual reports, clippings and scrapbooks, publications, subject files relating to chapter activities, and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.7 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/powrie.xml
+++ b/Real_Masters_all/powrie.xml
@@ -45,7 +45,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2010205 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Papers of Emerson F. Powrie, Ann Arbor, MI public schools teacher (1945-1948), principal (1948-1971), and Central Administration employee (1972-1977); and his wife Gwendolyn Sutton Powrie, teacher for the hearing-impaired children.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/powrie.xml
+++ b/Real_Masters_all/powrie.xml
@@ -47,8 +47,6 @@
       <abstract>Papers of Emerson F. Powrie, Ann Arbor, MI public schools teacher (1945-1948), principal (1948-1971), and Central Administration employee (1972-1977); and his wife Gwendolyn Sutton Powrie, teacher for the hearing-impaired children.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/ppldet.xml
+++ b/Real_Masters_all/ppldet.xml
@@ -54,8 +54,6 @@
       <abstract>Detroit, Michigan chapter of the Planned Parenthood Federation of America, founded in 1932 as the Detroit Chapter of the Michigan Birth Control League. Minutes, correspondence, reports, surveys, newsletters, and printed material document the efforts of the Planned Parenthood League to provide birth control information and services to residents of the Detroit area</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">8.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 9 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/ppldet.xml
+++ b/Real_Masters_all/ppldet.xml
@@ -52,7 +52,7 @@
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">85386 Bj 2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <abstract>Detroit, Michigan chapter of the Planned Parenthood Federation of America, founded in 1932 as the Detroit Chapter of the Michigan Birth Control League. Minutes, correspondence, reports, surveys, newsletters, and printed material document the efforts of the Planned Parenthood League to provide birth control information and services to residents of the Detroit area</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">8.5 linear feet</extent>
         <extent altrender="carrier">(in 9 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/prayff.xml
+++ b/Real_Masters_all/prayff.xml
@@ -44,7 +44,7 @@
       <abstract>Jackson, Michigan physician; medical records, files pertaining to farm business, and personal miscellaneous.</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">9425 Aa 2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.7 linear feet</extent>
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/prayff.xml
+++ b/Real_Masters_all/prayff.xml
@@ -46,8 +46,6 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2.7 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/psycdept.xml
+++ b/Real_Masters_all/psycdept.xml
@@ -45,7 +45,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">87162 Bimu C26 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Teaching and research unit of the College of Literature, Science and the Arts of the University of Michigan. Records include administrative files, committee minutes, reports, some course material and a topical file which contains some information on student antiwar activities, 1966-1967. Also several photos of the psychology laboratories, 1903-1915.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">9.25 linear feet</extent>
         <extent altrender="carrier">(in 10 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/psycdept.xml
+++ b/Real_Masters_all/psycdept.xml
@@ -47,8 +47,6 @@
       <abstract>Teaching and research unit of the College of Literature, Science and the Arts of the University of Michigan. Records include administrative files, committee minutes, reports, some course material and a topical file which contains some information on student antiwar activities, 1966-1967. Also several photos of the psychology laboratories, 1903-1915.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">9.25 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 10 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/randallh.xml
+++ b/Real_Masters_all/randallh.xml
@@ -43,8 +43,6 @@
       <abstract>Renowned physicist who studied, conducted research, and taught at the University of Michigan from the late 1800s until the 1960s; Dr. Harrison M. Randall helped develop the atomic and nuclear components of the physics program, and conducted research on infrared spectroscopy. Materials include correspondence, photos, postcards, research data, progress and final research reports, grant proposals, and reprints.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/randallh.xml
+++ b/Real_Masters_all/randallh.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">85521 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> and <language langcode="eng" encodinganalog="041">German</language>.</langmaterial>
       <abstract>Renowned physicist who studied, conducted research, and taught at the University of Michigan from the late 1800s until the 1960s; Dr. Harrison M. Randall helped develop the atomic and nuclear components of the physics program, and conducted research on infrared spectroscopy. Materials include correspondence, photos, postcards, research data, progress and final research reports, grant proposals, and reprints.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/ransomfm.xml
+++ b/Real_Masters_all/ransomfm.xml
@@ -47,8 +47,6 @@
       <abstract>Eugene Ransom was director of the Wesley Foundation at the University of Michigan (1951-1968). Jeanne Bailey Ransom was a teacher, writer, and family historian. The collection consists largely of binders of materials (photographs, clippings, and other memorabilia) relating to Eugene's service with the Civilian Public Service during World War II, to his work with the Wesley Foundation, and to the couples' involvement in issues of peace and justice. In addition, the collection includes collected genealogical materials and family documents pertaining to the Bailey family.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 8 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/ransomfm.xml
+++ b/Real_Masters_all/ransomfm.xml
@@ -45,7 +45,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2012115 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Eugene Ransom was director of the Wesley Foundation at the University of Michigan (1951-1968). Jeanne Bailey Ransom was a teacher, writer, and family historian. The collection consists largely of binders of materials (photographs, clippings, and other memorabilia) relating to Eugene's service with the Civilian Public Service during World War II, to his work with the Wesley Foundation, and to the couples' involvement in issues of peace and justice. In addition, the collection includes collected genealogical materials and family documents pertaining to the Bailey family.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">7 linear feet</extent>
         <extent altrender="carrier">(in 8 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/realestat.xml
+++ b/Real_Masters_all/realestat.xml
@@ -45,7 +45,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2011110 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>New World State Wide V’s Realty’s collection of Michigan real estate data and sales books for Albion County (1997-2003), Hillsdale County (1995-1999), Jackson County (1994-2009), Lenawee County (1993-2007, and 2010), Monroe (1988, 1993-1994, and 1996-2009), Washtenaw County (1973-2011), and Wayne County (1976-1982, 1985, and 1988-2004).</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">21.3 linear feet</extent>
         <extent altrender="carrier">(in 22 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/realestat.xml
+++ b/Real_Masters_all/realestat.xml
@@ -47,8 +47,6 @@
       <abstract>New World State Wide V’s Realty’s collection of Michigan real estate data and sales books for Albion County (1997-2003), Hillsdale County (1995-1999), Jackson County (1994-2009), Lenawee County (1993-2007, and 2010), Monroe (1988, 1993-1994, and 1996-2009), Washtenaw County (1973-2011), and Wayne County (1976-1982, 1985, and 1988-2004).</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">21.3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 22 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/revelliw.xml
+++ b/Real_Masters_all/revelliw.xml
@@ -62,8 +62,6 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">9 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 10 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/revelliw.xml
+++ b/Real_Masters_all/revelliw.xml
@@ -60,7 +60,7 @@
       <abstract>Conductor of bands and professor of wind instruments at the University of Michigan. The series in the collection include: Biographical/Personal information; Correspondence, 1921-1994; University of Michigan Activities (primarily relating to performances and tours of the Marching Band and the Symphony Band); Other Professional Activities (relating to Band Conductors Conferences and band clinics, and including files of Revelli's writings and musical compositions); Visual Materials; and Sound Recordings.</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">9622 Aa 2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">9 linear feet</extent>
         <extent altrender="carrier">(in 10 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/russlect.xml
+++ b/Real_Masters_all/russlect.xml
@@ -51,7 +51,7 @@
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">8724 Bimu C8 1</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <abstract>University of Michigan committee which selects the annual Henry Russell Lecturer, the highest faculty award and the nominee for the Henry Russell Award recognizing a junior faculty member for superior scholarship and teaching ability.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
         <extent altrender="carrier">(in 2.4 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/russlect.xml
+++ b/Real_Masters_all/russlect.xml
@@ -53,8 +53,6 @@
       <abstract>University of Michigan committee which selects the annual Henry Russell Lecturer, the highest faculty award and the nominee for the Henry Russell Award recognizing a junior faculty member for superior scholarship and teaching ability.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2.4 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/sheppard.xml
+++ b/Real_Masters_all/sheppard.xml
@@ -43,8 +43,6 @@
       <abstract>The Glen Sheppard Papers document the research and writing undertaken by Sheppard during his 40-year tenure as editor, publisher, and writer for the <title render="italic">North Woods Call</title>, a small conservation newspaper dedicated to the stewardship and protection of Northern Michigan's natural resources. The collection's three series contain Sheppard's articles and writings, press releases and newspaper articles written by others, government reports and publications, audio and visual materials.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">35.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 36 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/sheppard.xml
+++ b/Real_Masters_all/sheppard.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2013030 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>The Glen Sheppard Papers document the research and writing undertaken by Sheppard during his 40-year tenure as editor, publisher, and writer for the <title render="italic">North Woods Call</title>, a small conservation newspaper dedicated to the stewardship and protection of Northern Michigan's natural resources. The collection's three series contain Sheppard's articles and writings, press releases and newspaper articles written by others, government reports and publications, audio and visual materials.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">35.5 linear feet</extent>
         <extent altrender="carrier">(in 36 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/singerjd.xml
+++ b/Real_Masters_all/singerjd.xml
@@ -55,8 +55,6 @@
       <abstract>University of Michigan professor of political science, research scientist at the Mental Health Research Institute, and pioneer in the interdisciplinary and quantitative approach to conflict resolution. Administrative papers of Center for Research on Conflict Resolution, Correlates of War Project, and the Journal of Conflict Resolution, topical files on numerous organizations and subjects, and research papers from disarmament negotiations study.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">21.3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 23 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/singerjd.xml
+++ b/Real_Masters_all/singerjd.xml
@@ -53,7 +53,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">861057 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>University of Michigan professor of political science, research scientist at the Mental Health Research Institute, and pioneer in the interdisciplinary and quantitative approach to conflict resolution. Administrative papers of Center for Research on Conflict Resolution, Correlates of War Project, and the Journal of Conflict Resolution, topical files on numerous organizations and subjects, and research papers from disarmament negotiations study.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">21.3 linear feet</extent>
         <extent altrender="carrier">(in 23 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/stanleya.xml
+++ b/Real_Masters_all/stanleya.xml
@@ -43,8 +43,6 @@
       <abstract>Professor of music and director of the University Musical Society at University of Michigan. Correspondence, articles, lectures, speeches, autobiography, and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/stanleya.xml
+++ b/Real_Masters_all/stanleya.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">8642 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Professor of music and director of the University Musical Society at University of Michigan. Correspondence, articles, lectures, speeches, autobiography, and photographs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
         <extent altrender="carrier">(in 4 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/stewartmary.xml
+++ b/Real_Masters_all/stewartmary.xml
@@ -59,7 +59,7 @@ Stewart, Mary
 Mary Stewart papers
 <unitdate type="inclusive" encodinganalog="245$f">
 1980-2015</unitdate></unittitle>
-      <physdesc>
+      <physdesc altrender="whole">
         <extent encodinganalog="300">
 0.4 linear feet and 79.9 GB (online)
 </extent>

--- a/Real_Masters_all/stewfam.xml
+++ b/Real_Masters_all/stewfam.xml
@@ -43,8 +43,6 @@
       <abstract>Papers of the Stewart, Van Akin, and Seymour families, of Flint, Michigan. Includes correspondence, genealogies, newspaper clippings, family memorabilia and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.25 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/stewfam.xml
+++ b/Real_Masters_all/stewfam.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2010078 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Papers of the Stewart, Van Akin, and Seymour families, of Flint, Michigan. Includes correspondence, genealogies, newspaper clippings, family memorabilia and photographs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.25 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/stockton.xml
+++ b/Real_Masters_all/stockton.xml
@@ -44,7 +44,7 @@
       <unittitle encodinganalog="245">Ronald R. Stockton papers <unitdate type="inclusive" encodinganalog="245$f" normal="1960/2014" certainty="approximate">1960s-2014</unitdate></unittitle>
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2012043 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/stockton.xml
+++ b/Real_Masters_all/stockton.xml
@@ -46,8 +46,6 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/studleyw.xml
+++ b/Real_Masters_all/studleyw.xml
@@ -41,8 +41,6 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.6 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/studleyw.xml
+++ b/Real_Masters_all/studleyw.xml
@@ -39,7 +39,7 @@
       <unittitle encodinganalog="245">William Sprague Studley papers <unitdate type="inclusive" encodinganalog="245$f" normal="1846/1910">1846-1910</unitdate></unittitle>
       <unitid encodinganalog="099" repositorycode="MiU-H" countrycode="us" type="call number">8692 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.6 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/taylorho.xml
+++ b/Real_Masters_all/taylorho.xml
@@ -56,7 +56,7 @@
         <corpname><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>
         <extptr href="bhladd" show="embed" actuate="onload"/>
       </repository>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">23.1 linear feet</extent>
         <extent altrender="carrier">(in 25 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/taylorho.xml
+++ b/Real_Masters_all/taylorho.xml
@@ -58,8 +58,6 @@
       </repository>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">23.1 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 25 boxes)</extent>
       </physdesc>
       <physloc>Portions located in offsite storage; prior notification required for access.</physloc>

--- a/Real_Masters_all/ucellar.xml
+++ b/Real_Masters_all/ucellar.xml
@@ -45,7 +45,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">87469 Bimu F10 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Student-controlled bookstore at the University of Michigan (established 1970, ceased operation in 1987.) Minutes and memoranda of board of directors, financial records, labor negotiation files, and other subject files; and photographs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">5 linear feet</extent>
         <extent altrender="carrier">(in 6 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/ucellar.xml
+++ b/Real_Masters_all/ucellar.xml
@@ -47,8 +47,6 @@
       <abstract>Student-controlled bookstore at the University of Michigan (established 1970, ceased operation in 1987.) Minutes and memoranda of board of directors, financial records, labor negotiation files, and other subject files; and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 6 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/umhillel.xml
+++ b/Real_Masters_all/umhillel.xml
@@ -45,7 +45,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2009059 Bimu 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>The University of Michigan Hillel records cover the student organization's contribution to Jewish campus life. The collection consists primarily of calendar of events, newsletters, some correspondence, newspaper clippings, board minutes, brochures, programs, and posters.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/umhillel.xml
+++ b/Real_Masters_all/umhillel.xml
@@ -47,8 +47,6 @@
       <abstract>The University of Michigan Hillel records cover the student organization's contribution to Jewish campus life. The collection consists primarily of calendar of events, newsletters, some correspondence, newspaper clippings, board minutes, brochures, programs, and posters.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/umnap.xml
+++ b/Real_Masters_all/umnap.xml
@@ -44,7 +44,7 @@
       <abstract>University of Michigan program established in 1919 for the graduate training of nurses in anesthesia, closed in 1987. Records include Correspondence, newspaper clippings, and other papers containing some general information about the history and administration of the program (especially during the 1970s and 1980s), and the eventual closure of the program in 1987.</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">994 Bimu 2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/umnap.xml
+++ b/Real_Masters_all/umnap.xml
@@ -46,8 +46,6 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/unistrut.xml
+++ b/Real_Masters_all/unistrut.xml
@@ -46,8 +46,6 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <repository encodinganalog="852">

--- a/Real_Masters_all/unistrut.xml
+++ b/Real_Masters_all/unistrut.xml
@@ -44,7 +44,7 @@
       <abstract>Company established by Charles Attwood who was inventor and developer of a system of precast metal frame construction that came to be known as the Unistrut system. The company was originally known as Deceleco. The record group includes background and historical information about Unistrut; job files containing records pertaining to the planning and execution of Deceleco's contracts, 1929-1932; product literature and catalogs, 1927-1981; publications resulting from research into the Unistrut system of construction; and photographs.</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">0076 Bb 2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
         <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/vanbroek.xml
+++ b/Real_Masters_all/vanbroek.xml
@@ -47,8 +47,6 @@
       <abstract>Professor of mechanical engineering at University of Michigan. Correspondence concerning University and departmental business, World War II research projects, the American Society of Civil Engineering, and research projects of the Hamilton Watch Company and Hayes Wheel Company.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/vanbroek.xml
+++ b/Real_Masters_all/vanbroek.xml
@@ -45,7 +45,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">86160 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Professor of mechanical engineering at University of Michigan. Correspondence concerning University and departmental business, World War II research projects, the American Society of Civil Engineering, and research projects of the Hamilton Watch Company and Hayes Wheel Company.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.5 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/vpsaff.xml
+++ b/Real_Masters_all/vpsaff.xml
@@ -52,7 +52,7 @@
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">87290 Bimu B7 2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <abstract>University of Michigan administrative office, established as the Dean of Student Affairs in 1921, responsible for overseeing many aspects of non-academic student services and activities including at various times: counseling, financial aid, student housing, student activities and organizations, the health service, student discipline, and fraternities and sororities. Records provide extensive documentation of student life.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">41.5 linear feet</extent>
         <extent altrender="carrier">(in 42 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/vpsaff.xml
+++ b/Real_Masters_all/vpsaff.xml
@@ -54,8 +54,6 @@
       <abstract>University of Michigan administrative office, established as the Dean of Student Affairs in 1921, responsible for overseeing many aspects of non-academic student services and activities including at various times: counseling, financial aid, student housing, student activities and organizations, the health service, student discipline, and fraternities and sororities. Records provide extensive documentation of student life.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">41.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 42 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/wascohs.xml
+++ b/Real_Masters_all/wascohs.xml
@@ -1981,7 +1981,7 @@ Washtenaw County Historical Society records, Bentley Historical Library, Univers
       <c01 level="series">
         <did>
           <unittitle>Glass slides</unittitle>
-          <physdesc altrender="part">
+          <physdesc altrender="whole">
             <extent altrender="materialtype spaceoccupied">53 slides</extent>
             <extent altrender="carrier">1 box</extent>
           </physdesc>

--- a/Real_Masters_all/westmeth.xml
+++ b/Real_Masters_all/westmeth.xml
@@ -43,8 +43,6 @@
       <abstract>Church originally established by German immigrant families to Ann Arbor, Michigan. Quarterly and annual reports of the church, records of church boards and commissions, Sunday School minutes and reports, subject files, publications, visual materials, and sound recordings.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">16 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 17 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/westmeth.xml
+++ b/Real_Masters_all/westmeth.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">06100 Ba 2</unitid>
       <langmaterial>The material is primarily in <language langcode="eng" encodinganalog="041">English</language> with a some items, mainly prior to 1925, in German.</langmaterial>
       <abstract>Church originally established by German immigrant families to Ann Arbor, Michigan. Quarterly and annual reports of the church, records of church boards and commissions, Sunday School minutes and reports, subject files, publications, visual materials, and sound recordings.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">16 linear feet</extent>
         <extent altrender="carrier">(in 17 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/whithar.xml
+++ b/Real_Masters_all/whithar.xml
@@ -44,7 +44,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">88141 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Landscape architect, professor of landscape architecture at the University of Michigan. Files relating to various Michigan projects, notably in Ann Arbor, Hartland, Hillsdale, and Highland Park; subject files on professional activities; and photographs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">5.5 linear feet</extent>
         <extent altrender="carrier">(in 7 boxes)</extent>
       </physdesc>

--- a/Real_Masters_all/whithar.xml
+++ b/Real_Masters_all/whithar.xml
@@ -46,8 +46,6 @@
       <abstract>Landscape architect, professor of landscape architecture at the University of Michigan. Files relating to various Michigan projects, notably in Ann Arbor, Hartland, Hillsdale, and Highland Park; subject files on professional activities; and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">5.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 7 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/wickliff.xml
+++ b/Real_Masters_all/wickliff.xml
@@ -43,8 +43,6 @@
       <abstract>Teacher; Ann Arbor, Michigan, community activist; member of the North Central Property Owners Association in Ann Arbor. Articles written for the local newspaper, awards, scattered correspondence, biographical information, and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>
       <repository>

--- a/Real_Masters_all/wickliff.xml
+++ b/Real_Masters_all/wickliff.xml
@@ -41,7 +41,7 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">9745 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Teacher; Ann Arbor, Michigan, community activist; member of the North Central Property Owners Association in Ann Arbor. Articles written for the local newspaper, awards, scattered correspondence, biographical information, and photographs.</abstract>
-      <physdesc altrender="part">
+      <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.5 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
       </physdesc>


### PR DESCRIPTION
Only applied when the container summary had an obvious parent extent -- there may be some lone summaries still out there.
