### PR TITLE
manual extent fixes

### DIFF
--- a/Real_Masters_all/alumphot.xml
+++ b/Real_Masters_all/alumphot.xml
@@ -55004,13 +55004,13 @@ Alumni Association (University of Michigan),Individual Photographs, Bentley Hist
               <unittitle>
                 <persname>Schmidt, Herman</persname>
               </unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 photographs</extent>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1 with wife</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(includes 1 photograph with wife)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
@@ -61531,13 +61531,13 @@ Alumni Association (University of Michigan),Individual Photographs, Bentley Hist
               <unittitle>
                 <persname>Tappan, Henry Philip</persname>
               </unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 photographs</extent>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1 with wife</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(includes 1 photograph with wife)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
@@ -70330,13 +70330,13 @@ Alumni Association (University of Michigan),Individual Photographs, Bentley Hist
               <unittitle>
                 <persname>Young, E.H.</persname>
               </unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 photographs</extent>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1 with graduate students</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(includes 1 photograph with graduate students)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/alumphot.xml
+++ b/Real_Masters_all/alumphot.xml
@@ -51112,13 +51112,13 @@ Alumni Association (University of Michigan),Individual Photographs, Bentley Hist
               <unittitle>
                 <persname>Retirement Furlough</persname>
               </unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">9 photographs</extent>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">also 5 photocopies of related material</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(also 5 photocopies of related material)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
@@ -55774,13 +55774,13 @@ Alumni Association (University of Michigan),Individual Photographs, Bentley Hist
               <unittitle>
                 <persname>Scott, S. Spencer</persname>
               </unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">6 photographs</extent>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">including 2 of awards received</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(includes 2 photographs of awards received)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
@@ -55906,13 +55906,13 @@ Alumni Association (University of Michigan),Individual Photographs, Bentley Hist
               <unittitle>
                 <persname>Seaver, Jay J.</persname>
               </unittitle>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">3 photographs</extent>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">also 4 photographs given by Seaver</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">7 photographs</extent>
               </physdesc>
             </did>
+            <odd>
+              <p>(includes 4 photographs given by Seaver)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
@@ -57779,13 +57779,13 @@ Alumni Association (University of Michigan),Individual Photographs, Bentley Hist
               <unittitle>
                 <persname>Smith, Shirley</persname>
               </unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">11 photographs</extent>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1 of wife</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(includes 1 photograph of wife)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
@@ -63396,13 +63396,13 @@ Alumni Association (University of Michigan),Individual Photographs, Bentley Hist
               <unittitle>
                 <persname>Townsend, Earl C.</persname>
               </unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 photographs</extent>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">including 1 with wife &amp; children</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(includes 1 photograph with wife and children)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
@@ -66089,9 +66089,12 @@ Alumni Association (University of Michigan),Individual Photographs, Bentley Hist
                 <persname>Wallace, Mike</persname>
               </unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">11 photographs, includes photos with wife and also with Dagmar, Steve Allen; Gloria Swanson, Imperial Wizard of Ku Klux Klan and Diana Barrymore</extent>
+                <extent altrender="materialtype spaceoccupied">11 photographs</extent>
               </physdesc>
             </did>
+            <odd>
+                <p>(Includes photos with wife and also with Dagmar, Steve Allen; Gloria Swanson, Imperial Wizard of Ku Klux Klan and Diana Barrymore)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
@@ -68019,15 +68022,12 @@ Alumni Association (University of Michigan),Individual Photographs, Bentley Hist
               <unittitle>
                 <persname>Wenley, Robert M.</persname>
               </unittitle>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1 photographs</extent>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">2 photgraphs of portraits</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 photographs</extent>
               </physdesc>
             </did>
             <odd>
