### PR TITLE
adding type=add attributes to some descgrps

### DIFF
--- a/Real_Masters_all/aidspart.xml
+++ b/Real_Masters_all/aidspart.xml
@@ -208,7 +208,7 @@ AIDS Partnership Michigan Records
         </c02>
       </c01>
     </dsc>
-    <descgrp>
+    <descgrp type="add">
       <relatedmaterial>
         <head>Related materials</head>
         <p>The newsletters of the Wellness Networks, Inc, from 1986 to 1994, and AIDS Partnership Michigan, from 1996 to 2005, are available at the Bentley Historical Library and have been cataloged separately.</p>

--- a/Real_Masters_all/bassettl.xml
+++ b/Real_Masters_all/bassettl.xml
@@ -1937,7 +1937,7 @@ Leslie Bassett Papers, Bentley Historical Library, University of Michigan</p>
         </c02>
       </c01>
     </dsc>
-    <descgrp>
+    <descgrp type="add">
       <relatedmaterial>
         <head>Related resources</head>
         <p>Additional biographical information as well as comprehensive lists of his major works can be found on his personal website at http://www.lesliebassett.com/ and in Ellen Johnson's book <title render="italic">Leslie Bassett: a bio-bibliography</title> (1994).</p>

--- a/Real_Masters_all/binkodon.xml
+++ b/Real_Masters_all/binkodon.xml
@@ -1228,7 +1228,7 @@ Don Binkowski papers, Bentley Historical Library, University of Michigan</p>
         </c02>
       </c01>
     </dsc>
-    <descgrp>
+    <descgrp type="add">
       <relatedmaterial>
         <head>Related Material</head>
         <p>Additional material related to Binkowski's interest in Democratic politics and the Polish American community in Michigan can be found in another collection titled, "Don Binkowski, collected materials."</p>

--- a/Real_Masters_all/dentsch.xml
+++ b/Real_Masters_all/dentsch.xml
@@ -6436,7 +6436,7 @@ School of Dentistry (University of Michigan), Bentley Historical Library, Univer
         </c02>
       </c01>
     </dsc>
-    <descgrp>
+    <descgrp type="add">
       <relatedmaterial>
         <head>Related Material</head>
         <p>Miscellaneous material from the dental fraternity Delta Sigma Delta, including artifacts and photographs, are located in the Delta Sigma Delta Room at the Bentley Historical Library.</p>

