### PR TITLE
encodinganalog and source clean up

### DIFF
--- a/Real_Masters_all/alphanu.xml
+++ b/Real_Masters_all/alphanu.xml
@@ -84,7 +84,7 @@ Alpha Nu Literary Society (University of Michigan) Records, Bentley Historical L
         <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n86054943">McClelland, Robert, 1807-1880.</persname>
         <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n50002814">Schoolcraft, Henry Rowe, 1793-1864.</persname>
         <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n88002972">Seaman, Ezra C. (Ezra Champion), 1805-1880.</persname>
-        <title>The Sybil</title>
+        <title source="aacr2">The Sybil</title>
       </controlaccess>
     </controlaccess>
     <dsc type="combined">

--- a/Real_Masters_all/bellmarg.xml
+++ b/Real_Masters_all/bellmarg.xml
@@ -245,18 +245,18 @@ Margaret Bell Papers, Bentley Historical Library, University of Michigan</p>
       </controlaccess>
       <controlaccess>
         <head>Contributors:</head>
-        <persname encodinganalog="600" source="lcnaf">Bell, Margaret, 1888-1969.</persname>
-        <persname encodinganalog="600" source="lcnaf" authfilenumber="http://id.loc.gov/authorities/names/n79060532">Dewey, John, 1859-1952.</persname>
-        <persname encodinganalog="600" source="lcnaf" authfilenumber="http://id.loc.gov/authorities/names/nr94029651">Lee, Mabel.</persname>
-        <persname encodinganalog="600" source="lcnaf">Halsey, Elizabeth, b. 1890.</persname>
-        <persname encodinganalog="600" source="lcnaf">Jordan, Myra Beach, 1863-1946.</persname>
-        <persname encodinganalog="600" source="lcnaf" authfilenumber="http://id.loc.gov/authorities/names/no2004117161">McCloy, Charles H. (Charles Harold), 1886-1959.</persname>
-        <persname encodinganalog="600" source="lcnaf" authfilenumber="http://id.loc.gov/authorities/names/n81127252">Mitchell, Elmer Dayton, 1889-</persname>
-        <persname encodinganalog="600" source="lcnaf" authfilenumber="http://id.loc.gov/authorities/names/n81114561">Nash, Jay Bryan, 1886-1965.</persname>
-        <persname encodinganalog="600" source="lcnaf" authfilenumber="http://id.loc.gov/authorities/names/n91070136">Palmer, Thomas Witherell, 1830-1913.</persname>
-        <persname encodinganalog="600" source="lcnaf" authfilenumber="http://id.loc.gov/authorities/names/n90648453">Stagg, Amos Alonzo, 1862-1965.</persname>
-        <persname encodinganalog="600" source="lcnaf">Sundwall, John, 1880-1950.</persname>
-        <persname encodinganalog="600" source="lcnaf" authfilenumber="http://id.loc.gov/authorities/names/n92051380">Yost, Fielding Harris, 1871-1946.</persname>
+        <persname encodinganalog="700" source="lcnaf">Bell, Margaret, 1888-1969.</persname>
+        <persname encodinganalog="700" source="lcnaf" authfilenumber="http://id.loc.gov/authorities/names/n79060532">Dewey, John, 1859-1952.</persname>
+        <persname encodinganalog="700" source="lcnaf" authfilenumber="http://id.loc.gov/authorities/names/nr94029651">Lee, Mabel.</persname>
+        <persname encodinganalog="700" source="lcnaf">Halsey, Elizabeth, b. 1890.</persname>
+        <persname encodinganalog="700" source="lcnaf">Jordan, Myra Beach, 1863-1946.</persname>
+        <persname encodinganalog="700" source="lcnaf" authfilenumber="http://id.loc.gov/authorities/names/no2004117161">McCloy, Charles H. (Charles Harold), 1886-1959.</persname>
+        <persname encodinganalog="700" source="lcnaf" authfilenumber="http://id.loc.gov/authorities/names/n81127252">Mitchell, Elmer Dayton, 1889-</persname>
+        <persname encodinganalog="700" source="lcnaf" authfilenumber="http://id.loc.gov/authorities/names/n81114561">Nash, Jay Bryan, 1886-1965.</persname>
+        <persname encodinganalog="700" source="lcnaf" authfilenumber="http://id.loc.gov/authorities/names/n91070136">Palmer, Thomas Witherell, 1830-1913.</persname>
+        <persname encodinganalog="700" source="lcnaf" authfilenumber="http://id.loc.gov/authorities/names/n90648453">Stagg, Amos Alonzo, 1862-1965.</persname>
+        <persname encodinganalog="700" source="lcnaf">Sundwall, John, 1880-1950.</persname>
+        <persname encodinganalog="700" source="lcnaf" authfilenumber="http://id.loc.gov/authorities/names/n92051380">Yost, Fielding Harris, 1871-1946.</persname>
       </controlaccess>
       <controlaccess>
         <head>Genre Terms:</head>

