### PR TITLE
adding a space in triple dashed compound agents

### DIFF
--- a/Real_Masters_all/biochemp.xml
+++ b/Real_Masters_all/biochemp.xml
@@ -90,7 +90,7 @@ Department of Biological Chemistry (University of Michigan) publications, Bentle
       <controlaccess>
         <head>Subjects:</head>
         <corpname source="lcnaf" encodinganalog="610">University of Michigan. Dept. of Biological Chemistry.</corpname>
-        <persname source="lcnaf" encodinganalog="700">Christman, Adam Arthur, 1896---Department of Biological Chemistry, 1922-1955--1978.</persname>
+        <persname source="lcnaf" encodinganalog="700">Christman, Adam Arthur, 1896- --Department of Biological Chemistry, 1922-1955--1978.</persname>
         <title source="aacr2" encodinganalog="740">Biochemistry newsletter.</title>
         <title source="aacr2" encodinganalog="740">Biological chemistry newsletter.</title>
         <title source="aacr2" encodinganalog="740">Department of Biological Chemistry newsletter.</title>

--- a/Real_Masters_all/gilfilll.xml
+++ b/Real_Masters_all/gilfilll.xml
@@ -83,7 +83,7 @@ Lauren Gilfillan papers, Bentley Historical Library, University of Michigan</p>
       <controlaccess>
         <head>Subjects:</head>
         <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/nb98051213">Gilfillan, Lauren, 1909-</persname>
-        <persname source="lcnaf" encodinganalog="600">Gilfillan, Lauren, 1909---I went to pit college.</persname>
+        <persname source="lcnaf" encodinganalog="600">Gilfillan, Lauren, 1909- --I went to pit college.</persname>
         <subject source="lcsh" encodinganalog="650">Mentally ill--Michigan.</subject>
         <subject source="lcsh" encodinganalog="650">Proletariat in literature.</subject>
         <subject source="lcsh" encodinganalog="650">Women authors, American--20th century.</subject>

--- a/Real_Masters_all/jabara.xml
+++ b/Real_Masters_all/jabara.xml
@@ -104,7 +104,7 @@ Abdeen Jabara papers, Bentley Historical Library, University of Michigan</p>
         <subject source="lcsh" encodinganalog="650">Lawyers--Michigan.</subject>
         <geogname source="lcsh" encodinganalog="651">Lebanon--Relations--Israel.</geogname>
         <corpname source="lcnaf" encodinganalog="610" authfilenumber="http://id.loc.gov/authorities/names/n79054671">National Lawyers Guild.</corpname>
-        <persname source="lcnaf" encodinganalog="600">Sirhan, Sirhan Bishara, 1944---Trials, litigation, etc.</persname>
+        <persname source="lcnaf" encodinganalog="600">Sirhan, Sirhan Bishara, 1944- --Trials, litigation, etc.</persname>
       </controlaccess>
       <controlaccess>
         <head>Genre Terms:</head>

--- a/Real_Masters_all/ranville.xml
+++ b/Real_Masters_all/ranville.xml
@@ -92,7 +92,7 @@ Michael Ranville papers, Bentley Historical Library, University of Michigan</p>
         <persname source="lcnaf" encodinganalog="600">McCarthy, Joseph, 1908-1957--Influence.</persname>
         <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n96060693">Radulovich, Milo, 1926-2007.</persname>
         <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n96059329">Ranville, Michael, 1943-</persname>
-        <persname source="lcnaf" encodinganalog="600">Ranville, Michael, 1943---To strike at a king.</persname>
+        <persname source="lcnaf" encodinganalog="600">Ranville, Michael, 1943- --To strike at a king.</persname>
       </controlaccess>
       <controlaccess>
         <head>Subjects - Visual Materials:</head>


### PR DESCRIPTION
agent.text.split('--') doesn't work right when there are three dashes separating a persname and a subdivided term, as is the case for persnames that have a birth date but no death date.

This PR adds a space between the first and second dash which ought to help.
