### PR TITLE
standardizing titlepage/publisher statements

### DIFF
--- a/Real_Masters_all/aahumrel.xml
+++ b/Real_Masters_all/aahumrel.xml
@@ -26,7 +26,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Michigan Historical Collections Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding Aid for <lb/>Ann Arbor Human Rights Commission Records, 1957-1993</titleproper>
       <author>Finding aid prepared by: <lb/>Thomas E. Powers</author>
     </titlepage>

--- a/Real_Masters_all/albright.xml
+++ b/Real_Masters_all/albright.xml
@@ -34,7 +34,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>William Albright Papers, 1962-1998</titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Jennifer Jacobs</author>
     </titlepage>

--- a/Real_Masters_all/allenelizann .xml
+++ b/Real_Masters_all/allenelizann .xml
@@ -27,7 +27,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Michigan Historical Collections<lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/> Elizabeth Ann Allen Papers, 1918-2014</titleproper>
       <author>Finding aid created by<lb/> Alexa Hagen, in July 2015</author>
     </titlepage>

--- a/Real_Masters_all/alumasso.xml
+++ b/Real_Masters_all/alumasso.xml
@@ -34,7 +34,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Alumni Association <lb/>(University of Michigan) <lb/>Records, 1859-1998</titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Bentley Historical Library Staff <lb/>Last update: 2015</author>
     </titlepage>

--- a/Real_Masters_all/amorgan.xml
+++ b/Real_Masters_all/amorgan.xml
@@ -54,7 +54,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Angela Morgan Papers, <date>1861-1957</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>William McNitt, 1975 <lb/>Christopher Leonard, 1985 <lb/>Olga Virakhovskaya, 2014 (Boxes 50-61)</author>
     </titlepage>

--- a/Real_Masters_all/anatdona.xml
+++ b/Real_Masters_all/anatdona.xml
@@ -45,7 +45,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>University Archives Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding Aid for <lb/>Anatomical Donations Program <lb/>(University of Michigan) <lb/>Records, <date>1881-1980</date></titleproper>
       <author>Finding aid prepared by <lb/>Brian A. Williams, 1994</author>
     </titlepage>

--- a/Real_Masters_all/archcoll.xml
+++ b/Real_Masters_all/archcoll.xml
@@ -50,7 +50,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>A. Alfred Taubman College of Architecture + Urban Planning <lb/>(University of Michigan) <lb/>Records, 1876-2010</titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Bentley Historical Library Staff <lb/>Kathy Steiner, Dec. 2001 and May 2002 <lb/>Christie Peterson, November 2005 <lb/>Lisa Wright, January 2010</author>
     </titlepage>

--- a/Real_Masters_all/auditscharts.xml
+++ b/Real_Masters_all/auditscharts.xml
@@ -27,7 +27,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for <lb/>Office of University Audits <lb/>(University of Michigan) <lb/>organizational charts</titleproper>
       <author>Finding aid created by <lb/>Aprille C. McKay, in 2013.</author>
     </titlepage>

--- a/Real_Masters_all/auditsrcds.xml
+++ b/Real_Masters_all/auditsrcds.xml
@@ -27,7 +27,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher><lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for <lb/>Office of University Audits <lb/>(University of Michigan) <lb/>records, 1947-2012</titleproper>
       <author>Finding aid created by <lb/>Aprille C. McKay, in 2013</author>
     </titlepage>

--- a/Real_Masters_all/avpfacop.xml
+++ b/Real_Masters_all/avpfacop.xml
@@ -31,7 +31,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for
 Office of the Associate Vice President for Facilities and Operations <lb/>(University of Michigan) <lb/>records, 1925-2006</titleproper>
       <author>Finding aid created by <lb/>Chris Schunter, 2014</author>

--- a/Real_Masters_all/bentleya.xml
+++ b/Real_Masters_all/bentleya.xml
@@ -38,7 +38,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Alvin M. Bentley Papers, <date type="inclusive">1935-1969</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Thomas E. Powers</author>
     </titlepage>

--- a/Real_Masters_all/bethisraelcong.xml
+++ b/Real_Masters_all/bethisraelcong.xml
@@ -27,7 +27,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/> Beth Israel Congregation Jewish Life in Ann Arbor Oral History Project Records</titleproper>
       <author>Finding aid created by<lb/> Robert Goldey, in October 2013 </author>
     </titlepage>
@@ -55,7 +55,7 @@
     </did>
     <descgrp type="admin">
       <acqinfo encodinganalog="541">
-        <p> Materials were donated by the Beth Israel Congregation of Ann Arbor, Mich. (donor no. <num type="donor" encodinganalog="541$e">6312</num>) in 2013. </p>
+        <p>Materials were donated by the Beth Israel Congregation of Ann Arbor, Mich. (donor no. <num type="donor" encodinganalog="541$e">6312</num>) in 2013. </p>
       </acqinfo>
       <accruals encodinganalog="584">
         <p>Periodic additions to the records expected.</p>