-              <p>(see also negative #3293-glass slide and negative)</p>
+              <p>(includes 2 photographs of portraits; see also negative #3293-glass slide and negative)</p>
             </odd>
           </c03>
           <c03 level="file">
@@ -69071,9 +69071,12 @@ Alumni Association (University of Michigan),Individual Photographs, Bentley Hist
                 <persname>Wink, Helena Knauf</persname>
               </unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">4 photographs, including winter scenes</extent>
+                <extent altrender="materialtype spaceoccupied">4 photographs</extent>
               </physdesc>
             </did>
+            <odd>
+              <p>(includes winter scenes)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
@@ -69300,9 +69303,12 @@ Alumni Association (University of Michigan),Individual Photographs, Bentley Hist
                 <persname>Wolcott, Charles</persname>
               </unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">5 photographs, including photos with Leslie Caron and George Murphy,;Vincente Minelli</extent>
+                <extent altrender="materialtype spaceoccupied">5 photographs</extent>
               </physdesc>
             </did>
+            <odd>
+                <p>(includes photos with Leslie Caron and George Murphy,;Vincente Minelli)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
@@ -70029,13 +70035,13 @@ Alumni Association (University of Michigan),Individual Photographs, Bentley Hist
               <unittitle>
                 <persname>Wunsch, Josephine</persname>
               </unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 photographs</extent>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1 with daughter, Kay</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(includes 1 photograph with daughter, Kay)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/amorgan.xml
+++ b/Real_Masters_all/amorgan.xml
@@ -12557,9 +12557,12 @@
             <container type="box" label="Box">61</container>
             <unittitle><title render="italic">Utterance</title>, <unitdate type="inclusive" normal="1916">1916</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">106 pages, with Morgan's marginal notes</extent>
+              <extent altrender="materialtype spaceoccupied">106 pages</extent>
             </physdesc>
           </did>
+          <odd>
+            <p>(includes Morgan's marginal notes)</p>
+          </odd>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/athdept.xml
+++ b/Real_Masters_all/athdept.xml
@@ -22852,7 +22852,8 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                     <container type="box" label="Box">261</container>
                     <unittitle>Eastern Michigan Invitational <unitdate type="inclusive" normal="2004-01-17">1/17/2004</unitdate></unittitle>
                     <physdesc altrender="whole">
-                      <extent altrender="materialtype spaceoccupied">1 cd, May be bad</extent>
+                      <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+                      <physfacet>CDs; May be bad</physfacet>
                     </physdesc>
                   </did>
                 </c06>
@@ -39455,7 +39456,8 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                     <container type="box" label="Box">223</container>
                     <unittitle>Team and headshots</unittitle>
                     <physdesc altrender="whole">
-                      <extent altrender="materialtype spaceoccupied">2 cds, cs</extent>
+                      <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
+                      <physfacet>CDs; cs</physfacet>
                     </physdesc>
                   </did>
                 </c06>

--- a/Real_Masters_all/atwellhi.xml
+++ b/Real_Masters_all/atwellhi.xml
@@ -378,7 +378,8 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <container type="folder" label="Folder">3</container>
             <unittitle>Comparison of levels, Sinclair Mill power, Ann Arbor, Mich. / J. B. Davis <unitdate type="inclusive" normal="1888/1889">1888-1889</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">1 profile : ms</extent>
+              <extent altrender="materialtype spaceoccupied">1 maps</extent>
+              <physfacet>profile : ms</physfacet>
             </physdesc>
             <physdesc>
               <physfacet>Scale [1:1,200] Vertical scale [1:36] : 6 x 61 cm.</physfacet>

--- a/Real_Masters_all/auditscharts.xml
+++ b/Real_Masters_all/auditscharts.xml
@@ -165,9 +165,12 @@ Office of University Audits (University of Michigan) organizational charts, Bent
             <container type="box" label="Box">1</container>
             <unittitle>Organizational charts, University of Michigan <unitdate type="inclusive" normal="1969/1991">1969/70-1990/91</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">22 folders, comprehensive and inclusive</extent>
+              <extent altrender="materialtype spaceoccupied">22 folders</extent>
             </physdesc>
           </did>
+          <odd>
+              <p>(comprehensive and inclusive)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/barnettd.xml
+++ b/Real_Masters_all/barnettd.xml
@@ -1204,13 +1204,13 @@ Doug Barnett Photographs and Scrapbooks, Bentley Historical Library, University 
                 <did>
                   <container type="box" label="Box">1</container>
                   <unittitle>Al Renfrew</unittitle>
-                  <physdesc altrender="part">
+                  <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 photographs</extent>
                   </physdesc>
-                  <physdesc altrender="part">
-                    <extent altrender="materialtype spaceoccupied">1 with Mike Martilla</extent>
-                  </physdesc>
                 </did>
+                <odd>
+                  <p>(includes 1 photograph with Mike Martilla)</p>
+                </odd>
               </c05>
             </c04>
           </c03>

--- a/Real_Masters_all/bauereliz.xml
+++ b/Real_Masters_all/bauereliz.xml
@@ -938,7 +938,7 @@ Elizabeth W. Bauer papers, Bentley Historical Library, University of Michigan</p
               <container type="box" label="Box">4</container>
               <unittitle>Children's Hospital of Michigan Bio-ethics Committee <unitdate type="inclusive" normal="1984/1985">1984-1985</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2folders</extent>
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/belknapr.xml
+++ b/Real_Masters_all/belknapr.xml
@@ -52,7 +52,11 @@
         <extent altrender="materialtype spaceoccupied">1 microfilms</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">1 16mm film and DVD use copy</extent>
+        <extent altrender="materialtype spaceoccupied">1 16mm film</extent>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+        <physfacet>DVD use copy</physfacet>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
@@ -181,13 +185,13 @@ Ralph L. Belknap papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <unittitle>Negatives of Peary Monument at Cape York, Greenland</unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">10 negatives</extent>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">na3103-na3112</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(na3103-na3112)</p>
+            </odd>
             <odd>
               <p>(stored with copy negatives)</p>
             </odd>

--- a/Real_Masters_all/bentleya.xml
+++ b/Real_Masters_all/bentleya.xml
@@ -12068,11 +12068,9 @@
             <unittitle>
               <unitdate type="inclusive" normal="1943">1943</unitdate>
             </unittitle>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">3 volumes</extent>
-            </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">2 volumes of typescript</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">5 volumes</extent>
+              <physfacet>3 volumes original and 2 volumes of typescript</physfacet>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/bhl.xml
+++ b/Real_Masters_all/bhl.xml
@@ -2437,9 +2437,12 @@ Bentley Historical Library records, Bentley Historical Library, University of Mi
                 <container type="box" label="Box">8</container>
                 <unittitle>Pugh, Mary Jo Farewell Party</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">2 folders. includes snapshot photographs</extent>
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(includes snapshot photographs)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>
@@ -14490,9 +14493,12 @@ Bentley Historical Library records, Bentley Historical Library, University of Mi
               <container type="box" label="Box">54</container>
               <unittitle>2nd European Conference on Archives <unitdate type="inclusive" normal="1989">1989</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">12 cassette and Conference program</extent>
+                <extent altrender="materialtype spaceoccupied">12 audiocassettes</extent>
               </physdesc>
             </did>
+            <odd>
+              <p>(includes Conference program)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/bhlpolar.xml
+++ b/Real_Masters_all/bhlpolar.xml
@@ -57,7 +57,8 @@
         <extent altrender="materialtype spaceoccupied">0.3 linear feet</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">60 MB of digital files</extent>
+        <extent altrender="materialtype spaceoccupied">60 MB</extent>
+        <physfacet>digital files</physfacet>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/birkertg.xml
+++ b/Real_Masters_all/birkertg.xml
@@ -5393,9 +5393,14 @@
                 <container type="box" label="Box">9</container>
                 <unittitle>Photographs</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">1 and 1 prints</extent>
+                  <extent altrender="materialtype spaceoccupied">1 prints</extent>
                   <physfacet>black and white</physfacet>
-                  <dimensions>7x9-inch; 5x5-inch</dimensions>
+                  <dimensions>7x9-inch</dimensions>
+                </physdesc>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 prints</extent>
+                  <physfacet>black and white</physfacet>
+                  <dimensions>5x5-inch</dimensions>
                 </physdesc>
               </did>
             </c04>
@@ -5417,8 +5422,9 @@
                   <container label="Folder" type="folder">3</container>
                   <unittitle>Partial Plan, Elevations and Section [of Chair]</unittitle>
                   <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">2 blue-line prints with pencil sketches, &amp;</extent>
-                    <dimensions>21-1/4x30-1/2; 21-1/4x29-1/2 inches</dimensions>
+                    <extent altrender="materialtype spaceoccupied">2 prints</extent>
+                    <physfacet>pencil sketches on blue-line prints</physfacet>
+                    <dimensions>21-1/4x30-1/2 and 21-1/4x29-1/2 inches</dimensions>
                   </physdesc>
                 </did>
               </c05>

--- a/Real_Masters_all/blanchjj.xml
+++ b/Real_Masters_all/blanchjj.xml
@@ -1109,9 +1109,12 @@
                   <unitdate type="inclusive" normal="1989/1990">1989-1990</unitdate>
                 </unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">1 volume and notes</extent>
+                  <extent altrender="materialtype spaceoccupied">1 volumes</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(includes notes)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/bonnellj.xml
+++ b/Real_Masters_all/bonnellj.xml
@@ -117,7 +117,8 @@
             <container label="Folder" type="folder">2</container>
             <unittitle>Album</unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">1 volume with 104 images</extent>
+              <extent altrender="materialtype spaceoccupied">1 volume</extent>
+              <extent altrender="carrier">104 images</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/brownpre.xml
+++ b/Real_Masters_all/brownpre.xml
@@ -584,9 +584,6 @@
       <c01 level="series">
         <did>
           <unittitle>Legislative files <unitdate type="inclusive" normal="1933/1942">1933-1942</unitdate></unittitle>
-          <physdesc altrender="whole">
-            <extent altrender="materialtype spaceoccupied">1933-1942</extent>
-          </physdesc>
         </did>
         <scopecontent>
           <p>The Legislative files series (1933-1942.; 1933-1942) includes Brown's voting record in Congress and the record of bills which he introduced. This Legislative series also contains a great deal of material on specific legislation. Such files have been sorted by term of Congress, then by session in that Congress, and finally by the bill number. Although many of these files are on private bills (e.g. naturalization cases, relief of widows of Civil War veterans, etc.), there is also important material here on tax and banking legislation, the Mackinac Straits Bridge legislation, and legislation to amend the Hatch Act. These Legislative files are strongest for the period of 1936 to 1942, essentially the late New Deal and early years of the Second World War. As a rule, these files include a copy of the particular legislation, drafts of the bill, correspondence on the issue, and perhaps some related supplementary material.</p>

--- a/Real_Masters_all/busadmin.xml
+++ b/Real_Masters_all/busadmin.xml
@@ -61,7 +61,7 @@
         <extptr href="bhladd" show="embed" actuate="onload"/>
       </repository>
       <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">115 linear feet and feet</extent>
+        <extent altrender="materialtype spaceoccupied">115 linear feet</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3.82 GB</extent>
@@ -15084,9 +15084,12 @@
                 <container type="box" label="Box">101</container>
                 <unittitle>Activities and Publications <unitdate type="inclusive" normal="1949/1959">1949-1959</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">10 folders, generally by academic year</extent>
+                  <extent altrender="materialtype spaceoccupied">10 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(folders generally by academic year)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/caasum.xml
+++ b/Real_Masters_all/caasum.xml
@@ -56,7 +56,8 @@
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">approximately 800 GB</extent>
+        <extent altrender="materialtype spaceoccupied">800 GB</extent>
+        <extent altrender="carrier">approximate</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/cacioppo.xml
+++ b/Real_Masters_all/cacioppo.xml
@@ -4430,9 +4430,8 @@ George Cacioppo papers, Bentley Historical Library, University of Michigan</p>
             <did>
               <container type="box" label="Box">21</container>
               <unittitle>Blake, Eubie, from NPR, and rags <unitdate type="inclusive" normal="1971-06-09">June 9, 1971</unitdate></unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">reels</extent>
-                <physfacet>5-inch</physfacet>
+              <physdesc>
+                <physfacet>5-inch reel</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -4544,9 +4543,8 @@ George Cacioppo papers, Bentley Historical Library, University of Michigan</p>
             <did>
               <container type="box" label="Box">21</container>
               <unittitle>Salzman, Eric</unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">reels</extent>
-                <physfacet>5-inch</physfacet>
+              <physdesc>
+                <physfacet>5-inch reel</physfacet>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/carcats.xml
+++ b/Real_Masters_all/carcats.xml
@@ -562,10 +562,10 @@ Catalogs of Michigan-based automobile companies, 1896-1971 and undated, Bentley 
             <did>
               <container type="folder" label="Oversize Folder">NB D48 A938</container>
               <unittitle>Four advertising brochures <unitdate type="inclusive" normal="1939">1939</unitdate>, <unitdate type="inclusive" normal="1940">1940</unitdate>, <unitdate type="inclusive" normal="1941">1941</unitdate></unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2 copies of 1941</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(2 copies of 1941)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/cglas.xml
+++ b/Real_Masters_all/cglas.xml
@@ -2916,10 +2916,12 @@
           <did>
             <unittitle>Biological Studies</unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">8 folders, principal reports</extent>
-              <extent altrender="carrier">(in each folder are listed below)</extent>
+              <extent altrender="materialtype spaceoccupied">8 folders</extent>
             </physdesc>
           </did>
+          <odd>
+            <p>(principal reports in each folder are listed below)</p>
+          </odd>
           <c03 level="file">
             <did>
               <unittitle>Folder 1</unittitle>

--- a/Real_Masters_all/churchm.xml
+++ b/Real_Masters_all/churchm.xml
@@ -1456,15 +1456,9 @@ Michael P. Church papers, Bentley Historical Library, University of Michigan</p>
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"Images of Michigan" (copy);</unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
-                <physfacet>U-matic</physfacet>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">3/4 inches</extent>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">16 mm</extent>
+                <physfacet>U-matic; 3/4 inches; 16 mm</physfacet>
               </physdesc>
             </did>
             <odd>

--- a/Real_Masters_all/classalb.xml
+++ b/Real_Masters_all/classalb.xml
@@ -2608,10 +2608,7 @@ University of Michigan Class Albums, Bentley Historical Library, University of M
           <c03 level="item">
             <did>
               <container type="box" label="Box">7</container>
-              <unittitle>Armor, Samuel Glasgow</unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2</extent>
-              </physdesc>
+              <unittitle>Armor, Samuel Glasgow (2)</unittitle>
             </did>
           </c03>
           <c03 level="item">
@@ -2623,10 +2620,7 @@ University of Michigan Class Albums, Bentley Historical Library, University of M
           <c03 level="item">
             <did>
               <container type="box" label="Box">7</container>
-              <unittitle>Ford, Corydon La</unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2</extent>
-              </physdesc>
+              <unittitle>Ford, Corydon La (2)</unittitle>
             </did>
           </c03>
           <c03 level="item">
@@ -2644,10 +2638,7 @@ University of Michigan Class Albums, Bentley Historical Library, University of M
           <c03 level="item">
             <did>
               <container type="box" label="Box">7</container>
-              <unittitle>Haven, Rev. Erastus Otis</unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2</extent>
-              </physdesc>
+              <unittitle>Haven, Rev. Erastus Otis (2)</unittitle>
             </did>
           </c03>
           <c03 level="item">
@@ -2659,10 +2650,7 @@ University of Michigan Class Albums, Bentley Historical Library, University of M
           <c03 level="item">
             <did>
               <container type="box" label="Box">7</container>
-              <unittitle>Sager, Abram</unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2</extent>
-              </physdesc>
+              <unittitle>Sager, Abram (2)</unittitle>
             </did>
           </c03>
           <c03 level="item">

--- a/Real_Masters_all/commcats.xml
+++ b/Real_Masters_all/commcats.xml
@@ -3168,8 +3168,9 @@ Commercial catalog collection, Bentley Historical Library, University of Michiga
               <container type="box" label="Box">13</container>
               <unittitle>[Leaflet for roofing tile <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">4 p</extent>
-                <physfacet>1 sheet folded</physfacet>
+                <extent altrender="materialtype spaceoccupied">1 sheet</extent>
+                <extent altrender="carrier">4 pages</extent>
+                <physfacet>folder</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -4166,13 +4167,13 @@ Commercial catalog collection, Bentley Historical Library, University of Michiga
             <did>
               <container type="box" label="Box">15</container>
               <unittitle>Physical apparatus catalogue [instruments used for physics classes] <unitdate type="inclusive">after 1913</unitdate></unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 copies</extent>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1 with later additions tipped in</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(1 copy with later additions tipped in)</p>
+            </odd>
           </c03>
         </c02>
       </c01>

--- a/Real_Masters_all/compcent.xml
+++ b/Real_Masters_all/compcent.xml
@@ -2799,11 +2799,8 @@ Computing Center (University of Michigan) records, Bentley Historical Library, U
             <did>
               <container type="box" label="Box">25</container>
               <unittitle>2.1</unittitle>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">2.5" magnetic tapes (data tapes</extent>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">800 BPI</extent>
+              <physdesc>
+                <physfacet>2.5" magnetic tapes, 800 BPI</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -2811,11 +2808,8 @@ Computing Center (University of Michigan) records, Bentley Historical Library, U
             <did>
               <container type="box" label="Box">25</container>
               <unittitle>5.0</unittitle>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1.5" magnetic tape (data tape</extent>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1600 BPI</extent>
+              <physdesc>
+                <physfacet>1.5" magnetic tape, 1600 BPI</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -2823,11 +2817,8 @@ Computing Center (University of Michigan) records, Bentley Historical Library, U
             <did>
               <container type="box" label="Box">25</container>
               <unittitle>6.0</unittitle>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">6.5" magnetic tapes (data tapes</extent>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">6250 BPI</extent>
+              <physdesc>
+                <physfacet>6.5" magnetic tapes, 6250 BPI</physfacet>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/cranehh.xml
+++ b/Real_Masters_all/cranehh.xml
@@ -60,7 +60,15 @@
         <extent altrender="materialtype spaceoccupied">32.5 linear feet</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">1 motion picture film, DVD and streaming file</extent>
+        <extent altrender="materialtype spaceoccupied">1 motion picture film</extent>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+        <physfacet>DVDs</physfacet>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">1 digital files</extent>
+        <physfacet>streaming file</physfacet>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/davisannb.xml
+++ b/Real_Masters_all/davisannb.xml
@@ -73,7 +73,6 @@
         <p>[item], folder, box, Ann B. Davis papers, Bentley Historical Library, University of Michigan</p>
       </prefercite>
       <processinfo>
-        <p>[Delete this set of tags if not needed for digital material processing]</p>
         <p>
           <extptr href="digitalproc" show="embed" actuate="onload"/>
         </p>
@@ -937,8 +936,11 @@
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Color Slides, circa <unitdate type="inclusive" normal="1971/1976">1971-1976</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders and 10 slides boxes</extent>
+            <physdesc altrender="part">
+              <extent>2 folders</extent>
+            </physdesc>
+            <physdesc altrender="part">
+              <extent>10 slides boxes</extent>
             </physdesc>
           </did>
           <odd>

--- a/Real_Masters_all/demparty.xml
+++ b/Real_Masters_all/demparty.xml
@@ -23801,12 +23801,10 @@ Democratic Party of Michigan records, Bentley Historical Library, University of 
             <did>
               <container type="box" label="Box">96</container>
               <unittitle>Unidentified Democratic conference <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 audiotapes</extent>
                 <physfacet>3 3/4 ips; reel-to-reel tapes</physfacet>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">5 inches and 7 inches</extent>
+                <dimensions>5 inches and 7 inches</dimensions>
               </physdesc>
             </did>
             <odd>
@@ -23857,8 +23855,8 @@ Democratic Party of Michigan records, Bentley Historical Library, University of 
               <container type="box" label="Box">97</container>
               <unittitle>Recording <unitdate type="inclusive" normal="1968-03/1968-04">March-April 1968</unitdate> featuring in part President Lyndon Johnson on Public Affairs News (Democratic Party program) (in part test tape); also discussion of <unitdate type="inclusive" normal="1968">1968</unitdate> election campaign.</unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">1 sound tape reel: and</extent>
-                <physfacet>7 1/2 ips; 3 3/4 ips</physfacet>
+                <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
+                <physfacet>7 1/2 ips and 3 3/4 ips; reel-to-reel tapes</physfacet>
               </physdesc>
             </did>
             <odd>
@@ -23871,7 +23869,7 @@ Democratic Party of Michigan records, Bentley Historical Library, University of 
               <unittitle>Interview <unitdate type="inclusive" normal="1970" certainty="approximate">circa 1970</unitdate> with Fred Harris, chairman of the Democratic National Committee.</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                <physfacet>; 7 1/2 ips; 5 inches; reel-to-reel tapes</physfacet>
+                <physfacet>7 1/2 ips; 5 inches; reel-to-reel tapes</physfacet>
                 <dimensions>13:26</dimensions>
               </physdesc>
             </did>
@@ -24026,12 +24024,10 @@ Democratic Party of Michigan records, Bentley Historical Library, University of 
             <did>
               <container type="box" label="Box">97</container>
               <unittitle>Unidentified.</unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
                 <physfacet>3 3/4 ips; reel-to-reel tapes</physfacet>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">7 inches and 2 inches</extent>
+                <dimensions>7 inches and 2 inches</dimensions>
               </physdesc>
             </did>
             <odd>

--- a/Real_Masters_all/detobs.xml
+++ b/Real_Masters_all/detobs.xml
@@ -46,7 +46,8 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>The Detroit Observatory, an astronomical observatory on the campus of the University of Michigan, was the vision of University of Michigan President Henry Philip Tappan. He recognized the need for institutions of higher education to pursue scientific endeavors. Built in 1854, the Detroit Observatory was named after the Detroit residents who helped finance the building project. Extensive restoration work of the Observatory was completed in 1999.</abstract>
       <physdesc altrender="whole">
-        <extent altrender="materialtype spaceoccupied">29 linear feet and oversize material</extent>
+        <extent altrender="materialtype spaceoccupied">29 linear feet</extent>
+        <extent altrender="carrier">and oversize material</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/detroitnews.xml
+++ b/Real_Masters_all/detroitnews.xml
@@ -2386,7 +2386,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
                 <physloc>Online</physloc>
                 <unittitle>New Building-Excavation, <unitdate type="inclusive" normal="1915">1915</unitdate> </unittitle>
                 <physdesc altrender="whole">
-                  <extent>7 negatives 1 of 7</extent>
+                  <extent>1 negatives</extent>
                 </physdesc>
                 <dao href="2014153-201" show="new" actuate="onrequest">
                   <daodesc>
@@ -2394,13 +2394,16 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
                   </daodesc>
                 </dao>
               </did>
+              <odd>
+                  <p>(1 of 7 negatives)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>
                 <physloc>Online</physloc>
                 <unittitle>New Building-Excavation, <unitdate type="inclusive" normal="1915">1915</unitdate> </unittitle>
                 <physdesc altrender="whole">
-                  <extent>7 negatives, 2-7 of 7</extent>
+                  <extent>6 negatives</extent>
                 </physdesc>
                 <dao href="2014153-201" show="new" actuate="onrequest">
                   <daodesc>
@@ -2408,6 +2411,9 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
                   </daodesc>
                 </dao>
               </did>
+              <odd>
+                  <p>(2-7 of 7 negatives)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>
@@ -2478,7 +2484,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
                 <physloc>Online</physloc>
                 <unittitle>New Building-Exterior-Views of Side Facing Fort Street, <unitdate type="inclusive">undated</unitdate> </unittitle>
                 <physdesc altrender="whole">
-                  <extent>6 negatives, 1-2 of 6 </extent>
+                  <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-62" show="new" actuate="onrequest">
                   <daodesc>
@@ -2487,7 +2493,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
                 </dao>
               </did>
               <odd>
-                <p>[see also: film negatives]</p>
+                <p>[1-2 of 6 negatives; see also: film negatives]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -2495,7 +2501,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
                 <physloc>Online</physloc>
                 <unittitle>New Building-Exterior-Views of Side Facing Fort Street, <unitdate type="inclusive">undated</unitdate> </unittitle>
                 <physdesc altrender="whole">
-                  <extent>6 negatives,3-6 of 6</extent>
+                  <extent>4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-62" show="new" actuate="onrequest">
                   <daodesc>
@@ -2504,7 +2510,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
                 </dao>
               </did>
               <odd>
-                <p>[see also: film negatives]</p>
+                <p>[3-6 of 6 negatives; see also: film negatives]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3183,7 +3189,7 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
                 <physloc>Online</physloc>
                 <unittitle>Library-New Building, <unitdate type="inclusive">undated</unitdate> </unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives,1-2 of 3</extent>
+                  <extent>2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-253" show="new" actuate="onrequest">
                   <daodesc>
@@ -3191,13 +3197,16 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
                   </daodesc>
                 </dao>
               </did>
+              <odd>
+                  <p>(1-2 of 3 negatives)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Library-New Building, <unitdate type="inclusive">undated</unitdate> </unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives, 3 of 3</extent>
+                  <extent>1 negatives</extent>
                 </physdesc>
                 <dao href="2014153-253" show="new" actuate="onrequest">
                   <daodesc>
@@ -3205,6 +3214,9 @@ The collection includes two primary series: Visual Materials and Scrapbooks.
                   </daodesc>
                 </dao>
               </did>
+              <odd>
+                  <p>(3 of 3 negatives)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/deweesec.xml
+++ b/Real_Masters_all/deweesec.xml
@@ -41,11 +41,10 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2010136 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Maps of Oakland and Livingston Counties and Detroit, Mich., and the state of Michigan, and other items relating to Bloomfield Township, Mich., photographed from the holdings of the Burton Historical Collection, Detroit Public Library.</abstract>
-      <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">56 maps</extent>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">other images on 1 DVD-R</extent>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+        <extent altrender="carrier">56 maps and other images</extent>
+        <physfacet>DVD-R</physfacet>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/downst.xml
+++ b/Real_Masters_all/downst.xml
@@ -447,9 +447,12 @@ The collection is organized in the following series: Political and other activit
             <container type="box" label="Box">18</container>
             <unittitle>Interview of TD <unitdate type="inclusive" normal="1995-03-30">March 30, 1995</unitdate> conducted by Sidney Fine</unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">2 sound cassettes, transcription and related material</extent>
+              <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
             </physdesc>
           </did>
+          <odd>
+            <p>(includes transcription and related material)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/duderst.xml
+++ b/Real_Masters_all/duderst.xml
@@ -5721,10 +5721,7 @@
         </c02>
         <c02 level="series">
           <did>
-            <unittitle>Strategic Planning</unittitle>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">1986-1996</extent>
-            </physdesc>
+            <unittitle>Strategic Planning, <unitdate type="inclusive" normal="1986/1996">1986-1996</unitdate></unittitle>
           </did>
           <scopecontent>
             <p>The series Strategic Planning (.75 linear feet, 1986-1996) includes materials mainly from the first few years of Duderstadt's presidential tenure. This series includes background materials on the Michigan Mandate and Michigan Plan as well as reference notebooks used in strategic planning meetings. Related strategic planning material can be found in the Strategy series within the Digital Documents Subgroup.</p>

--- a/Real_Masters_all/duffivan.xml
+++ b/Real_Masters_all/duffivan.xml
@@ -286,9 +286,12 @@
               <container type="box" label="Box">1</container>
               <unittitle>Turner Community Advisory Committee <unitdate type="inclusive" normal="1979/1985">1979-1985</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">3 folders, includes scattered minutes</extent>
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
+            <odd>
+              <p>(includes scattered minutes)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/durbanl.xml
+++ b/Real_Masters_all/durbanl.xml
@@ -7310,7 +7310,7 @@
                       <unitdate type="inclusive" normal="1961/1967">1961-1967</unitdate>
                     </unittitle>
                     <physdesc altrender="whole">
-                      <extent altrender="materialtype spaceoccupied">7 of 18 folders</extent>
+                      <extent altrender="materialtype spaceoccupied">7 folders</extent>
                     </physdesc>
                   </did>
                 </c06>

--- a/Real_Masters_all/ecologyc.xml
+++ b/Real_Masters_all/ecologyc.xml
@@ -6379,10 +6379,10 @@ Ecology Center of Ann Arbor records, Bentley Historical Library, University of M
             <did>
               <container type="box" label="Box">18</container>
               <unittitle>"Earth Day is Every Day" <unitdate type="inclusive" normal="1992">1992</unitdate></unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">30 and 60 second PSA</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(30 and 60 second PSA)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/engcoll.xml
+++ b/Real_Masters_all/engcoll.xml
@@ -11342,7 +11342,7 @@
               <container type="box" label="Box">82</container>
               <unittitle>Building Exteriors <unitdate type="inclusive" normal="1961/1988">1961-1988</unitdate>, <unitdate>undated</unitdate></unittitle>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">13</extent>
+                <extent altrender="materialtype spaceoccupied">13 prints</extent>
                 <physfacet>black and white</physfacet>
               </physdesc>
               <physdesc altrender="part">
@@ -11536,7 +11536,7 @@
               <container type="box" label="Box">82</container>
               <unittitle>Recruitment Fair <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">2</extent>
+                <extent altrender="materialtype spaceoccupied">2 prints</extent>
                 <physfacet>black and white</physfacet>
               </physdesc>
               <physdesc altrender="part">

--- a/Real_Masters_all/engcoll.xml
+++ b/Real_Masters_all/engcoll.xml
@@ -11475,9 +11475,13 @@
               <did>
                 <container type="box" label="Box">82</container>
                 <unittitle>Student Life, incl. Society of Women Engineers Career Fair <unitdate type="inclusive" normal="1987/1988">1987-1988</unitdate></unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">5 contact sheets, a few negatives</extent>
+                <physdesc altrender="part">
+                  <extent altrender="materialtype spaceoccupied">5 contact sheets</extent>
                   <physfacet>black and white</physfacet>
+                </physdesc>
+                <physdesc altrender="part">
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
+                  <extent altrender="carrier">number approximate</extent>
                 </physdesc>
               </did>
             </c04>
@@ -11487,7 +11491,7 @@
               <container type="box" label="Box">82</container>
               <unittitle>Miscellaneous <unitdate type="inclusive" normal="1970/1989" certainty="approximate">circa 1970s-1980s</unitdate></unittitle>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">4</extent>
+                <extent altrender="materialtype spaceoccupied">4 prints</extent>
                 <physfacet>color</physfacet>
               </physdesc>
               <physdesc altrender="part">

--- a/Real_Masters_all/englerj.xml
+++ b/Real_Masters_all/englerj.xml
@@ -33440,11 +33440,10 @@ Topics extensively documented include state welfare and school funding reform, r
               <did>
                 <container type="box" label="Box">156</container>
                 <unittitle>"Once upon a time there was politics," <unitdate type="inclusive" normal="1973-02-10">February 10, 1973</unitdate> Superbowl Sundae, <unitdate type="inclusive" normal="1972-03-06">March 6, 1972</unitdate></unittitle>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">1 VHS Tape (black and white</extent>
-                </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">60 min</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 VHS Tape</extent>
+                  <extent altrender="carrier">ca. 60 min.</extent>
+                  <physfacet>black and white</physfacet>
                 </physdesc>
               </did>
               <odd>

--- a/Real_Masters_all/englerj.xml
+++ b/Real_Masters_all/englerj.xml
@@ -34792,9 +34792,7 @@ Topics extensively documented include state welfare and school funding reform, r
                 <container type="box" label="Box">149</container>
                 <unittitle>"Assorted Nuts," Michigan Department of Transportation Give 'em a Break Public Service Announcement <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">30</extent>
-                </physdesc>
-                <physdesc>
+                  <extent altrender="materialtype spaceoccupied">30 seconds</extent>
                   <physfacet>U-matic format</physfacet>
                 </physdesc>
               </did>
@@ -34918,9 +34916,7 @@ Topics extensively documented include state welfare and school funding reform, r
                 <container type="box" label="Box">149</container>
                 <unittitle>"I'm at Risk/K-Mart," Michigan Department of Public Health, Brogan &amp; Partners <unitdate type="inclusive" normal="1993-03-15">March 15, 1993</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">30</extent>
-                </physdesc>
-                <physdesc>
+                  <extent altrender="materialtype spaceoccupied">30 seconds</extent>
                   <physfacet>U-matic format</physfacet>
                 </physdesc>
               </did>
@@ -34957,9 +34953,7 @@ Topics extensively documented include state welfare and school funding reform, r
                 <container type="box" label="Box">149</container>
                 <unittitle>"I'm at Risk/MDPH," Michigan Department of Public Health, Brogan &amp; Partners <unitdate type="inclusive" normal="1993-03-15">March 15, 1993</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">30</extent>
-                </physdesc>
-                <physdesc>
+                  <extent altrender="materialtype spaceoccupied">30 seconds</extent>
                   <physfacet>U-matic format</physfacet>
                 </physdesc>
               </did>
@@ -38372,7 +38366,7 @@ Topics extensively documented include state welfare and school funding reform, r
                 <container type="box" label="Box">161</container>
                 <unittitle>"Together," Cut &amp; Cap Proposal 'C,' Marketing Resource Group <unitdate type="inclusive" normal="1992-10-07">October 7, 1992</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">60</extent>
+                  <extent altrender="materialtype spaceoccupied">60 seconds</extent>
                 </physdesc>
               </did>
               <odd>
@@ -38384,7 +38378,7 @@ Topics extensively documented include state welfare and school funding reform, r
                 <container type="box" label="Box">161</container>
                 <unittitle>"Hike-D" and "Hike-O," Cut &amp; Cap Proposal 'C,' Marketing Resource Group <unitdate type="inclusive" normal="1992-10-24">October 24, 1992</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">60</extent>
+                  <extent altrender="materialtype spaceoccupied">60 seconds</extent>
                 </physdesc>
               </did>
               <odd>
@@ -38627,7 +38621,7 @@ Topics extensively documented include state welfare and school funding reform, r
                 <container type="box" label="Box">161</container>
                 <unittitle>"Way," Cut &amp; Cap, Marketing Resource Group <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">60</extent>
+                  <extent altrender="materialtype spaceoccupied">60 seconds</extent>
                 </physdesc>
               </did>
               <odd>
@@ -38639,7 +38633,7 @@ Topics extensively documented include state welfare and school funding reform, r
                 <container type="box" label="Box">161</container>
                 <unittitle>Democratic National Committee <unitdate type="inclusive" normal="1992-09">September 1992</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">60</extent>
+                  <extent altrender="materialtype spaceoccupied">60 seconds</extent>
                 </physdesc>
               </did>
               <odd>
@@ -38651,7 +38645,7 @@ Topics extensively documented include state welfare and school funding reform, r
                 <container type="box" label="Box">161</container>
                 <unittitle>"Binge Drinking," Michigan State Police, Public Service Announcement <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">30</extent>
+                  <extent altrender="materialtype spaceoccupied">30 seconds</extent>
                 </physdesc>
               </did>
               <odd>
@@ -38672,7 +38666,7 @@ Topics extensively documented include state welfare and school funding reform, r
                 <container type="box" label="Box">161</container>
                 <unittitle>"Engler Endorsement," Bush-Quayle '92 <unitdate type="inclusive" normal="1992-03-10">March 10, 1992</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">60</extent>
+                  <extent altrender="materialtype spaceoccupied">60 seconds</extent>
                 </physdesc>
               </did>
               <odd>
@@ -39116,7 +39110,7 @@ Topics extensively documented include state welfare and school funding reform, r
                 <container type="box" label="Box">162</container>
                 <unittitle>"Michelle/Verne Immunization," Michigan Department of Public Health <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">60</extent>
+                  <extent altrender="materialtype spaceoccupied">60 seconds</extent>
                 </physdesc>
               </did>
               <odd>
@@ -39614,7 +39608,7 @@ Topics extensively documented include state welfare and school funding reform, r
                 <container type="box" label="Box">163</container>
                 <unittitle>Nancy Crandall Director of OSA, Sound Bite, Harvest Productions, Lansing, Michigan <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">30</extent>
+                  <extent altrender="materialtype spaceoccupied">30 seconds</extent>
                 </physdesc>
               </did>
               <odd>
@@ -40265,7 +40259,7 @@ Topics extensively documented include state welfare and school funding reform, r
                 <container type="box" label="Box">164</container>
                 <unittitle>"Michelle &amp; Cynthia," Michigan Harvest Gathering Public Service Announcement, Producer Glenn Brown, Marketing Resource Group <unitdate type="inclusive" normal="1998-08-31">August 31, 1998</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">60</extent>
+                  <extent altrender="materialtype spaceoccupied">60 seconds</extent>
                 </physdesc>
               </did>
               <odd>

--- a/Real_Masters_all/extserv.xml
+++ b/Real_Masters_all/extserv.xml
@@ -7565,7 +7565,8 @@
                 <container type="box" label="Box">57</container>
                 <unittitle>University Center for Adult Education (UCAE), Wayne State University <unitdate>undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">1 print with negative</extent>
+                  <extent altrender="materialtype spaceoccupied">1 prints</extent>
+                  <extent altrender="carrier">with negatives</extent>
                   <physfacet>black and white</physfacet>
                 </physdesc>
               </did>

--- a/Real_Masters_all/fergusnj.xml
+++ b/Real_Masters_all/fergusnj.xml
@@ -44,11 +44,9 @@
       <unittitle encodinganalog="245">John W. Ferguson photograph collection <unitdate type="inclusive" encodinganalog="245$f" normal="1919" certainty="approximate">circa 1919</unitdate></unittitle>
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2012081 Aa 2</unitid>
       <abstract>Papers of a soldier in the Allied intervention in Russia, 1918-1920, the "Polar Bear Expedition."</abstract>
-      <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">1 digital files</extent>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">6.12 mb</extent>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">6.12 MB</extent>
+        <extent altrender="carrier">1 digital file</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/freshair.xml
+++ b/Real_Masters_all/freshair.xml
@@ -474,9 +474,8 @@
           <did>
             <container label="Box" type="box">2</container>
             <unittitle>Camp Tamarack <genreform normal="Photographs">Slide</genreform> and Tape Program, <unitdate type="inclusive" normal="1969">1969</unitdate></unittitle>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">reels</extent>
-              <physfacet>5 inch; 3 3/4 ips</physfacet>
+            <physdesc>
+              <physfacet>5 inch; 3 3/4 ips; reel-to-reel-tape</physfacet>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/friezehs.xml
+++ b/Real_Masters_all/friezehs.xml
@@ -188,11 +188,11 @@
             <container type="box" label="Box">1</container>
             <unittitle>Diary and jotting books of European trip <unitdate type="inclusive" normal="1855/1856">1855-1856</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">15 notebooks, no. 1-15</extent>
+              <extent altrender="materialtype spaceoccupied">15 notebooks</extent>
             </physdesc>
           </did>
           <odd>
-            <p>(folder 18)</p>
+            <p>(folder 18; notebooks no. 1-15)</p>
           </odd>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/fullerel.xml
+++ b/Real_Masters_all/fullerel.xml
@@ -49,11 +49,12 @@
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">92159 Aa/2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">240 glass negatives (approximate</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="materialtype spaceoccupied">240 glass negatives</extent>
+        <extent altrender="carrier">(approximate; in 2 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">0.5 linear feet of contact prints and collected information</extent>
+        <extent altrender="materialtype spaceoccupied">0.5 linear feet</extent>
+        <physfacet>contact prints and collected information</physfacet>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/gablercl.xml
+++ b/Real_Masters_all/gablercl.xml
@@ -177,7 +177,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
                 <extent altrender="carrier">(in folder)</extent>
               </physdesc>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">19</extent>
+                <extent altrender="materialtype spaceoccupied">19 slides</extent>
                 <extent altrender="carrier">(in box)</extent>
               </physdesc>
             </did>
@@ -194,7 +194,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
                 <extent altrender="carrier">(in folder)</extent>
               </physdesc>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">24</extent>
+                <extent altrender="materialtype spaceoccupied">24 slides</extent>
                 <extent altrender="carrier">(in box)</extent>
               </physdesc>
             </did>
@@ -224,7 +224,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
                 <extent altrender="carrier">(in folder)</extent>
               </physdesc>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">18</extent>
+                <extent altrender="materialtype spaceoccupied">18 slides</extent>
                 <extent altrender="carrier">(in box)</extent>
               </physdesc>
             </did>
@@ -241,7 +241,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
                 <extent altrender="carrier">(in folder)</extent>
               </physdesc>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">3</extent>
+                <extent altrender="materialtype spaceoccupied">3 slides</extent>
                 <extent altrender="carrier">(in box)</extent>
               </physdesc>
             </did>
@@ -258,7 +258,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
                 <extent altrender="carrier">(in folder)</extent>
               </physdesc>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">26</extent>
+                <extent altrender="materialtype spaceoccupied">26 slides</extent>
                 <extent altrender="carrier">(in box)</extent>
               </physdesc>
             </did>
@@ -344,7 +344,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
               <physfacet>color</physfacet>
             </physdesc>
             <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">2</extent>
+              <extent altrender="materialtype spaceoccupied">2 slides</extent>
               <extent altrender="carrier">(in box)</extent>
             </physdesc>
           </did>
@@ -457,7 +457,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
               <extent altrender="carrier">(in folder)</extent>
             </physdesc>
             <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">125</extent>
+              <extent altrender="materialtype spaceoccupied">125 slides</extent>
               <extent altrender="carrier">(in box)</extent>
             </physdesc>
           </did>

--- a/Real_Masters_all/gamua.xml
+++ b/Real_Masters_all/gamua.xml
@@ -1043,7 +1043,8 @@ Event, unidentified probably reunion, <unitdate type="inclusive">undated</unitda
               <container type="box" label="Box">3</container>
               <unittitle>Michigamua Plaza, <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc>
-                <extent>(one color Polaroid print)</extent>
+                <extent>1 photographs</extent>
+                <physfacet>color Polaroid print</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -1061,7 +1062,8 @@ Event, unidentified probably reunion, <unitdate type="inclusive">undated</unitda
               <container type="box" label="Box">3</container>
               <unittitle>Reunion, <unitdate type="inclusive" normal="1961">1961</unitdate> (includes totem pole)</unittitle>
               <physdesc>
-                <extent>2 folders of black and white positive prints</extent>
+                <extent>2 folders</extent>
+                <physfacet>black and white positive prints</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -1079,7 +1081,8 @@ Event, unidentified probably reunion, <unitdate type="inclusive">undated</unitda
               <container type="box" label="Box">3</container>
               <unittitle>Totem Pole, <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc>
-                <extent>one black and white positive prin</extent>
+                <extent>1 photographs</extent>
+                <physfacet>black and white positive print</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -1204,7 +1207,7 @@ Event, unidentified probably reunion, <unitdate type="inclusive">undated</unitda
               <container type="box" label="Box">3</container>
               <unittitle>Wigwam, interior</unittitle>
               <physdesc>
-                <extent>one black and white negative</extent>
+                <physfacet>black and white negative</physfacet>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/gbassoc.xml
+++ b/Real_Masters_all/gbassoc.xml
@@ -62,7 +62,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physloc>Some records are located offsite. Two days notice required for retrieval.</physloc>
       <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">87 linear feet of records</extent>
+        <extent altrender="materialtype spaceoccupied">87 linear feet</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">10000 drawings</extent>
@@ -41780,9 +41780,9 @@
                 <container type="box" label="Box">79</container>
                 <unittitle>Construction Photographs by Haddad Studio Photographers and H. Bernstein Assoc. <unitdate type="inclusive" normal="1969-12-10/1972-03-15">12/10/1969-3/15/1972</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">2 folders of 110 and 74 prints</extent>
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   <physfacet>black and white</physfacet>
-                  <dimensions>8x10-inch; 3x5-inch</dimensions>
+                  <dimensions>110 8x10-inch; 74 3x5-inch</dimensions>
                 </physdesc>
               </did>
             </c04>
@@ -42021,7 +42021,8 @@
                 <container type="box" label="Box">80</container>
                 <unittitle>Construction Photographs by Win Brunner Photographer <unitdate type="inclusive" normal="1976-05-04/1979-03-02">5/4/1976-3/2/1979</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">3 folders of 138 prints</extent>
+                  <extent altrender="materialtype spaceoccupied">3 folders</extent>
+                  <extent>138 prints</extent>
                   <physfacet>black and white</physfacet>
                   <dimensions>8 x 10-inch</dimensions>
                 </physdesc>
@@ -42345,14 +42346,16 @@
               <did>
                 <container type="box" label="Box">82</container>
                 <unittitle>Construction Photographs <unitdate type="inclusive" normal="1991/1993">1991-1993</unitdate></unittitle>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">21 slides and 179</extent>
-                  <physfacet>color</physfacet>
-                  <dimensions>4x6; 8x10-inch</dimensions>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
                 <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">prints</extent>
-                  <extent altrender="carrier">(in 2 folders)</extent>
+                  <extent altrender="materialtype spaceoccupied">21 slides</extent>
+                  <physfacet>color</physfacet>
+                </physdesc>
+                <physdesc altrender="part">
+                  <extent altrender="materialtype spaceoccupied">179 photographs</extent>
+                  <dimensions>4x6 and 8x10-inch</dimensions>
                   <physfacet>color</physfacet>
                 </physdesc>
               </did>
@@ -42853,7 +42856,8 @@
                 <container type="box" label="Box">74</container>
                 <unittitle>Construction Photographs <unitdate type="inclusive" normal="1987-07-16/1988-12-20">7/16/1987-12/20/1988</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">2 folders of 434 prints</extent>
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
+                  <extent altrender="carrier">434 prints</extent>
                   <physfacet>color</physfacet>
                   <dimensions>3-1/2x5 to 4 x 6-inch</dimensions>
                 </physdesc>
@@ -43642,10 +43646,13 @@
                   <container type="box" label="Box">73</container>
                   <unittitle>Models <unitdate type="inclusive" normal="1972-04">4/1972</unitdate></unittitle>
                   <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">64 slides by Gary Desmond, Photographer</extent>
+                    <extent altrender="materialtype spaceoccupied">64 slides</extent>
                     <physfacet>color</physfacet>
                   </physdesc>
                 </did>
+                <odd>
+                  <p>(slides by Gary Desmond, Photographer)</p>
+                </odd>
               </c05>
               <c05 level="file">
                 <did>
@@ -43846,7 +43853,7 @@
                 <container type="box" label="Box">71</container>
                 <unittitle>Photographs of Building Model <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">8 and prints</extent>
+                  <extent altrender="materialtype spaceoccupied">8 photographs</extent>
                   <physfacet>black and white</physfacet>
                   <dimensions>8 x 10-inch</dimensions>
                 </physdesc>
@@ -43984,18 +43991,17 @@
               <did>
                 <container type="box" label="Box">81</container>
                 <unittitle>Construction Photographs <unitdate type="inclusive" normal="1991/1993">1991-1993</unitdate></unittitle>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
+                </physdesc>
                 <physdesc altrender="part">
                   <extent altrender="materialtype spaceoccupied">200 slides</extent>
                   <physfacet>color</physfacet>
                 </physdesc>
                 <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">228</extent>
-                  <dimensions>3-1/2 x 5 and 4 x 6-inch</dimensions>
-                </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">prints</extent>
-                  <extent altrender="carrier">(in 2 folders)</extent>
+                  <extent altrender="materialtype spaceoccupied">228 prints</extent>
                   <physfacet>color</physfacet>
+                  <dimensions>3-1/2 x 5 and 4 x 6-inch</dimensions>
                 </physdesc>
               </did>
             </c04>
@@ -44169,7 +44175,8 @@
                 <container type="box" label="Box">76</container>
                 <unittitle>Construction Photographs, 9/1/1983-1/15/1986</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">3 folders of 122 prints</extent>
+                  <extent altrender="materialtype spaceoccupied">3 folders</extent>
+                  <extent altrender="carrier">122 prints</extent>
                   <physfacet>color and black and white</physfacet>
                   <dimensions>8 x 10-inch</dimensions>
                 </physdesc>
@@ -44180,7 +44187,8 @@
                 <container type="box" label="Box">76</container>
                 <unittitle>Construction Photographs <unitdate type="inclusive" normal="1984/1985">1984-1985</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">2 folders of 380 slides</extent>
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
+                  <extent altrender="carrier">380 slides</extent>
                   <physfacet>color</physfacet>
                 </physdesc>
               </did>
@@ -44308,18 +44316,17 @@
               <did>
                 <container type="box" label="Box">82</container>
                 <unittitle>Construction Photographs <unitdate type="inclusive" normal="1989/1990">1989-1990</unitdate></unittitle>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
+                </physdesc>
                 <physdesc altrender="part">
                   <extent altrender="materialtype spaceoccupied">3 slides</extent>
                   <physfacet>color</physfacet>
                 </physdesc>
                 <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">445</extent>
-                  <dimensions>3-1/2x5 and 4x6-inch</dimensions>
-                </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">prints</extent>
-                  <extent altrender="carrier">(in 2 folders)</extent>
+                  <extent altrender="materialtype spaceoccupied">445 prints</extent>
                   <physfacet>color</physfacet>
+                  <dimensions>3-1/2x5 and 4x6-inch</dimensions>
                 </physdesc>
               </did>
             </c04>
@@ -45634,7 +45641,7 @@
               <container type="box" label="Box">84</container>
               <unittitle>Photographs of site, presentation drawings and model by unknown photographer</unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">18 and slides</extent>
+                <extent altrender="materialtype spaceoccupied">18 slides</extent>
                 <physfacet>black and white; color</physfacet>
               </physdesc>
             </did>
@@ -46453,9 +46460,13 @@
             <did>
               <container type="box" label="Box">86</container>
               <unittitle>Photographs of market, models and presentation drawings by unknown photographers and Gunnar Birkerts, as stamped</unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">130 slides and 12 prints</extent>
-                <physfacet>color; color</physfacet>
+              <physdesc altrender="part">
+                <extent altrender="materialtype spaceoccupied">130 slides</extent>
+                <physfacet>color</physfacet>
+              </physdesc>
+              <physdesc altrender="part">
+                <extent altrender="materialtype spaceoccupied">12 photographs</extent>
+                <physfacet>color</physfacet>
                 <dimensions>4x6-inch</dimensions>
               </physdesc>
             </did>

--- a/Real_Masters_all/gbassoc.xml
+++ b/Real_Masters_all/gbassoc.xml
@@ -45595,7 +45595,7 @@
               <container type="box" label="Box">84</container>
               <unittitle>Photographs of presentation drawings and model by unknown photographer</unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">13</extent>
+                <extent altrender="materialtype spaceoccupied">13 slides</extent>
               </physdesc>
             </did>
           </c03>
@@ -45627,7 +45627,8 @@
               <container type="box" label="Box">84</container>
               <unittitle>Photographs of presentation drawings, model, construction and exterior by unknown photographer and Daniel Bartush, as stamped</unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">25 colors slides</extent>
+                <extent altrender="materialtype spaceoccupied">25 slides</extent>
+                <physfacet>color</physfacet>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/gmwill.xml
+++ b/Real_Masters_all/gmwill.xml
@@ -41908,7 +41908,7 @@
                   <container type="box" label="Box">509</container>
                   <unittitle>Italian</unittitle>
                   <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">3 folders) folders</extent>
+                    <extent altrender="materialtype spaceoccupied">3 folders</extent>
                   </physdesc>
                 </did>
               </c05>

--- a/Real_Masters_all/gmwill.xml
+++ b/Real_Masters_all/gmwill.xml
@@ -51070,9 +51070,12 @@
                   <container type="box" label="Box">6-P</container>
                   <unittitle>With Ted Kennedy</unittitle>
                   <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">2 folders, includes negatives</extent>
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
+                <odd>
+                  <p>(includes negatives)</p>
+                </odd>
               </c05>
               <c05 level="file">
                 <did>
@@ -59497,12 +59500,10 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
               <did>
                 <container type="box" label="Box">3-S</container>
                 <unittitle>Announcement by GMW of his support of JFK for president, June ? <unitdate type="inclusive" normal="1960">1960</unitdate></unittitle>
-                <physdesc altrender="part">
+                <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">7.5 ips, 2 inches</extent>
+                  <physfacet>7.5 ips; reel-to-reel tapes</physfacet>
+                  <dimensions>2 inches</dimensions>
                 </physdesc>
               </did>
               <odd>

--- a/Real_Masters_all/gonzalesjess.xml
+++ b/Real_Masters_all/gonzalesjess.xml
@@ -48,7 +48,7 @@
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">7.7GB</extent>
+        <extent altrender="materialtype spaceoccupied">7.7 GB</extent>
         <physfacet>online</physfacet>
       </physdesc>
       <repository>

--- a/Real_Masters_all/granholm.xml
+++ b/Real_Masters_all/granholm.xml
@@ -50,7 +50,7 @@
         <extent altrender="carrier">(in 227 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">1 oversize folder</extent>
+        <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 oversize items</extent>

--- a/Real_Masters_all/griffinj.xml
+++ b/Real_Masters_all/griffinj.xml
@@ -4344,18 +4344,24 @@
             <container type="box" label="Box">14</container>
             <unittitle>Lewis, T.M.N. <unitdate type="inclusive" normal="1935/1975">1935-1975</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">1 of 2 folders</extent>
+              <extent altrender="materialtype spaceoccupied">1 folders</extent>
             </physdesc>
           </did>
+          <odd>
+            <p>(1 of 2 folders)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">15</container>
             <unittitle>Lewis, T.M.N. <unitdate type="inclusive" normal="1935/1975">1935-1975</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">2 of 2 folders</extent>
+              <extent altrender="materialtype spaceoccupied">1 folders</extent>
             </physdesc>
           </did>
+          <odd>
+            <p>(2 of 2 folders)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -9277,18 +9283,24 @@
             <container type="box" label="Box">32</container>
             <unittitle>Williams, Stephen <unitdate type="inclusive" normal="1976/1997">1976-1997</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">3 of 12 folders</extent>
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
+          <odd>
+            <p>(3 of 12 folders)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">33</container>
             <unittitle>Williams, Stephen <unitdate type="inclusive" normal="1976/1997">1976-1997</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">9 of 12 folders</extent>
+              <extent altrender="materialtype spaceoccupied">9 folders</extent>
             </physdesc>
           </did>
+          <odd>
+            <p>(9 of 12 folders)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -17325,18 +17337,24 @@
               <container type="box" label="Box">84</container>
               <unittitle>Art of the First Americans Exhibit -- Cincinnati Art Museum <unitdate type="inclusive" normal="1975/1976">1975-1976</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2 of 5 folders</extent>
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <odd>
+              <p>(2 of 5 folders)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Art of the First Americans Exhibit -- Cincinnati Art Museum <unitdate type="inclusive" normal="1975/1976">1975-1976</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">3 of 5 folders</extent>
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
+            <odd>
+              <p>(3 of 5 folders)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/hcadams.xml
+++ b/Real_Masters_all/hcadams.xml
@@ -1664,9 +1664,12 @@
               <container type="box" label="Box">27</container>
               <unittitle>Collected essays and addresses</unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">1 volume of published articles</extent>
+                <extent altrender="materialtype spaceoccupied">1 volumes</extent>
               </physdesc>
             </did>
+            <odd>
+              <p>(published articles)</p>
+            </odd>
           </c03>
         </c02>
       </c01>

--- a/Real_Masters_all/henkelma.xml
+++ b/Real_Masters_all/henkelma.xml
@@ -42,8 +42,8 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Map created by a soldier in the Allied intervention in Russia, 1918-1919, the "Polar Bear Expedition."</abstract>
       <physdesc altrender="whole">
-        <extent altrender="materialtype spaceoccupied">1 map : ms.,; on sheet</extent>
-        <physfacet>color</physfacet>
+        <extent altrender="materialtype spaceoccupied">1 maps</extent>
+        <physfacet>map : ms., col. ; on sheet</physfacet>
         <dimensions>46 x 61 cm.</dimensions>
       </physdesc>
       <repository>

--- a/Real_Masters_all/highscop.xml
+++ b/Real_Masters_all/highscop.xml
@@ -816,9 +816,12 @@
               <container type="box" label="Box">13</container>
               <unittitle>Colombia <unitdate type="inclusive" normal="1971/1974">1971-1974</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2 folders, includes an audiocassette</extent>
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <odd>
+              <p>(includes an audiocassette)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/hofdavid.xml
+++ b/Real_Masters_all/hofdavid.xml
@@ -2766,14 +2766,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
               <unittitle>
                 <bibref><title render="italic">Vegetarian cooking</title>. <edition>5th ed.</edition> <imprint>(Benton Harbor, Mich. : House of David <date type="publication">1951</date>)</imprint> 55 p.</bibref>
               </unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 copies</extent>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1 with brown wraps</extent>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1 with blue wraps</extent>
+                <physfacet>1 with brown wraps; 1 with blue wraps</physfacet>
               </physdesc>
             </did>
             <odd>

--- a/Real_Masters_all/ilirauto.xml
+++ b/Real_Masters_all/ilirauto.xml
@@ -41,12 +41,9 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">851743 Bimu C542 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Transcripts of interviews conducted with Michigan labor leaders by staff of University of Michigan and Wayne State University Institute of Labor and Industrial Relations.</abstract>
-      <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">130 transcripts</extent>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">volumes</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">130 transcripts and indices</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/infolib.xml
+++ b/Real_Masters_all/infolib.xml
@@ -6883,9 +6883,8 @@
             <did>
               <container type="box" label="Box">31</container>
               <unittitle>Casy, Geneviere <unitdate type="inclusive" normal="1973-04-07">April 7, 1973</unitdate> "Alternative Futures for the Public Library"</unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">reels</extent>
-                <physfacet>7"; 3.75 ips</physfacet>
+              <physdesc>
+                <physfacet>7"; 3.75 ips reel</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -6944,9 +6943,8 @@
             <did>
               <container type="box" label="Box">31</container>
               <unittitle><unitdate type="inclusive" normal="1965-10-21">October 21, 1965</unitdate> Dan Fink, "Aims of Documentation"</unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">reels</extent>
-                <physfacet>7"; 3.75 ips</physfacet>
+              <physdesc>
+                <physfacet>7"; 3.75 ips reel</physfacet>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/itdrec.xml
+++ b/Real_Masters_all/itdrec.xml
@@ -1282,7 +1282,7 @@ Information Technology Division (University of Michigan) records, Bentley Histor
                 <container type="box" label="Box">26</container>
                 <unittitle>Information Technology Architecture Committee (ITAC)<unitdate type="inclusive" normal="1986/1988">1986-1988</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">2 expandable folders</extent>
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>

--- a/Real_Masters_all/ivoryph.xml
+++ b/Real_Masters_all/ivoryph.xml
@@ -6277,9 +6277,12 @@
                           <unitdate type="inclusive" normal="1952">1952</unitdate>
                         </unittitle>
                         <physdesc altrender="whole">
-                          <extent altrender="materialtype spaceoccupied">5 negatives, different houses</extent>
+                          <extent altrender="materialtype spaceoccupied">5 negatives</extent>
                         </physdesc>
                       </did>
+                      <odd>
+                        <p>(negatives of different houses)</p>
+                      </odd>
                     </c08>
                     <c08 level="file">
                       <did>
@@ -6288,9 +6291,12 @@
                           <unitdate type="inclusive" normal="1953" certainty="approximate">circa 1953</unitdate>
                         </unittitle>
                         <physdesc altrender="whole">
-                          <extent altrender="materialtype spaceoccupied">6 negatives, different houses</extent>
+                          <extent altrender="materialtype spaceoccupied">6 negatives</extent>
                         </physdesc>
                       </did>
+                      <odd>
+                        <p>(negatives of different houses)</p>
+                      </odd>
                     </c08>
                   </c07>
                   <c07 level="file">
@@ -7354,9 +7360,12 @@
                   <container type="box" label="Box">6</container>
                   <unittitle>Unidentified schools -- 1937 <unitdate type="inclusive" normal="1940/1949" certainty="approximate">circa 1940s</unitdate>, <unitdate type="inclusive" normal="1952">1952</unitdate></unittitle>
                   <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">5 negatives of 3 schools</extent>
+                    <extent altrender="materialtype spaceoccupied">5 negatives</extent>
                   </physdesc>
                 </did>
+                <odd>
+                  <p>(3 schools)</p>
+                </odd>
               </c05>
             </c04>
             <c04 level="otherlevel" otherlevel="sub-subseries">
@@ -12547,7 +12556,8 @@
                 <container type="box" label="Box">11</container>
                 <unittitle>Old West Side Association -- Picnic <unitdate type="inclusive" normal="1969-08-24">August 24, 1969</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">35 mm strip of 6 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">1 35 mm negative strips</extent>
+                  <extent altrender="carrier">6 negatives</extent>
                 </physdesc>
               </did>
               <odd>

--- a/Real_Masters_all/johnstondona.xml
+++ b/Real_Masters_all/johnstondona.xml
@@ -214,7 +214,7 @@
             <container type="box" label="Box">10</container>
             <unittitle>SAI Boot Camp responses, <unitdate type="inclusive" normal="2006/2012">2006-2012</unitdate> </unittitle>
             <physdesc>
-              <extent>1 folder</extent>
+              <extent>1 folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/kahnalb.xml
+++ b/Real_Masters_all/kahnalb.xml
@@ -2413,13 +2413,13 @@
             <did>
               <container type="volume" label="Volume">7</container>
               <unittitle>Photographs of exterior and interior by Hance</unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">7 prints</extent>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">2 not identified, but most probably of Cadillac Service Building</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(2 prints not identified, but most probably of Cadillac Service Building)</p>
+            </odd>
             <odd>
               <p>(building is located in Detroit, not in NY, as is noted on portfolio cover)</p>
             </odd>
@@ -2503,13 +2503,13 @@
             <did>
               <container type="volume" label="Volume">12</container>
               <unittitle>Photographs of exterior and interior by John Wallace Gillies, New York</unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">9 prints</extent>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">6 not identified, but most probably by Gillies</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(6 prints note identified, but most probably by Gillies)</p>
+            </odd>
           </c03>
         </c02>
         <c02 level="file">
@@ -2865,7 +2865,8 @@
                 <container type="volume" label="Volume">29</container>
                 <unittitle>Photos by Hance</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">59 prints and duplicates</extent>
+                  <extent altrender="materialtype spaceoccupied">59 prints</extent>
+                  <extent altrender="carrier">includes duplicates</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3124,13 +3125,13 @@
             <did>
               <container type="volume" label="Volume">7</container>
               <unittitle>Photographs of exterior and interior by John Wallace Gillies, New York</unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">11 prints</extent>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1 not identified, but is most probably by Gillies</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(1 print not identified, but most probably by Gillies)</p>
+            </odd>
           </c03>
         </c02>
         <c02 level="file">
@@ -4349,12 +4350,13 @@
               <container type="box" label="Box">1</container>
               <unittitle>Interior Hall <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1 and print</extent>
+                <extent altrender="materialtype spaceoccupied">1 prints</extent>
                 <physfacet>black and white</physfacet>
                 <dimensions>8x10-inch</dimensions>
               </physdesc>
               <physdesc altrender="part">
                 <extent altrender="materialtype spaceoccupied">1 prints</extent>
+                <physfacet>copy print</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -4376,13 +4378,13 @@
               <did>
                 <container type="box" label="Box">4</container>
                 <unittitle>3/19/1916-6/11/1916</unittitle>
-                <physdesc altrender="part">
+                <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">40 prints</extent>
                 </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">14 by Manning Bros., Commercial Photographers</extent>
-                </physdesc>
               </did>
+              <odd>
+                <p>(14 prints by Manning Bros., Commercial Photographers)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>
@@ -4505,7 +4507,7 @@
               <container type="box" label="Box">4</container>
               <unittitle>Construction of Building by Camera Craft Photographers <unitdate type="inclusive" normal="1917-10-26/1918-12-19">10/26/1917-12/19/1918</unitdate></unittitle>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">17 and prints</extent>
+                <extent altrender="materialtype spaceoccupied">17 prints</extent>
                 <physfacet>black and white</physfacet>
                 <dimensions>8x10-inch</dimensions>
               </physdesc>
@@ -4739,13 +4741,13 @@
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>By Manning Bros., Commercial Photographers <unitdate type="inclusive" normal="1920-12-23">12/23/1920</unitdate></unittitle>
-                <physdesc altrender="part">
+                <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">35 prints</extent>
                 </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">only 2 dated</extent>
-                </physdesc>
               </did>
+              <odd>
+                <p>(only 2 prints dates)</p>
+              </odd>
             </c04>
           </c03>
           <c03 level="file">
@@ -4883,18 +4885,15 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Construction of Building, 8/27/1930-4/21/1931</unittitle>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">prints</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">36 prints</extent>
                 <physfacet>black and white</physfacet>
                 <dimensions>7-1/2x 9-1/2-inch</dimensions>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">13 by N. L. Coe and Son</extent>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">23 by Irving Underhill, Photographer and Inc</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(13 prints by N. L. Coe and Son and 23 by Irving Underhill, Photographer and Inc.)</p>
+            </odd>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -4921,10 +4920,15 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Construction of Building by Hedrich-Blessing Studio <unitdate type="inclusive" normal="1932-05-23/1933-03-09">5/23/1932-3/9/1933</unitdate></unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">35 prints and 2; prints by unknown photographer</extent>
-                <physfacet>black and white; black and white</physfacet>
-                <dimensions>7-1/2x9-1/2-inch; 8x10-inch</dimensions>
+              <physdesc altrender="part">
+                <extent altrender="materialtype spaceoccupied">35 prints</extent>
+                <physfacet>black and white</physfacet>
+                <dimensions>7-1/2x9-1/2-inch</dimensions>
+              </physdesc>
+              <physdesc altrender="part">
+                <extent altrender="materialtype spaceoccupied">2 prints</extent>
+                <physfacet>black and white; by unknown photographer</physfacet>
+                <dimensions>8x10-inch</dimensions>
               </physdesc>
             </did>
           </c03>
@@ -4937,10 +4941,15 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Construction of Building by Kaufmann-Fabry Commercial Photographers, 2/26/1934-5/23/1934</unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">25 prints and 1 print by unknown photographer</extent>
-                <physfacet>black and white; black and white</physfacet>
-                <dimensions>7-1/2x9-1/2-inch; 8x10-inch</dimensions>
+              <physdesc altrender="part">
+                <extent altrender="materialtype spaceoccupied">25 prints</extent>
+                <physfacet>black and white</physfacet>
+                <dimensions>7-1/2x9-1/2-inch</dimensions>
+              </physdesc>
+              <physdesc altrender="part">
+                <extent altrender="materialtype spaceoccupied">1 prints</extent>
+                <physfacet>black and white; by unknown photographer</physfacet>
+                <dimensions>8x10-inch</dimensions>
               </physdesc>
             </did>
           </c03>
@@ -5132,9 +5141,13 @@
               <did>
                 <container type="box" label="Box">4</container>
                 <unittitle>(1) <unitdate type="inclusive" normal="1937-09-03/1938-01-07">9/3/1937-1/7/1938</unitdate></unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">30 prints and 1 print by Don Walker, Detroit News Airphoto</extent>
-                  <dimensions>7-1/2x9-1/2-inch; 8x10-inch</dimensions>
+                <physdesc altrender="part">
+                  <extent altrender="materialtype spaceoccupied">30 prints</extent>
+                  <dimensions>7-1/2x9-1/2-inch</dimensions>
+                </physdesc>
+                <physdesc altrender="part">
+                  <extent altrender="materialtype spaceoccupied">1 prints</extent>
+                  <dimensions>8x10-inch; by Don Walker, Detroit News Airphoto</dimensions>
                 </physdesc>
               </did>
             </c04>
@@ -5142,9 +5155,13 @@
               <did>
                 <container type="box" label="Box">4</container>
                 <unittitle>(2) 1/25/1938-4/26/1938</unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">25 prints and 3 prints by Fred Eggert</extent>
-                  <dimensions>7-1/2x9-1/2-inch; 8x10-inch</dimensions>
+                <physdesc altrender="part">
+                  <extent altrender="materialtype spaceoccupied">25 prints</extent>
+                  <dimensions>7-1/2x9-1/2-inch</dimensions>
+                </physdesc>
+                <physdesc altrender="part">
+                  <extent altrender="materialtype spaceoccupied">3 prints</extent>
+                  <dimensions>8x10-inch; by Fred Eggert</dimensions>
                 </physdesc>
               </did>
             </c04>
@@ -5253,9 +5270,13 @@
               <did>
                 <container type="box" label="Box">5</container>
                 <unittitle>(9) 6/17/1941-1/4/1943</unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">7 prints and 39 prints</extent>
-                  <dimensions>7x9-inch; 8x10-inch</dimensions>
+                <physdesc altrender="part">
+                  <extent altrender="materialtype spaceoccupied">7 prints</extent>
+                  <dimensions>7x9-inch</dimensions>
+                </physdesc>
+                <physdesc altrender="part">
+                  <extent altrender="materialtype spaceoccupied">39 prints</extent>
+                  <dimensions>8x10-inch</dimensions>
                 </physdesc>
               </did>
             </c04>
@@ -5850,18 +5871,15 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>Construction of Building by Eric J. Baker, Elizabeth, N. J.</unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">77 prints</extent>
                 <physfacet>black and white</physfacet>
                 <dimensions>7-1/2x9-1/2-inch</dimensions>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">64 by Baker</extent>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">13 by unknown photographers</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(64 prints by Baker; 13 prints by unknown photographers)</p>
+            </odd>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">10</container>
@@ -5885,10 +5903,15 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>Construction of Foundation by unknown photographer <unitdate type="inclusive" normal="1938-08-10/1938-08-30">8/10/1938-8/30/1938</unitdate></unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">25 prints and 4; prints</extent>
-                <physfacet>black and white; black and white</physfacet>
-                <dimensions>2-3/4x4-1/2 inch; 3x5-inch</dimensions>
+              <physdesc altrender="part">
+                <extent altrender="materialtype spaceoccupied">25 prints</extent>
+                <physfacet>black and white</physfacet>
+                <dimensions>2-3/4x4-1/2 inch</dimensions>
+              </physdesc>
+              <physdesc altrender="part">
+                <extent altrender="materialtype spaceoccupied">4 prints</extent>
+                <physfacet>black and white</physfacet>
+                <dimensions>3x5-inch</dimensions>
               </physdesc>
             </did>
           </c03>
@@ -5902,17 +5925,34 @@
               <container type="box" label="Box">10</container>
               <unittitle>Construction of Foundation by unknown photographer, 7/8/1929-10/23/1929</unittitle>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">5 1</extent>
-                <dimensions>4x6-1/4-inch; 4x13-inch</dimensions>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">7 1</extent>
-                <dimensions>6-1/4x9-inch; 6x26-inch</dimensions>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1 and 1; prints</extent>
+                <extent altrender="materialtype spaceoccupied">5 prints</extent>
                 <physfacet>black and white</physfacet>
-                <dimensions>5-1/2x17-inch; 6x17-1/2-inch</dimensions>
+                <dimensions>4x6-1/4-inch</dimensions>
+              </physdesc>
+              <physdesc altrender="part">
+                <extent altrender="materialtype spaceoccupied">1 prints</extent>
+                <physfacet>black and white</physfacet>
+                <dimensions>4x13-inch</dimensions>
+              </physdesc>
+              <physdesc altrender="part">
+                <extent altrender="materialtype spaceoccupied">7 prints</extent>
+                <physfacet>black and white</physfacet>
+                <dimensions>6-1/4x9-inch</dimensions>
+              </physdesc>
+              <physdesc altrender="part">
+                <extent altrender="materialtype spaceoccupied">1 prints</extent>
+                <physfacet>black and white</physfacet>
+                <dimensions>6x26-inch</dimensions>
+              </physdesc>
+              <physdesc altrender="part">
+                <extent altrender="materialtype spaceoccupied">1 prints</extent>
+                <physfacet>black and white</physfacet>
+                <dimensions>5-1/2x7-inch</dimensions>
+              </physdesc>
+              <physdesc altrender="part">
+                <extent altrender="materialtype spaceoccupied">1 prints</extent>
+                <physfacet>black and white</physfacet>
+                <dimensions>6x17-1/2-inch</dimensions>
               </physdesc>
             </did>
           </c03>
@@ -5920,18 +5960,15 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>Construction of Steel Structure, received by Albert Kahn, Inc. 7/24/1929-5/5/1930</unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">12 prints</extent>
                 <physfacet>black and white</physfacet>
                 <dimensions>8x10-inch</dimensions>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">9 by Santangelo Studio, Pottstown and PA</extent>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">3 by unknown photographer</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(9 prints by Santangelo Studio, Pottstown, PA; 3 prints by unknown photographer)</p>
+            </odd>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -5943,11 +5980,14 @@
               <container type="box" label="Box">10</container>
               <unittitle>Construction of Steel Structure, received by Albert Kahn, Inc.5/5/1930</unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">4 prints by The Conrad Studio and Allentown, PA</extent>
+                <extent altrender="materialtype spaceoccupied">4 prints</extent>
                 <physfacet>black and white</physfacet>
                 <dimensions>8x10-inch</dimensions>
               </physdesc>
             </did>
+            <odd>
+              <p>(Prints by the Conrad Studio, Allentown, PA)</p>
+            </odd>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -5958,10 +5998,20 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>Construction of Alterations and Addition, one dated <unitdate type="inclusive" normal="1941-10-21">10/21/1941</unitdate></unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">3 prints by Sheill and 6 prints by unknown photographer;1 print by unknown photographer</extent>
-                <physfacet>black and white; black and white; black and white</physfacet>
-                <dimensions>5x8-inch; 5x7-inch; 8x10-inch</dimensions>
+              <physdesc altrender="part">
+                <extent altrender="materialtype spaceoccupied">3 prints</extent>
+                <physfacet>black and white; by Sheill</physfacet>
+                <dimensions>5x8-inch</dimensions>
+              </physdesc>
+              <physdesc altrender="part">
+                <extent altrender="materialtype spaceoccupied">6 prints</extent>
+                <physfacet>black and white; by unknown photographer</physfacet>
+                <dimensions>5x7-inch</dimensions>
+              </physdesc>
+              <physdesc altrender="part">
+                <extent altrender="materialtype spaceoccupied">1 prints</extent>
+                <physfacet>black and white; by unknown photographer</physfacet>
+                <dimensions>8x10-inch</dimensions>
               </physdesc>
             </did>
           </c03>
@@ -10216,8 +10266,8 @@
                   <container type="tube" label="Tube">1</container>
                   <unittitle>Plot Plan</unittitle>
                   <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">2 drawings, and</extent>
-                    <dimensions>33x47 inches; 33x39 inches</dimensions>
+                    <extent altrender="materialtype spaceoccupied">2 drawings</extent>
+                    <dimensions>33x47 inches and 33x39 inches</dimensions>
                   </physdesc>
                 </did>
               </c05>
@@ -10938,13 +10988,13 @@
                   <container type="map-case" label="Drawer">10</container>
                   <container type="folder" label="Folder">10</container>
                   <unittitle>Front and Rear Elevations (7), revised <unitdate type="inclusive" normal="1911-05-30">5/30/1911</unitdate></unittitle>
-                  <physdesc altrender="part">
+                  <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 drawings</extent>
                   </physdesc>
-                  <physdesc altrender="part">
-                    <extent altrender="materialtype spaceoccupied">only 1 revised</extent>
-                  </physdesc>
                 </did>
+                <odd>
+                  <p>(only 1 drawing revised)</p>
+                </odd>
               </c05>
               <c05 level="file">
                 <did>
@@ -11361,13 +11411,13 @@
                   <container type="map-case" label="Drawer">8</container>
                   <container type="folder" label="Folder">4</container>
                   <unittitle>Foundation and Parquet Floor Plans (1), revised <unitdate type="inclusive" normal="1911-04-18">4/18/1911</unitdate></unittitle>
-                  <physdesc altrender="part">
+                  <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 drawings</extent>
                   </physdesc>
-                  <physdesc altrender="part">
-                    <extent altrender="materialtype spaceoccupied">only 1 revised</extent>
-                  </physdesc>
                 </did>
+                <odd>
+                  <p>(only 1 drawing revised)</p>
+                </odd>
               </c05>
               <c05 level="file">
                 <did>
@@ -23888,13 +23938,13 @@
                   <container type="map-case" label="Drawer">11</container>
                   <container type="folder" label="Folder">9</container>
                   <unittitle>Heating Riser Diagrams (27M-29M), revised <unitdate type="inclusive" normal="1928-08-27">8/27/1928</unitdate></unittitle>
-                  <physdesc altrender="part">
+                  <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">3 drawings</extent>
                   </physdesc>
-                  <physdesc altrender="part">
-                    <extent altrender="materialtype spaceoccupied">only 1 revised</extent>
-                  </physdesc>
                 </did>
+                <odd>
+                  <p>(only 1 drawing revised)</p>
+                </odd>
               </c05>
               <c05 level="file">
                 <did>
@@ -24335,8 +24385,8 @@
                   <container type="folder" label="Folder">4</container>
                   <unittitle>Detail of Ducts thru' Telegraph Office, Schemes A &amp; B (103M &amp; 104M) <unitdate type="inclusive" normal="1928-04-06">4/6/1928</unitdate></unittitle>
                   <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">2 drawings, &amp;</extent>
-                    <dimensions>25-3/4x29-1/2; 25-1/2x30 inches</dimensions>
+                    <extent altrender="materialtype spaceoccupied">2 drawings</extent>
+                    <dimensions>25-3/4x29-1/2 and 25-1/2x30 inches</dimensions>
                   </physdesc>
                 </did>
               </c05>

--- a/Real_Masters_all/kahnalb.xml
+++ b/Real_Masters_all/kahnalb.xml
@@ -4411,7 +4411,7 @@
               <container type="box" label="Box">1</container>
               <unittitle>Construction of Building <unitdate type="inclusive" normal="1914-05-19/1915-04-05">5/19/1914-4/5/1915</unitdate></unittitle>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">22</extent>
+                <extent altrender="materialtype spaceoccupied">22 prints</extent>
                 <dimensions>7-1/2x9-1/2-inch</dimensions>
               </physdesc>
               <physdesc altrender="part">
@@ -4613,13 +4613,13 @@
               <did>
                 <container type="box" label="Box">1</container>
                 <unittitle>(2) 7/14/1919-8/11/1919</unittitle>
-                <physdesc altrender="part">
+                <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">39 prints</extent>
                 </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">1 by Alliance Commercial Photo Co</extent>
-                </physdesc>
               </did>
+              <odd>
+                <p>(1 print by Alliance Commercial Photo Co)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>
@@ -4790,11 +4790,11 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>(1) <unitdate type="inclusive" normal="1923-04-11/1923-10-01">4/11/1923-10/1/1923</unitdate></unittitle>
                 <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">22</extent>
+                  <extent altrender="materialtype spaceoccupied">22 prints</extent>
                   <dimensions>7-1/2x9-1/2-inch</dimensions>
                 </physdesc>
                 <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">1</extent>
+                  <extent altrender="materialtype spaceoccupied">1 prints</extent>
                   <dimensions>7-1/2x18-inch</dimensions>
                 </physdesc>
                 <physdesc altrender="part">
@@ -5290,11 +5290,14 @@
             <did>
               <unittitle>Construction of Plant</unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">814 prints by unknown photographer</extent>
+                <extent altrender="materialtype spaceoccupied">814 prints</extent>
                 <physfacet>black and white</physfacet>
                 <dimensions>8x10-inch</dimensions>
               </physdesc>
             </did>
+            <odd>
+              <p>(prints by unknown photographer)</p>
+            </odd>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">5</container>
@@ -5335,13 +5338,13 @@
               <did>
                 <container type="box" label="Box">5</container>
                 <unittitle>(5) #165-194, Late Summer 1941-10/21/1941</unittitle>
-                <physdesc altrender="part">
+                <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">39 prints</extent>
                 </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">10 without numbers by Stegeman</extent>
-                </physdesc>
               </did>
+              <odd>
+                <p>(10 prints without numbers by Stegeman)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/kahnfam.xml
+++ b/Real_Masters_all/kahnfam.xml
@@ -365,7 +365,7 @@ Albert Kahn Family Papers, Bentley Historical Library, University of Michigan</p
               <container type="box" label="Box">1</container>
               <unittitle>Edgar Kahn's Trip to Bilbao, Spain <unitdate type="inclusive" normal="1940">1940</unitdate></unittitle>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">5 and prints</extent>
+                <extent altrender="materialtype spaceoccupied">5 prints</extent>
                 <physfacet>black and white</physfacet>
                 <dimensions>8x10-inch</dimensions>
               </physdesc>
@@ -402,13 +402,11 @@ Albert Kahn Family Papers, Bentley Historical Library, University of Michigan</p
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>Albert Kahn <unitdate type="inclusive" normal="1941-11-03">11/3/1941</unitdate></unittitle>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1 and original</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 prints</extent>
+                <extent altrender="carrier">1 original print and 1 copy print</extent>
                 <physfacet>black and white</physfacet>
                 <dimensions>8x10-inch</dimensions>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1 prints</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/kauschjk.xml
+++ b/Real_Masters_all/kauschjk.xml
@@ -736,7 +736,7 @@ Jack Kausch collection, Bentley Historical Library, University of Michigan</p>
               <container type="box" label="Box">5</container>
               <unittitle><unitdate type="inclusive" normal="1980">1980</unitdate> Mag</unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">16 mm film reel</extent>
+                <extent altrender="materialtype spaceoccupied">1 16 mm film reels</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/kelseymu.xml
+++ b/Real_Masters_all/kelseymu.xml
@@ -3274,7 +3274,7 @@
         <did>
           <unittitle>Institute for Archaeological Research records <unitdate type="inclusive" encodinganalog="245$f" normal="1924/1949">1924-1949</unitdate></unittitle>
           <physdesc altrender="whole">
-            <extent altrender="materialtype spaceoccupied">2 linear feet and 11 inches</extent>
+            <extent altrender="materialtype spaceoccupied">2.9 linear feet</extent>
           </physdesc>
         </did>
         <scopecontent encodinganalog="520">

--- a/Real_Masters_all/kennedycg.xml
+++ b/Real_Masters_all/kennedycg.xml
@@ -3221,7 +3221,8 @@ Cornelia G. Kennedy papers, Bentley Historical Library, University of Michigan</
               <container type="box" label="Box">30</container>
               <unittitle><unitdate type="inclusive" normal="2001/2002">2001-2002</unitdate>, <unitdate type="inclusive" normal="2003/2004">2003-2004</unitdate>, <unitdate type="inclusive" normal="2005/2006">2005-2006</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">3 bound, hardcover volumes</extent>
+                <extent altrender="materialtype spaceoccupied">3 volumes</extent>
+                <physfacet>bound, hardcover</physfacet>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/langlands.xml
+++ b/Real_Masters_all/langlands.xml
@@ -42,7 +42,8 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Papers of Charlotte Langlands (1927-), member of Collegiate Sorosis. It includes records of Collegiate Sorosis, photographs, scrapbooks, and books. The collection also contains items from Langlands' first husband, Thomas Kuzma, that relate to his friendship with Tom Harmon.</abstract>
       <physdesc altrender="whole">
-        <extent altrender="materialtype spaceoccupied">1.4 linear feet including 1 oversize box</extent>
+        <extent altrender="materialtype spaceoccupied">1.4 linear feet</extent>
+        <extent altrender="carrier">includes 1 oversize box</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/macadamb.xml
+++ b/Real_Masters_all/macadamb.xml
@@ -991,9 +991,12 @@ Barbara MacAdam papers, Bentley Historical Library, University of Michigan</p>
               <container type="box" label="Box">7</container>
               <unittitle>Symposium <unitdate type="inclusive" normal="1987/1988">1987-1988</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2 folders, includes negatives</extent>
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <odd>
+              <p>(includes negatives)</p>
+            </odd>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/matthaei.xml
+++ b/Real_Masters_all/matthaei.xml
@@ -1786,17 +1786,23 @@ Matthaei Botanical Gardens (University of Michigan) records, Bentley Historical 
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">6</container>
-                  <unittitle>Seeds <unitdate type="inclusive" normal="1930/1946">1930-1946</unitdate> (special requests)</unittitle>
+                  <unittitle>Seeds <unitdate type="inclusive" normal="1930/1946">1930-1946</unitdate></unittitle>
                 </did>
+                <odd>
+                  <p>(special requests)</p>
+                </odd>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">6</container>
                   <unittitle>Species <unitdate type="inclusive" normal="1914/1927">1914-1927</unitdate></unittitle>
                   <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">13 folders, arranged alphabetically by plant name</extent>
+                    <extent altrender="materialtype spaceoccupied">13 folders</extent>
                   </physdesc>
                 </did>
+                <odd>
+                  <p>(folders arranged alphabetically by plant name)</p>
+                </odd>
               </c05>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/mcook.xml
+++ b/Real_Masters_all/mcook.xml
@@ -1161,18 +1161,15 @@ Martha Cook Building (University of Michigan) Records, Bentley Historical Librar
         <c02 level="file">
           <did>
             <container type="box" label="Box">5</container>
-            <unittitle>Negatives <unitdate type="inclusive" normal="1965-10">October 1965</unitdate></unittitle>
-            <physdesc altrender="part">
+            <unittitle>Negatives by U-M News Service <unitdate type="inclusive" normal="1965-10">October 1965</unitdate></unittitle>
+            <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">109 negatives</extent>
-              <extent altrender="carrier">(in 20 strips, of furnishings and architecture; people)</extent>
-            </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">activities</extent>
-            </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">10/1965 by U-M News Service</extent>
+              <extent altrender="carrier">(in 20 strips)</extent>
             </physdesc>
           </did>
+          <odd>
+            <p>(includes furnishing, architecture, people, and activities)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -1191,7 +1188,7 @@ Martha Cook Building (University of Michigan) Records, Bentley Historical Librar
                   <container type="box" label="Box">5</container>
                   <unittitle>General</unittitle>
                   <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">14 images, mostly</extent>
+                    <extent altrender="materialtype spaceoccupied">14 images</extent>
                     <physfacet>black and white</physfacet>
                     <dimensions>8x10</dimensions>
                   </physdesc>
@@ -1201,15 +1198,15 @@ Martha Cook Building (University of Michigan) Records, Bentley Historical Librar
                 <did>
                   <container type="box" label="Box">5</container>
                   <unittitle>Construction views</unittitle>
-                  <physdesc altrender="part">
-                    <extent altrender="materialtype spaceoccupied">9 images; mostly</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">9 images</extent>
                     <physfacet>black and white</physfacet>
                     <dimensions>8x10</dimensions>
                   </physdesc>
-                  <physdesc altrender="part">
-                    <extent altrender="materialtype spaceoccupied">see na 9281-9282</extent>
-                  </physdesc>
                 </did>
+                <odd>
+                  <p>(see na 9281-9282)</p>
+                </odd>
               </c05>
             </c04>
             <c04 level="file">
@@ -1221,7 +1218,7 @@ Martha Cook Building (University of Michigan) Records, Bentley Historical Librar
                   <container type="box" label="Box">5</container>
                   <unittitle>Corridor, Right</unittitle>
                   <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">4 images, mostly</extent>
+                    <extent altrender="materialtype spaceoccupied">4 images</extent>
                     <physfacet>black and white</physfacet>
                     <dimensions>7x9</dimensions>
                   </physdesc>
@@ -1254,7 +1251,7 @@ Martha Cook Building (University of Michigan) Records, Bentley Historical Librar
                   <container type="box" label="Box">5</container>
                   <unittitle>Large Parlor (Blue/Gold Room)</unittitle>
                   <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">8 images, mostly</extent>
+                    <extent altrender="materialtype spaceoccupied">8 images</extent>
                     <physfacet>black and white</physfacet>
                     <dimensions>8x10</dimensions>
                   </physdesc>
@@ -1283,31 +1280,28 @@ Martha Cook Building (University of Michigan) Records, Bentley Historical Librar
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Costumes</unittitle>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">11</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">11 images</extent>
                 <physfacet>black and white</physfacet>
                 <dimensions>4x6</dimensions>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">see na 9280</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(see na 9280)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Garden</unittitle>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">19 images; mostly &amp;</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">19 images</extent>
                 <physfacet>black and white</physfacet>
                 <dimensions>8x10; 5x7</dimensions>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">see na 9283</extent>
-              </physdesc>
             </did>
             <odd>
-              <p>(includes gardens of Martha Cook Building and Condon House)</p>
+              <p>(includes gardens of Martha Cook Building and Condon House; see na 9283)</p>
             </odd>
           </c03>
           <c03 level="file">
@@ -1315,11 +1309,12 @@ Martha Cook Building (University of Michigan) Records, Bentley Historical Librar
               <container type="box" label="Box">5</container>
               <unittitle>Groups</unittitle>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">6</extent>
+                <extent altrender="materialtype spaceoccupied">6 images</extent>
                 <physfacet>black and white</physfacet>
+                <dimensions>8x10</dimensions>
               </physdesc>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1; mostly</extent>
+                <extent altrender="materialtype spaceoccupied">1 images</extent>
                 <physfacet>color</physfacet>
                 <dimensions>8x10</dimensions>
               </physdesc>
@@ -1330,12 +1325,12 @@ Martha Cook Building (University of Michigan) Records, Bentley Historical Librar
               <container type="box" label="Box">5</container>
               <unittitle>Individuals</unittitle>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">12 images of varying size</extent>
+                <extent altrender="materialtype spaceoccupied">12 images</extent>
                 <physfacet>black and white</physfacet>
               </physdesc>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">23 proofs, approx</extent>
-                <dimensions>2x2-1/2</dimensions>
+                <extent altrender="materialtype spaceoccupied">23 proofs</extent>
+                <dimensions>approx. 2x2-1/2</dimensions>
               </physdesc>
             </did>
           </c03>
@@ -1343,25 +1338,28 @@ Martha Cook Building (University of Michigan) Records, Bentley Historical Librar
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>May Day Party <unitdate type="inclusive" normal="1928-05-26">May 26, 1928</unitdate></unittitle>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">41 images, mostly &amp; ;collage</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">41 images</extent>
                 <physfacet>black and white</physfacet>
                 <dimensions>4x5; 2x4</dimensions>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">see na 9278-9279</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(see na 9278-9279)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Sculptures</unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">5 images of Portia, varying size</extent>
+                <extent altrender="materialtype spaceoccupied">5 images</extent>
                 <physfacet>black and white</physfacet>
               </physdesc>
             </did>
+            <odd>
+              <p>(images of Portia)</p>
+            </odd>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/mcrc.xml
+++ b/Real_Masters_all/mcrc.xml
@@ -970,13 +970,13 @@
               <did>
                 <container type="box" label="Box">5</container>
                 <unittitle>"Lima Center Township Hall, redevelopment study," <unitdate type="inclusive" normal="1974">1974</unitdate></unittitle>
-                <physdesc altrender="part">
+                <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 folders</extent>
                 </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">includes 8 architects drawings</extent>
-                </physdesc>
               </did>
+              <odd>
+                <p>(includes 8 architects drawings)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/meamum.xml
+++ b/Real_Masters_all/meamum.xml
@@ -1802,8 +1802,11 @@ Department of Mechanical Engineering (University of Michigan) records, Bentley H
           <did>
             <container type="box" label="Box">15</container>
             <unittitle>35 mm slides <unitdate type="inclusive">undated</unitdate></unittitle>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">24 containers and binder</extent>
+            <physdesc altrender="part">
+              <extent altrender="materialtype spaceoccupied">24 containers</extent>
+            </physdesc>
+            <physdesc altrender="part">
+              <extent altrender="materialtype spaceoccupied">1 binders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/medschl.xml
+++ b/Real_Masters_all/medschl.xml
@@ -27929,7 +27929,7 @@
                 <container type="box" label="Box">136</container>
                 <unittitle>Histology Classes</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">3 items including 1 Gibson print</extent>
+                  <extent altrender="materialtype spaceoccupied">3 items</extent>
                 </physdesc>
                 <dao href="87253-G-8" show="new" actuate="onrequest">
                   <daodesc>
@@ -27937,6 +27937,9 @@
                   </daodesc>
                 </dao>
               </did>
+              <odd>
+                <p>(includes 1 Gibson print)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>
@@ -27946,11 +27949,8 @@
                 <did>
                   <container type="box" label="Box">136</container>
                   <unittitle>Amphitheater Views, Dissections</unittitle>
-                  <physdesc altrender="part">
+                  <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">6 items</extent>
-                  </physdesc>
-                  <physdesc altrender="part">
-                    <extent altrender="materialtype spaceoccupied">including 4 Gibson prints</extent>
                   </physdesc>
                   <dao href="87253-G-6" show="new" actuate="onrequest">
                     <daodesc>
@@ -27958,28 +27958,28 @@
                     </daodesc>
                   </dao>
                 </did>
+                <odd>
+                  <p>(includes 4 Gibson prints)</p>
+                </odd>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">136</container>
                   <unittitle>Groups, formal</unittitle>
-                  <physdesc altrender="part">
+                  <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">5 items</extent>
                   </physdesc>
-                  <physdesc altrender="part">
-                    <extent altrender="materialtype spaceoccupied">including 3 Gibson prints</extent>
-                  </physdesc>
                 </did>
+                <odd>
+                  <p>(includes 3 Gibson prints)</p>
+                </odd>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">136</container>
                   <unittitle>Groups, informal</unittitle>
-                  <physdesc altrender="part">
+                  <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">5 items</extent>
-                  </physdesc>
-                  <physdesc altrender="part">
-                    <extent altrender="materialtype spaceoccupied">including 3 Gibson prints</extent>
                   </physdesc>
                   <dao href="87253-G-7" show="new" actuate="onrequest">
                     <daodesc>
@@ -27987,6 +27987,9 @@
                     </daodesc>
                   </dao>
                 </did>
+                <odd>
+                  <p>(includes 3 Gibson prints)</p>
+                </odd>
               </c05>
             </c04>
           </c03>
@@ -29357,7 +29360,7 @@
                 <container type="box" label="Box">136</container>
                 <unittitle>Histology Classes</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">3 items including 1 Gibson print</extent>
+                  <extent altrender="materialtype spaceoccupied">3 items</extent>
                 </physdesc>
                 <dao href="87253-G-8" show="new" actuate="onrequest">
                   <daodesc>
@@ -29365,6 +29368,9 @@
                   </daodesc>
                 </dao>
               </did>
+              <odd>
+                <p>(includes 1 Gibson print)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>
@@ -29374,11 +29380,8 @@
                 <did>
                   <container type="box" label="Box">136</container>
                   <unittitle>Amphitheater Views, Dissections</unittitle>
-                  <physdesc altrender="part">
+                  <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">6 items</extent>
-                  </physdesc>
-                  <physdesc altrender="part">
-                    <extent altrender="materialtype spaceoccupied">including 4 Gibson prints</extent>
                   </physdesc>
                   <dao href="87253-G-6" show="new" actuate="onrequest">
                     <daodesc>
@@ -29386,28 +29389,28 @@
                     </daodesc>
                   </dao>
                 </did>
+                <odd>
+                  <p>(includes 4 Gibson prints)</p>
+                </odd>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">136</container>
                   <unittitle>Groups, formal</unittitle>
-                  <physdesc altrender="part">
+                  <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">5 items</extent>
                   </physdesc>
-                  <physdesc altrender="part">
-                    <extent altrender="materialtype spaceoccupied">including 3 Gibson prints</extent>
-                  </physdesc>
                 </did>
+                <odd>
+                  <p>(includes 3 Gibson prints)</p>
+                </odd>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">136</container>
                   <unittitle>Groups, informal</unittitle>
-                  <physdesc altrender="part">
+                  <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">5 items</extent>
-                  </physdesc>
-                  <physdesc altrender="part">
-                    <extent altrender="materialtype spaceoccupied">including 3 Gibson prints</extent>
                   </physdesc>
                   <dao href="87253-G-7" show="new" actuate="onrequest">
                     <daodesc>
@@ -29415,6 +29418,9 @@
                     </daodesc>
                   </dao>
                 </did>
+                <odd>
+                  <p>(includes 3 Gibson prints)</p>
+                </odd>
               </c05>
             </c04>
           </c03>

--- a/Real_Masters_all/medthes.xml
+++ b/Real_Masters_all/medthes.xml
@@ -49,7 +49,8 @@
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">87223 Bimu C53 2</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
-        <extent altrender="materialtype spaceoccupied">57 rolls of microfilm: 1449 theses</extent>
+        <extent altrender="materialtype spaceoccupied">57 microfilms</extent>
+        <extent altrender="carrier">1449 theses</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/michcitizen.xml
+++ b/Real_Masters_all/michcitizen.xml
@@ -139,7 +139,7 @@
               <unitdate type="inclusive" normal="1978/1994">1978-1994</unitdate>
             </unittitle>
             <physdesc>
-              <extent>5 microfilm reels</extent>
+              <extent>5 microfilms</extent>
             </physdesc>
           </did>
           <accessrestrict>

--- a/Real_Masters_all/miforens.xml
+++ b/Real_Masters_all/miforens.xml
@@ -9443,7 +9443,7 @@ Michigan Interscholastic Forensic Association records, Bentley Historical Librar
               <container type="box" label="Box">50</container>
               <unittitle>Debate Final Class C/D <unitdate type="inclusive" normal="1999/2000">1999-2000</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2 tapes, VHS videotape</extent>
+                <extent altrender="materialtype spaceoccupied">2 VHS Tapes</extent>
               </physdesc>
             </did>
           </c03>
@@ -9464,7 +9464,7 @@ Michigan Interscholastic Forensic Association records, Bentley Historical Librar
               <container type="box" label="Box">50</container>
               <unittitle>C/D Debate Finals <unitdate type="inclusive" normal="2000/2001">2000-2001</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2 tapes, VHS videotape</extent>
+                <extent altrender="materialtype spaceoccupied">2 VHS Tapes</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/milliken.xml
+++ b/Real_Masters_all/milliken.xml
@@ -16600,7 +16600,7 @@
           <did>
             <unittitle>Special Letters <unitdate type="inclusive" normal="1979/1982">1979-1982</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">3.f linear feet</extent>
+              <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
             </physdesc>
           </did>
           <scopecontent>

--- a/Real_Masters_all/milliken.xml
+++ b/Real_Masters_all/milliken.xml
@@ -49877,54 +49877,72 @@
                       <container type="box" label="Box">806</container>
                       <unittitle><unitdate type="inclusive" normal="1980">1980</unitdate> Winter, February 24-26</unittitle>
                       <physdesc altrender="whole">
-                        <extent altrender="materialtype spaceoccupied">3 folders, including Executive Committee Meeting</extent>
+                        <extent altrender="materialtype spaceoccupied">3 folders</extent>
                       </physdesc>
                     </did>
+                    <odd>
+                      <p>(includes Executive Committee Meetings</p>
+                    </odd>
                   </c07>
                   <c07 level="file">
                     <did>
                       <container type="box" label="Box">807</container>
                       <unittitle><unitdate type="inclusive" normal="1980">1980</unitdate> Summer, August 3-5</unittitle>
                       <physdesc altrender="whole">
-                        <extent altrender="materialtype spaceoccupied">8 folders, including Executive Committee Meetings and Policy Research Board</extent>
+                        <extent altrender="materialtype spaceoccupied">8 folders</extent>
                       </physdesc>
                     </did>
+                    <odd>
+                      <p>(includes Executive Committee Meetings and Policy Research Board)</p>
+                    </odd>
                   </c07>
                   <c07 level="file">
                     <did>
                       <container type="box" label="Box">807</container>
                       <unittitle><unitdate type="inclusive" normal="1981">1981</unitdate> Winter, February 22-25</unittitle>
                       <physdesc altrender="whole">
-                        <extent altrender="materialtype spaceoccupied">6 folders, including Executive Committee Meetings and Policy Research Board</extent>
+                        <extent altrender="materialtype spaceoccupied">6 folders</extent>
                       </physdesc>
                     </did>
+                    <odd>
+                      <p>(includes Executive Committee Meetings and Policy Research Board)</p>
+                    </odd>
                   </c07>
                   <c07 level="file">
                     <did>
                       <container type="box" label="Box">807</container>
                       <unittitle><unitdate type="inclusive" normal="1981">1981</unitdate> Summer, August 9-11</unittitle>
                       <physdesc altrender="whole">
-                        <extent altrender="materialtype spaceoccupied">4 folders, including Executive Committee Meetings and Policy Research Board</extent>
+                        <extent altrender="materialtype spaceoccupied">4 folders</extent>
                       </physdesc>
                     </did>
+                    <odd>
+                      <p>(includes Executive Committee Meetings and Policy Research Board)</p>
+                    </odd>
                   </c07>
                   <c07 level="file">
                     <did>
                       <container type="box" label="Box">807</container>
                       <unittitle><unitdate type="inclusive" normal="1982">1982</unitdate> Winter, February 21-23</unittitle>
                       <physdesc altrender="whole">
-                        <extent altrender="materialtype spaceoccupied">4 folders, including Executive Committee Meetings and Policy Research Board</extent>
+                        <extent altrender="materialtype spaceoccupied">4 folders</extent>
                       </physdesc>
                     </did>
+                    <odd>
+                      <p>(includes Executive Committee Meetings and Policy Research Board)</p>
+                    </odd>
                   </c07>
                   <c07 level="file">
                     <did>
                       <container type="box" label="Box">807</container>
                       <unittitle><unitdate type="inclusive" normal="1982">1982</unitdate> Summer, August 8-10</unittitle>
                       <physdesc altrender="whole">
-                        <extent altrender="materialtype spaceoccupied">4 folders, including Executive Committee Meeting</extent>
+                        <extent altrender="materialtype spaceoccupied">4 folders</extent>
                       </physdesc>
                     </did>
+                    <odd>
+                      <p>(includes Executive Committee Meetings)</p>
+                    </odd>
                   </c07>
                 </c06>
                 <c06 level="file">

--- a/Real_Masters_all/mohr.xml
+++ b/Real_Masters_all/mohr.xml
@@ -76,7 +76,7 @@
         <extent altrender="carrier">(in 14 boxes)</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">1 oversize folder</extent>
+        <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of

--- a/Real_Masters_all/mooreev.xml
+++ b/Real_Masters_all/mooreev.xml
@@ -422,8 +422,9 @@
               <container type="box" label="Box">3</container>
               <unittitle>University of Michigan School of Music assorted recordings <unitdate type="inclusive" normal="1974/1979">1974-1979</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">5 phonograph records, 7.5 inches</extent>
+                <extent altrender="materialtype spaceoccupied">5 phonograph records</extent>
                 <physfacet>33 1/3 rpm</physfacet>
+                <dimensions>7.5 inches</dimensions>
               </physdesc>
             </did>
           </c03>
@@ -567,9 +568,12 @@
                 <container type="folder" label="Oversize Folder">1</container>
                 <unittitle>Junior Hop <unitdate type="inclusive" normal="1911">1911</unitdate>, <unitdate type="inclusive" normal="1912">1912</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">2 photo albums from Phi Delta Theta fraternity's classes of 1912 and 1913</extent>
+                  <extent altrender="materialtype spaceoccupied">2 volumes</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(photo albums from Phi Delta Theta fraternity's classes of 1912 and 1913)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/muschba.xml
+++ b/Real_Masters_all/muschba.xml
@@ -61411,7 +61411,8 @@ YDA.1986.004.02865</unitid>
                 <container type="box" label="Box">B10</container>
                 <unittitle>Photographs</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">50 prints with 35mm negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">50 prints</extent>
+                  <extent altrender="carrier">with 35mm negatives</extent>
                   <physfacet>color; approximate</physfacet>
                 </physdesc>
               </did>

--- a/Real_Masters_all/muschba.xml
+++ b/Real_Masters_all/muschba.xml
@@ -16266,13 +16266,10 @@ YDA.1986.004.00674</unitid>
             <c04 level="otherlevel" otherlevel="sub-sub-subseries">
               <did>
                 <unittitle>Drawings, #.00801-.00820 <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
-                <physdesc altrender="part">
+                <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">20 drawings</extent>
                   <physfacet>pencil on tracing paper</physfacet>
-                </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">or smaller</extent>
-                  <dimensions>62.2 x 61 cm.; 24-1/2 x 24 inches</dimensions>
+                  <dimensions>62.2 x 61 cm. (24-1/2 x 24 inches) or smaller</dimensions>
                 </physdesc>
               </did>
               <c05 level="file">
@@ -39016,24 +39013,13 @@ YDA.1986.004.01993</unitid>
                 <unittitle>Drawings, #.02020-.02026</unittitle>
                 <physdesc altrender="part">
                   <extent altrender="materialtype spaceoccupied">7 sheets</extent>
-                </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">or smaller. This set consists of 2 pencil on paper</extent>
-                  <dimensions>55 x 86.5 cm.; 21-5/8 x 34-1/8 inches</dimensions>
-                </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">2 blueprints</extent>
-                  <physfacet>blueprints with pastel</physfacet>
-                </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">2 drawings</extent>
-                  <physfacet>pencil on paper</physfacet>
-                </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">1 drawings</extent>
-                  <physfacet>blueline print on paper</physfacet>
+                  <physfacet>various media</physfacet>
+                  <dimensions>55 x 86.5 cm (21-5/8 x 34-1/8 in.) or smaller</dimensions>
                 </physdesc>
               </did>
+              <odd>
+                <p>(This set consists of 2 pencil on paper, 2 blueprints with pastel, 2 pencil on paper, and 1 blueline print on paper.)</p>
+              </odd>
               <c05 level="file">
                 <did>
                   <physloc>Avery</physloc>
@@ -63976,15 +63962,10 @@ YDA.1986.004.02865</unitid>
           <c03 level="file">
             <did>
               <container type="box" label="Box">B9</container>
-              <unittitle>Notes: Engineering Mechanics War Training Course</unittitle>
-              <physdesc altrender="part">
+              <unittitle>Notes: Engineering Mechanics War Training Course, <unitdate type="inclusive" normal="1934/1936">1934-1936</unitdate></unittitle>
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">volumes</extent>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1934-1936</extent>
+                <extent altrender="carrier">contents of 2 notebooks</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/muschen.xml
+++ b/Real_Masters_all/muschen.xml
@@ -2117,15 +2117,10 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">9</container>
-            <unittitle>Notes: Engineering Mechanics War Training Course</unittitle>
-            <physdesc altrender="part">
+            <unittitle>Notes: Engineering Mechanics War Training Course, <unitdate type="inclusive" normal="1934/1936">1934-1936</unitdate></unittitle>
+            <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 folders</extent>
-            </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">volumes</extent>
-            </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">1934-1936</extent>
+              <extent altrender="carrier">contents of 2 notebooks</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/nisbettf.xml
+++ b/Real_Masters_all/nisbettf.xml
@@ -329,7 +329,7 @@ Nisbett Family papers, Bentley Historical Library, University of Michigan</p>
             <container type="box" label="Box">1</container>
             <unittitle>"Personal reminiscences of Pontiac, Mich. in the 1860s and 1870s" <unitdate type="inclusive">undated</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">19 p</extent>
+              <extent altrender="materialtype spaceoccupied">19 pages</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/nisphoto.xml
+++ b/Real_Masters_all/nisphoto.xml
@@ -5414,8 +5414,8 @@ University of Michigan News and Information Services Photographs, Bentley Histor
       <c01 level="series">
         <did>
           <unittitle>Series C <unitdate type="inclusive" normal="1961/1997">1961-1997</unitdate></unittitle>
-          <physdesc altrender="whole">
-            <extent altrender="materialtype spaceoccupied">35mm negatives</extent>
+          <physdesc>
+            <physfacet>35mm negatives</physfacet>
           </physdesc>
         </did>
         <scopecontent>
@@ -15822,9 +15822,12 @@ University of Michigan News and Information Services Photographs, Bentley Histor
               <unitdate type="inclusive" normal="1995-01-23">January 23, 1995</unitdate>
             </unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">2 folders, includes extra prints</extent>
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
+          <odd>
+            <p>(includes extra prints)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -16073,9 +16076,12 @@ University of Michigan News and Information Services Photographs, Bentley Histor
               <unitdate type="inclusive" normal="1996-03-26">March 26, 1996</unitdate>
             </unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">2 folders, includes prints not used</extent>
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
+          <odd>
+            <p>(includes prints not used)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/nispodcast.xml
+++ b/Real_Masters_all/nispodcast.xml
@@ -2144,10 +2144,9 @@ The collection is divided into four series: Audio Materials, Video Materials, Au
               <container type="box" label="Box">5</container>
               <unittitle>Interviews shortly before and during the 1980 reunion of UM Symphony Band members who toured the Soviet Union in 1961.</unittitle>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">4 audiotapes (reel-to-reel</extent>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">7-inch</extent>
+                <extent altrender="materialtype spaceoccupied">4 audiotapes</extent>
+                <physfacet>reel-to-reels</physfacet>
+                <dimensions>7-inch</dimensions>
               </physdesc>
               <abstract>Interviews include William Revelli, Donald Sinta, George Cavendish and Fred Moncrieff. Fred was director of the UM News Service in 1961 and traveled with the band.</abstract>
             </did>

--- a/Real_Masters_all/odellfc.xml
+++ b/Real_Masters_all/odellfc.xml
@@ -278,12 +278,15 @@
             <container type="folder" label="Folder">11</container>
             <unittitle>Territory from <geogname normal="Lyavalya (Russia)">Lyavalya</geogname> to <geogname normal="Konetsbor (Russia)">Konetsbor</geogname>, south of Dvina River, <unitdate>undated</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">8 sheets (of a 10 sheet map ?</extent>
+              <extent altrender="materialtype spaceoccupied">8 sheets</extent>
             </physdesc>
             <physdesc>
               <physfacet>Scale 1:20,000</physfacet>
             </physdesc>
           </did>
+          <odd>
+            <p>(8 sheets of a 10 sheet map?)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/oslerdav.xml
+++ b/Real_Masters_all/oslerdav.xml
@@ -450,13 +450,13 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Evergreen North Housing for the Elderly <unitdate type="inclusive">undated</unitdate></unittitle>
-            <physdesc altrender="part">
+            <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 prints</extent>
             </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">1 by Balthazar Korab</extent>
-            </physdesc>
           </did>
+          <odd>
+            <p>(1 print by Balthazar Korab)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -564,23 +564,26 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Independence Lake Park Pavilions and Meeting Center, Washtenaw County <unitdate type="inclusive">undated</unitdate></unittitle>
-            <physdesc altrender="part">
+            <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">6 prints</extent>
             </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">1 by Greg Hursley</extent>
-            </physdesc>
           </did>
+          <odd>
+            <p>(1 print by Greg Hursley)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Kahler, Dr. &amp; Mrs. Frank W., Residence, Ann Arbor <unitdate type="inclusive" normal="2014-03">March 2014</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">40 thumbnail prints by Rapattoni Corporation</extent>
-              <physfacet>color</physfacet>
+              <extent altrender="materialtype spaceoccupied">40 prints</extent>
+              <physfacet>color; thumbnail prints</physfacet>
             </physdesc>
           </did>
+          <odd>
+            <p>(prints by Rapattoni Corporation)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -658,40 +661,37 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Mill Creek Low-Income Housing, Ann Arbor <unitdate type="inclusive">undated</unitdate></unittitle>
-            <physdesc altrender="part">
+            <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 prints</extent>
             </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">1 by Greg Hursley</extent>
-            </physdesc>
           </did>
+          <odd>
+            <p>(1 print by Greg Hursley)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Mundus Residence, Ann Arbor <unitdate type="inclusive">undated</unitdate></unittitle>
-            <physdesc altrender="part">
+            <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 prints</extent>
             </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">1 by Greg Hursley</extent>
-            </physdesc>
           </did>
+          <odd>
+            <p>(1 print by Greg Hursley)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>National Bank and Trust Company, Ann Arbor <unitdate type="inclusive" normal="1975">1975</unitdate></unittitle>
-            <physdesc altrender="part">
+            <physdesc altrender="odd">
               <extent altrender="materialtype spaceoccupied">7 prints</extent>
             </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">2 by Balthazar Korab</extent>
-            </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">1 by Daniel Bartush</extent>
-            </physdesc>
           </did>
+          <odd>
+            <p>(2 prints by Balthazar Korab; 1 print by Daniel Bartush)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -772,28 +772,25 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unidentified Exteriors <unitdate type="inclusive">undated</unitdate></unittitle>
-            <physdesc altrender="part">
+            <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">8 prints</extent>
             </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">2 by Balthazar Korab</extent>
-            </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">4 by Greg Hursley</extent>
-            </physdesc>
           </did>
+          <odd>
+            <p>(2 prints by Balthazar Korab; 4 prints by Greg Hursley)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unidentified Interiors <unitdate type="inclusive">undated</unitdate></unittitle>
-            <physdesc altrender="part">
+            <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">10 prints</extent>
             </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">1 by Balthazar Korab</extent>
-            </physdesc>
           </did>
+          <odd>
+            <p>(1 print by Balthazar Korab)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/oslerdav.xml
+++ b/Real_Masters_all/oslerdav.xml
@@ -54,11 +54,9 @@
         <physfacet>architectural drawings</physfacet>
       </physdesc>
       <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">1.3 linear feet of textual</extent>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">photographs</extent>
+        <extent altrender="materialtype spaceoccupied">1.3 linear feet</extent>
         <extent altrender="carrier">(in 2 boxes)</extent>
+        <physfacet>textual and photographic material</physfacet>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
@@ -491,13 +489,13 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Gerstacker Language Center, Albion College <unitdate type="inclusive" normal="1970">1970</unitdate></unittitle>
-            <physdesc altrender="part">
+            <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">5 prints</extent>
             </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">1 by Hursley and Lark</extent>
-            </physdesc>
           </did>
+          <odd>
+            <p>(1 print by Hursley and Lark)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
@@ -709,7 +707,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
             <container type="box" label="Box">1</container>
             <unittitle>Osler, David <unitdate type="inclusive">undated</unitdate></unittitle>
             <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">2 and portrait prints</extent>
+              <extent altrender="materialtype spaceoccupied">2 portrait prints</extent>
               <physfacet>black and white</physfacet>
             </physdesc>
             <physdesc altrender="part">
@@ -722,10 +720,12 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
             <container type="box" label="Box">1</container>
             <unittitle>Oslund Condominiums, Ann Arbor <unitdate type="inclusive">undated</unitdate></unittitle>
             <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">2 transparencies by Balthazar Korab</extent>
+              <extent altrender="materialtype spaceoccupied">2 transparencies</extent>
+              <physfacet>by Balthazar Korab</physfacet>
             </physdesc>
             <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">11 prints by unknown photographers</extent>
+              <extent altrender="materialtype spaceoccupied">11 prints</extent>
+              <physfacet>by unknown photographer</physfacet>
             </physdesc>
           </did>
         </c02>
@@ -826,24 +826,21 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Williams Research Corporation <unitdate type="inclusive" normal="1974">1974</unitdate></unittitle>
-            <physdesc altrender="part">
+            <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">10 prints</extent>
             </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">1 by Balthazar Korab</extent>
-            </physdesc>
           </did>
+          <odd>
+            <p>(1 print by Balthazar Korab)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
             <container type="panel" label="Panel">1</container>
             <unittitle>Exhibition Panel I <unitdate type="inclusive" normal="1974">undated</unitdate></unittitle>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">7 folders</extent>
-            </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">with 36 prints of unidentified interiors and exteriors;architect's statement</extent>
-              <physfacet>color</physfacet>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">7 accordion panels</extent>
+              <physfacet>on foam core, with thirty-six color prints of unidentified interiors and exteriors and architect's statement</physfacet>
             </physdesc>
           </did>
         </c02>
@@ -851,12 +848,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
           <did>
             <container type="panel" label="Panel">2</container>
             <unittitle>Exhibition Panel II <unitdate type="inclusive" normal="1974">undated</unitdate></unittitle>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">6 folders</extent>
-            </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">with 36 prints of unidentified interiors and exteriors</extent>
-              <physfacet>color</physfacet>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">6 accordion panels</extent>
+              <physfacet>on foam core, with thirty-six color prints of unidentified interiors and exteriors</physfacet>
             </physdesc>
           </did>
         </c02>
@@ -2059,12 +2053,15 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <container type="folder" label="Folder">8</container>
               <unittitle>Perspective Drawing by David W. Osler <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">1 drawing of 2 elevations</extent>
+                <extent altrender="materialtype spaceoccupied">1 drawings</extent>
               </physdesc>
               <physdesc>
                 <physfacet>pencil-on-vellum original</physfacet>
               </physdesc>
             </did>
+            <odd>
+              <p>(1 drawing of 2 elevations)</p>
+            </odd>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -3232,10 +3229,7 @@ sections (orthographic projections)</physfacet>
                 <container type="folder" label="Folder">13</container>
                 <unittitle>Site Plans and Perspective Drawings <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc>
-                  <physfacet>pencil drawings</physfacet>
-                </physdesc>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">4 sheets of artist's paper</extent>
+                  <physfacet>pencil drawings on four sheets of artist's paper</physfacet>
                 </physdesc>
               </did>
             </c04>

--- a/Real_Masters_all/ovpr.xml
+++ b/Real_Masters_all/ovpr.xml
@@ -45552,9 +45552,12 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
                 <container type="box" label="Box">171</container>
                 <unittitle><unitdate type="inclusive" normal="1986/1987">1986-1987</unitdate> Proposals 1-22</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">22 folders, by log number</extent>
+                  <extent altrender="materialtype spaceoccupied">22 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(arranged by log number)</p>
+              </odd>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2023-07-01">July 1, 2023</date>]</p>
               </accessrestrict>
@@ -45564,9 +45567,12 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
                 <container type="box" label="Box">172</container>
                 <unittitle><unitdate type="inclusive" normal="1986/1987">1986-1987</unitdate> Proposals 23-106</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">84 folders, by log number</extent>
+                  <extent altrender="materialtype spaceoccupied">84 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(arranged by log number)</p>
+              </odd>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2023-07-01">July 1, 2023</date>]</p>
               </accessrestrict>
@@ -45576,9 +45582,12 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
                 <container type="box" label="Box">173</container>
                 <unittitle><unitdate type="inclusive" normal="1986/1987">1986-1987</unitdate> Proposals 107-146</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">40 folders, by log number</extent>
+                  <extent altrender="materialtype spaceoccupied">40 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(arranged by log number)</p>
+              </odd>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2023-07-01">July 1, 2023</date>]</p>
               </accessrestrict>
@@ -45588,9 +45597,12 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
                 <container type="box" label="Box">173</container>
                 <unittitle><unitdate type="inclusive" normal="1987/1988">1987-1988</unitdate> Proposals 1-30</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">30 folders, by log number</extent>
+                  <extent altrender="materialtype spaceoccupied">30 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(arranged by log number)</p>
+              </odd>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2023-07-01">July 1, 2023</date>]</p>
               </accessrestrict>
@@ -45600,9 +45612,12 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
                 <container type="box" label="Box">174</container>
                 <unittitle><unitdate type="inclusive" normal="1987/1988">1987-1988</unitdate> Proposals 31-43</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">13 folders, by log number</extent>
+                  <extent altrender="materialtype spaceoccupied">13 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(arranged by log number)</p>
+              </odd>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2023-07-01">July 1, 2023</date>]</p>
               </accessrestrict>
@@ -45612,9 +45627,12 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
                 <container type="box" label="Box">174</container>
                 <unittitle><unitdate type="inclusive" normal="1988/1989">1988-1989</unitdate> Pre-Proposals 1-82</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">82 folders, by log number</extent>
+                  <extent altrender="materialtype spaceoccupied">82 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(arranged by log number)</p>
+              </odd>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2023-07-01">July 1, 2023</date>]</p>
               </accessrestrict>
@@ -45624,9 +45642,12 @@ Office of the Vice-President for Research (University of Michigan) Records, Bent
                 <container type="box" label="Box">175</container>
                 <unittitle><unitdate type="inclusive" normal="1988/1989">1988-1989</unitdate> Pre-Proposals 83-105</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">23 folders, by log number</extent>
+                  <extent altrender="materialtype spaceoccupied">23 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(arranged by log number)</p>
+              </odd>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2023-07-01">July 1, 2023</date>]</p>
               </accessrestrict>

--- a/Real_Masters_all/peacecorps.xml
+++ b/Real_Masters_all/peacecorps.xml
@@ -41,8 +41,11 @@
       <unitid encodinganalog="852$h" repositorycode="MiU-H" countrycode="us" type="call number">2014125 Aa 3</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Office responsible for administering Peace Corps programming at the University of Michigan. Collection consists of video and web content surrounding the fiftieth anniversary celebration in 2010 of the proposal of the Peace Corps at the Michigan Union by Sen. John F. Kennedy.</abstract>
-      <physdesc altrender="whole">
-        <extent altrender="materialtype spaceoccupied">2.18 GB and archived website</extent>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">2.18 GB</extent>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">1 archived websites</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/personel.xml
+++ b/Real_Masters_all/personel.xml
@@ -5549,27 +5549,25 @@ Personnel Office (University of Michigan) Records, Bentley Historical Library, U
           <did>
             <container type="box" label="Box">36</container>
             <unittitle>Revisions <unitdate type="inclusive" normal="1993">1993</unitdate></unittitle>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">7 folders; folders</extent>
-            </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">1-4</extent>
-              <extent altrender="carrier">(in Box 36)</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
+          <odd>
+            <p>(1-4 of 7 folders)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">37</container>
             <unittitle>Revisions <unitdate type="inclusive" normal="1993">1993</unitdate></unittitle>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">7 folders; folders</extent>
-            </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">5-7</extent>
-              <extent altrender="carrier">(in Box 37)</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
+          <odd>
+            <p>(5-7 of 7 folders)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/physics.xml
+++ b/Real_Masters_all/physics.xml
@@ -1612,7 +1612,7 @@ MI <unitdate type="inclusive" normal="1937-04-20">April 20,
                 <container type="box" label="Box">14</container>
                 <unittitle>Budget Files <unitdate type="inclusive" normal="1920/1945" certainty="approximate">circa 1920-1945</unitdate></unittitle>
                 <physdesc>
-                  <extent>1 microfilm</extent>
+                  <extent>1 microfilms</extent>
                 </physdesc>
               </did>
             </c04>

--- a/Real_Masters_all/pionband.xml
+++ b/Real_Masters_all/pionband.xml
@@ -1381,9 +1381,9 @@ Pioneer Band Association records, Bentley Historical Library, University of Mich
           <c03 level="file">
             <did>
               <container type="box" label="Box">6</container>
-              <unittitle><title render="italic">Ann Arbor Observer</title>, <unitdate type="inclusive" normal="2006">2006</unitdate></unittitle>
+              <unittitle><title render="italic">Ann Arbor Observer</title>, <unitdate type="inclusive" normal="2006-05/2006-06">May and June 2006</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2 issues, May and June</extent>
+                <extent altrender="materialtype spaceoccupied">2 issues</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/pondfam.xml
+++ b/Real_Masters_all/pondfam.xml
@@ -378,7 +378,8 @@
               <container label="Roll" type="reel">1</container>
               <unittitle>Autobiography of Irving Kane Pond</unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">1 microfilm roll, positive and negative copies</extent>
+                <extent altrender="materialtype spaceoccupied">1 microfilms</extent>
+                <physfacet>positive and negative copies</physfacet>
               </physdesc>
             </did>
             <odd>

--- a/Real_Masters_all/postfam.xml
+++ b/Real_Masters_all/postfam.xml
@@ -1209,7 +1209,7 @@ and "The Common People")</p>
                 <container type="box" label="Box">46</container>
                 <unittitle>Ledgers and journal <unitdate type="inclusive" normal="1900/1906">1900-1906</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">5volumes</extent>
+                  <extent altrender="materialtype spaceoccupied">5 volumes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3244,12 +3244,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1935-03/1935-05">March-May 1935</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">1-10</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-1]</p>
+                <p>[pages 1-10; folder 10-1]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3258,12 +3255,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1935-05/1935-06">May-June 1935</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">11-20</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-2]</p>
+                <p>[pages 11-20; folder 10-2]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3272,12 +3266,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1935-06/1935-09">June-September 1935</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">21-30</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-3]</p>
+                <p>[pages 21-30; folder 10-3]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3286,12 +3277,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1935-09">September 1935</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">31-40</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-4]</p>
+                <p>[pages 31-40; folder 10-4]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3300,12 +3288,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1935-10/1935-11">October-November 1935</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">34-50</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-5]</p>
+                <p>[pages 34-50; folder 10-5]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3314,12 +3299,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1935-12">December 1935</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">51-60</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-6]</p>
+                <p>[pages 51-60; folder 10-6]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3329,12 +3311,9 @@ and "The Common People")</p>
                   <unitdate type="inclusive" normal="1935" certainty="approximate">1935 undated</unitdate>
                   <unitdate type="inclusive" normal="1936-01/1936-05">January-May 1936</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">61-70</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-7]</p>
+                <p>[pages 61-70; folder 10-7]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3343,12 +3322,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1936-05">May 1936</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">71-80</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-8]</p>
+                <p>[pages 71-80; folder 10-8]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3357,12 +3333,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1936-05/1936-12">May-December 1936</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">81-90</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-9]</p>
+                <p>[pages 81-90; folder 10-9]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3371,12 +3344,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1937-01/1937-07">January-July 1937</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">1-15</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-10]</p>
+                <p>[pages 1-15; folder 10-10]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3385,12 +3355,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1937-07/1937-10">July-October 1937</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">16-30</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-11]</p>
+                <p>[pages 16-30; folder 10-11]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3399,12 +3366,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1937-10">October 1937</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">31-45</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-12]</p>
+                <p>[pages 31-45; folder 10-12]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3413,12 +3377,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1937-10">October 1937</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">46-60</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-13]</p>
+                <p>[pages 46-60; folder 10-13]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3427,12 +3388,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1937-10">October 1937</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">61-70</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-14]</p>
+                <p>[pages 61-70; folder 10-14]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3441,12 +3399,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1937-10/1937-11">October-November 1937</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">71-90</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-15]</p>
+                <p>[pages 71-90; folder 10-15]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3455,12 +3410,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1937-11">November 1937</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">91-100</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-16]</p>
+                <p>[pages 91-100; folder 10-16]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3469,12 +3421,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1937-11/1937-12">November-December 1937</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">101-121</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-17]</p>
+                <p>[pages 101-121; folder 10-17]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3483,12 +3432,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1938-01/1938-04">January-April 1938</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">1-15</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-18]</p>
+                <p>[pages 1-15; folder 10-18]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3497,12 +3443,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1938-06/1938-10">June-October 1938</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">16-30</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-19]</p>
+                <p>[pages 16-30; folder 10-19]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3511,12 +3454,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1938-10">October 1938</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">31-47</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-20]</p>
+                <p>[pages 31-47; folder 10-20]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3525,12 +3465,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1938-10">October 1938</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">48-60</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-21]</p>
+                <p>[pages 48-60; folder 10-21]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3539,12 +3476,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1938-10/1938-11">October-November 1938</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">61-81</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-22]</p>
+                <p>[pages 61-81; folder 10-22]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3553,12 +3487,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1939-01/1939-06">January-June 1939</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">1-15</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-23]</p>
+                <p>[pages 1-15; folder 10-23]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3567,12 +3498,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1939-06">June 1939</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">16-30</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-24]</p>
+                <p>[pages 16-30; folder 10-24]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3581,12 +3509,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1939-06/1939-07">June-July 1939</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">31-50</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-25]</p>
+                <p>[pages 31-50; folder 10-25]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3595,12 +3520,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1939-07/1939-09">July-September 1939</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">51-71</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-26]</p>
+                <p>[pages 51-71; folder 10-26]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3609,12 +3531,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1939-09/1939-10">September-October 1939</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">72-87</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-27]</p>
+                <p>[pages 72-87; folder 10-27]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3623,12 +3542,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1939-10">October 1939</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">88-100</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-28]</p>
+                <p>[pages 88-100; folder 10-28]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3637,12 +3553,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1939-10">October 1939</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">101-115</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[10-29]</p>
+                <p>[pages 101-115; folder 10-29]</p>
               </odd>
             </c04>
           </c03>
