### PR TITLE
descgrp type add note wrapping

### DIFF
--- a/Real_Masters_all/anonasp.xml
+++ b/Real_Masters_all/anonasp.xml
@@ -506,7 +506,7 @@ Anonymous Association of Suburban People officer’s papers, Bentley Historical 
       </c01>
     </dsc>
     <descgrp type="add">
-      <otherfindaid>
+      <odd>
       <head>Inventory and Descriptive Notes Prepared by the Donor</head>
         <list type="simple">
           <item>
@@ -925,7 +925,7 @@ Anonymous Association of Suburban People officer’s papers, Bentley Historical 
             </list>
           </item>
         </list>
-      </otherfindaid>
+      </odd>
       <relatedmaterial>
         <head>Related Material</head>
         <p>The papers of ASP president Daniel R. Sivil (0167 Aa 2) and Douglas M. Haller (2011138 Aa 2, Ac) contain files relating to the history of ASP. The organization's newsletters are cataloged separately in the Bentley collection (EA 186 A838 N558).</p>

--- a/Real_Masters_all/burtonml.xml
+++ b/Real_Masters_all/burtonml.xml
@@ -7232,6 +7232,7 @@
         </indexentry>
       </index>
       <descgrp>
+        <odd>
         <head>Selective Subject Index to Correspondence</head>
         <p>The subject index is arranged in four broad categories: Administration, Building Program, Academic Units, and Miscellaneous. Entries under a subject include name of correspondent, box and folder number, and date. When no date is given, the entire folder is relevant except for a few cases where there may be only an occasional useful item. Most of the correspondents included in the index are university regents or top level administrators.</p>
         <list type="simple">
@@ -7825,6 +7826,7 @@
             </list>
           </item>
         </list>
+      </odd>
       </descgrp>
     </descgrp>
   </archdesc>

--- a/Real_Masters_all/buttstom.xml
+++ b/Real_Masters_all/buttstom.xml
@@ -1834,6 +1834,7 @@ Thomas A. Butts papers, Bentley Historical Library, University of Michigan</p>
         <p>University of Michigan Vice President of Government Relations</p>
       </relatedmaterial>
       <descgrp>
+        <odd>
         <head>List of Common Acronyms</head>
         <list type="simple">
           <item>ACRAO -- American Association of Collegiate Registrars and Admission Officers</item>
@@ -1850,6 +1851,7 @@ Thomas A. Butts papers, Bentley Historical Library, University of Michigan</p>
           <item>NASFAA -- National Association of Student Financial Aid Administrators</item>
           <item>NCHELP -- National Council of Higher Education Loan Programs</item>
         </list>
+      </odd>
       </descgrp>
     </descgrp>
   </archdesc>

--- a/Real_Masters_all/communic.xml
+++ b/Real_Masters_all/communic.xml
@@ -2092,6 +2092,7 @@ Department of Communication (University of Michigan) records, Bentley Historical
     </dsc>
     <descgrp type="add">
       <descgrp>
+        <odd>
         <head>Index to Student Internship Files, by Newspaper</head>
         <p>Note: As part of their studies in the department of communication, students had the opportunity to work on various Michigan newspapers. Their reports and other papers to the department of communication often include information of interests to researchers of specific newspapers. The materials will be found in the students' internship file (foreign or American). The following is an index by name of newspaper to these files:</p>
         <table>
@@ -2202,6 +2203,7 @@ Department of Communication (University of Michigan) records, Bentley Historical
             </tbody>
           </tgroup>
         </table>
+      </odd>
       </descgrp>
     </descgrp>
   </archdesc>

--- a/Real_Masters_all/finopum.xml
+++ b/Real_Masters_all/finopum.xml
@@ -3073,8 +3073,9 @@ Financial Operations (University of Michigan) records, Bentley Historical Librar
     </dsc>
     <descgrp type="add">
       <descgrp>
-      <head>Listing of Outsized Volumes</head>
+        <odd>
         <list type="simple">
+          <head>Listing of Outsized Volumes</head>
           <item>No. 1, Secretary's Journal of Receipts and Disbursements, 1914-1918</item>
           <item>No. 2, Secretary's Journal of Receipts and Disbursements, 1918-1921</item>
           <item>No. 3, Secretary's Journal of Receipts and Disbursements, 1921-1924</item>
@@ -3128,6 +3129,7 @@ Financial Operations (University of Michigan) records, Bentley Historical Librar
           <item>No. 51, Income Records-State Fund Ledger, 1931-1948</item>
           <item>No. 52, Land Records-Land Contracts, 1902-1916</item>
         </list>