--- a/Real_Masters_all/brazermc.xml
+++ b/Real_Masters_all/brazermc.xml
@@ -108,7 +108,7 @@ Marjorie Cahn Brazer papers, Bentley Historical Library, University of Michigan<
       </controlaccess>
       <controlaccess>
         <head>Contributors: Sound Recordings</head>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n82041090">Brazer, Marjorie Cahn.</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n82041090">Brazer, Marjorie Cahn.</persname>
         <persname source="lcnaf" encodinganalog="700">Briggs, Robert Peter, 1903-</persname>
         <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/no2008089479">Cudlip, William B., 1904-1988</persname>
         <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/no2004086597">Kelly, E. Lowell (Everett Lowell), 1905-1986</persname>

--- a/Real_Masters_all/busadmin.xml
+++ b/Real_Masters_all/busadmin.xml
@@ -289,7 +289,7 @@
       </controlaccess>
       <controlaccess>
         <head>Contributors:</head>
-        <corpname source="lcnaf" encodinganalog="610">University of Michigan. Ross School of Business.</corpname>
+        <corpname source="lcnaf" encodinganalog="710">University of Michigan. Ross School of Business.</corpname>
       </controlaccess>
       <controlaccess>
         <head>Genre/Form:</head>

--- a/Real_Masters_all/coepub.xml
+++ b/Real_Masters_all/coepub.xml
@@ -204,7 +204,7 @@
       </controlaccess>
       <controlaccess>
         <head>Contributors:</head>
-        <corpname source="lcnaf" encodinganalog="610">Tau Beta Pi. Gamma Chapter (University of Michigan)</corpname>
+        <corpname source="lcnaf" encodinganalog="710">Tau Beta Pi. Gamma Chapter (University of Michigan)</corpname>
         <corpname source="lcnaf" encodinganalog="710">University of Michigan. Bioengineering Program.</corpname>
         <corpname source="lcnaf" encodinganalog="710" authfilenumber="http://id.loc.gov/authorities/names/nr92013251">University of Michigan. Center for Research on Integrated Manufacturing.</corpname>
         <corpname source="lcnaf" encodinganalog="710">University of Michigan. Michigan Engineering Television Network.</corpname>

--- a/Real_Masters_all/davisjl.xml
+++ b/Real_Masters_all/davisjl.xml
@@ -100,7 +100,7 @@ Joe Lee Davis papers, Bentley Historical Library, University of Michigan</p>
       </controlaccess>
       <controlaccess>
         <head>Contributors:</head>
-        <persname source="lcnaf" encodinganalog="600">Davis, Joe Lee.</persname>
+        <persname source="lcnaf" encodinganalog="700">Davis, Joe Lee.</persname>
         <persname source="lcnaf" encodinganalog="700">Davis, R. Lee, 1868-1935.</persname>
         <persname source="lcnaf" encodinganalog="700">Davis, Thomas O.</persname>
       </controlaccess>

--- a/Real_Masters_all/dekers.xml
+++ b/Real_Masters_all/dekers.xml
@@ -91,7 +91,7 @@ Dekers Blue Line Club, Bentley Historical Library, University of Michigan</p>
         <corpname encodinganalog="610" source="lcnaf">Dekers Blue Line Club.</corpname>
         <corpname encodinganalog="610" source="lcnaf">University of Michigan--Hockey.</corpname>
         <subject source="lctgm" encodinganalog="650">Ice hockey--Michigan.</subject>
-        <title encodinganalog="740">Inside the Goal Crease</title>
+        <title encodinganalog="740" source="aacr2">Inside the Goal Crease</title>
       </controlaccess>
       <controlaccess>
         <head>Subjects - Visual Materials:</head>

--- a/Real_Masters_all/dentpub.xml
+++ b/Real_Masters_all/dentpub.xml
@@ -121,6 +121,7 @@
         <corpname source="lcnaf" encodinganalog="710">University of Michigan. School of Dentistry. Dept. of Oral Surgery.</corpname>
         <corpname source="lcnaf" encodinganalog="710">University of Michigan. Dept. of Orthodontics.</corpname>
         <corpname source="lcnaf" encodinganalog="710">University of Michigan. Dept. of Periodontics.</corpname>
+        <corpname source="lcnaf" encodinganalog="710">University of Michigan. Dept. of Community Dentistry.</corpname>
       </controlaccess>
       <controlaccess>
         <head>Genre/Form:</head>
@@ -132,7 +133,6 @@
         <genreform source="aat" encodinganalog="655">Manuals.</genreform>
         <genreform source="aat" encodinganalog="655">Newsletters.</genreform>
         <genreform source="aat" encodinganalog="655">Programs.</genreform>
-        <corpname source="lcnaf" encodinganalog="710">University of Michigan. Dept. of Community Dentistry.</corpname>
       </controlaccess>
     </controlaccess>
     <dsc type="combined">

--- a/Real_Masters_all/gamua.xml
+++ b/Real_Masters_all/gamua.xml
@@ -116,7 +116,7 @@
       </controlaccess>
       <controlaccess>
         <head>Publication Titles</head>
-        <title source="AACR2" encodinganalog="730" render="italic">Tower talk</title>
+        <title source="aacr2" encodinganalog="730" render="italic">Tower talk</title>
       </controlaccess>
     </controlaccess>
     <dsc type="combined">