@@ -3657,12 +3570,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1939-10/1939-11">October-November 1939</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">116-130</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[11-1]</p>
+                <p>[pages 116-130; folder 11-1]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3671,12 +3581,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1939-11">November 1939</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">131-145</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[11-2]</p>
+                <p>[pages 131-145; folder 11-2]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3685,12 +3592,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1939-11/1939-12">November-December 1939</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">146-160</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[11-3]</p>
+                <p>[pages 146-160; folder 11-3]</p>
               </odd>
             </c04>
             <c04 level="file">
@@ -3699,12 +3603,9 @@ and "The Common People")</p>
                 <unittitle>
                   <unitdate type="inclusive" normal="1939-12/1940-05">December 1939-May 1940</unitdate>
                 </unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">161-185</extent>
-                </physdesc>
               </did>
               <odd>
-                <p>[11-4]</p>
+                <p>[pages 161-185; folder 11-4]</p>
               </odd>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/postum.xml
+++ b/Real_Masters_all/postum.xml
@@ -53,7 +53,7 @@
         <extent altrender="materialtype spaceoccupied">164 oversize volumes</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">1 reel of Microfilm</extent>
+        <extent altrender="materialtype spaceoccupied">1 microfilms</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/prohpart.xml
+++ b/Real_Masters_all/prohpart.xml
@@ -918,11 +918,9 @@ Prohibition National Committee (U.S.) records, Bentley Historical Library, Unive
             <did>
               <container type="box" label="Box">8</container>
               <unittitle><unitdate type="inclusive" normal="1963">1963</unitdate> Convention</unittitle>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">3 film reels, various times</extent>