--- a/Real_Masters_all/birkertg.xml
+++ b/Real_Masters_all/birkertg.xml
@@ -30,7 +30,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Gunnar Birkerts Papers, 1930-2002</titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Sally Bund, 2002</author>
     </titlepage>

--- a/Real_Masters_all/blanchjj.xml
+++ b/Real_Masters_all/blanchjj.xml
@@ -58,7 +58,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>James J. Blanchard Papers, 1982-2002</titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Matthew T. Schaefer, 1991 <lb/>Karen Jania, 1991</author>
     </titlepage>

--- a/Real_Masters_all/brewerdwight.xml
+++ b/Real_Masters_all/brewerdwight.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE ead PUBLIC "+//ISBN 1-931666-00-8//DTD ead.dtd (Encoded Archival Description (EAD) Version 2002)//EN" "ead.dtd">
 <ead>
   <eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
-    <eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::brewerdwight.xml//EN" encodinganalog="Identifier"> umich-bhl-2014076</eadid>
+    <eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::brewerdwight.xml//EN" encodinganalog="Identifier">umich-bhl-2014076</eadid>
     <filedesc>
       <titlestmt>
         <titleproper encodinganalog="Title">Finding Aid for Dwight J. Brewer papers, 1862-1898 </titleproper>
@@ -27,7 +27,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/> Dwight J. Brewer papers, 1862-1898 </titleproper>
       <author>Finding aid created by<lb/> Olga Virakhovskaya </author>
     </titlepage>

--- a/Real_Masters_all/bschser.xml
+++ b/Real_Masters_all/bschser.xml
@@ -30,7 +30,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Bureau of School Services <lb/>(University of Michigan) <lb/>Records, 1871-1992</titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Kimberlee J. Mayer, 1997</author>
     </titlepage>

--- a/Real_Masters_all/busadmin.xml
+++ b/Real_Masters_all/busadmin.xml
@@ -42,7 +42,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Ross School of Business <lb/>(University of Michigan) <lb/>Records, 1916-2013</titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Bentley Historical Library staff</author>
     </titlepage>

--- a/Real_Masters_all/castagnacci.xml
+++ b/Real_Masters_all/castagnacci.xml
@@ -30,7 +30,7 @@ umich-bhl-2011012</eadid>
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher> Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/>
 Vincent Castagnacci papers
 </titleproper>

--- a/Real_Masters_all/cherrindan.xml
+++ b/Real_Masters_all/cherrindan.xml
@@ -29,7 +29,7 @@ umich-bhl-2015026</eadid>
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Michigan Historical Collections<lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/>
 Daniel Cherrin Papers, 2008-2009</titleproper>
       <author>Finding aid created by<lb/> Michael Shallcross, June 2015.</author>

--- a/Real_Masters_all/choffman.xml
+++ b/Real_Masters_all/choffman.xml
@@ -50,7 +50,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Clare E. Hoffman Papers, <date>1934-1962</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Thomas E. Powers and Gregory Kinney, 1986</author>
     </titlepage>

--- a/Real_Masters_all/clarkedewitt.xml
+++ b/Real_Masters_all/clarkedewitt.xml
@@ -31,7 +31,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Michigan Historical Collections<lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/> De Witt and Sarah Clarke Papers, 1864-1900</titleproper>
       <author>Finding aid created by<lb/> Daina Andries, July, 2015</author>
     </titlepage>

--- a/Real_Masters_all/darmich.xml
+++ b/Real_Masters_all/darmich.xml
@@ -35,7 +35,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for <lb/>Daughters of the American Revolution of Michigan <lb/>Records, 1893-2014</titleproper>
       <author>Finding aid created by <lb/>Michigan Historical Collections staff</author>
     </titlepage>

--- a/Real_Masters_all/davisannb.xml
+++ b/Real_Masters_all/davisannb.xml
@@ -27,7 +27,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/> Ann B. Davis papers </titleproper>
       <author>Finding aid created by<lb/> Dallas Pillen in August, 2015 </author>
     </titlepage>
@@ -37,7 +37,7 @@
       <origination>
         <corpname source="lcnaf" encodinganalog="110"> Davis, Ann B., 1926-2014 </corpname>
       </origination>
-      <unittitle encodinganalog="245"> Ann B. Davis papers <unitdate type="inclusive" encodinganalog="245$f"> 1944-2014 </unitdate> <unitdate type="bulk" encodinganalog="245$g"> 1956-2010 </unitdate> </unittitle>
+      <unittitle encodinganalog="245">Ann B. Davis papers <unitdate type="inclusive" encodinganalog="245$f"> 1944-2014 </unitdate> <unitdate type="bulk" encodinganalog="245$g"> 1956-2010 </unitdate> </unittitle>
       <physdesc altrender="part">
         <extent encodinganalog="300">3.5 linear feet</extent>
       </physdesc>