@@ -292,7 +292,7 @@ Event, unidentified probably reunion, <unitdate type="inclusive">undated</unitda
 <c05 level="file"><did><container type="box" label="Box">3</container><unittitle>Tribe of 1984</unittitle><physdesc><physfacet>(photocopy only)</physfacet></physdesc></did></c05>
 <c05 level="file"><did><container type="box" label="Box">3</container><unittitle>Tribes, (undated)</unittitle><physdesc><physfacet>three black and white positive prints</physfacet></physdesc></did></c05>
 <c05 level="file"><did><container type="box" label="Box">3</container><unittitle>50th reunion, <unitdate type="inclusive" normal="1951">1951</unitdate></unittitle><physdesc><extent>2 copies</extent></physdesc></did></c05></c04>
-<c04 level="file"><did><unittitle>Rope Day Photos </unittitle></did> 
+<c04 level="file"><did><unittitle>Rope Day Photos </unittitle></did>
 <c05 level="file"><did><container type="box" label="Box">5</container><unittitle>Tribe of, (undated)</unittitle><physdesc><extent>2 prints</extent></physdesc></did></c05>
 <c05 level="file"><did><container type="box" label="Box">5</container><unittitle>Tribe of  ca. 1904</unittitle></did></c05>
 <c05 level="file"><did><container type="box" label="Box">5</container><unittitle>Tribe of 1909</unittitle></did></c05>

--- a/Real_Masters_all/gasspub.xml
+++ b/Real_Masters_all/gasspub.xml
@@ -99,7 +99,7 @@
         <corpname source="lcnaf" encodinganalog="610">University of Michigan. Gilbert and Sullivan Society. Friends.</corpname>
         <corpname source="lcnaf" encodinganalog="610">University of Michigan--Students--Social life and customs.</corpname>
         <corpname source="lcnaf" encodinganalog="710">University of Michigan. Gilbert and Sullivan Society. Friends.</corpname>
-        <title encodinganalog="740">Pudding full of plums.</title>
+        <title encodinganalog="740" source="aacr2">Pudding full of plums.</title>
       </controlaccess>
       <controlaccess>
         <head>Genre/Form:</head>

--- a/Real_Masters_all/grandval.xml
+++ b/Real_Masters_all/grandval.xml
@@ -78,7 +78,7 @@ Grand Valley State Colleges Oral History Project, Bentley Historical Library, Un
       <controlaccess>
         <head>Subjects - Sound Recordings:</head>
         <geogname source="lcsh" encodinganalog="651">Grand Rapids (Mich.)--History.</geogname>
-        <title>Fitzgerald's prophecy (Radio program)</title>
+        <title source="aacr2">Fitzgerald's prophecy (Radio program)</title>
       </controlaccess>
       <controlaccess>
         <head>Contributors: Sound Recordings</head>

--- a/Real_Masters_all/griffinj.xml
+++ b/Real_Masters_all/griffinj.xml
@@ -224,43 +224,43 @@
       </controlaccess>
       <controlaccess>
         <head>Contributors:</head>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n50031636">Griffin, James B. (James Bennett), 1905-1997</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n85133207">Williams, Stephen, 1926-</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n50026056">Ford, James Alfred, 1911-1968.</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n79089017">Phillips, Philip, 1900-1994</persname>