-              </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">15-30 min</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 film reels</extent>
+                <dimensions>various times, ca. 15-30 min.</dimensions>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/rfwms.xml
+++ b/Real_Masters_all/rfwms.xml
@@ -2277,30 +2277,21 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">14</container>
-                <unittitle>"Pride and Shame in the Martin Luther King Era", videotape of Oprah Winfrey Show</unittitle>
-                <physdesc altrender="part">
+                <unittitle>"Pride and Shame in the Martin Luther King Era", videotape of Oprah Winfrey Show (reel 4)</unittitle>
+                <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
-                  <physfacet>VHS (TM)</physfacet>
-                </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">120 minutes</extent>
-                  <physfacet>color</physfacet>
-                </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">reels 4</extent>
+                  <physfacet>VHS (TM); color</physfacet>
+                  <dimensions>120 minutes</dimensions>
                 </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">14</container>
-                <unittitle>Memorial service for Robert F. Williams held at Central Methodist Church, Monroe, North Carolina, Oct. 22, 1996</unittitle>
-                <physdesc altrender="part">
+                <unittitle>Memorial service for Robert F. Williams held at Central Methodist Church, Monroe, North Carolina, Oct. 22, 1996 (reels 5-6)</unittitle>
+                <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
-                </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">reels 5-6</extent>
                 </physdesc>
               </did>
             </c04>