+      </odd>
       </descgrp>
     </descgrp>
   </archdesc>

--- a/Real_Masters_all/hatfldm.xml
+++ b/Real_Masters_all/hatfldm.xml
@@ -361,8 +361,8 @@ Malcolm Keith Hatfield Papers, Bentley Historical Library, University of Michiga
     </dsc>
     <descgrp type="add">
       <descgrp>
-        <head>Selective Index to Correspondents</head>
         <index>
+          <head>Selective Index to Correspondents</head>
           <indexentry>
             <persname>Dickinson, Luren Dudley, 1859-1943.</persname>
             <ref>

--- a/Real_Masters_all/houghton.xml
+++ b/Real_Masters_all/houghton.xml
@@ -348,6 +348,7 @@
         <p>A portrait of Houghton painted by Alvah Bradish in 1850 is found in the Michigan Historical Collections works of art collection. A daguerreotype of another portrait of Houghton painted by Bradish is cataloged in the photograph collection.</p>
       </relatedmaterial>
       <descgrp>
+        <odd>
         <head>Index to Maps in the Houghton Papers</head>
         <p>This inventory includes the manuscript maps drawn on and pasted into the pages of the field notes volume, other manuscript maps that have been removed from the volume and stored with outsize unbound manuscripts, a complementary group of maps in the collections of the Michigan State Archives, and a group of photostatic copies at the William L. Clements Library. Photostat use copies of most of the original maps in this collection are also available at the Bentley Historical Library.</p>
         <p>The maps fall into three main groups: <list type="ordered"><item>Maps of the Lake Huron shore of the Lower Peninsula from north of Port Huron north to Mackinac Island and the Lake Michigan shore south from Mackinac to the South Haven area, probably drawn in 1838.</item><item>Maps of the St. Marys River and the Lake Huron and Lake Michigan shore of the Upper Peninsula, probably drawn in 1839.</item><item>Maps of the Lake Superior shore of the Upper Peninsula, from Sault Ste. Marie to La Pointe, Wis., probably drawn in 1840.</item></list></p>
@@ -1592,6 +1593,7 @@
             </archref>
           </item>
         </list>
+      </odd>
       </descgrp>
     </descgrp>
   </archdesc>

--- a/Real_Masters_all/hrecsurv.xml
+++ b/Real_Masters_all/hrecsurv.xml
@@ -10893,6 +10893,7 @@ s offices (as well as having some of its own work done by WPA workers), the Bent
     </dsc>
     <descgrp type="add">
       <descgrp>
+        <odd>
         <head>1987 Survey of Records of Records in Counties and Municipalities</head>
         <p>In 1987 the Bentley Library conducted a survey of the counties and municipalities whose transcripts of government records were included in the H.R.S. collection. It revealed that most of the originals still exist in their home locales, but some have been lost, burned, or discarded, leaving the library with probably the only extant copies of those records. Although the bulk of the transcripts (55 linear feet of material in 44 Paige boxes) will remain as they are, the unique ones (10 linear feet) have been microfilmed. Most of the counties of Michigan are represented, as well as fifteen municipalities (see contents list). All are valuable sources of historical information.</p>
         <p>
@@ -10985,6 +10986,7 @@ s offices (as well as having some of its own work done by WPA workers), the Bent
             </item>
           </list>
         </p>
+      </odd>
       </descgrp>
       <relatedmaterial>
         <head>Related Material</head>

--- a/Real_Masters_all/hutchhb.xml
+++ b/Real_Masters_all/hutchhb.xml
@@ -1926,6 +1926,7 @@
         </indexentry>
       </index>
       <descgrp>
+        <odd>
         <head>Selective Subject Index to Correspondence</head>
         <p>This index covers only materials generated during President Hutchins term as interim president, 1909-1910, and as president, 1910-1920. Papers of 1897-98, when he was acting president, are not included in the index. The correspondence of that year deals mainly with routine business matters -- requests for catalogs, inquiries about entrance requirements, or lecture arrangements for the president, and letters of recommendation. A few letters touch on such matters of public interest as state support of higher education, or the university's position on the Cuban question and the war with Spain.</p>
         <p>The subject index has been organized into five broad categories: Administration, Building Program, Academic Units and Programs, Student Life and Campus Social Problems, Social and Political Issues of the Time. Index entries under subject terms include name of correspondent, box and folder numbers, and date of the document.</p>
@@ -2840,6 +2841,7 @@
             </list>
           </item>
         </list>
+      </odd>
       </descgrp>
     </descgrp>
   </archdesc>