-        <persname source="lcnaf" encodinganalog="600">Cole, Fay-Cooper, b. 1881.</persname>
-        <persname source="lcnaf" encodinganalog="600">Morgan, Richard Guy, 1903-</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n79106006">Rouse, Irving, 1913-2006</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n79128489">Greber, N'omi.</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/nr2002017577">Spaulding, Albert C. (Albert Clanton), 1914-1990</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n80109844">Guthe, Carl E. (Carl Eugen), 1893-1974</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n82240486">Lilly, Eli, 1885-1977</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n79128120">Morse, Dan F.</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n84053297">Stephenson, Robert L. (Robert Lloyd), 1919-</persname>
-        <persname source="lcnaf" encodinganalog="600">MacNeish, Richard S.</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n79026682">Jennings, Jesse D. (Jesse David), 1909-1997</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n87884290">Black, Glenn A. (Glenn Albert), 1900-1964.</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n79066115">Chapman, Carl H. (Carl Haley), 1915-1987</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n50030235">Eggan, Fred, 1906-1991</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n82128879">Titterington, Paul Francis, 1895-1969.</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n79117145">Willey, Gordon R. (Gordon Randolph), 1913-2002</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n78034948">Drooker, Penelope B.</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n79115057">Roosevelt, Anna Curtenius.</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n89629566">Krieger, Alex D. (Alex Dony), 1911-1991</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n85203957">Perino, Gregory.</persname>
-        <corpname source="lcnaf" encodinganalog="610" authfilenumber="http://id.loc.gov/authorities/names/n79063899">University of Michigan. Museum of Anthropology.</corpname>
-        <corpname source="lcnaf" encodinganalog="610">University of Michigan. Dept. of Anthropology.</corpname>
-        <corpname source="lcnaf" encodinganalog="610">University of Michigan. Radiocarbon Laboratory.</corpname>
-        <corpname source="lcnaf" encodinganalog="610">University of Michigan--Faculty.</corpname>
-        <corpname source="lcnaf" encodinganalog="610" authfilenumber="http://id.loc.gov/authorities/names/n79134997">Society for American Archaeology.</corpname>
-        <corpname source="lcnaf" encodinganalog="610" authfilenumber="http://id.loc.gov/authorities/names/n79061234">American Anthropological Association.</corpname>
-        <corpname source="lcnaf" encodinganalog="611" authfilenumber="http://id.loc.gov/authorities/names/n84238119">Southeastern Archaeological Conference.</corpname>
-        <corpname source="lcnaf" encodinganalog="610" authfilenumber="http://id.loc.gov/authorities/names/n80072473">International Union of Prehistoric and Protohistoric Sciences.</corpname>
-        <corpname source="lcnaf" encodinganalog="610">Conference on Michigan Archaeology.</corpname>
-        <corpname source="lcnaf" encodinganalog="610">Central Mississippi Valley Archaeological Survey.</corpname>
-        <corpname source="lcnaf" encodinganalog="610" authfilenumber="http://id.loc.gov/authorities/names/n81068111">Lower Mississippi Survey.</corpname>
-        <corpname source="lcnaf" encodinganalog="610">National Academy of Sciences (U.S.). Anthropology Section.</corpname>
-        <corpname source="lcnaf" encodinganalog="610">Ceramic Repository for the Eastern United States.</corpname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n50031636">Griffin, James B. (James Bennett), 1905-1997</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n85133207">Williams, Stephen, 1926-</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n50026056">Ford, James Alfred, 1911-1968.</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n79089017">Phillips, Philip, 1900-1994</persname>
+        <persname source="lcnaf" encodinganalog="700">Cole, Fay-Cooper, b. 1881.</persname>
+        <persname source="lcnaf" encodinganalog="700">Morgan, Richard Guy, 1903-</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n79106006">Rouse, Irving, 1913-2006</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n79128489">Greber, N'omi.</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/nr2002017577">Spaulding, Albert C. (Albert Clanton), 1914-1990</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n80109844">Guthe, Carl E. (Carl Eugen), 1893-1974</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n82240486">Lilly, Eli, 1885-1977</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n79128120">Morse, Dan F.</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n84053297">Stephenson, Robert L. (Robert Lloyd), 1919-</persname>
+        <persname source="lcnaf" encodinganalog="700">MacNeish, Richard S.</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n79026682">Jennings, Jesse D. (Jesse David), 1909-1997</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n87884290">Black, Glenn A. (Glenn Albert), 1900-1964.</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n79066115">Chapman, Carl H. (Carl Haley), 1915-1987</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n50030235">Eggan, Fred, 1906-1991</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n82128879">Titterington, Paul Francis, 1895-1969.</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n79117145">Willey, Gordon R. (Gordon Randolph), 1913-2002</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n78034948">Drooker, Penelope B.</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n79115057">Roosevelt, Anna Curtenius.</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n89629566">Krieger, Alex D. (Alex Dony), 1911-1991</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n85203957">Perino, Gregory.</persname>
+        <corpname source="lcnaf" encodinganalog="710" authfilenumber="http://id.loc.gov/authorities/names/n79063899">University of Michigan. Museum of Anthropology.</corpname>
+        <corpname source="lcnaf" encodinganalog="710">University of Michigan. Dept. of Anthropology.</corpname>
+        <corpname source="lcnaf" encodinganalog="710">University of Michigan. Radiocarbon Laboratory.</corpname>
+        <corpname source="lcnaf" encodinganalog="710">University of Michigan--Faculty.</corpname>
+        <corpname source="lcnaf" encodinganalog="710" authfilenumber="http://id.loc.gov/authorities/names/n79134997">Society for American Archaeology.</corpname>
+        <corpname source="lcnaf" encodinganalog="710" authfilenumber="http://id.loc.gov/authorities/names/n79061234">American Anthropological Association.</corpname>
+        <corpname source="lcnaf" encodinganalog="711" authfilenumber="http://id.loc.gov/authorities/names/n84238119">Southeastern Archaeological Conference.</corpname>
+        <corpname source="lcnaf" encodinganalog="710" authfilenumber="http://id.loc.gov/authorities/names/n80072473">International Union of Prehistoric and Protohistoric Sciences.</corpname>
+        <corpname source="lcnaf" encodinganalog="710">Conference on Michigan Archaeology.</corpname>
+        <corpname source="lcnaf" encodinganalog="710">Central Mississippi Valley Archaeological Survey.</corpname>
+        <corpname source="lcnaf" encodinganalog="710" authfilenumber="http://id.loc.gov/authorities/names/n81068111">Lower Mississippi Survey.</corpname>
+        <corpname source="lcnaf" encodinganalog="710">National Academy of Sciences (U.S.). Anthropology Section.</corpname>
+        <corpname source="lcnaf" encodinganalog="710">Ceramic Repository for the Eastern United States.</corpname>
       </controlaccess>
       <controlaccess>
         <head>Genre/Form:</head>

--- a/Real_Masters_all/jonesvh.xml
+++ b/Real_Masters_all/jonesvh.xml
@@ -113,7 +113,7 @@
       </controlaccess>
       <controlaccess>
         <head>Contributors:</head>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n86025928">Murphy, Frank, 1890-1949.</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n86025928">Murphy, Frank, 1890-1949.</persname>
         <persname source="lcnaf" encodinganalog="700">Osborn, Chase S. (Chase Salmon), b. 1860.</persname>
         <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n92118551">Osborn, Stellanova, 1894-1988.</persname>
         <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n79093112">Quaife, Milo Milton, 1880-1959.</persname>