--- a/Real_Masters_all/romneyg.xml
+++ b/Real_Masters_all/romneyg.xml
@@ -44427,8 +44427,8 @@
         <c02 level="series">
           <did>
             <unittitle>Chronological Series II</unittitle>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">5-inch tapes</extent>
+            <physdesc>
+              <physfacet>5-inch tapes</physfacet>
             </physdesc>
           </did>
           <c03 level="file">
@@ -45197,8 +45197,8 @@
         <c02 level="series">
           <did>
             <unittitle>Chronological Series III</unittitle>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">3-inch tapes</extent>
+            <physdesc>
+              <physfacet>3-inch tapes</physfacet>
             </physdesc>
           </did>
           <c03 level="file">

--- a/Real_Masters_all/romneyg.xml
+++ b/Real_Masters_all/romneyg.xml
@@ -32247,13 +32247,13 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1955/1962">1955-1962</unitdate>
                 </unittitle>
-                <physdesc altrender="part">
+                <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">6 folders</extent>
                 </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">no 1960</extent>
-                </physdesc>
               </did>
+              <odd>
+                <p>(no 1960)</p>
+              </odd>
             </c04>
           </c03>
           <c03 level="file">
@@ -32266,13 +32266,13 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1944/1957">1944-1957</unitdate>
                 </unittitle>