--- a/Real_Masters_all/kelseymu.xml
+++ b/Real_Masters_all/kelseymu.xml
@@ -21886,6 +21886,7 @@
     </dsc>
     <descgrp type="add">
       <descgrp>
+        <odd>
       <head>Indexes</head>
         <list type="simple">
           <head>Indexes to Francis W. Kelsey Papers</head>
@@ -22757,6 +22758,7 @@
             </list>
           </item>
         </list>
+      </odd>
       </descgrp>
       <descgrp>
         <relatedmaterial>

--- a/Real_Masters_all/littlecc.xml
+++ b/Real_Masters_all/littlecc.xml
@@ -3672,7 +3672,8 @@
     </dsc>
     <descgrp type="add">
       <descgrp>
-      <head><emph>Subject Indexes</emph></head>
+        <odd>
+      <head>Subject Indexes</head>
       <p>The subject index is a selective index to subject matter found in the chronologically arranged papers of C.C. Little. Subject entries include name of correspondent or folder, box and folder numbers, and date of document. For alphabet-labelled folders, the name of correspondent is added after the folder number.</p>
         <list type="simple">
           <item>
@@ -4455,6 +4456,7 @@
             </list>
           </item>
         </list>
+      </odd>
       </descgrp>
     </descgrp>
   </archdesc>

--- a/Real_Masters_all/mccallej.xml
+++ b/Real_Masters_all/mccallej.xml
@@ -257,8 +257,8 @@ Ernest James McCall papers, Bentley Historical Library, University of Michigan</
     </dsc>
     <descgrp type="add">
       <descgrp>
-        <head>Selective Index to Correspondences</head>
         <index>
+          <head>Selective Index to Correspondences</head>
           <indexentry>
             <persname>Currie, Gilbert Archibald, 1882-1960.</persname>
             <ref>

--- a/Real_Masters_all/medschl.xml
+++ b/Real_Masters_all/medschl.xml
@@ -30534,10 +30534,9 @@
     </dsc>
     <descgrp type="add">
       <descgrp>
-        <head>Index to Major Subjects</head>
-        <p>The locations specified for the various added and subject entries are not necessarily the only locations within the collection where material on the specified subject will be found. In particular, important matters are often discussed in the Executive Committee minutes or the Dean's Advisory Council minutes. Neither of these are indexed here.</p>
         <index>
-          <head>Partial Index to Correspondence</head>
+         <head>Index to Major Subjects and Partial Index to Correspondence</head>
+         <p>The locations specified for the various added and subject entries are not necessarily the only locations within the collection where material on the specified subject will be found. In particular,    important matters are often discussed in the Executive Committee minutes or the Dean's Advisory Council minutes. Neither of these are indexed here.</p>
           <indexentry>
             <subject>Academic Freedom (Loyalty investigation of Mark Nickerson, 1954)</subject>
             <ref>

--- a/Real_Masters_all/michener.xml
+++ b/Real_Masters_all/michener.xml
@@ -365,8 +365,8 @@ Earl C. Michener papers, Bentley Historical Library, University of Michigan</p>
     </dsc>
     <descgrp type="add">
       <descgrp>
-        <head>Selective Index to Correspondents</head>
         <index>
+          <head>Selective Index to Correspondents</head>
           <indexentry>
             <persname>Adams, Charles Francis, 1866-1954.</persname>
             <ref>

--- a/Real_Masters_all/mimediaf.xml
+++ b/Real_Masters_all/mimediaf.xml
@@ -45545,6 +45545,7 @@ are organized by series established by the Media Resources Center. Within each s
     </dsc>
     <descgrp type="add">
       <descgrp>
+        <odd>
       <head>List of Abbreviations for University Uits</head>
         <list type="simple">
           <item>Anthro. -- Department of Anthropology</item>
@@ -45599,6 +45600,7 @@ are organized by series established by the Media Resources Center. Within each s
           <item>VPAA -- Vice President for Academic Affairs</item>
           <item>Zool. -- Department of Zoology</item>
         </list>
+      </odd>
       </descgrp>
     </descgrp>
   </archdesc>