--- a/Real_Masters_all/lawpub.xml
+++ b/Real_Masters_all/lawpub.xml
@@ -114,12 +114,12 @@
       </controlaccess>
       <controlaccess>
         <head>Publications</head>
-        <title encodinganalog="740">Law School photographic roster.</title>
-        <title encodinganalog="740">Law School, 1940-1973.</title>
-        <title encodinganalog="740">Michigan journal of international law.</title>
-        <title encodinganalog="740">Law quadrangle notes.</title>
-        <title encodinganalog="740">Codicil.</title>
-        <title encodinganalog="740">Res gestae.</title>
+        <title encodinganalog="740" source="aacr2">Law School photographic roster.</title>
+        <title encodinganalog="740" source="aacr2">Law School, 1940-1973.</title>
+        <title encodinganalog="740" source="aacr2">Michigan journal of international law.</title>
+        <title encodinganalog="740" source="aacr2">Law quadrangle notes.</title>
+        <title encodinganalog="740" source="aacr2">Codicil.</title>
+        <title encodinganalog="740" source="aacr2">Res gestae.</title>
       </controlaccess>
       <controlaccess>
         <head>Genre/Form:</head>

--- a/Real_Masters_all/ltconser.xml
+++ b/Real_Masters_all/ltconser.xml
@@ -228,8 +228,8 @@
       </controlaccess>
       <controlaccess>
         <head>Contributors:</head>
-        <persname source="lcnaf" encodinganalog="600">Bailey, Tom.</persname>
-        <persname source="lcnaf" encodinganalog="600">Huffman, Horace M.</persname>
+        <persname source="lcnaf" encodinganalog="700">Bailey, Tom.</persname>
+        <persname source="lcnaf" encodinganalog="700">Huffman, Horace M.</persname>
       </controlaccess>
       <controlaccess>
         <head>Genre/Form:</head>

--- a/Real_Masters_all/mcdonjh.xml
+++ b/Real_Masters_all/mcdonjh.xml
@@ -120,7 +120,7 @@
         <persname source="lcnaf" encodinganalog="700">Jewell, Ogden.</persname>
         <persname source="lcnaf" encodinganalog="700">Jewell, William Franklin.</persname>
         <persname source="lcnaf" encodinganalog="700">McDonald, Christine Jewell.</persname>
-        <persname source="lcnaf" encodinganalog="600">McDonald, James Henry, 1853-1934.</persname>
+        <persname source="lcnaf" encodinganalog="700">McDonald, James Henry, 1853-1934.</persname>
         <persname source="lcnaf" encodinganalog="700">McLellan, Martha Wells.</persname>
       </controlaccess>
       <controlaccess>

--- a/Real_Masters_all/museums.xml
+++ b/Real_Masters_all/museums.xml
@@ -108,10 +108,10 @@
       </controlaccess>
       <controlaccess>
         <head>Contributors:</head>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n80109844">Guthe, Carl E. (Carl Eugen), 1893-1974</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n88163469">Kahn, Albert, 1869-1942.</persname>
-        <persname source="lcnaf" encodinganalog="600">Reimann, Irving G.</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n87828171">Ruthven, Alexander Grant, 1882-1971.</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n80109844">Guthe, Carl E. (Carl Eugen), 1893-1974</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n88163469">Kahn, Albert, 1869-1942.</persname>
+        <persname source="lcnaf" encodinganalog="700">Reimann, Irving G.</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n87828171">Ruthven, Alexander Grant, 1882-1971.</persname>
       </controlaccess>
     </controlaccess>
     <dsc type="combined">

--- a/Real_Masters_all/nsfnet.xml
+++ b/Real_Masters_all/nsfnet.xml
@@ -168,8 +168,8 @@ NSFNET 20th Anniversary collection, Bentley Historical Library, University of Mi
       </controlaccess>
       <controlaccess>
         <head>Contributors:</head>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/nr92016715">Aupperle, Eric M.</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/no90000557">Brown, John Seely.</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/nr92016715">Aupperle, Eric M.</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/no90000557">Brown, John Seely.</persname>
         <persname encodinganalog="700" source="lcnaf">Cerf, Vinton G., 1940-</persname>
         <persname encodinganalog="700" source="lcnaf" authfilenumber="http://id.loc.gov/authorities/names/n93110219">Van Houweling, Douglas E.</persname>
       </controlaccess>

--- a/Real_Masters_all/nursepub.xml
+++ b/Real_Masters_all/nursepub.xml
@@ -232,8 +232,8 @@
         <genreform source="aat" encodinganalog="655">Proposals.</genreform>
         <genreform source="lcsh" encodinganalog="655">Student publications.</genreform>
         <genreform source="lcsh" encodinganalog="655">Yearbooks.</genreform>
-        <title render="italic">Scalpel.</title>
-        <title encodinganalog="740">Artery</title>
+        <title render="italic" source="aacr2">Scalpel.</title>
+        <title encodinganalog="740" source="aacr2">Artery</title>
       </controlaccess>
     </controlaccess>
     <dsc type="combined">

--- a/Real_Masters_all/pharmpub.xml
+++ b/Real_Masters_all/pharmpub.xml
@@ -179,10 +179,10 @@
         <genreform source="aat" encodinganalog="655">Programs.</genreform>
         <genreform source="lcsh" encodinganalog="655">Student publications.</genreform>
         <corpname source="lcnaf" encodinganalog="710">University of Michigan. Pharmacy Advancement Program.</corpname>