-                <physdesc altrender="part">
+                <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">13 folders</extent>
                 </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">no 1945</extent>
-                </physdesc>
               </did>
+              <odd>
+                <p>(no 1945)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>
@@ -44271,10 +44271,10 @@
                 <physdesc altrender="part">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
                 </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">tape 1 is missing</extent>
-                </physdesc>
               </did>
+              <odd>
+                <p>(tape 1 is missing)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/schmidfr.xml
+++ b/Real_Masters_all/schmidfr.xml
@@ -131,7 +131,7 @@ Friedrich Schmid church records, Bentley Historical Library, University of Michi
             <physloc>Online</physloc>
             <unittitle>Record of Baptisms <unitdate type="inclusive" normal="1845/1875">1845-1875</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">1.6GB</extent>
+              <extent altrender="materialtype spaceoccupied">1.6 GB</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/99575" show="new" actuate="onrequest">
               <daodesc>

--- a/Real_Masters_all/schofed.xml
+++ b/Real_Masters_all/schofed.xml
@@ -6027,13 +6027,13 @@ School of Education (University of Michigan) Records, Bentley Historical Library
             <did>
               <container type="box" label="Box">32</container>
               <unittitle>Bureau of School Services <unitdate type="inclusive" normal="1982">1982</unitdate></unittitle>