--- a/Real_Masters_all/detroitnews.xml
+++ b/Real_Masters_all/detroitnews.xml
@@ -35,7 +35,7 @@ Olga Virakhovskaya
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/>
 Detroit News records.
 </titleproper>

--- a/Real_Masters_all/devineed.xml
+++ b/Real_Masters_all/devineed.xml
@@ -27,7 +27,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/> Edmond DeVine papers </titleproper>
       <author>Finding aid created by<lb/> Elena Colon-Marrero, in October, 2015. </author>
     </titlepage>

--- a/Real_Masters_all/durbanl.xml
+++ b/Real_Masters_all/durbanl.xml
@@ -42,7 +42,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Detroit Urban League Records, <date type="inclusive">1916-1992</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Michigan Historical Collections Library Staff, <lb/>Matthew Schafer, <lb/>Nancy Webster</author>
     </titlepage>

--- a/Real_Masters_all/engcoll.xml
+++ b/Real_Masters_all/engcoll.xml
@@ -46,7 +46,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>College of Engineering <lb/>(University of Michigan) <lb/>Records, <date>1860-2010</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Bentley Library Staff</author>
     </titlepage>

--- a/Real_Masters_all/fordwd.xml
+++ b/Real_Masters_all/fordwd.xml
@@ -42,7 +42,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>William D. Ford Papers, 1955-1995</titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Lisa Humm, 1995</author>
     </titlepage>

--- a/Real_Masters_all/gbassoc.xml
+++ b/Real_Masters_all/gbassoc.xml
@@ -46,7 +46,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding Aid for <lb/>Gunnar Birkerts and Associates <lb/>Records, 1960-2014</titleproper>
       <author>Finding aid prepared by: <lb/>Sally L. Bund, June 1999, February 2008, <lb/>Last update: May 2015</author>
     </titlepage>

--- a/Real_Masters_all/gmwill.xml
+++ b/Real_Masters_all/gmwill.xml
@@ -58,7 +58,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>G. Mennen Williams Papers, <lb/><date type="inclusive">1883-1988 (bulk 1958-1980)</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Michigan Historical Collections Staff</author>
     </titlepage>

--- a/Real_Masters_all/gonzalesjess.xml
+++ b/Real_Masters_all/gonzalesjess.xml
@@ -27,7 +27,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan </publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for <lb/> Jesse Gonzales papers </titleproper>
       <author>Finding aid created by <lb/> Olga Virakhovskaya, May 2014 </author>
     </titlepage>
@@ -52,7 +52,7 @@
         <physfacet>online</physfacet>
       </physdesc>
       <repository>
-        <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan </corpname>
+        <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, Univeristy of Michigan</corpname>
         <extptr href="bhladd" show="embed" actuate="onload"/>
       </repository>
     </did>

--- a/Real_Masters_all/grahamwd.xml
+++ b/Real_Masters_all/grahamwd.xml
@@ -27,7 +27,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Michigan Historical Collections<lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/> Walter D. Graham Papers, 1900-1908</titleproper>
       <author>Finding aid created by<lb/> Greg Kinney, 2015</author>
     </titlepage>

--- a/Real_Masters_all/griffinj.xml
+++ b/Real_Masters_all/griffinj.xml
@@ -42,7 +42,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>James B. Griffin <lb/>Papers, <date type="inclusive">1922-1997</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Christine Di Bella, 2003</author>
     </titlepage>

--- a/Real_Masters_all/hartphil.xml
+++ b/Real_Masters_all/hartphil.xml
@@ -54,7 +54,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Philip A. Hart Papers, <date type="inclusive">1949-1976</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Thomas E. Powers</author>
     </titlepage>

--- a/Real_Masters_all/hatcherh.xml
+++ b/Real_Masters_all/hatcherh.xml
@@ -34,7 +34,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Harlan Henthorne Hatcher Papers, <date>1837-1998</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Michigan Historical Collections Staff <lb/> and Amy K. Watia (1999 accession)</author>
     </titlepage>

--- a/Real_Masters_all/hullfam.xml
+++ b/Real_Masters_all/hullfam.xml
@@ -34,7 +34,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Michigan Historical Collections<lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/> Hull Family Papers, 1869-1984</titleproper>
       <author>Finding aid created by<lb/> Jan Martz, 1990 <lb/>Alexis A. Antracoli, 2009</author>
     </titlepage>

--- a/Real_Masters_all/infolib.xml
+++ b/Real_Masters_all/infolib.xml
@@ -42,7 +42,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>School of Information <lb/>(University of Michigan) <lb/>Records, 1901-2012 (bulk 1926-1994)</titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>University Archives Staff</author>
     </titlepage>