-        <title encodinganalog="740">Drugs and pharmacy.</title>
-        <title encodinganalog="740">College of Pharmacy newsletter. Capsules.</title>
-        <title encodinganalog="740">Equilibrium. Hash sheet</title>
-        <title encodinganalog="740">Pharmacy newsletter. Pharmacy paper.</title>
+        <title encodinganalog="740" source="aacr2">Drugs and pharmacy.</title>
+        <title encodinganalog="740" source="aacr2">College of Pharmacy newsletter. Capsules.</title>
+        <title encodinganalog="740" source="aacr2">Equilibrium. Hash sheet</title>
+        <title encodinganalog="740" source="aacr2">Pharmacy newsletter. Pharmacy paper.</title>
       </controlaccess>
     </controlaccess>
     <dsc type="combined">

--- a/Real_Masters_all/pythsis.xml
+++ b/Real_Masters_all/pythsis.xml
@@ -94,7 +94,7 @@ Order of Pythian Sisters. Huron-Arbor Temple no. 66 (Ypsilanti, Mich.) records, 
       <controlaccess>
         <head>Contributors:</head>
         <corpname source="lcnaf" encodinganalog="710">Order of Pythian Sisters. Huron Temple no. 66 (Ypsilanti, Mich.)</corpname>
-        <corpname source="lcnaf" encodinganalog="610">Order of Pythian Sisters. Arbor Temple no. 80 (Ann Arbor, Mich.)</corpname>
+        <corpname source="lcnaf" encodinganalog="710">Order of Pythian Sisters. Arbor Temple no. 80 (Ann Arbor, Mich.)</corpname>
       </controlaccess>
     </controlaccess>
     <dsc type="combined">

--- a/Real_Masters_all/sincljl.xml
+++ b/Real_Masters_all/sincljl.xml
@@ -355,10 +355,10 @@
       </controlaccess>
       <controlaccess>
         <head>Contributors - Visual Materials:</head>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n85050309">Sinclair, John, 1941-</persname>
-        <persname source="lcnaf" encodinganalog="600">Sinclair, Leni, 1940-</persname>
-        <corpname source="lcnaf" encodinganalog="611" authfilenumber="http://id.loc.gov/authorities/names/no2010194423">Ann Arbor Blues Festival.</corpname>
-        <corpname source="lcnaf" encodinganalog="611">Ann Arbor Sun.</corpname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n85050309">Sinclair, John, 1941-</persname>
+        <persname source="lcnaf" encodinganalog="700">Sinclair, Leni, 1940-</persname>
+        <corpname source="lcnaf" encodinganalog="711" authfilenumber="http://id.loc.gov/authorities/names/no2010194423">Ann Arbor Blues Festival.</corpname>
+        <corpname source="lcnaf" encodinganalog="711">Ann Arbor Sun.</corpname>
         <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/no2001062192">Eckert, Bob.</persname>
         <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/no2012013862">Grimshaw, Gary.</persname>
         <persname source="lcnaf" encodinganalog="700">Johnson, David.</persname>
@@ -409,7 +409,7 @@
       </controlaccess>
       <controlaccess>
         <head>Contributors: Sound Recordings:</head>
-        <corpname source="lcnaf" encodinganalog="611" authfilenumber="http://id.loc.gov/authorities/names/no2010194423">Ann Arbor Blues Festival.</corpname>
+        <corpname source="lcnaf" encodinganalog="711" authfilenumber="http://id.loc.gov/authorities/names/no2010194423">Ann Arbor Blues Festival.</corpname>
         <corpname source="lcnaf" encodinganalog="710">Lightnin (Rock music group)</corpname>
         <persname source="lcnaf" encodinganalog="700">Plamondon, Genie.</persname>
         <persname source="lcnaf" encodinganalog="700">Plamondon, Pun.</persname>

--- a/Real_Masters_all/triangle.xml
+++ b/Real_Masters_all/triangle.xml
@@ -120,9 +120,9 @@
         <subject source="lcsh" encodinganalog="650">Gay rights--Michigan.</subject>
         <subject source="lcsh" encodinganalog="650">Gay activists.</subject>
         <subject source="lcsh" encodinganalog="650">Gays--Michigan.</subject>
-        <title encodinganalog="730" render="italic">Lambda digest.</title>
-        <title encodinganalog="730" render="italic">Lambda report.</title>
-        <title encodinganalog="730" render="italic">Lambda journal.</title>
+        <title encodinganalog="730" render="italic" source="aacr2">Lambda digest.</title>
+        <title encodinganalog="730" render="italic" source="aacr2">Lambda report.</title>
+        <title encodinganalog="730" render="italic" source="aacr2">Lambda journal.</title>
       </controlaccess>
       <controlaccess>
         <head>Contributors:</head>

--- a/Real_Masters_all/umarchdr.xml
+++ b/Real_Masters_all/umarchdr.xml
@@ -126,28 +126,28 @@
       </controlaccess>
       <controlaccess>
         <head>Contributors:</head>