-              <physdesc altrender="part">
+              <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">from SOE Review exhibits 130-132</extent>
-              </physdesc>
             </did>
+            <odd>
+              <p>(from SOE Review exhibits 130-132)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
@@ -11539,9 +11539,12 @@ School of Education (University of Michigan) Records, Bentley Historical Library
               <container type="box" label="Box">19</container>
               <unittitle>Evaluation and Planning Study <unitdate type="inclusive" normal="1975/1977">1975-1977</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2 folders, university-wide study</extent>
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <odd>
+              <p>(university-wide study)</p>
+            </odd>
           </c03>
         </c02>
       </c01>

--- a/Real_Masters_all/seagrpub.xml
+++ b/Real_Masters_all/seagrpub.xml
@@ -52,8 +52,11 @@
       <unitid encodinganalog="099" repositorycode="MiU-H" countrycode="us" type="call number">0438; Bimu; 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>The Michigan Sea Grant Program is a joint project between the University of Michigan, Michigan State University, and the National Oceanic and Atmospheric Administration (NOAA) addressing issues concerning the livelihood of the Michigan Great Lakes area. Includes technical reports, annual reports, newsletters, brochures and other printed material produced by the program.</abstract>
-      <physdesc altrender="whole">
-        <extent altrender="materialtype spaceoccupied">5.5 linear feet and 1 oversize folder</extent>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">5.5 linear feet</extent>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/sectryvp.xml
+++ b/Real_Masters_all/sectryvp.xml
@@ -2328,9 +2328,12 @@
                 <container type="box" label="Box">10</container>
                 <unittitle>Correspondence and Reports, <unitdate type="inclusive" normal="1972/1989">1972-1989</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">2 folders, includes CD</extent>
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(includes CD)</p>
+              </odd>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date normal="2033-07-01" type="restrict">July 1, 2033</date>]</p>
               </accessrestrict>
@@ -3029,9 +3032,12 @@
               <container type="box" label="Box">15</container>
               <unittitle>President's Speeches, <unitdate type="inclusive" normal="1999/2006">1999-2006</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2 folders, includes cassette tapes</extent>
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <odd>
+              <p>(includes cassette tapes)</p>
+            </odd>
             <accessrestrict>
               <p>[ER RESTRICTED until <date normal="2033-07-01" type="restrict">July 1, 2033</date>]</p>
             </accessrestrict>

--- a/Real_Masters_all/sinkchas.xml
+++ b/Real_Masters_all/sinkchas.xml
@@ -1170,7 +1170,8 @@ Charles A. Sink Papers, Bentley Historical Library, University of Michigan</p>
             <container type="box" label="Box">21</container>
             <unittitle>Oral interview with Alva Gordon Sink <unitdate type="inclusive" normal="1994-06">June 1994</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">2 cassettes with duplicate copies</extent>
+              <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
+              <extent altrender="carrier">with duplicate copies</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/snre.xml
+++ b/Real_Masters_all/snre.xml
@@ -9374,7 +9374,8 @@
                   <container type="box" label="Box">49</container>
                   <unittitle>Miscellaneous States and Unidentified</unittitle>
                   <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">2 folders of 34 images</extent>
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
+                    <extent>34 images</extent>
                     <physfacet>black and white</physfacet>
                   </physdesc>
                 </did>
@@ -10740,14 +10741,13 @@
               <did>
                 <container type="box" label="Box">71</container>
                 <unittitle>Saginaw Forest <unitdate type="inclusive" normal="1904/1945">1904-1945</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
-                <physdesc altrender="part">
+                <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">8 photographs</extent>
                 </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">oversize</extent>
-                  <extent altrender="carrier">(located in oversize folder in Box 76)</extent>
-                </physdesc>
               </did>
+              <odd>
+                <p>(oversize located in oversize folder in Box 76)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/sphum.xml
+++ b/Real_Masters_all/sphum.xml
@@ -2089,7 +2089,7 @@ Philip J. Deloria, December 2006; Michael Shallcross in 2012 and 2015.</p>
                   <unitdate type="inclusive" normal="1985/1989">1985-1989</unitdate>
                 </unittitle>
                 <physdesc>
-                  <extent>5 expandable folders</extent>
+                  <extent>5 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -2100,7 +2100,7 @@ Philip J. Deloria, December 2006; Michael Shallcross in 2012 and 2015.</p>
                   <unitdate type="inclusive" normal="1990/1991">1990-1991</unitdate>
                 </unittitle>
                 <physdesc>
-                  <extent>2 expandable folders</extent>
+                  <extent>2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -12129,7 +12129,7 @@ Philip J. Deloria, December 2006; Michael Shallcross in 2012 and 2015.</p>
                 <container type="box" label="Box">63</container>
                 <unittitle>Students <unitdate type="inclusive" normal="1989">1989</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">1 folder</extent>
+                  <extent altrender="materialtype spaceoccupied">1 folders</extent>
                 </physdesc>
               </did>
               <accessrestrict>
@@ -12224,7 +12224,7 @@ Philip J. Deloria, December 2006; Michael Shallcross in 2012 and 2015.</p>
                 <container type="box" label="Box">63</container>
                 <unittitle>Epidemiology (D. Schottenfeld) <unitdate type="inclusive" normal="1988/1989">1988-1989</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">1 folder</extent>
+                  <extent altrender="materialtype spaceoccupied">1 folders</extent>
                 </physdesc>
               </did>
               <accessrestrict>

--- a/Real_Masters_all/spoonerc.xml
+++ b/Real_Masters_all/spoonerc.xml
@@ -42,10 +42,15 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <abstract>Films, DVD use copies and streaming files the construction of the Great Lakes freighter Edmund Fitzgerald, the launchings of the freighters Herbert C. Jackson and Arthur B. Homer, and the maiden voyage of the Homer. These freighters were the last ships built by Great Lakes Engineering Works, River Rouge, Michigan</abstract>
       <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">2 film reels (8mm</extent>
+        <extent altrender="materialtype spaceoccupied">2 film reels</extent>
+        <physfacet>8 mm; 550 feet</physfacet>
       </physdesc>
       <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">550 feet) with DVD use copy and streaming file</extent>
+        <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+        <physfacet>DVDs</physfacet>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">1 digital files</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/stoneman.xml
+++ b/Real_Masters_all/stoneman.xml
@@ -337,9 +337,12 @@ William Harlan Stoneman Papers, Bentley Historical Library, University of Michig
             <container type="box" label="Box">6</container>
             <unittitle>Scrapbooks <unitdate type="inclusive" normal="1963-02/1973">February 1963-1973</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">3 volumes and loose clippings</extent>
+              <extent altrender="materialtype spaceoccupied">3 volumes</extent>
             </physdesc>
           </did>
+          <odd>
+            <p>(includes loose clippings)</p>
+          </odd>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/tausigd.xml
+++ b/Real_Masters_all/tausigd.xml
@@ -210,13 +210,13 @@ Tau Sigma Delta. Alpha Chapter (University of Michigan) records, Bentley Histori
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Reports <unitdate type="inclusive" normal="1958/1984">1958-1984</unitdate></unittitle>
-            <physdesc altrender="part">
+            <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">includes 2 photographs</extent>
-            </physdesc>
           </did>
+          <odd>
+            <p>(includes 2 photographs)</p>
+          </odd>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/towsleyh.xml
+++ b/Real_Masters_all/towsleyh.xml
@@ -399,7 +399,7 @@
               <container type="box" label="Box">1</container>
               <unittitle>Tintypes</unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">11</extent>
+                <extent altrender="materialtype spaceoccupied">11 photographs</extent>
               </physdesc>
             </did>
           </c03>
@@ -408,7 +408,7 @@
               <container type="box" label="Box">1</container>
               <unittitle>Cartes-de-Visite Photographs</unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">20</extent>