--- a/Real_Masters_all/ootbmpm.xml
+++ b/Real_Masters_all/ootbmpm.xml
@@ -1096,9 +1096,9 @@ Out of the Blue: The Michigan Difference (television program (University of Mich
     </dsc>
     <descgrp type="add">
       <descgrp>
+        <odd>
       <head>Index to Out to the Blue Participants</head>
-      <p>The following index lists individuals who appeared in episodes of <title render="italic">Out of the Blue</title>. The index is arranged by season (broadcast year) and episode. It includes University of Michigan faculty, staff and students and outside guests.
-        </p>
+      <p>The following index lists individuals who appeared in episodes of <title render="italic">Out of the Blue</title>. The index is arranged by season (broadcast year) and episode. It includes University of Michigan faculty, staff and students and outside guests.</p>
         <list type="simple">
           <item>Season One
             <list type="simple">
@@ -1496,6 +1496,7 @@ Out of the Blue: The Michigan Difference (television program (University of Mich
             </list>
           </item>
         </list>
+      </odd>
       </descgrp>
     </descgrp>
   </archdesc>

--- a/Real_Masters_all/shengb.xml
+++ b/Real_Masters_all/shengb.xml
@@ -4268,6 +4268,7 @@ Bright Sheng Papers, Bentley Historical Library, University of Michigan</p>
     </dsc>
     <descgrp type="add">
       <descgrp>
+        <odd>
         <head>Appendix 1</head>
         <p>
           <emph render="bold">Biographical Essay by Pamela Chen, Bentley Historical Library project archivist and Ph.D. student, Michigan State University, 2004</emph>
@@ -4321,6 +4322,7 @@ Bright Sheng Papers, Bentley Historical Library, University of Michigan</p>
           </list>
         </p>
         <p>Bright Sheng's music is published exclusively by G. Schirmer. As a conductor and pianist, he is represented worldwide by Columbia Artists Management (www.cami.com). His discography includes recordings on the Sony Classical, BIS, Delos, Koch International, New World, and Naxos labels.</p>
+      </odd>
       </descgrp>
     </descgrp>
   </archdesc>

--- a/Real_Masters_all/stlandof.xml
+++ b/Real_Masters_all/stlandof.xml
@@ -1263,6 +1263,7 @@ Michigan State Land Office Board records, Bentley Historical Library, University
     </dsc>
     <descgrp type="add">
       <descgrp>
+        <odd>
         <head>Range and Township Index to Tract Books</head>
         <table>
           <tgroup cols="3">
@@ -5708,6 +5709,7 @@ Michigan State Land Office Board records, Bentley Historical Library, University
             </tbody>
           </tgroup>
         </table>
+      </odd>
       </descgrp>
     </descgrp>
   </archdesc>

--- a/Real_Masters_all/stonerct.xml
+++ b/Real_Masters_all/stonerct.xml
@@ -22243,6 +22243,7 @@
     </dsc>
     <descgrp type="add">
       <descgrp>
+        <odd>
       <head>Index to railroads and company names</head>
       <p>The letter/number code following each heading refers to Stoner's system for identifying his collection of railroad negatives. Descriptions of the images will be found in the Classified Photograph series.</p>
         <list type="simple">
@@ -22601,8 +22602,10 @@
           <item>Addison, Mich. -- see unclassified negatives under Miscellaneous non-railroad topics</item>
           <item>Adrian, Mich. -- TW21, also unclassified photos and negatives under Railroad stations</item>
         </list>
+      </odd>
       </descgrp>
       <descgrp>
+        <odd>
         <head>Index to Subjects Other than Locomotives</head>
         <list>
           <item>Agricultural machinery -- GTR13, IR17, also unclassified photos under Illinois Central, and unclassified negatives under Miscellaneous non-railroad topics</item>
@@ -23069,6 +23072,7 @@
           <item>Ypsilanti, Mich. -- AAY4, DJC1, MC10-13, MC39, MC41, NYC34</item>
           <item>Yuma, Mich. -- AA135</item>
         </list>
+      </odd>
       </descgrp>
     </descgrp>
   </archdesc>

--- a/Real_Masters_all/suomicol.xml
+++ b/Real_Masters_all/suomicol.xml
@@ -8133,6 +8133,7 @@ Suomi College Finnish-American collection, Bentley Historical Library, Universit
     </dsc>
     <descgrp type="add">
       <descgrp>
+        <odd>
       <head>Subject Index to Microfilm</head>
       <p>This index was prepared from the original container listing. As the materials were microfilmed in a somewhat random order, this index intends to bring together church, temperance, labor, and other organizational records. In this index, the records are further listed alphabetically and then by place name.</p>
         <list type="simple">
@@ -8446,6 +8447,7 @@ Suomi College Finnish-American collection, Bentley Historical Library, Universit
             </list>
           </item>
         </list>
+      </odd>
       </descgrp>
     </descgrp>
   </archdesc>

--- a/Real_Masters_all/vandenba.xml
+++ b/Real_Masters_all/vandenba.xml
@@ -5971,6 +5971,7 @@
         </indexentry>
       </index>
       <descgrp>
+        <odd>
         <head>Index to Scrapbooks</head>
         <p>The scrapbooks in the Arthur H. Vandenberg Collection are an invaluable series within the total collection. The scrapbooks include clippings, tear sheets from the Congressional Record, speeches, articles written by or about Vandenberg, occasional correspondence and photographs, and diary-like notes which Vandenberg himself typed and appended with the relevant clipping or speech. The following index was a compilation made by a researcher who used the scrapbooks. The index was intended for his use only, but the library requested permission to copy it and make it available to other Vandenberg scholars. The index is not as polished as it might be; some of the entries are abbreviated in note-taking fashion. Yet the result is a detailed guide to the contents of the scrapbooks. Each entry gives a page number, date of the article/item, and a brief description.</p>
         <list type="simple">
@@ -6866,6 +6867,7 @@
             </list>
           </item>
         </list>
+      </odd>
       </descgrp>
     </descgrp>
   </archdesc>

--- a/Real_Masters_all/warnerrm.xml
+++ b/Real_Masters_all/warnerrm.xml
@@ -4350,6 +4350,7 @@ Robert M. Warner Papers, Bentley Historical Library, University of Michigan</p>
     </dsc>
     <descgrp type="add">
       <descgrp>
+        <odd>
         <head>Key to Correspondence Symbols of Selected National Archives Officials</head>
         <table>
           <tgroup cols="3">
@@ -4449,6 +4450,7 @@ Robert M. Warner Papers, Bentley Historical Library, University of Michigan</p>
             </tbody>
           </tgroup>
         </table>
+      </odd>
       </descgrp>
     </descgrp>
   </archdesc>

--- a/Real_Masters_all/winchell.xml
+++ b/Real_Masters_all/winchell.xml
@@ -4668,6 +4668,7 @@
     </dsc>
     <descgrp type="add">
       <descgrp>
+        <odd>
         <head>Maps found in the Winchell Papers</head>
         <p>
           <list type="simple">
@@ -5303,8 +5304,10 @@
             </item>
           </list>
         </p>
+      </odd>
       </descgrp>
       <descgrp>
+        <odd>
         <head>Location of Former Folder and Volume Numbers</head>
         <table>
           <tgroup cols="2" colsep="0">
@@ -5718,6 +5721,7 @@
             </tbody>
           </tgroup>
         </table>
+      </odd>
       </descgrp>
     </descgrp>
   </archdesc>

--- a/Real_Masters_all/zinnkarl.xml
+++ b/Real_Masters_all/zinnkarl.xml
@@ -3039,6 +3039,7 @@ Karl L. Zinn papers, Bentley Historical Library, University of Michigan</p>
     </dsc>
     <descgrp type="add">
       <descgrp>
+        <odd>
         <head>Summary of CONFER Session print-outs</head>
         <p>This list was compiled using similar lists located in the manuscripts and by reading through the purpose statements for many of the CONFER sessions. Note that over time, certain conventions evolved within CONFER including a brief welcome message that included a statement on the scope of the conference.</p>
         <p>The names given for the CONFERs were based on a scheme that aimed to start all class conferences with a sequence of numbers (e.g. 2Q1A:Argue) and that included CRLT as the pre-fix for all conferences facilitated by Center for Learning and Teaching staff. Other conventions draw on the use of acronyms (e.g. CAP for Computer Assistance Program of the Political Science Department, ISTA for International Science Technology Assessment) and other abbreviations such as TA for Technology Assessment, Word for Microsoft Word, and MICRO for Microcomputers.</p>
@@ -3300,6 +3301,7 @@ Karl L. Zinn papers, Bentley Historical Library, University of Michigan</p>
             </tgroup>
           </table>
         </p>
+      </odd>
       </descgrp>
       <relatedmaterial>
         <head>Related Material</head>


### PR DESCRIPTION
I went ahead and wrapped some of the lists, tables, indexes, and other loosely defined 'notes' that show up in <descgrp type="add"> sections of the finding aids (the "Additional Descriptive Information" section at the end) in <odd> tags. This should ensure that most of the content gets imported into ArchivesSpace as General Notes. Things with bona fide lists and indexes will also get the appropriate kind of note, whereas things like tables will just be imported as a mixed content note with all the tags intact. These will also be the only resource level General Notes, so it shouldn't be too difficult to modify the exporter to group all resource level general notes into <descgrp type="add"> sections for now to play nicely with DLXS. We'll still need to verify that a lot of this content migrates over properly after the fact, but this should ensure that we're not losing a ton of descriptive content like we have been.