-        <corpname source="lcnaf" encodinganalog="610">Albert Kahn Associated Architects &amp; Engineers, Inc.</corpname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/no2003036753">Bailey, Vernon Howe, 1874-1953.</persname>
-        <corpname source="lcnaf" encodinganalog="610">Black and Black.</corpname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/nr2002036607">Cobb, Henry Ives, 1859-1931.</persname>
-        <corpname source="lcnaf" encodinganalog="610">Colvin, Robinson and Associates.</corpname>
-        <corpname source="lcnaf" encodinganalog="610">Dahlstrom and Schmitz.</corpname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n80153777">Davis, Alexander Jackson, 1803-1892.</persname>
-        <persname source="lcnaf" encodinganalog="600">Fry, Lynn W., 1894-1976.</persname>
-        <corpname source="lcnaf" encodinganalog="610">Fry and Kasurin.</corpname>
-        <corpname source="lcnaf" encodinganalog="610">Giffels &amp; Vallet, and Rossetti.</corpname>
-        <corpname source="lcnaf" encodinganalog="610">Harley, Ellington &amp; Day.</corpname>
-        <persname source="lcnaf" encodinganalog="600">Hubel, R. W.</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n78050673">Jenney, William Le Baron, 1832-1907.</persname>
-        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n88163469">Kahn, Albert, 1869-1942.</persname>
-        <persname source="lcnaf" encodinganalog="600">Loree, Douglas D.</persname>
-        <corpname source="lcnaf" encodinganalog="610">Malcomson &amp; Higginbotham, architects.</corpname>
-        <corpname source="lcnaf" encodinganalog="610">Otis and Clark (Chicago, Ill.)</corpname>
-        <persname source="lcnaf" encodinganalog="600">Palmer, C. William, 1886-1965.</persname>
-        <corpname source="lcnaf" encodinganalog="610">Pond &amp; Pond Architects.</corpname>
-        <corpname source="lcnaf" encodinganalog="610">Van Brunt and Howe (Boston, Mass.)</corpname>
-        <corpname source="lcnaf" encodinganalog="610">Ware and Van Brunt (Boston, Mass.)</corpname>
-        <corpname source="lcnaf" encodinganalog="610">York &amp; Sawyer.</corpname>
+        <corpname source="lcnaf" encodinganalog="710">Albert Kahn Associated Architects &amp; Engineers, Inc.</corpname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/no2003036753">Bailey, Vernon Howe, 1874-1953.</persname>
+        <corpname source="lcnaf" encodinganalog="710">Black and Black.</corpname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/nr2002036607">Cobb, Henry Ives, 1859-1931.</persname>
+        <corpname source="lcnaf" encodinganalog="710">Colvin, Robinson and Associates.</corpname>
+        <corpname source="lcnaf" encodinganalog="710">Dahlstrom and Schmitz.</corpname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n80153777">Davis, Alexander Jackson, 1803-1892.</persname>
+        <persname source="lcnaf" encodinganalog="700">Fry, Lynn W., 1894-1976.</persname>
+        <corpname source="lcnaf" encodinganalog="710">Fry and Kasurin.</corpname>
+        <corpname source="lcnaf" encodinganalog="710">Giffels &amp; Vallet, and Rossetti.</corpname>
+        <corpname source="lcnaf" encodinganalog="710">Harley, Ellington &amp; Day.</corpname>
+        <persname source="lcnaf" encodinganalog="700">Hubel, R. W.</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n78050673">Jenney, William Le Baron, 1832-1907.</persname>
+        <persname source="lcnaf" encodinganalog="700" authfilenumber="http://id.loc.gov/authorities/names/n88163469">Kahn, Albert, 1869-1942.</persname>
+        <persname source="lcnaf" encodinganalog="700">Loree, Douglas D.</persname>
+        <corpname source="lcnaf" encodinganalog="710">Malcomson &amp; Higginbotham, architects.</corpname>
+        <corpname source="lcnaf" encodinganalog="710">Otis and Clark (Chicago, Ill.)</corpname>
+        <persname source="lcnaf" encodinganalog="700">Palmer, C. William, 1886-1965.</persname>
+        <corpname source="lcnaf" encodinganalog="710">Pond &amp; Pond Architects.</corpname>
+        <corpname source="lcnaf" encodinganalog="710">Van Brunt and Howe (Boston, Mass.)</corpname>
+        <corpname source="lcnaf" encodinganalog="710">Ware and Van Brunt (Boston, Mass.)</corpname>
+        <corpname source="lcnaf" encodinganalog="710">York &amp; Sawyer.</corpname>
       </controlaccess>
       <controlaccess>
         <head>Genre/Form:</head>

--- a/Real_Masters_all/umpubs.xml
+++ b/Real_Masters_all/umpubs.xml
@@ -178,29 +178,29 @@ University of Michigan assorted publications, Bentley Historical Library, Univer
         <corpname source="lcnaf" encodinganalog="610" authfilenumber="http://id.loc.gov/authorities/names/n84017513">William L. Clements Library.</corpname>
         <corpname source="lcnaf" encodinganalog="610">William Monroe Trotter House (University of Michigan)</corpname>
         <corpname source="lcnaf" encodinganalog="610">Women's Student Government (University of Michigan)</corpname>