+                <extent altrender="materialtype spaceoccupied">20 photographs</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/toyjim.xml
+++ b/Real_Masters_all/toyjim.xml
@@ -1132,8 +1132,11 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>Gay Issues in Social Work (later Lesbian and Gay Issues in Social Work <unitdate type="inclusive" normal="1978/1979">1978-1979</unitdate>, <unitdate type="inclusive" normal="1984">1984</unitdate></unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2 folders and 1 expandable folder</extent>
+              <physdesc altrender="part">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
+              </physdesc>
+              <physdesc altrender="part">
+                <extent altrender="materialtype spaceoccupied">1 expandable folders</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/toyjim.xml
+++ b/Real_Masters_all/toyjim.xml
@@ -2039,9 +2039,9 @@
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">28</container>
-                  <unittitle><title render="italic">The Record</title>, <unitdate type="inclusive" normal="1974/2008">1974-2008</unitdate></unittitle>
+                  <unittitle><title render="italic">The Record</title>, <unitdate type="inclusive" normal="1974/2008">1974-2008 (scattered)</unitdate></unittitle>
                   <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">2 folders, scattered</extent>
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
               </c05>

--- a/Real_Masters_all/turkusat.xml
+++ b/Real_Masters_all/turkusat.xml
@@ -12974,7 +12974,7 @@ Satakunta Region immigrant letters, Bentley Historical Library, University of Mi
               <container type="reel" label="Roll">16</container>
               <unittitle>from: Paavo Uusitalo. Calif. <unitdate type="inclusive" normal="1964">1964</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2, items</extent>
+                <extent altrender="materialtype spaceoccupied">2 items</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/turkvais.xml
+++ b/Real_Masters_all/turkvais.xml
@@ -3921,7 +3921,7 @@ thousands of letters written by Finnish emigrants from Varsinais-Suomi (Southwes
               <container type="reel" label="Roll">7</container>
               <unittitle>from: Walfrid Rosten. Minn. <unitdate type="inclusive" normal="1963">1963</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">11items</extent>
+                <extent altrender="materialtype spaceoccupied">11 items</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/ulibrary.xml
+++ b/Real_Masters_all/ulibrary.xml
@@ -51935,8 +51935,11 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
                   <unittitle>
                     <unitdate type="inclusive" normal="1970/1971">1970-1971</unitdate>
                   </unittitle>
-                  <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">1 box and 1 folder</extent>
+                  <physdesc altrender="part">
+                    <extent altrender="materialtype spaceoccupied">1 boxes</extent>
+                  </physdesc>
+                  <physdesc altrender="part">
+                    <extent altrender="materialtype spaceoccupied">1 folders</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -51946,8 +51949,11 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
                   <unittitle>
                     <unitdate type="inclusive" normal="1971/1972">1971-1972</unitdate>
                   </unittitle>
-                  <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">1 box and 1 folder</extent>
+                  <physdesc altrender="part">
+                    <extent altrender="materialtype spaceoccupied">1 boxes</extent>
+                  </physdesc>
+                  <physdesc altrender="part">
+                    <extent altrender="materialtype spaceoccupied">1 folders</extent>
                   </physdesc>
                 </did>
               </c05>

--- a/Real_Masters_all/ulibrary.xml
+++ b/Real_Masters_all/ulibrary.xml
@@ -34473,8 +34473,11 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
                   <unittitle>
                     <unitdate type="inclusive" normal="1963/1964">1963-1964</unitdate>
                   </unittitle>
-                  <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">2 folders and 1 box</extent>
+                  <physdesc altrender="part">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
+                  </physdesc>
+                  <physdesc altrender="part">
+                    <extent altrender="materialtype spaceoccupied">1 boxes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -34484,8 +34487,11 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
                   <unittitle>
                     <unitdate type="inclusive" normal="1964/1965">1964-1965</unitdate>
                   </unittitle>
-                  <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">1 folder and 1 box</extent>
+                  <physdesc altrender="part">
+                    <extent altrender="materialtype spaceoccupied">1 folders</extent>
+                  </physdesc>
+                  <physdesc altrender="part">
+                    <extent altrender="materialtype spaceoccupied">1 boxes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -34575,8 +34581,11 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
                   <unittitle>
                     <unitdate type="inclusive" normal="1969/1970">1969-1970</unitdate>
                   </unittitle>
-                  <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">4 folders and 1 box</extent>
+                  <physdesc altrender="part">
+                    <extent altrender="materialtype spaceoccupied">4 folders</extent>
+                  </physdesc>
+                  <physdesc altrender="part">
+                    <extent altrender="materialtype spaceoccupied">1 boxes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -35222,8 +35231,14 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
                   <unittitle>
                     <unitdate type="inclusive" normal="1962/1963">1962-1963</unitdate>
                   </unittitle>
-                  <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">1 folder, 1 box, and 3 volumes</extent>
+                  <physdesc altrender="part">
+                    <extent altrender="materialtype spaceoccupied">1 folders</extent>
+                  </physdesc>
+                  <physdesc altrender="part">
+                    <extent altrender="materialtype spaceoccupied">1 boxes</extent>
+                  </physdesc>
+                  <physdesc altrender="part">
+                    <extent altrender="materialtype spaceoccupied">3 volumes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -35233,8 +35248,14 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
                   <unittitle>
                     <unitdate type="inclusive" normal="1963/1964">1963-1964</unitdate>
                   </unittitle>
-                  <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">2 folders, l box, and 6 volumes</extent>
+                  <physdesc altrender="part">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
+                  </physdesc>
+                  <physdesc altrender="part">
+                    <extent altrender="materialtype spaceoccupied">1 boxes</extent>
+                  </physdesc>
+                  <physdesc altrender="part">
+                    <extent altrender="materialtype spaceoccupied">6 volumes</extent>
                   </physdesc>
                 </did>
               </c05>

--- a/Real_Masters_all/umpresid.xml
+++ b/Real_Masters_all/umpresid.xml
@@ -80224,7 +80224,7 @@
                   <container type="box" label="Box">259</container>
                   <unittitle>Stadium Construction</unittitle>
                   <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">2 s</extent>
+                    <extent altrender="materialtype spaceoccupied">2 photographs</extent>
                     <physfacet>color</physfacet>
                     <dimensions>8x10</dimensions>
                   </physdesc>
@@ -80235,7 +80235,7 @@
                   <container type="box" label="Box">259</container>
                   <unittitle>Tom Harmon with Duderstadt</unittitle>
                   <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">1</extent>
+                    <extent altrender="materialtype spaceoccupied">1 photographs</extent>
                     <physfacet>black and white</physfacet>
                     <dimensions>8x10</dimensions>
                   </physdesc>

--- a/Real_Masters_all/umpresid.xml
+++ b/Real_Masters_all/umpresid.xml
@@ -33343,19 +33343,19 @@
               <did>
                 <container type="box" label="Box">270</container>
                 <unittitle>Campaign</unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">1 of 2 folders</extent>
-                </physdesc>
               </did>
+              <odd>
+                <p>(1 of 2 folders)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">271</container>
                 <unittitle>Campaign</unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">2 of 2 folders</extent>
-                </physdesc>
               </did>
+              <odd>
+                <p>(2 of 2 folders)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>
@@ -47131,9 +47131,12 @@
                 <container type="box" label="Box">363</container>
                 <unittitle>General</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">3 folders; includes material on decommissioning the Ford Nuclear Reactor, and the annual report for the Michigan Memorial Phoenix Project</extent>
+                  <extent altrender="materialtype spaceoccupied">3 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(includes material on decommissioning the Ford Nuclear Reactor, and the annual report for the Michigan Memorial Phoenix Project)</p>
+              </odd>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date normal="2030-07-01" type="restriction">July 1, 2030</date>]</p>
               </accessrestrict>
@@ -49532,9 +49535,12 @@
               <container type="box" label="Box">381</container>
               <unittitle>International</unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">4 folders; includes external review committee report on the Center for Japanese Studies</extent>
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
+            <odd>
+              <p>(includes external review committee report on the Center for Japanese Studies)</p>
+            </odd>
             <accessrestrict>
               <p>[ER RESTRICTED until <date normal="2030-07-01" type="restriction">July 1, 2030</date>]</p>
             </accessrestrict>
@@ -60051,9 +60057,12 @@
               <container type="box" label="Box">376</container>
               <unittitle>Public Policy, Gerald R. Ford School of</unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2 folders; includes architectural proposals</extent>
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <odd>
+              <p>(includes architectural proposals)</p>
+            </odd>
             <accessrestrict>
               <p>[ER RESTRICTED until <date normal="2030-07-01" type="restriction">July 1, 2030</date>]</p>
             </accessrestrict>

--- a/Real_Masters_all/umussoc.xml
+++ b/Real_Masters_all/umussoc.xml
@@ -5127,10 +5127,11 @@ University Musical Society (University of Michigan) Records, Bentley Historical 
               <container type="box" label="Box">101</container>
               <unittitle>Fairlane Festival <unitdate type="inclusive" normal="1967">1967</unitdate></unittitle>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">4 11" by 14" prints</extent>
+                <extent altrender="materialtype spaceoccupied">4 prints</extent>
+                <dimensions>11" x 14"</dimensions>
               </physdesc>
-              <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">35mm negatives</extent>
+              <physdesc>
+                <physfacet>35mm negatives</physfacet>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/umuugdo.xml
+++ b/Real_Masters_all/umuugdo.xml
@@ -57,7 +57,8 @@
         <extent altrender="materialtype spaceoccupied">35 oversize volumes</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent altrender="materialtype spaceoccupied">3.71 GB of digital files</extent>
+        <extent altrender="materialtype spaceoccupied">3.71 GB</extent>
+        <physfacet>digital files</physfacet>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/vpaastaf.xml
+++ b/Real_Masters_all/vpaastaf.xml
@@ -7779,7 +7779,7 @@
                     <container type="box" label="Box">45</container>
                     <unittitle>Medical School</unittitle>
                     <physdesc altrender="whole">
-                      <extent altrender="materialtype spaceoccupied">2 folders, includes Inteflex</extent>
+                      <extent altrender="materialtype spaceoccupied">2 folders</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -8888,9 +8888,12 @@
                     <container type="box" label="Box">50</container>
                     <unittitle>Medical School</unittitle>
                     <physdesc altrender="whole">
-                      <extent altrender="materialtype spaceoccupied">2 folders, includes Inteflex</extent>
+                      <extent altrender="materialtype spaceoccupied">2 folders</extent>
                     </physdesc>
                   </did>
+                  <odd>
+                    <p>(includes Inteflex)</p>
+                  </odd>
                 </c06>
                 <c06 level="file">
                   <did>
@@ -40394,21 +40397,24 @@
                 <did>
                   <container type="box" label="Box">170</container>
                   <unittitle>Collaborative Projects with UM</unittitle>
-                  <physdesc altrender="part">
-                    <extent altrender="materialtype spaceoccupied">15 folders</extent>
-                  </physdesc>
-                  <physdesc altrender="part">
-                    <extent altrender="materialtype spaceoccupied">folders 1-11</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">11 folders</extent>
                   </physdesc>
                 </did>
+                <odd>
+                  <p>(folders 1-11 of 15)</p>
+                </odd>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">171</container>
                   <unittitle>Collaborative Projects with UM</unittitle>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">3 folders</extent>
+                  </physdesc>
                 </did>
                 <odd>
-                  <p>folders 12-15</p>
+                  <p>(folders 12-15 of 15)</p>
                 </odd>
               </c05>
               <c05 level="file">
@@ -47481,9 +47487,12 @@
               <container type="box" label="Box">115</container>
               <unittitle>Nursing, School of</unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2 folders, includes Budget Conference</extent>
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
+            <odd>
+              <p>(includes Budget Conference)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
@@ -60051,9 +60060,12 @@
                   <container type="box" label="Box">402</container>
                   <unittitle>Resources</unittitle>
                   <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">2 expandable files, the bulk is university publications explaining resources for victims</extent>
+                    <extent altrender="materialtype spaceoccupied">2 expandable files</extent>
                   </physdesc>
                 </did>
+                <odd>
+                  <p>(buld is university publications explaining resources for victims)</p>
+                </odd>
                 <accessrestrict>
                   <p>[ER RESTRICTED until <date type="restriction" normal="2024-07-01">July 1, 2024</date>]</p>
                 </accessrestrict>

--- a/Real_Masters_all/vpgovrel.xml
+++ b/Real_Masters_all/vpgovrel.xml
@@ -4489,19 +4489,25 @@ Vice President for Government Relations (University of Michigan) records, Bentle
               <physfacet>color</physfacet>
             </physdesc>
             <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">1 audio cassette tape, printed script</extent>
+              <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
             </physdesc>
           </did>
+          <odd>
+            <p>(includes printed script)</p>
+          </odd>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">28</container>
             <unittitle>Proposal D (Tisch Amendment) slide show <unitdate type="inclusive" normal="1980">1980</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">139 35mm slides, printed script</extent>
+              <extent altrender="materialtype spaceoccupied">139 35mm slides</extent>
               <physfacet>color</physfacet>
             </physdesc>
           </did>
+          <odd>
+            <p>(includes printed script)</p>
+          </odd>
         </c02>
       </c01>
       <c01 level="series">

--- a/Real_Masters_all/vpsaff.xml
+++ b/Real_Masters_all/vpsaff.xml
@@ -2360,9 +2360,12 @@
               <container type="box" label="Box">9</container>
               <unittitle>Recruitment and Placement <unitdate type="inclusive" normal="1968/1970">1968-1970</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">4 folders, photos</extent>
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
+            <odd>
+              <p>(includes photographs)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>
@@ -2372,8 +2375,11 @@
           </c03>
           <c03 level="file">
             <did>
-              <unittitle>Student Discipline <unitdate type="inclusive" normal="1968/1970">1968-1970</unitdate> (see also Judiciary file)</unittitle>
+              <unittitle>Student Discipline <unitdate type="inclusive" normal="1968/1970">1968-1970</unitdate></unittitle>
             </did>
+            <odd>
+              <p>(see also Judiciary file)</p>
+            </odd>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">9</container>

--- a/Real_Masters_all/wallm60m.xml
+++ b/Real_Masters_all/wallm60m.xml
@@ -6716,9 +6716,12 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
                 <container type="box" label="Box">29</container>
                 <unittitle>Background/Post-Show</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">2 folders; includes tape cassette</extent>
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(includes tape cassette)</p>
+              </odd>
             </c04>
             <c04 level="file">
               <did>
@@ -19101,9 +19104,12 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
               <did>
                 <unittitle>Speeches and Appearances</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">19 folders, arranged chronologically</extent>
+                  <extent altrender="materialtype spaceoccupied">19 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(arranged chronologically)</p>
+              </odd>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">74</container>
@@ -19589,9 +19595,12 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
               <did>
                 <unittitle>Speeches and Appearances</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">11 folders, arranged chronologically</extent>
+                  <extent altrender="materialtype spaceoccupied">11 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(arranged chronologically)</p>
+              </odd>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">76</container>
@@ -20105,9 +20114,12 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
               <did>
                 <unittitle>Speeches and Appearances</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">9 folders, arranged chronologically</extent>
+                  <extent altrender="materialtype spaceoccupied">9 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(arranged chronologically)</p>
+              </odd>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">78</container>
@@ -20891,9 +20903,12 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
               <did>
                 <unittitle>Speeches and Appearances</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">16 folders, arranged chronologically</extent>
+                  <extent altrender="materialtype spaceoccupied">16 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(arranged chronologically)</p>
+              </odd>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">80</container>
@@ -21114,9 +21129,12 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
               <did>
                 <unittitle>Speeches and Appearances</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">10 folders, arranged chronologically</extent>
+                  <extent altrender="materialtype spaceoccupied">10 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(arranged chronologically)</p>
+              </odd>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">81</container>
@@ -21316,9 +21334,12 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
               <did>
                 <unittitle>Speeches and Appearances</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">7 folders, arranged chronologically</extent>
+                  <extent altrender="materialtype spaceoccupied">7 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(arranged chronologically)</p>
+              </odd>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">82</container>
@@ -21560,9 +21581,12 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
               <did>
                 <unittitle>Speeches and Appearances</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">9 folders, arranged chronologically</extent>
+                  <extent altrender="materialtype spaceoccupied">9 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(arranged chronologically)</p>
+              </odd>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">83</container>
@@ -21845,9 +21869,12 @@ Mike Wallace CBS/60 Minutes papers, Bentley Historical Library, University of Mi
               <did>
                 <unittitle>Speeches and Appearances</unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">8 folders, arranged chronologically</extent>
+                  <extent altrender="materialtype spaceoccupied">8 folders</extent>
                 </physdesc>
               </did>
+              <odd>
+                <p>(arranged chronologically)</p>
+              </odd>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">84</container>

--- a/Real_Masters_all/watsonas.xml
+++ b/Real_Masters_all/watsonas.xml
@@ -497,12 +497,8 @@ Andrew S. Watson Papers, Bentley Historical Library, University of Michigan</p>
         <c02 level="file">
           <did>
             <unittitle>Videotapes</unittitle>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">1-inch</extent>
-            </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">audiotapes</extent>
-              <physfacet>3/4-inch.; reel-to-reel tapes</physfacet>
+            <physdesc>
+              <physfacet>1-inch and 3/4 inch reel-to-reels</physfacet>
             </physdesc>
           </did>
           <c03 level="file">
@@ -513,9 +509,8 @@ Andrew S. Watson Papers, Bentley Historical Library, University of Michigan</p>
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Direct and Cross of Dr. Burton <unitdate type="inclusive" normal="1977">1977</unitdate></unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">reels</extent>
-                  <physfacet>3/4-inch</physfacet>
+                <physdesc>
+                  <physfacet>3/4-inch reel</physfacet>
                 </physdesc>
               </did>
             </c04>
@@ -523,9 +518,8 @@ Andrew S. Watson Papers, Bentley Historical Library, University of Michigan</p>
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Cross Examination of Dr. Watson <unitdate type="inclusive" normal="1977-05-14">May 14, 1977</unitdate></unittitle>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">reels</extent>
-                  <physfacet>3/4-inch</physfacet>
+                <physdesc>
+                  <physfacet>3/4-inch reel</physfacet>
                 </physdesc>
               </did>
             </c04>
@@ -534,9 +528,8 @@ Andrew S. Watson Papers, Bentley Historical Library, University of Michigan</p>
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Council on Legal Education for Professional Responsibility (CLEPR), Inc. unidentified <unitdate type="inclusive" normal="1976" certainty="approximate">circa 1976</unitdate></unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">reels</extent>
-                <physfacet>3/4-inch</physfacet>
+              <physdesc>
+                <physfacet>3/4-inch reel</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -544,9 +537,8 @@ Andrew S. Watson Papers, Bentley Historical Library, University of Michigan</p>
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Family Law <unitdate type="inclusive" normal="1974-04-22">April 22, 1974</unitdate></unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">reels</extent>
-                <physfacet>3/4-inch</physfacet>
+              <physdesc>
+                <physfacet>3/4-inch reel</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -554,9 +546,8 @@ Andrew S. Watson Papers, Bentley Historical Library, University of Michigan</p>
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Human Relations (Audience Reaction on the Dynamics of the Correction Officer and the Inmate) <unitdate type="inclusive" normal="1971-09-09">September 9, 1971</unitdate></unittitle>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">reels</extent>
-                <physfacet>3/4-inch</physfacet>
+              <physdesc>
+                <physfacet>3/4-inch reel</physfacet>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/wernette.xml
+++ b/Real_Masters_all/wernette.xml
@@ -1222,9 +1222,11 @@ J. Philip Wernette Papers, Bentley Historical Library, University of Michigan</p
               <unittitle>Kemmerer Commission reports <unitdate type="inclusive" normal="1931">1931</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">19 pamphlets</extent>
-                <extent altrender="carrier">(in English and Spanish)</extent>
               </physdesc>
             </did>
+            <odd>
+              <p>(in English and Spanish)</p>
+            </odd>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/winchell.xml
+++ b/Real_Masters_all/winchell.xml
@@ -695,11 +695,9 @@
             <unittitle>Pocket diaries</unittitle>
             <unitdate type="inclusive" normal="1864/1865">1864-1865</unitdate>
             <unitdate type="inclusive" normal="1867/1891">1867-1891</unitdate>
-            <physdesc altrender="part">
+            <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">28 volumes</extent>
-            </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">including 2 v. for 1874</extent>
+              <extent altrender="carrier">includes 2 volumes for 1874</extent>
             </physdesc>
           </did>
           <odd>

--- a/Real_Masters_all/zionaa.xml
+++ b/Real_Masters_all/zionaa.xml
@@ -1097,10 +1097,10 @@ Zion Lutheran Church (Ann Arbor, Mich.) records, Bentley Historical Library, Uni
               <container type="box" label="Box">8</container>
               <unittitle>Minutes <unitdate type="inclusive" normal="1948/1963">1948-1963</unitdate></unittitle>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">3 volumes, l folder</extent>
+                <extent altrender="materialtype spaceoccupied">3 volumes</extent>
               </physdesc>
               <physdesc altrender="part">
-                <extent altrender="materialtype spaceoccupied">1 folder</extent>
+                <extent altrender="materialtype spaceoccupied">1 folders</extent>
               </physdesc>
             </did>
           </c03>


### PR DESCRIPTION
I started looking for things to fix in extents and then I couldn't stop.

It looks like some of the EADs that we knew would be problematic for extent clean up (e.g., architectural finding aids) actually were problematic. I found a lot of things that were originally really convoluted but still intelligible extent statements (e.g., 3 folders of 4 8x10 color prints and 39 4x6 color prints) that got split into very strange things that I could only make sense of by looking at the original EAD. I know we said we're kind of done with manual extent clean up, but I think it might be worth spending a little more time doing some post-clean up clean up, at least on some of the finding aids that had really non-typical extents that might have gotten strangely parsed using rules that could safely be applied to more standard extent statements.