--- a/Real_Masters_all/ivoryph.xml
+++ b/Real_Masters_all/ivoryph.xml
@@ -38,7 +38,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Ivory Photo, Ann Arbor, Michigan <date type="inclusive">ca. 1927-1971</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Susan Wineberg, 1982 <lb/>Karen Mason, 1986</author>
     </titlepage>

--- a/Real_Masters_all/johnstondona.xml
+++ b/Real_Masters_all/johnstondona.xml
@@ -31,7 +31,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/> Donald A. Johnston papers </titleproper>
       <author>Finding aid created by<lb/> Emily Riippa, September 2015 </author>
     </titlepage>

--- a/Real_Masters_all/kellaahc.xml
+++ b/Real_Masters_all/kellaahc.xml
@@ -34,7 +34,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>University Records and Archives Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding Aid for <lb/>Kellogg African American Health Care Project <lb/>Records, <date type="inclusive">1918-2000</date></titleproper>
       <author>Finding aid prepared by: <lb/>Suzanne Bergstrom, 1998 <lb/>Rebecca Bizonet, 2001</author>
     </titlepage>

--- a/Real_Masters_all/kelseymu.xml
+++ b/Real_Masters_all/kelseymu.xml
@@ -34,7 +34,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Kelsey Museum of Archaeology <lb/>Papers, <date type="inclusive" normal="1890/1987">1890-1987</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Carol Finerman, Kelsey Museum of Archaeology, 1981-1983 <lb/>On-line finding aid encoded by: <lb/>Archives Practicum students and <lb/>Bentley Historical Library staff, 2003. Last update: September 2015.</author>
     </titlepage>

--- a/Real_Masters_all/kevorkian.xml
+++ b/Real_Masters_all/kevorkian.xml
@@ -39,7 +39,7 @@ Greg Kinney
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Michigan Historical Collections<lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/>
 Jack Kevorkian papers, 1911-2014</titleproper>
       <author>Finding aid created by<lb/> 

--- a/Real_Masters_all/lawlib.xml
+++ b/Real_Masters_all/lawlib.xml
@@ -46,8 +46,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>University Archives and Records Program <lb/>Bentley Historical Library
-        <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding Aid for <lb/>Law Library (University of Michigan) <lb/>Records,
         1859-2006</titleproper>
       <author>Finding aid prepared by: <lb/>Michigan Historical Collections Staff</author>

--- a/Real_Masters_all/lawsch.xml
+++ b/Real_Masters_all/lawsch.xml
@@ -46,7 +46,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Law School (University of Michigan) <lb/>Records, 1852-2010</titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Bentley Library Staff</author>
     </titlepage>

--- a/Real_Masters_all/lorche.xml
+++ b/Real_Masters_all/lorche.xml
@@ -38,7 +38,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Emil Lorch Papers, <date>1891-2004</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Thomas E. Powers</author>
     </titlepage>

--- a/Real_Masters_all/mbotclub.xml
+++ b/Real_Masters_all/mbotclub.xml
@@ -46,7 +46,7 @@
       </origination>
       <unittitle encodinganalog="245">Michigan Botanical Club Records <unitdate type="inclusive" encodinganalog="245$f" normal="1941/2009">1941-2009</unitdate></unittitle>
       <physdesc altrender="whole">
-        6 linear feet
+        <extent>6 linear feet</extent>
       </physdesc>
       <abstract>Organization formed in 1941 with the purpose of conserving all plants native to Michigan. The name of the organization was originally the Michigan Wildflower Association. The name was changed in 1949. Series in record group include: History and constitution; Membership records; Minutes; Reports; Newsletters; Financial materials; Correspondence; Chapter records; and Activities files.</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">9440 Bn 2</unitid>

--- a/Real_Masters_all/mccrackp.xml
+++ b/Real_Masters_all/mccrackp.xml
@@ -42,7 +42,7 @@ Greg Kinney,
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Michigan Historical Collections<lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/>
 Paul Winston McCracken Papers, 1940-2011</titleproper>
       <author>Finding aid created by<lb/> 

--- a/Real_Masters_all/mdaily.xml
+++ b/Real_Masters_all/mdaily.xml
@@ -38,7 +38,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Michigan Daily Records, 1950-2006</titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Bentley Historical Library Staff</author>
     </titlepage>

--- a/Real_Masters_all/medthes.xml
+++ b/Real_Masters_all/medthes.xml
@@ -34,7 +34,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>University of Michigan. <lb/>Dept. of Medicine and Surgery <lb/>Theses, 1851-1878</titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Michigan Historical Collections staff <lb/>Ann Flowers, supervisor [1995 preparation for microfilming]</author>
     </titlepage>