-        <title encodinganalog="740">Ack! The all campus konstitution.</title>
-        <title encodinganalog="740">Activist newsletter.</title>
-        <title encodinganalog="740">ARCANA: a guide to the North Campus area.</title>
-        <title encodinganalog="740">Blue ice.</title>
-        <title encodinganalog="740">Contemporary fiction review.</title>
-        <title encodinganalog="740">D'Scream.</title>
-        <title encodinganalog="740">DiaLogos.</title>
-        <title encodinganalog="740">G-Spot.</title>
-        <title encodinganalog="740">International observer.</title>
-        <title encodinganalog="740">Player.</title>
-        <title encodinganalog="740">Redial.</title>
-        <title encodinganalog="740">Rising star.</title>
-        <title encodinganalog="740">Shaking through.</title>
-        <title encodinganalog="740">Shei.</title>
-        <title encodinganalog="740">StillPoint magazine.</title>
-        <title encodinganalog="740">Stretch out and wait.</title>
-        <title encodinganalog="740">Third wave.</title>
-        <title encodinganalog="740">U-M voice of reason.</title>
-        <title encodinganalog="740">University of Michigan-Birzeit University: university relationship newsletter.</title>
-        <title encodinganalog="740">UnOfficial student guide.</title>
-        <title encodinganalog="740">Veritas forum.</title>
-        <title encodinganalog="740">Water.</title>
-        <title encodinganalog="740">Wolverine handbook.</title>
+        <title encodinganalog="740" source="aacr2">Ack! The all campus konstitution.</title>
+        <title encodinganalog="740" source="aacr2">Activist newsletter.</title>
+        <title encodinganalog="740" source="aacr2">ARCANA: a guide to the North Campus area.</title>
+        <title encodinganalog="740" source="aacr2">Blue ice.</title>
+        <title encodinganalog="740" source="aacr2">Contemporary fiction review.</title>
+        <title encodinganalog="740" source="aacr2">D'Scream.</title>
+        <title encodinganalog="740" source="aacr2">DiaLogos.</title>
+        <title encodinganalog="740" source="aacr2">G-Spot.</title>
+        <title encodinganalog="740" source="aacr2">International observer.</title>
+        <title encodinganalog="740" source="aacr2">Player.</title>
+        <title encodinganalog="740" source="aacr2">Redial.</title>
+        <title encodinganalog="740" source="aacr2">Rising star.</title>
+        <title encodinganalog="740" source="aacr2">Shaking through.</title>
+        <title encodinganalog="740" source="aacr2">Shei.</title>
+        <title encodinganalog="740" source="aacr2">StillPoint magazine.</title>
+        <title encodinganalog="740" source="aacr2">Stretch out and wait.</title>
+        <title encodinganalog="740" source="aacr2">Third wave.</title>
+        <title encodinganalog="740" source="aacr2">U-M voice of reason.</title>
+        <title encodinganalog="740" source="aacr2">University of Michigan-Birzeit University: university relationship newsletter.</title>
+        <title encodinganalog="740" source="aacr2">UnOfficial student guide.</title>
+        <title encodinganalog="740" source="aacr2">Veritas forum.</title>
+        <title encodinganalog="740" source="aacr2">Water.</title>
+        <title encodinganalog="740" source="aacr2">Wolverine handbook.</title>
       </controlaccess>
       <controlaccess>
         <head>Contributors:</head>

--- a/Real_Masters_all/unistrut.xml
+++ b/Real_Masters_all/unistrut.xml
@@ -104,7 +104,7 @@
       </controlaccess>
       <controlaccess>
         <head>Contributors:</head>
-        <persname source="lcnaf" encodinganalog="600">Attwood, Charles.</persname>
+        <persname source="lcnaf" encodinganalog="700">Attwood, Charles.</persname>
       </controlaccess>
       <controlaccess>
         <head>Genre/Form:</head>

--- a/Real_Masters_all/ymcadet.xml
+++ b/Real_Masters_all/ymcadet.xml
@@ -105,7 +105,7 @@
         <head>Subjects:</head>
         <subject source="lcsh" encodinganalog="650">African Americans--Michigan--Detroit.</subject>
         <geogname source="lcsh" encodinganalog="651" authfilenumber="http://id.loc.gov/authorities/names/n79045539.html">Detroit (Mich.)</geogname>
-        <title>Detroit young men</title>
+        <title source="aacr2">Detroit young men</title>
         <subject source="lcsh" encodinganalog="650">Physical fitness.</subject>
         <corpname source="lcnaf" encodinganalog="610">YMCA of Metropolitan Detroit.</corpname>
         <corpname source="lcnaf" encodinganalog="610">YMCA of Metropolitan Detroit. Metropolitan Offices.</corpname>


### PR DESCRIPTION
Mostly cleaning up encodinganalog values for agents identified as "Contributors" so that the EAD importer can be modified to add a Relator value of "Contributor" to those linked agents. 

I also noticed that there are some <title>s in controlaccess, which I guess should be imported as subjects with a type of "uniform title"? I hadn't noticed those before... these will come out a little different in that they're currently tagged as title but will be re-exported as subjects, but I think that still makes enough sense since they can still be identified as uniform titles by looking at the source or the term type. Also, a lot of our titles have a "source" attribute of "aacr2" which is not entirely correct. It would probably be more appropriate to say that they follow the rules of aacr2, but ArchivesSpace does not allow to have rules associated with subjects like it does with agents. There were also some titles that had no sources, so I went ahead and added a source of aacr2 to those so that they can be imported properly, and I have modified by subject posting script accordingly.