--- a/Real_Masters_all/dpgmed.xml
+++ b/Real_Masters_all/dpgmed.xml
@@ -2417,7 +2417,7 @@ Dept. of Postgraduate Medicine and Health Professions Education (University of M
         </c02>
       </c01>
     </dsc>
-    <descgrp>
+    <descgrp type="add">
       <relatedmaterial>
         <head>Related Material</head>
         <p>The James D. Bruce series contains speeches given by Dr. Bruce, who served as the first chairman of the department from 1927 to 1942. The speeches were given between 1919 and 1938 at a number of locations and events throughout Michigan and the nation. The speeches provide insight into the state of medical education and postgraduate medical education in particular in the 1920s and 1930s. Each folder in the series has its own index telling where and when most speeches were given.</p>

--- a/Real_Masters_all/fletchfa.xml
+++ b/Real_Masters_all/fletchfa.xml
@@ -1000,7 +1000,7 @@ Fletcher Family Papers, Bentley Historical Library, University of Michigan</p>
         </c02>
       </c01>
     </dsc>
-    <descgrp>
+    <descgrp type="add">
       <relatedmaterial>
         <head>Related material</head>
         <p>The research should note that related collections of records have been received and are separated cataloged. These include the Thunder River Boom Company, the Fletcher, Pack &amp; Company Records, the Frank W. Fletcher papers, and the Gilchrist Family papers. The Frank W. Fletcher papers relate mainly to his service as a Regent of the University of Michigan.</p>

--- a/Real_Masters_all/gargoyle.xml
+++ b/Real_Masters_all/gargoyle.xml
@@ -275,7 +275,7 @@ Gargoyle records, Bentley Historical Library, University of Michigan</p>
         </c02>
       </c01>
     </dsc>
-    <descgrp>
+    <descgrp type="add">
       <relatedmaterial>
         <head>Related Material</head>
         <p>Additional <title render="italic">Gargoyle</title> materials can be found in other collections at the Bentley, including the Board for Student Publications records and the Paul Showers papers. The Board for Student Publications includes some <title render="italic">Gargoyle</title> financial and administrative material (1937-1951). The Paul Showers papers contain writings and correspondence when Showers was on the <title render="italic">Gargoyle</title> staff in the 1930s. The Bentley also owns issues of the <title render="italic">Baby Gargoyle</title>, a separate annual "pocket-sized" publication produced by <title render="italic">Gargoyle</title>.</p>

--- a/Real_Masters_all/glazerla.xml
+++ b/Real_Masters_all/glazerla.xml
@@ -133,12 +133,10 @@ Lawrence M. Glazer papers, Bentley Historical Library, University of Michigan</p
       </c01>
     </dsc>
     <descgrp type="add">
-      <descgrp>
         <relatedmaterial>
           <head>Related Material</head>
           <p>The library also has the gubernatorial and political papers of Governor James Blanchard.</p>
         </relatedmaterial>
-      </descgrp>
     </descgrp>
   </archdesc>
 </ead>

--- a/Real_Masters_all/hrparty.xml
+++ b/Real_Masters_all/hrparty.xml
@@ -907,7 +907,7 @@ Human Rights Party (Ann Arbor, Mich.) Records, Bentley Historical Library, Unive
         </c02>
       </c01>
     </dsc>
-    <descgrp>
+    <descgrp type="add">
       <relatedmaterial>
         <head>Related Material</head>
         <p>The John and Leni Sinclair collection contains HRP records, particularly dealing with the campaign of David Sinclair and Frank Shoichet in the Second Ward Primary in 1974. Other related collections include: the papers of Robert Alexander and of William McNitt, and the Contemporary History Project oral interviews.</p>

--- a/Real_Masters_all/markcom.xml
+++ b/Real_Masters_all/markcom.xml
@@ -3354,7 +3354,7 @@ Marketing and Communications (University of Michigan) Records
         </c02>
       </c01>
     </dsc>
-    <descgrp>
+    <descgrp type="add">
       <relatedmaterial>
         <head>Related Material</head>
         <p>Researchers seeking additional information about Marketing Communications' predecessor should examine the University of Michigan University Publications finding aid located at the Bentley Historical Library. The record group consists of photographic images from 1950 to 1970. There is also some additional information regarding the Publication Office within the Vice President for Development record group.</p>

--- a/Real_Masters_all/mortarbd.xml
+++ b/Real_Masters_all/mortarbd.xml
@@ -146,7 +146,7 @@ Mortar Board, Pi Sigma Alpha Chapter (University of Michigan) records, Bentley H
         </c02>
       </c01>
     </dsc>
-    <descgrp>
+    <descgrp type="add">
       <relatedmaterial>
         <head>Related Material</head>
         <p>Researchers should note that related material on the Mortar Board Society, also located at the Bentley Historical Library, may be found in the Mortar Board Alumnae Club, Ann Arbor Chapter records,1953-1973, as well as in <title render="italic">Unscrambling the Maize: Mortar Board's Guide to Student Life at the University of Michigan</title> by Members of Mortar Board Senior Honor Society, 1976-77, compiled and edited by Karen Ann Brzys.</p>

--- a/Real_Masters_all/pillsbwp.xml
+++ b/Real_Masters_all/pillsbwp.xml
@@ -317,7 +317,7 @@ W. B. Pillsbury pamphlets and reprints, Bentley Historical Library, University o
         </c02>
       </c01>
     </dsc>
-    <descgrp>
+    <descgrp type="add">
       <relatedmaterial>
         <head>Related Material</head>
         <p>W. B. Pillsbury papers, 1890-1942 (3.5 linear feet) are held by the Bentley Historical Library. Walter</p>

--- a/Real_Masters_all/regentag.xml
+++ b/Real_Masters_all/regentag.xml
@@ -348,7 +348,7 @@ Board of Regents (University of Michigan)agendas, Bentley Historical Library, Un
         </c02>
       </c01>
     </dsc>
-    <descgrp>
+    <descgrp type="add">
       <relatedmaterial>
         <head>Related Material</head>
         <p>The official set of Board of Regents records, inducing the original exhibits and agenda as maintained by the Secretary of the University, are transferred to the custody of the archives on a fixed twenty-five year schedule (e.g., the "official" agendas and exhibits for 1980 Regents meetings are scheduled for transfer to the archives in 2005). For the record group containing the original exhibits, see the separate record group and finding aid for University of Michigan. Board of Regents (call no. 8722 Bimu B2 2).</p>

--- a/Real_Masters_all/schulers.xml
+++ b/Real_Masters_all/schulers.xml
@@ -3064,7 +3064,7 @@ Schuler's Restaurant Records
         </c02>
       </c01>
     </dsc>
-    <descgrp>
+    <descgrp type="add">
       <relatedmaterial>
         <head>Additional Resources</head>
         <p>Researchers may want to consult <title render="italic">Schuler's: fresh recipes &amp; warm memories</title>, a cookbook put together by Hans Schuler and Chef Jonathan Schuler in 2004. In addition to featuring many of Schuler's recipes, the book also gives an excellent history of Schuler's restaurant, illustrated with historical photographs. The Bentley owns a copy of this book.</p>

--- a/Real_Masters_all/seagrpub.xml
+++ b/Real_Masters_all/seagrpub.xml
@@ -1606,7 +1606,7 @@ Michigan Seagrant Program, Publications, Bentley Historical Library, University 
         </c02>
       </c01>
     </dsc>
-    <descgrp>
+    <descgrp type="add">
       <relatedmaterial>
         <head>Related Material</head>
         <p>Many Sea Grant reports are available on-line within the University of Michigan Technical Reports collection digitized by the University of Michigan Digital Library Production Service. The reports are available at the following URL (as of March 2004): http://www.hti.umich.edu/u/umr/</p>

--- a/Real_Masters_all/sinkalva.xml
+++ b/Real_Masters_all/sinkalva.xml
@@ -424,7 +424,7 @@ University of Michigan Alumnae Club of Ann Arbor, Alva Gordon Sink Group Records
         </c02>
       </c01>
     </dsc>
-    <descgrp>
+    <descgrp type="add">
       <relatedmaterial>
         <head>Related Material</head>
         <p>Researchers interested in the Alva Gordon Sink Group records may also wish to consult the Charles Sink records, the Henderson House (University of Michigan) records, the Alumni Association (University of Michigan) records, and the Center for the Education of Women (University of Michigan) records. Records for three other University of Michigan Alumnae Clubs, the Margaret L. Waterman group, the Sarah Browne Smith group, and the Lucille B. Conger group are also available. The Bentley library holds the records of the Martha Cook Alumnae Association as well.</p>

--- a/Real_Masters_all/starrfld.xml
+++ b/Real_Masters_all/starrfld.xml
@@ -305,7 +305,7 @@ Floyd Starr papers, Bentley Historical Library, University of Michigan</p>
         </c02>
       </c01>
     </dsc>
-    <descgrp>
+    <descgrp type="add">
       <relatedmaterial>
         <head>Related Material</head>
         <p>The original Starr scrapbooks and other materials are available at the Starr Commonwealth Archives in Albion, Michigan.</p>

--- a/Real_Masters_all/willsonj.xml
+++ b/Real_Masters_all/willsonj.xml
@@ -1480,7 +1480,7 @@ J. Robert Willson Papers
         </c02>
       </c01>
     </dsc>
-    <descgrp>
+    <descgrp type="add">
       <relatedmaterial>
         <head>Related Material</head>
         <p>For related record groups within the Bentley Historical Library, researchers are advised to consult the records of the University of Michigan Department of Obstetrics and Gynecology, University of Michigan Medical School Records, and University of Michigan School of Nursing Records. A segment of the Willson papers, primarily relating to his tenure at Temple University, is housed in the College of Physicians archives and library in Philadelphia.</p>


### PR DESCRIPTION
We had some descgrp tags that should have had a type attribute of 'add' but did not. Now they do!