--- a/Real_Masters_all/michcitizen.xml
+++ b/Real_Masters_all/michcitizen.xml
@@ -27,7 +27,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/> Michigan Citizen Records </titleproper>
       <author>Finding aid created by<lb/> Julia Teran in October 2015 </author>
     </titlepage>

--- a/Real_Masters_all/milliken.xml
+++ b/Real_Masters_all/milliken.xml
@@ -34,7 +34,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>William G. Milliken Papers, <date type="inclusive">1961-1982</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Avra Michaelson, 1983-1984 <lb/>Michigan Historical Collections staff, 1984, 1991-1992</author>
     </titlepage>

--- a/Real_Masters_all/mitechc.xml
+++ b/Real_Masters_all/mitechc.xml
@@ -45,7 +45,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>University Archives Program <lb/>Bentley Historical Library, <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Michigan Technology Council Records, <date>1968-1987</date></titleproper>
       <author>Finding aid prepared by <lb/>Sondra Smith, 1996</author>
     </titlepage>

--- a/Real_Masters_all/mohr.xml
+++ b/Real_Masters_all/mohr.xml
@@ -50,8 +50,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of
-        Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding Aid for <lb/>Michigan Organization for Human Rights <lb/>Records,
           <date>1970-1995</date></titleproper>
       <author>Finding aid prepared by: <lb/>Bentley Historical Library Staff</author>

--- a/Real_Masters_all/mooregeo.xml
+++ b/Real_Masters_all/mooregeo.xml
@@ -31,7 +31,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Michigan Historical Collections<lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/>George William Moore papers, 1859-1956</titleproper>
       <author>Finding aid created by<lb/>Carrie Hintz, November 2007<lb/>Michael Shallcross, February 2010</author>
     </titlepage>

--- a/Real_Masters_all/morrisseylew.xml
+++ b/Real_Masters_all/morrisseylew.xml
@@ -41,7 +41,7 @@ Olga Virakhovskaya
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/>
 Lewis A. Morrissey papers
 </titleproper>

--- a/Real_Masters_all/muschba.xml
+++ b/Real_Masters_all/muschba.xml
@@ -42,7 +42,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Avery Architectural and Fine Arts Library <lb/>Columbia University <lb/> and <lb/>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Avery Architectural and Fine Arts Library <lb/>Columbia University <lb/> and <lb/>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Muschenheim, William. <lb/>Architectural Drawings and Papers <date type="inclusive">1925-1957</date></titleproper>
       <author encodinganalog="creator">Collections processed and finding aids prepared by: <lb/>Avery Library Staff; <lb/>Kathy Steiner, Bentley Historical Library <lb/>Electronic finding aid prepared by: <lb/>Greg Kinney, Bentley Historical Library <lb/>Zheng (Jessica) Lu, Bentley Historical Library <lb/>Finding aid and Image access system: <lb/>Digital Library Production Services, University of Michigan</author>
     </titlepage>

--- a/Real_Masters_all/nispodcast.xml
+++ b/Real_Masters_all/nispodcast.xml
@@ -35,7 +35,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for <lb/>News and Information Services <lb/>(University of Michigan) <lb/>Audiovisual Materials, 1975-2012</titleproper>
       <author>Finding aid created by <lb/>Alexis Antrcoli, May 2011<lb/>Robert Goldey, April 2015</author>
     </titlepage>

--- a/Real_Masters_all/nursing.xml
+++ b/Real_Masters_all/nursing.xml
@@ -46,7 +46,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>School of Nursing (University of Michigan) <lb/>Records, 1891-2010.</titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Frank Boles, April 1983. <lb/>Matthew T. Schaefer, February 1991. <lb/>William Landis, April 1994. <lb/>Christine Di Bella, June 2002. <lb/>Polly Reynolds, 2006</author>
     </titlepage>

--- a/Real_Masters_all/oslerdav.xml
+++ b/Real_Masters_all/oslerdav.xml
@@ -685,7 +685,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>National Bank and Trust Company, Ann Arbor <unitdate type="inclusive" normal="1975">1975</unitdate></unittitle>
-            <physdesc altrender="odd">
+            <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">7 prints</extent>
             </physdesc>
           </did>

--- a/Real_Masters_all/ovshinskyharv.xml
+++ b/Real_Masters_all/ovshinskyharv.xml
@@ -27,7 +27,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Michigan Historical Collections<lb/>Bentley Historical Library<lb/>University of Michigan </publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for <lb/> Harvey Ovshinsky Papers, 1948-2014 </titleproper>
       <author>Finding aid created by <lb/> Daina Andries, June 2015 </author>
     </titlepage>
@@ -55,7 +55,7 @@
         <physfacet>online</physfacet>
       </physdesc>
       <repository>
-        <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan </corpname>
+        <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, Univeristy of Michigan</corpname>
         <extptr href="bhladd" show="embed" actuate="onload"/>
       </repository>
     </did>

--- a/Real_Masters_all/penncent.xml
+++ b/Real_Masters_all/penncent.xml
@@ -38,7 +38,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Penn Central Transportation Company <lb/>Records, <date>1835-1981</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Karen Mason and Catherine Arnott</author>
     </titlepage>

--- a/Real_Masters_all/pflaglan.xml
+++ b/Real_Masters_all/pflaglan.xml
@@ -41,13 +41,9 @@ A/E.</item>
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Michigan
-Historical Collections <lb/>Bentley Historical Library <lb/>University of
-Michigan</publisher>
-      <titleproper>Finding Aid for <lb/>Parents, Families and
-Friends of Lesbians and Gays, Lansing area chapter records, <date type="inclusive">1972-1999</date></titleproper>
-      <author>Finding aid
-prepared by: <lb/>Riva Pollard</author>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <titleproper>Finding Aid for <lb/>Parents, Families and Friends of Lesbians and Gays, Lansing area chapter records, <date type="inclusive">1972-1999</date></titleproper>
+      <author>Finding aid prepared by: <lb/>Riva Pollard</author>
     </titlepage>
   </frontmatter>
   <archdesc audience="external" type="inventory" level="recordgrp" encodinganalog="110" relatedencoding="MARC21">

--- a/Real_Masters_all/phoenix.xml
+++ b/Real_Masters_all/phoenix.xml
@@ -38,7 +38,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Michigan Memorial Phoenix Project <lb/>Records, 1947-2003</titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Helmi Raaska, June 1982 <lb/>Kathy Steiner, March 2002 <lb/>Kate Donovan, 2008</author>
     </titlepage>

--- a/Real_Masters_all/physics.xml
+++ b/Real_Masters_all/physics.xml
@@ -50,9 +50,7 @@ finding aid created by Greg Kinney <date>August
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>University
-Archives and Records Program <lb/>Bentley Historical Library <lb/>University of
-Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding Aid for <lb/>Dept. of Physics <lb/>(University of Michigan) <lb/>Records, 1873-ongoing</titleproper>
       <author>Finding aid prepared by: <lb/>Amy Watia,
 2000 <lb/>Christine Di Bella, 2002 <lb/>Nancy Deromedi, 2006<lb/>Elizabeth Carron, 2015</author>

--- a/Real_Masters_all/pohrtkarl.xml
+++ b/Real_Masters_all/pohrtkarl.xml
@@ -27,7 +27,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Michigan Historical Collections<lb/>Bentley Historical Library<lb/>University of Michigan </publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for <lb/> Karl Pohrt Papers, 1976-2013 </titleproper>
       <author>Finding aid created by <lb/> Daina Andries, July 2015 </author>
     </titlepage>
@@ -53,7 +53,7 @@
         <physfacet>online</physfacet>
       </physdesc>
       <repository>
-        <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan </corpname>
+        <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, Univeristy of Michigan</corpname>
         <extptr href="bhladd" show="embed" actuate="onload"/>
       </repository>
     </did>

--- a/Real_Masters_all/pollockj.xml
+++ b/Real_Masters_all/pollockj.xml
@@ -38,7 +38,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>James K. Pollock Papers, 1920-1968</titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Dennis Anderson, 1969 <lb/>Beth Lindblom, 1989</author>
     </titlepage>

--- a/Real_Masters_all/postfam.xml
+++ b/Real_Masters_all/postfam.xml
@@ -46,7 +46,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Post Family Papers, <date type="inclusive">1882-1973</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Frank Boles (boxes 1-44), 1979. <lb/>Gary Kwiatek (boxes 45-46), 1981 <lb/>Nancy Bartlett (boxes 47-48), February 1983. <lb/>May Davis Hill (boxes 49-55), 1979</author>
     </titlepage>

--- a/Real_Masters_all/provost.xml
+++ b/Real_Masters_all/provost.xml
@@ -27,7 +27,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>University Archives and records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for <lb/>Provost (University of Michigan) <lb/>Records, 1934-1951</titleproper>
       <author>Finding aid created by <lb/>Bentley Historical Library Staff</author>
     </titlepage>

--- a/Real_Masters_all/psychiap.xml
+++ b/Real_Masters_all/psychiap.xml
@@ -31,7 +31,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher><lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for <lb/>Dept. of Psychiatry <lb/>(University of Michigan) <lb/>records, 1959-2013</titleproper>
       <author>Finding aid created by <lb/>Jennifer Jacobs, 1999; <lb/>Melissa Hernandez-Duran, November 2014.</author>
     </titlepage>

--- a/Real_Masters_all/quezon.xml
+++ b/Real_Masters_all/quezon.xml
@@ -35,8 +35,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Michigan Historical Collections<lb/>Bentley Historical Library<lb/>University of Michigan
-      </publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/>Manuel Luis Quezon papers, 1909-1944
       </titleproper>
       <author>Finding aid created by

--- a/Real_Masters_all/rackhamg.xml
+++ b/Real_Masters_all/rackhamg.xml
@@ -38,7 +38,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Horace H. Rackham School of Graduate Studies <lb/>(University of Michigan) <lb/>Records, 1892-2014</titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>University Archives Staff <lb/>Last updated February 2015</author>
     </titlepage>

--- a/Real_Masters_all/regents.xml
+++ b/Real_Masters_all/regents.xml
@@ -58,7 +58,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Board of Regents <lb/>(University of Michigan) <lb/><date type="inclusive">Records, 1817-2011 (bulk 1899-1988)</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Frank Boles and University Archives Staff, <lb/>last updated 3/13/2011</author>
     </titlepage>

--- a/Real_Masters_all/romneyg.xml
+++ b/Real_Masters_all/romneyg.xml
@@ -46,7 +46,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>George Romney Papers <lb/><date>1920s-1973</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Thomas E. Powers and Gregory Kinney</author>
     </titlepage>

--- a/Real_Masters_all/ruthvena.xml
+++ b/Real_Masters_all/ruthvena.xml
@@ -38,7 +38,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Alexander G. Ruthven Papers, <date type="inclusive">1901-1961</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Michigan Historical Collections staff</author>
     </titlepage>

--- a/Real_Masters_all/saastudent.xml
+++ b/Real_Masters_all/saastudent.xml
@@ -27,7 +27,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/> Society of American Archivists Student Chapter <lb/>(University of Michigan) <lb/>records, 1993-1996</titleproper>
       <author>Finding aid created by<lb/> Max Eckard, in October 2015. </author>
     </titlepage>

--- a/Real_Masters_all/sciclub.xml
+++ b/Real_Masters_all/sciclub.xml
@@ -53,7 +53,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>University Archives Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding Aid for <lb/>Science Research Club <lb/>(University of Michigan) <lb/>Records, <date>1902-2004</date></titleproper>
       <author>Finding aid prepared by <lb/>Joseph D. Quain, 1996 and Alexis Antracoli, 2009</author>
     </titlepage>

--- a/Real_Masters_all/sectryvp.xml
+++ b/Real_Masters_all/sectryvp.xml
@@ -27,7 +27,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>University Archives and Records Program<lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/> Office of the Vice President and Secretary of the University<lb/> (University of Michigan) <lb/>Records, 1935-2007 </titleproper>
       <author>Finding aid created by<lb/> Elise Reynolds, 2015 </author>
     </titlepage>

--- a/Real_Masters_all/shockn.xml
+++ b/Real_Masters_all/shockn.xml
@@ -34,7 +34,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Nathan W. Shock Papers, <date type="inclusive">1906-1989</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Katherine C. Owen</author>
     </titlepage>

--- a/Real_Masters_all/sincljl.xml
+++ b/Real_Masters_all/sincljl.xml
@@ -57,7 +57,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>John and Leni Sinclair Papers, <date type="inclusive">1957-2003</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Stephen Meyers, 1979 (papers); <lb/>Mary Lisa Tanner, 1980 (sound reels); <lb/>Marilyn F. McLaughlin, 1991 (sound cassettes and discs) <lb/>Dan Santamaria, 2000</author>
     </titlepage>

--- a/Real_Masters_all/smithglk.xml
+++ b/Real_Masters_all/smithglk.xml
@@ -42,7 +42,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Gerald L. K. Smith Papers, <date>1922-1976</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Michigan Historical Collections Staff</author>
     </titlepage>

--- a/Real_Masters_all/snre.xml
+++ b/Real_Masters_all/snre.xml
@@ -42,7 +42,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>School of Natural Resources and Environment <lb/>(University of Michigan) <lb/>Records, 1903-2012.</titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Processed by Bentley Staff. Last updated May 2013</author>
     </titlepage>

--- a/Real_Masters_all/sphum.xml
+++ b/Real_Masters_all/sphum.xml
@@ -50,7 +50,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>School of Public Health <lb/>(University of Michigan) <lb/>Records, 1909-2015 (bulk 1941-2004).</titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Greg Kinney, November 1988 <lb/>Matthew T. Schaefer, May 1990 <lb/>Brian Williams, October 1995, <lb/>Phil Deloria, 2007, <lb/>Michael Shallcross, 2012 and 2015</author>
     </titlepage>

--- a/Real_Masters_all/stewartmary.xml
+++ b/Real_Masters_all/stewartmary.xml
@@ -31,7 +31,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for<lb/> Mary Stewart Papers, 1980-2015 </titleproper>
       <author>Finding aid created by<lb/> Elena Colon-Marrero in September, 2015. </author>
     </titlepage>

--- a/Real_Masters_all/stonerct.xml
+++ b/Real_Masters_all/stonerct.xml
@@ -30,7 +30,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Claude Thomas Stoner Photographs and Papers, <date type="inclusive">1870s-1977</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Leonard A. Coombs</author>
     </titlepage>

--- a/Real_Masters_all/thomasc.xml
+++ b/Real_Masters_all/thomasc.xml
@@ -45,7 +45,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Michigan Historical Collection <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding Aid for <lb/>Charles Thomas, Jr. <lb/>Papers, <date>1965-1994</date></titleproper>
       <author>Finding aid prepared by <lb/>Amy L. James, 1995</author>
     </titlepage>

--- a/Real_Masters_all/tuttleaj.xml
+++ b/Real_Masters_all/tuttleaj.xml
@@ -38,7 +38,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Arthur J. Tuttle Papers, <date type="inclusive">1849-1958</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Aprille Cooke McKay</author>
     </titlepage>

--- a/Real_Masters_all/ulibrary.xml
+++ b/Real_Masters_all/ulibrary.xml
@@ -82920,7 +82920,7 @@ Library (University of Michigan) Record, Bentley Historical Library, University 
             <c04 level="file">
               <did>
                 <container type="box" label="Box">230</container>
-                <unittitle>Marketing and Publicity <unitdate type="inclusive" normal="1988/1987">1988-1987</unitdate></unittitle>
+                <unittitle>Marketing and Publicity <unitdate type="inclusive" normal="1988/1997">1988-1997</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/vpaastaf.xml
+++ b/Real_Masters_all/vpaastaf.xml
@@ -38,7 +38,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Provost and Executive Vice-President for Academic Affairs <lb/>(University of Michigan) <lb/>Staff Files, <date type="inclusive">1947-[ongoing]</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Bentley Historical Library Staff <lb/>Lisa Gibbon Pratt (reprocessing), 1995 <lb/>Aprille Cooke McKay, 2004</author>
     </titlepage>

--- a/Real_Masters_all/vpdev.xml
+++ b/Real_Masters_all/vpdev.xml
@@ -38,7 +38,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Vice-President for Development <lb/>(University of Michigan) <lb/>Records, <date type="inclusive">1948-[ongoing]</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>University Archives Staff</author>
     </titlepage>

--- a/Real_Masters_all/vpsaff.xml
+++ b/Real_Masters_all/vpsaff.xml
@@ -38,7 +38,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher encodinganalog="publisher">Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Vice President for Student Affairs <lb/>(University of Michigan) <lb/>Records, <date>1908-2005</date></titleproper>
       <author encodinganalog="creator">Finding aid prepared by: <lb/>Matthew T. Schaefer, 1987, 1988 <lb/>Karen L. Jania, 1993, <lb/>Lisa M. McNamara, May 1998 <lb/>Samuel Jacob, July 2002 <lb/>Hannah Jenkins, 2013</author>
     </titlepage>

--- a/Real_Masters_all/wallacem.xml
+++ b/Real_Masters_all/wallacem.xml
@@ -31,7 +31,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan.</publisher>
+      <publisher>Michigan Historical Collections <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper>Finding aid for <lb/>Mike Wallace Papers, 1956-1963.</titleproper>
       <author>Finding aid created by <lb/>Chris Leonard, November 1984.</author>
     </titlepage>

--- a/Real_Masters_all/womsath.xml
+++ b/Real_Masters_all/womsath.xml
@@ -41,7 +41,7 @@
   </eadheader>
   <frontmatter>
     <titlepage>
-      <publisher>University Archives Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
+      <publisher>University Archives and Records Program <lb/>Bentley Historical Library <lb/>University of Michigan</publisher>
       <titleproper encodinganalog="title">Finding Aid for <lb/>Women's Athletics <lb/>(University of Michigan) <lb/>Records, 1972-1990</titleproper>
       <author>Finding aid prepared by <lb/>Karen Jania, 1990 <lb/>Greg Kinney, 1994</author>
     </titlepage>


### PR DESCRIPTION
So I always knew that ArchivesSpace ignores the titlepage and all subelements, which in theory makes sense -- titlepage is discouraged by LoC, it's being deprecated in EAD3, and usually the content is duplicated elsewhere (like in the eadheader). However, apparently our titlepage/publisher statements are the only reliable way that I can tell to identify if a finding aid is MHC or UARP. In our eadheader publisher statement, it just says "Bentley Historical Library," not the subunit. We'll need to look into where we should be importing this info into ArchivesSpace, but for now I standardized our titlepage/publisher statements to make things easier.

Something like this would come in really handy for, like, knowing whether or not university restriction policies should be displayed.
