### PR TITLE
removing parens from unitids

### DIFF
--- a/Real_Masters_all/bldgrds.xml
+++ b/Real_Masters_all/bldgrds.xml
@@ -1937,7 +1937,7 @@
       <c01 level="series">
         <did>
           <unittitle><genreform normal="Maps">Topographical Maps</genreform>, <unitdate type="inclusive" normal="1921/1938">1921-1938</unitdate></unittitle>
-          <unitid>(M4114 .A8:2U5 svar U5 Out)</unitid>
+          <unitid>M4114 .A8:2U5 svar U5 Out</unitid>
         </did>
         <scopecontent>
           <p>The series Topographical Maps (1921-1938) includes oversized maps which detail the topography of the area surrounding and including the University of Michigan.</p>

--- a/Real_Masters_all/burnsleo.xml
+++ b/Real_Masters_all/burnsleo.xml
@@ -107,70 +107,70 @@ Leo A. Burns photograph collection, Bentley Historical Library, University of Mi
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>1)</unitid>
+              <unitid>1</unitid>
               <unittitle>"Watering horses at Yankee Springs"</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>2)</unitid>
+              <unitid>2</unitid>
               <unittitle>Two girls with doll in front of house</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>3)</unitid>
+              <unitid>3</unitid>
               <unittitle>Boathouse and 3 women in rowboat</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>4)</unitid>
+              <unitid>4</unitid>
               <unittitle>Two men standing in "Marguerite" (rowboat) with many other men on shore</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>5)</unitid>
+              <unitid>5</unitid>
               <unittitle>Man reading by his front porch, two children playing at his feet</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>6)</unitid>
+              <unitid>6</unitid>
               <unittitle>Two adults and two children in rowboat, on a lake or pond</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>7)</unitid>
+              <unitid>7</unitid>
               <unittitle>Two women standing next to a rowboat on a lake or pond</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>8)</unitid>
+              <unitid>8</unitid>
               <unittitle>Eight people on picnic</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>9)</unitid>
+              <unitid>9</unitid>
               <unittitle>Man standing on hill</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>10)</unitid>
+              <unitid>10</unitid>
               <unittitle>Two children standing in pond or lake</unittitle>
             </did>
           </c03>
@@ -182,7 +182,7 @@ Leo A. Burns photograph collection, Bentley Historical Library, University of Mi
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>11-12)</unitid>
+              <unitid>11-12</unitid>
               <unittitle>Two girls in costumes</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 negatives</extent>
@@ -192,35 +192,35 @@ Leo A. Burns photograph collection, Bentley Historical Library, University of Mi
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>13)</unitid>
+              <unitid>13</unitid>
               <unittitle>Three women and child cavorting, one woman on table top</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>14)</unitid>
+              <unitid>14</unitid>
               <unittitle>Room Interior: Mother reading to two children</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>15)</unitid>
+              <unitid>15</unitid>
               <unittitle>Three women and two children on porch, No. 303 (Lake Ave.?, Battle Creek?)</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>16)</unitid>
+              <unitid>16</unitid>
               <unittitle>Woman, two children and dog on porch</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>17)</unitid>
+              <unitid>17</unitid>
               <unittitle>Woman standing on porch, one child in dog-cart, another sitting on porch steps</unittitle>
             </did>
             <odd>
@@ -230,14 +230,14 @@ Leo A. Burns photograph collection, Bentley Historical Library, University of Mi
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>18)</unitid>
+              <unitid>18</unitid>
               <unittitle>Three men standing on Grand Trunk Railroad tank car</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>19)</unitid>
+              <unitid>19</unitid>
               <unittitle>Man watering lawn with hose, woman and two children, next to their home</unittitle>
             </did>
             <odd>
@@ -247,35 +247,35 @@ Leo A. Burns photograph collection, Bentley Historical Library, University of Mi
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>20)</unitid>
+              <unitid>20</unitid>
               <unittitle>Group of 5 women sitting on porch steps</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>21)</unitid>
+              <unitid>21</unitid>
               <unittitle>Room interior-Victorian style</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>22)</unitid>
+              <unitid>22</unitid>
               <unittitle>Room interior with man reading magazine</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>23)</unitid>
+              <unitid>23</unitid>
               <unittitle>Young boy playing Indian, on a hill</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>24)</unitid>
+              <unitid>24</unitid>
               <unittitle>Young boy playing cowboy</unittitle>
             </did>
             <odd>
@@ -285,21 +285,21 @@ Leo A. Burns photograph collection, Bentley Historical Library, University of Mi
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>25)</unitid>
+              <unitid>25</unitid>
               <unittitle>Water heater/boiler</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>26)</unitid>
+              <unitid>26</unitid>
               <unittitle>Outdoor Fall or Spring scene: Group standing outdoors near a horse-drawn buggy</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>27)</unitid>
+              <unitid>27</unitid>
               <unittitle>"B.R. Murry's Res. Battle Creek, Mich."</unittitle>
             </did>
           </c03>

--- a/Real_Masters_all/cmpdavis.xml
+++ b/Real_Masters_all/cmpdavis.xml
@@ -805,7 +805,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>1)</unitid>
+                <unitid>1</unitid>
                 <unittitle>Looking down Hoback Canyon</unittitle>
               </did>
               <odd>
@@ -815,7 +815,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>2)</unitid>
+                <unitid>2</unitid>
                 <unittitle>Looking toward Rangers' station</unittitle>
               </did>
               <odd>
@@ -825,7 +825,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>3)</unitid>
+                <unitid>3</unitid>
                 <unittitle>Head of stream supplying camp water</unittitle>
               </did>
               <odd>
@@ -835,7 +835,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>4)</unitid>
+                <unitid>4</unitid>
                 <unittitle>Looking northeasterly-Hoback Canyon</unittitle>
               </did>
               <odd>
@@ -845,49 +845,49 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>5)</unitid>
+                <unitid>5</unitid>
                 <unittitle>Looking towards canyon</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>6)</unitid>
+                <unitid>6</unitid>
                 <unittitle>Party group (Smith, De La Reza, Farrozas, Joumepin)</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>7)</unitid>
+                <unitid>7</unitid>
                 <unittitle>Party group (Spoden, Sikso, Weber, Pierce)</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>8)</unitid>
+                <unitid>8</unitid>
                 <unittitle>Party group (Schneider, Fan, Shia, Jenkins, McRay)</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>9)</unitid>
+                <unitid>9</unitid>
                 <unittitle>Party group (Williams, Edmunds, Shelly, Bosworth)</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>10)</unitid>
+                <unitid>10</unitid>
                 <unittitle>Mess and kitchen <unitdate type="inclusive" normal="1929-07-05">07/05/1929</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>11)</unitid>
+                <unitid>11</unitid>
                 <unittitle>View from mess and kitchen <unitdate type="inclusive" normal="1929-07-03">07/03/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -897,7 +897,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>12)</unitid>
+                <unitid>12</unitid>
                 <unittitle>Shop floor (Prof. Young at saw) <unitdate type="inclusive" normal="1929-07-03">07/03/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -907,7 +907,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>13)</unitid>
+                <unitid>13</unitid>
                 <unittitle>Floor of instrument room <unitdate type="inclusive" normal="1929-07-03">07/03/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -917,7 +917,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>14)</unitid>
+                <unitid>14</unitid>
                 <unittitle>Floor of administration building <unitdate type="inclusive" normal="1929-07-03">07/03/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -927,7 +927,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>15)</unitid>
+                <unitid>15</unitid>
                 <unittitle>Flume carrying small stream over pipeline ditch <unitdate type="inclusive" normal="1929-07-03">07/03/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -937,7 +937,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>16)</unitid>
+                <unitid>16</unitid>
                 <unittitle>Faculty bath house under construction <unitdate type="inclusive" normal="1929-07-03">07/03/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -947,7 +947,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>17)</unitid>
+                <unitid>17</unitid>
                 <unittitle>Typical steel building under construction</unittitle>
               </did>
               <odd>
@@ -957,7 +957,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>18)</unitid>
+                <unitid>18</unitid>
                 <unittitle>Construction of typical steel building</unittitle>
               </did>
               <odd>
@@ -967,7 +967,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>19)</unitid>
+                <unitid>19</unitid>
                 <unittitle>Northwest view of camp <unitdate type="inclusive" normal="1929-07-03">07/03/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -977,7 +977,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>20)</unitid>
+                <unitid>20</unitid>
                 <unittitle>Southeast view of camp <unitdate type="inclusive" normal="1929-07-03">07/03/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -987,7 +987,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>21)</unitid>
+                <unitid>21</unitid>
                 <unittitle>Faculty bath house under construction</unittitle>
               </did>
               <odd>
@@ -997,7 +997,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>22)</unitid>
+                <unitid>22</unitid>
                 <unittitle>Digging hole for septic tank <unitdate type="inclusive" normal="1929-07-03">07/03/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1007,7 +1007,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>23)</unitid>
+                <unitid>23</unitid>
                 <unittitle>Source of camp water supply</unittitle>
               </did>
               <odd>
@@ -1017,7 +1017,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>24)</unitid>
+                <unitid>24</unitid>
                 <unittitle>Laying floor in kitchen <unitdate type="inclusive" normal="1929-07-03">07/03/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1027,7 +1027,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>25)</unitid>
+                <unitid>25</unitid>
                 <unittitle>Mess hall from southwest <unitdate type="inclusive" normal="1929-07-04">07/04/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1037,7 +1037,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>26)</unitid>
+                <unitid>26</unitid>
                 <unittitle>Putting steel on west side of mess hall</unittitle>
               </did>
               <odd>
@@ -1047,7 +1047,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>27)</unitid>
+                <unitid>27</unitid>
                 <unittitle>Mess hall <unitdate type="inclusive" normal="1929-07-03">07/03/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1057,7 +1057,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>28)</unitid>
+                <unitid>28</unitid>
                 <unittitle>Camp from southwest</unittitle>
               </did>
               <odd>
@@ -1067,7 +1067,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>29)</unitid>
+                <unitid>29</unitid>
                 <unittitle>Mess hall</unittitle>
               </did>
               <odd>
@@ -1077,7 +1077,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>30)</unitid>
+                <unitid>30</unitid>
                 <unittitle>Panorama from hill west of Willow Creek</unittitle>
               </did>
               <odd>
@@ -1087,7 +1087,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>31)</unitid>
+                <unitid>31</unitid>
                 <unittitle>Panorama from hill west of Willow Creek</unittitle>
               </did>
               <odd>
@@ -1097,7 +1097,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>32)</unitid>
+                <unitid>32</unitid>
                 <unittitle>Panorama from hill west of Willow Creek</unittitle>
               </did>
               <odd>
@@ -1107,7 +1107,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>33)</unitid>
+                <unitid>33</unitid>
                 <unittitle>Panorama southwest of camp</unittitle>
               </did>
               <odd>
@@ -1117,7 +1117,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>34)</unitid>
+                <unitid>34</unitid>
                 <unittitle>Panorama southwest of camp</unittitle>
               </did>
               <odd>
@@ -1127,7 +1127,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>35)</unitid>
+                <unitid>35</unitid>
                 <unittitle>Panorama southwest of camp</unittitle>
               </did>
               <odd>
@@ -1137,14 +1137,14 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>36)</unitid>
+                <unitid>36</unitid>
                 <unittitle>Drain of camp water supply, no. 1</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>37)</unitid>
+                <unitid>37</unitid>
                 <unittitle>Drain of camp water supply, no. 2</unittitle>
               </did>
               <odd>
@@ -1154,7 +1154,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>38)</unitid>
+                <unitid>38</unitid>
                 <unittitle>View from west of Willow Creek</unittitle>
               </did>
               <odd>
@@ -1164,7 +1164,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>39)</unitid>
+                <unitid>39</unitid>
                 <unittitle>View from Willow Creek valley</unittitle>
               </did>
               <odd>
@@ -1174,7 +1174,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>40-41)</unitid>
+                <unitid>40-41</unitid>
                 <unittitle>Looking up Willow Creek Valley</unittitle>
               </did>
               <odd>
@@ -1184,7 +1184,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>42)</unitid>
+                <unitid>42</unitid>
                 <unittitle>Prof. Young's washing machine</unittitle>
               </did>
               <odd>
@@ -1194,7 +1194,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>43)</unitid>
+                <unitid>43</unitid>
                 <unittitle>View from E'ly up the Hoback Canyon</unittitle>
               </did>
               <odd>
@@ -1204,7 +1204,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>44)</unitid>
+                <unitid>44</unitid>
                 <unittitle>View down camp road</unittitle>
               </did>
               <odd>
@@ -1214,7 +1214,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>45)</unitid>
+                <unitid>45</unitid>
                 <unittitle>View up the Hoback</unittitle>
               </did>
               <odd>
@@ -1224,7 +1224,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>46)</unitid>
+                <unitid>46</unitid>
                 <unittitle>Duplicate of no. 44</unittitle>
               </did>
               <odd>
@@ -1234,7 +1234,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>47)</unitid>
+                <unitid>47</unitid>
                 <unittitle>Hoback Canyon</unittitle>
               </did>
               <odd>
@@ -1244,14 +1244,14 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>48)</unitid>
+                <unitid>48</unitid>
                 <unittitle>Hoback River</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>49)</unitid>
+                <unitid>49</unitid>
                 <unittitle>Hoback River and Canyon</unittitle>
               </did>
               <odd>
@@ -1261,7 +1261,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>50)</unitid>
+                <unitid>50</unitid>
                 <unittitle>Hoback Canyon, looking downstream</unittitle>
               </did>
               <odd>
@@ -1271,7 +1271,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>51-)</unitid>
+                <unitid>51-</unitid>
                 <unittitle>Mouth of Hoback Canyon</unittitle>
               </did>
               <odd>
@@ -1281,7 +1281,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>52)</unitid>
+                <unitid>52</unitid>
                 <unittitle>Hoback Canyon</unittitle>
               </did>
               <odd>
@@ -1291,7 +1291,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>53)</unitid>
+                <unitid>53</unitid>
                 <unittitle>Looking down Hoback Canyon westerly</unittitle>
               </did>
               <odd>
@@ -1306,14 +1306,14 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>54)</unitid>
+                <unitid>54</unitid>
                 <unittitle>Crook in road</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>55a-e)</unitid>
+                <unitid>55a-e</unitid>
                 <unittitle>Camp Davis <unitdate type="inclusive" normal="1940/1949" certainty="approximate">1940s</unitdate>, <unitdate type="inclusive" normal="1950/1959" certainty="approximate">1950s</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">5 negatives</extent>
@@ -1323,126 +1323,126 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>56a-c)</unitid>
+                <unitid>56a-c</unitid>
                 <unittitle>Camp Davis 3 negatives</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>57)</unitid>
+                <unitid>57</unitid>
                 <unittitle>mountain top</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>58)</unitid>
+                <unitid>58</unitid>
                 <unittitle>Hoback Road and River (car in foreground)</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>59)</unitid>
+                <unitid>59</unitid>
                 <unittitle>High cliff</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>60)</unitid>
+                <unitid>60</unitid>
                 <unittitle>River to canyon</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>61)</unitid>
+                <unitid>61</unitid>
                 <unittitle>Road and river to canyon</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>62)</unitid>
+                <unitid>62</unitid>
                 <unittitle>River road to canyon and camp</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>63)</unitid>
+                <unitid>63</unitid>
                 <unittitle>Hoback near V-V Ranch</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>64)</unitid>
+                <unitid>64</unitid>
                 <unittitle>Valley fence in foreground</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>65)</unitid>
+                <unitid>65</unitid>
                 <unittitle>Canyon (view from east of camp)</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>66)</unitid>
+                <unitid>66</unitid>
                 <unittitle>Beaver Mountain</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>67)</unitid>
+                <unitid>67</unitid>
                 <unittitle>Looking toward gate and camp creek</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>68)</unitid>
+                <unitid>68</unitid>
                 <unittitle>Woods Lodge pale pine</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>69)</unitid>
+                <unitid>69</unitid>
                 <unittitle>Camp water supply intake</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>70)</unitid>
+                <unitid>70</unitid>
                 <unittitle>Woods</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>71)</unitid>
+                <unitid>71</unitid>
                 <unittitle>Woods and Ant Hill</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>72)</unitid>
+                <unitid>72</unitid>
                 <unittitle>Looking towards canyon from east side of camp</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>73)</unitid>
+                <unitid>73</unitid>
                 <unittitle>Staff <unitdate type="inclusive" normal="1929" certainty="approximate">1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1452,140 +1452,140 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>74)</unitid>
+                <unitid>74</unitid>
                 <unittitle>Yellowstone Falls</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>75)</unitid>
+                <unitid>75</unitid>
                 <unittitle>Yellowstone Canyon (below Lower Falls)</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>76)</unitid>
+                <unitid>76</unitid>
                 <unittitle>Clouds and mountains</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>77)</unitid>
+                <unitid>77</unitid>
                 <unittitle>Clouds and mountains</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>78)</unitid>
+                <unitid>78</unitid>
                 <unittitle>Camp Davis</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>79)</unitid>
+                <unitid>79</unitid>
                 <unittitle>Camp Davis</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>80)</unitid>
+                <unitid>80</unitid>
                 <unittitle>Camp Davis (short focus)</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>81)</unitid>
+                <unitid>81</unitid>
                 <unittitle>Camp Davis (from hill)</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>82)</unitid>
+                <unitid>82</unitid>
                 <unittitle>Camp Davis</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>83)</unitid>
+                <unitid>83</unitid>
                 <unittitle>Camp Davis (valley scene)</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>84)</unitid>
+                <unitid>84</unitid>
                 <unittitle>Hoback River and Mountain slopes</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>85)</unitid>
+                <unitid>85</unitid>
                 <unittitle>Hoback Canyon</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>86)</unitid>
+                <unitid>86</unitid>
                 <unittitle>Valley southeast of camp</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>87)</unitid>
+                <unitid>87</unitid>
                 <unittitle>View of camp looking easterly</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>88)</unitid>
+                <unitid>88</unitid>
                 <unittitle>Camp Davis</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>89)</unitid>
+                <unitid>89</unitid>
                 <unittitle>Camp Davis shelters (from path)</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>90)</unitid>
+                <unitid>90</unitid>
                 <unittitle>Camp Davis, stone steps</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>91)</unitid>
+                <unitid>91</unitid>
                 <unittitle>Camp Davis, on axis</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>92)</unitid>
+                <unitid>92</unitid>
                 <unittitle>Group shot <unitdate type="inclusive" normal="1930">1930</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>93)</unitid>
+                <unitid>93</unitid>
                 <unittitle>Group shot, 1930.</unittitle>
               </did>
               <odd>
@@ -1595,7 +1595,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>94)</unitid>
+                <unitid>94</unitid>
                 <unittitle>[#94 discarded]</unittitle>
               </did>
               <odd>
@@ -1605,7 +1605,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>95)</unitid>
+                <unitid>95</unitid>
                 <unittitle>[#95 discarded]</unittitle>
               </did>
               <odd>
@@ -1621,14 +1621,14 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>96)</unitid>
+                <unitid>96</unitid>
                 <unittitle>Hoback River in Canyon <unitdate type="inclusive" normal="1930">1930</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>97)</unitid>
+                <unitid>97</unitid>
                 <unittitle>Camp Davis, log house and barn <unitdate type="inclusive" normal="1929-07-18">07/18/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1638,7 +1638,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>98)</unitid>
+                <unitid>98</unitid>
                 <unittitle>Camp Davis, camp mess <unitdate type="inclusive" normal="1929-07-18">07/18/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1648,7 +1648,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>99)</unitid>
+                <unitid>99</unitid>
                 <unittitle>Camp Davis, camp mess <unitdate type="inclusive" normal="1929-07-18">07/18/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1658,7 +1658,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>100)</unitid>
+                <unitid>100</unitid>
                 <unittitle>Camp Davis, camp mess <unitdate type="inclusive" normal="1929-07-18">07/18/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1668,7 +1668,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>101)</unitid>
+                <unitid>101</unitid>
                 <unittitle>Hoback Canyon</unittitle>
               </did>
               <odd>
@@ -1678,7 +1678,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>102)</unitid>
+                <unitid>102</unitid>
                 <unittitle>Camp panorama</unittitle>
               </did>
               <odd>
@@ -1688,7 +1688,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>103)</unitid>
+                <unitid>103</unitid>
                 <unittitle>Camp Davis</unittitle>
               </did>
               <odd>
@@ -1698,7 +1698,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>104)</unitid>
+                <unitid>104</unitid>
                 <unittitle>Camp Davis, view from south <unitdate type="inclusive" normal="1929-07-18">07/18/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1708,7 +1708,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>105)</unitid>
+                <unitid>105</unitid>
                 <unittitle>Camp Davis, camp mess from south <unitdate type="inclusive" normal="1929-07-18">07/18/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1718,35 +1718,35 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>106)</unitid>
+                <unitid>106</unitid>
                 <unittitle>Camp Davis, sunset from the camp <unitdate type="inclusive" normal="1929-07-18">07/18/1929</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>107)</unitid>
+                <unitid>107</unitid>
                 <unittitle>Mountains northeast of camp <unitdate type="inclusive" normal="1930-06-29">06/29/1930</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>108)</unitid>
+                <unitid>108</unitid>
                 <unittitle>Camp Davis, view of Hoback Valley <unitdate type="inclusive" normal="1929-07-18">07/18/1929</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>109)</unitid>
+                <unitid>109</unitid>
                 <unittitle>Spring at Hoback <unitdate type="inclusive" normal="1930-06-29">06/29/1930</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>110)</unitid>
+                <unitid>110</unitid>
                 <unittitle>Camp Davis <unitdate type="inclusive" normal="1929-07-18">07/18/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1756,21 +1756,21 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>111)</unitid>
+                <unitid>111</unitid>
                 <unittitle>View of camp <unitdate type="inclusive" normal="1929-07-18">07/18/1929</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>112)</unitid>
+                <unitid>112</unitid>
                 <unittitle>Hoback River in Canyon</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>113)</unitid>
+                <unitid>113</unitid>
                 <unittitle>Camp Davis, Grand Teton with Mt. Owen-to right <unitdate type="inclusive" normal="1929-07-30">07/30/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1780,35 +1780,35 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>114)</unitid>
+                <unitid>114</unitid>
                 <unittitle>Hoback River in Canyon <unitdate type="inclusive" normal="1929-07-30">07/30/1929</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>115)</unitid>
+                <unitid>115</unitid>
                 <unittitle>Hoback River in Canyon <unitdate type="inclusive" normal="1929-07-30">07/30/1929</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>116)</unitid>
+                <unitid>116</unitid>
                 <unittitle>Road in Canyon, River and high mountains</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>117)</unitid>
+                <unitid>117</unitid>
                 <unittitle>Road, River and high cliff in canyon</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>118)</unitid>
+                <unitid>118</unitid>
                 <unittitle>Teton Range <unitdate type="inclusive" normal="1929-07-30">07/30/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1818,7 +1818,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>119)</unitid>
+                <unitid>119</unitid>
                 <unittitle>Teton Range <unitdate type="inclusive" normal="1929-07-30">07/30/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1828,7 +1828,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>120)</unitid>
+                <unitid>120</unitid>
                 <unittitle>Camp Davis <unitdate type="inclusive" normal="1929-07-30">07/30/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1838,7 +1838,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>121)</unitid>
+                <unitid>121</unitid>
                 <unittitle>Jenny Lake, looking west <unitdate type="inclusive" normal="1929-07-30">07/30/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1848,7 +1848,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>122)</unitid>
+                <unitid>122</unitid>
                 <unittitle>Jenny Lake, looking northwest, Mt. Moran in center</unittitle>
               </did>
               <odd>
@@ -1858,7 +1858,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>123)</unitid>
+                <unitid>123</unitid>
                 <unittitle>View of Camp Davis, north of Hoback River</unittitle>
               </did>
               <odd>
@@ -1868,7 +1868,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>124)</unitid>
+                <unitid>124</unitid>
                 <unittitle>Camp Davis <unitdate type="inclusive" normal="1929-08-04">08/04/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1878,7 +1878,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>125)</unitid>
+                <unitid>125</unitid>
                 <unittitle>Camp Davis <unitdate type="inclusive" normal="1929-08-04">08/04/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1888,7 +1888,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>126)</unitid>
+                <unitid>126</unitid>
                 <unittitle>Camp Davis group <unitdate type="inclusive" normal="1929-08-04">08/04/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1898,7 +1898,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>127)</unitid>
+                <unitid>127</unitid>
                 <unittitle>View of shop, instrument room, keeper's house <unitdate type="inclusive" normal="1929-08-04">08/04/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1908,7 +1908,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>128)</unitid>
+                <unitid>128</unitid>
                 <unittitle>View of keeper's house and mess <unitdate type="inclusive" normal="1929-08-04">08/04/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1918,7 +1918,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>129)</unitid>
+                <unitid>129</unitid>
                 <unittitle>"Old Faithful" geyser <unitdate type="inclusive" normal="1929-08-10">08/10/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1928,7 +1928,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>130)</unitid>
+                <unitid>130</unitid>
                 <unittitle>"Old Faithful" geyser <unitdate type="inclusive" normal="1929-08-10">08/10/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1938,7 +1938,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>131)</unitid>
+                <unitid>131</unitid>
                 <unittitle>"Old Faithful" geyser <unitdate type="inclusive" normal="1929-08-10">08/10/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1948,7 +1948,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>132)</unitid>
+                <unitid>132</unitid>
                 <unittitle>Camp Davis group (Mr. and Mrs. Owen in center) <unitdate type="inclusive" normal="1929-08-18">08/18/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1958,7 +1958,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>133)</unitid>
+                <unitid>133</unitid>
                 <unittitle>Camp Davis group (Mr. and Mrs. Oven in center) <unitdate type="inclusive" normal="1929-08-18">08/18/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1968,7 +1968,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>134)</unitid>
+                <unitid>134</unitid>
                 <unittitle>Camp Davis <unitdate type="inclusive" normal="1929-08-18">08/18/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -1978,14 +1978,14 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>135)</unitid>
+                <unitid>135</unitid>
                 <unittitle>Hoback Valley</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>136)</unitid>
+                <unitid>136</unitid>
                 <unittitle>West part of camp</unittitle>
               </did>
               <odd>
@@ -1995,7 +1995,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>137)</unitid>
+                <unitid>137</unitid>
                 <unittitle>View of camp</unittitle>
               </did>
               <odd>
@@ -2005,7 +2005,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>138)</unitid>
+                <unitid>138</unitid>
                 <unittitle>View of camp</unittitle>
               </did>
               <odd>
@@ -2015,7 +2015,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>139)</unitid>
+                <unitid>139</unitid>
                 <unittitle>Camp Davis showing the Hoback Canyon</unittitle>
               </did>
               <odd>
@@ -2025,7 +2025,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>140)</unitid>
+                <unitid>140</unitid>
                 <unittitle>Camp Davis <unitdate type="inclusive" normal="1929-08-18">08/18/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -2035,7 +2035,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>141)</unitid>
+                <unitid>141</unitid>
                 <unittitle>Hoback River <unitdate type="inclusive" normal="1929-08-21">08/21/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -2045,14 +2045,14 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>142)</unitid>
+                <unitid>142</unitid>
                 <unittitle>Camp Davis <unitdate type="inclusive" normal="1929-08-21">08/21/1929</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>143)</unitid>
+                <unitid>143</unitid>
                 <unittitle>Camp Davis, typical residence building <unitdate type="inclusive" normal="1929-08-21">08/21/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -2062,7 +2062,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>144)</unitid>
+                <unitid>144</unitid>
                 <unittitle>Interior of residence building <unitdate type="inclusive" normal="1929-08-21">08/21/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -2072,7 +2072,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>145)</unitid>
+                <unitid>145</unitid>
                 <unittitle>View of camp <unitdate type="inclusive" normal="1929-08-21">08/21/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -2082,7 +2082,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>146)</unitid>
+                <unitid>146</unitid>
                 <unittitle>View of center of camp <unitdate type="inclusive" normal="1929-08-21">08/21/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -2092,7 +2092,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>147)</unitid>
+                <unitid>147</unitid>
                 <unittitle>Interior view of mess</unittitle>
               </did>
               <odd>
@@ -2102,7 +2102,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>148)</unitid>
+                <unitid>148</unitid>
                 <unittitle>View of camp</unittitle>
               </did>
               <odd>
@@ -2112,7 +2112,7 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>149)</unitid>
+                <unitid>149</unitid>
                 <unittitle>View of camp</unittitle>
               </did>
               <odd>
@@ -2122,14 +2122,14 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>150)</unitid>
+                <unitid>150</unitid>
                 <unittitle>View of camp <unitdate type="inclusive" normal="1929-08-21">08/21/1929</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>151)</unitid>
+                <unitid>151</unitid>
                 <unittitle>Camp Davis <unitdate type="inclusive" normal="1929-08-21">08/21/1929</unitdate></unittitle>
               </did>
               <odd>
@@ -2139,49 +2139,49 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>152)</unitid>
+                <unitid>152</unitid>
                 <unittitle>Camp Davis, waiting for the steel</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>153)</unitid>
+                <unitid>153</unitid>
                 <unittitle>Camp Davis, waiting for the steel</unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>154)</unitid>
+                <unitid>154</unitid>
                 <unittitle>Hoback Valley in Canyon <unitdate type="inclusive" normal="1930-06-29">06/29/1930</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>155)</unitid>
+                <unitid>155</unitid>
                 <unittitle>Hoback River <unitdate type="inclusive" normal="1930-06-29">06/29/1930</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>156)</unitid>
+                <unitid>156</unitid>
                 <unittitle>Hoback River <unitdate type="inclusive" normal="1933-07-14">07/14/1933</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>157)</unitid>
+                <unitid>157</unitid>
                 <unittitle>Snake River <unitdate type="inclusive" normal="1933-07-18">07/18/1933</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>158)</unitid>
+                <unitid>158</unitid>
                 <unittitle>Camp Davis group <unitdate type="inclusive" normal="1933-07-25">07/25/1933</unitdate></unittitle>
               </did>
               <odd>
@@ -2191,21 +2191,21 @@
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>159)</unitid>
+                <unitid>159</unitid>
                 <unittitle>"Old Faithful" <unitdate type="inclusive" normal="1933-07-29">07/29/1933</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>160)</unitid>
+                <unitid>160</unitid>
                 <unittitle>Camp Davis <unitdate type="inclusive" normal="1933-08-13">08/13/1933</unitdate></unittitle>
               </did>
             </c04>
             <c04 level="item">
               <did>
                 <container type="box" label="Box">5</container>
-                <unitid>161)</unitid>
+                <unitid>161</unitid>
                 <unittitle>Camp Davis, looking southeast, Aspens <unitdate type="inclusive" normal="1933-08-13">08/13/1933</unitdate></unittitle>
               </did>
             </c04>

--- a/Real_Masters_all/fullerel.xml
+++ b/Real_Masters_all/fullerel.xml
@@ -361,7 +361,7 @@
           <did>
             <container label="Box" type="box">2</container>
             <unittitle>Two men in apple orchard standing (Ira Fuller left)</unittitle>
-            <unitid>(negative no. 1)</unitid>
+            <unitid>negative no. 1</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 3)</p>
@@ -371,7 +371,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 2)</unitid>
+            <unitid>negative no. 2</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -381,7 +381,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Barnyard and buggy</unittitle>
-            <unitid>(negative no. 3)</unitid>
+            <unitid>negative no. 3</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 8)</p>
@@ -391,7 +391,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Family-reunion (?). Group portrait with watermelon.</unittitle>
-            <unitid>(negative no. 4)</unitid>
+            <unitid>negative no. 4</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -401,7 +401,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Horses in yard</unittitle>
-            <unitid>(negative no. 5)</unitid>
+            <unitid>negative no. 5</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 4)</p>
@@ -411,7 +411,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Horse and barn.</unittitle>
-            <unitid>(negative no. 6)</unitid>
+            <unitid>negative no. 6</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 8)</p>
@@ -421,7 +421,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Little girl in rocker in house.</unittitle>
-            <unitid>(negative no. 7)</unitid>
+            <unitid>negative no. 7</unitid>
           </did>
           <odd>
             <p>(see also negative no. 153; contact print in envelope no. 6)</p>
@@ -431,7 +431,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>House, Heath family in yard.</unittitle>
-            <unitid>(negative no. 8)</unitid>
+            <unitid>negative no. 8</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 14)</p>
@@ -441,7 +441,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Charles Newton reading the newspaper probably in Derbyshire house.</unittitle>
-            <unitid>(negative no. 9)</unitid>
+            <unitid>negative no. 9</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 1)</p>
@@ -451,7 +451,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Drummer-boy.</unittitle>
-            <unitid>(negative no. 10)</unitid>
+            <unitid>negative no. 10</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 16)</p>
@@ -461,7 +461,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>The ditch.</unittitle>
-            <unitid>(negative no. 11)</unitid>
+            <unitid>negative no. 11</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 9)</p>
@@ -471,7 +471,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Fuller barn.</unittitle>
-            <unitid>(negative no. 12)</unitid>
+            <unitid>negative no. 12</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 10)</p>
@@ -481,7 +481,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Portrait of a couple in the house.</unittitle>
-            <unitid>(negative no. 13)</unitid>
+            <unitid>negative no. 13</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -491,7 +491,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Little boy (William Middleton) with chickens.</unittitle>
-            <unitid>(negative no. 14)</unitid>
+            <unitid>negative no. 14</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -501,7 +501,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Double exposure on the porch.</unittitle>
-            <unitid>(negative no. 15)</unitid>
+            <unitid>negative no. 15</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -511,7 +511,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>House and lady, probably Rose Arbogast.</unittitle>
-            <unitid>(negative no. 16)</unitid>
+            <unitid>negative no. 16</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 14)</p>
@@ -521,7 +521,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 17)</unitid>
+            <unitid>negative no. 17</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -531,7 +531,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 18)</unitid>
+            <unitid>negative no. 18</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -541,7 +541,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Ira Fuller's grandmothers in yard (Left to right, Fuller and Raymond).</unittitle>
-            <unitid>(negative no. 19)</unitid>
+            <unitid>negative no. 19</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -551,7 +551,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Bearded man in Ballard house.</unittitle>
-            <unitid>(negative no. 20)</unitid>
+            <unitid>negative no. 20</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 1)</p>
@@ -561,7 +561,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Three men in interior, portraits behind.</unittitle>
-            <unitid>(negative no. 21)</unitid>
+            <unitid>negative no. 21</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -571,7 +571,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 22)</unitid>
+            <unitid>negative no. 22</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -581,7 +581,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Young man, buggy beyond and Fuller barnyard. "Dandy" (2 copies)</unittitle>
-            <unitid>(negative no. 23)</unitid>
+            <unitid>negative no. 23</unitid>
           </did>
           <odd>
             <p>(contact prints in envelopes nos. 1 &amp; 10)</p>
@@ -591,7 +591,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Buggy on road.</unittitle>
-            <unitid>(negative no. 23a)</unitid>
+            <unitid>negative no. 23a</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 5)</p>
@@ -601,7 +601,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Snow on road.</unittitle>
-            <unitid>(negative no. 24)</unitid>
+            <unitid>negative no. 24</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 9)</p>
@@ -611,7 +611,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Man with sheep in barnyard, Hewens farm.</unittitle>
-            <unitid>(negative no. 25)</unitid>
+            <unitid>negative no. 25</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 13)</p>
@@ -621,7 +621,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Large house.</unittitle>
-            <unitid>(negative no. 26)</unitid>
+            <unitid>negative no. 26</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 14)</p>
@@ -631,7 +631,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Binder, cutting wheat.</unittitle>
-            <unitid>(negative no. 27)</unitid>
+            <unitid>negative no. 27</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 9)</p>
@@ -641,7 +641,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Man in interior with calendar dated 1912.</unittitle>
-            <unitid>(negative no. 28)</unitid>
+            <unitid>negative no. 28</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 1)</p>
@@ -651,7 +651,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Wagon, team, and driver.</unittitle>
-            <unitid>(negative no. 29)</unitid>
+            <unitid>negative no. 29</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 4)</p>
@@ -661,7 +661,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 30)</unitid>
+            <unitid>negative no. 30</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -671,7 +671,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 31)</unitid>
+            <unitid>negative no. 31</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -681,7 +681,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Horse and buggy before a winter ride.</unittitle>
-            <unitid>(negative no. 32)</unitid>
+            <unitid>negative no. 32</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 5)</p>
@@ -691,7 +691,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Bull.</unittitle>
-            <unitid>(negative no. 33)</unitid>
+            <unitid>negative no. 33</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 2)</p>
@@ -701,7 +701,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Cows and barn.</unittitle>
-            <unitid>(negative no. 34)</unitid>
+            <unitid>negative no. 34</unitid>
           </did>
           <odd>
             <p>(see also 97; contact print in envelope no. 8)</p>
@@ -711,7 +711,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Man with sheep, Hewens farm.</unittitle>
-            <unitid>(negative no. 35)</unitid>
+            <unitid>negative no. 35</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 13)</p>
@@ -721,7 +721,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>View of Derbyshire house and yard with swing.</unittitle>
-            <unitid>(negative no. 36)</unitid>
+            <unitid>negative no. 36</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 7)</p>
@@ -731,7 +731,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Frolic in apple orchard.</unittitle>
-            <unitid>(negative no. 37)</unitid>
+            <unitid>negative no. 37</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 3)</p>
@@ -741,7 +741,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Fuller family reunion-group portrait.</unittitle>
-            <unitid>(negative no. 38)</unitid>
+            <unitid>negative no. 38</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -751,7 +751,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 39)</unitid>
+            <unitid>negative no. 39</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -761,7 +761,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>By the mailbox-Johnny Wright.</unittitle>
-            <unitid>(negative no. 40)</unitid>
+            <unitid>negative no. 40</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 16)</p>
@@ -771,7 +771,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 41)</unitid>
+            <unitid>negative no. 41</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -781,7 +781,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Fuller barnyard.</unittitle>
-            <unitid>(negative no. 42)</unitid>
+            <unitid>negative no. 42</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 10)</p>
@@ -791,7 +791,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Ella Fuller and others on swing.</unittitle>
-            <unitid>(negative no. 43)</unitid>
+            <unitid>negative no. 43</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -801,7 +801,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Derbyshire house back view.</unittitle>
-            <unitid>(negative no. 44)</unitid>
+            <unitid>negative no. 44</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 7)</p>
@@ -811,7 +811,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Man relaxing on porch.</unittitle>
-            <unitid>(negative no. 45)</unitid>
+            <unitid>negative no. 45</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 16)</p>
@@ -821,7 +821,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Family portrait on the yard.</unittitle>
-            <unitid>(negative no. 46)</unitid>
+            <unitid>negative no. 46</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -831,7 +831,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Family portrait on the lawn.</unittitle>
-            <unitid>(negative no. 46a)</unitid>
+            <unitid>negative no. 46a</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -841,7 +841,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Ella Fuller with calf.</unittitle>
-            <unitid>(negative no. 47)</unitid>
+            <unitid>negative no. 47</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 10)</p>
@@ -851,7 +851,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Little boy in muddy yard-front view.</unittitle>
-            <unitid>(negative no. 48)</unitid>
+            <unitid>negative no. 48</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -861,7 +861,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Little boy in muddy yard-from behind.</unittitle>
-            <unitid>(negative no. 49)</unitid>
+            <unitid>negative no. 49</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -871,7 +871,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 50)</unitid>
+            <unitid>negative no. 50</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -881,7 +881,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Feeding chickens and geese in the Fuller barnyard.</unittitle>
-            <unitid>(negative no. 51)</unitid>
+            <unitid>negative no. 51</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 10)</p>
@@ -891,7 +891,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Interior portrait-boy and man, Derbyshire house.</unittitle>
-            <unitid>(negative no. 52)</unitid>
+            <unitid>negative no. 52</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -901,7 +901,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 53)</unitid>
+            <unitid>negative no. 53</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -911,7 +911,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Interior of house-woman in rocker. (Rose Arbogast?)</unittitle>
-            <unitid>(negative no. 54)</unitid>
+            <unitid>negative no. 54</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 1)</p>
@@ -921,7 +921,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Fuller barn.</unittitle>
-            <unitid>(negative no. 55)</unitid>
+            <unitid>negative no. 55</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 10)</p>
@@ -931,7 +931,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Boy holding dead chicken in the Fuller yard.</unittitle>
-            <unitid>(negative no. 56)</unitid>
+            <unitid>negative no. 56</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 10)</p>
@@ -941,7 +941,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Solarized interior of room, Derbyshire house</unittitle>
-            <unitid>(negative no. 57)</unitid>
+            <unitid>negative no. 57</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 7)</p>
@@ -951,7 +951,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Fuller turkey yard.</unittitle>
-            <unitid>(negative no. 58)</unitid>
+            <unitid>negative no. 58</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 2)</p>
@@ -961,7 +961,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Charles Newton at the desk with pictures.</unittitle>
-            <unitid>(negative no. 59)</unitid>
+            <unitid>negative no. 59</unitid>
           </did>
           <odd>
             <p>(see also 96; contact print in envelope no. 1)</p>
@@ -971,7 +971,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Sheep shearing, Hewens farm.</unittitle>
-            <unitid>(negative no. 60)</unitid>
+            <unitid>negative no. 60</unitid>
           </did>
           <odd>
             <p>(see also 180; contact print in envelope no. 13)</p>
@@ -981,7 +981,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Family group relaxing under trees.</unittitle>
-            <unitid>(negative no. 61)</unitid>
+            <unitid>negative no. 61</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -991,7 +991,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Man holding sheep.</unittitle>
-            <unitid>(negative no. 62)</unitid>
+            <unitid>negative no. 62</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 1)</p>
@@ -1001,7 +1001,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Elders in buggy.</unittitle>
-            <unitid>(negative no. 63)</unitid>
+            <unitid>negative no. 63</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 5)</p>
@@ -1011,7 +1011,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Fuller barnyard.</unittitle>
-            <unitid>(negative no. 64)</unitid>
+            <unitid>negative no. 64</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 10)</p>
@@ -1021,7 +1021,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Child with toys in yard of Lowden house.</unittitle>
-            <unitid>(negative no. 65)</unitid>
+            <unitid>negative no. 65</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -1031,7 +1031,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Going fishing, two couples, horse and wagon.</unittitle>
-            <unitid>(negative no. 66)</unitid>
+            <unitid>negative no. 66</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 5)</p>
@@ -1041,7 +1041,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Fuller barnyard with workers and pails.</unittitle>
-            <unitid>(negative no. 67)</unitid>
+            <unitid>negative no. 67</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 10)</p>
@@ -1051,7 +1051,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Derbyshire house and group.</unittitle>
-            <unitid>(negative no. 68)</unitid>
+            <unitid>negative no. 68</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 7)</p>
@@ -1061,7 +1061,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Group in swing in yard of Derbyshire house.</unittitle>
-            <unitid>(negative no. 69)</unitid>
+            <unitid>negative no. 69</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -1071,7 +1071,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Tea party.</unittitle>
-            <unitid>(negative no. 70)</unitid>
+            <unitid>negative no. 70</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -1081,7 +1081,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Tuttle Hill bridge, river in flood.</unittitle>
-            <unitid>(negative no. 71)</unitid>
+            <unitid>negative no. 71</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 9)</p>
@@ -1091,7 +1091,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>New home owners-bike by porch.</unittitle>
-            <unitid>(negative no. 72)</unitid>
+            <unitid>negative no. 72</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 14)</p>
@@ -1101,7 +1101,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Fuller barnyard.</unittitle>
-            <unitid>(negative no. 73)</unitid>
+            <unitid>negative no. 73</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 10)</p>
@@ -1111,7 +1111,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Ira Fuller in apple wagon.</unittitle>
-            <unitid>(negative no. 74)</unitid>
+            <unitid>negative no. 74</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 3)</p>
@@ -1121,7 +1121,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Derbyshire house with people in swing-from mailbox.</unittitle>
-            <unitid>(negative no. 75)</unitid>
+            <unitid>negative no. 75</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 7)</p>
@@ -1131,7 +1131,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Leaving home, Derbyshire house.</unittitle>
-            <unitid>(negative no. 76)</unitid>
+            <unitid>negative no. 76</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 7)</p>
@@ -1141,7 +1141,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Woodcutters eating.</unittitle>
-            <unitid>(negative no. 77)</unitid>
+            <unitid>negative no. 77</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 18)</p>
@@ -1151,7 +1151,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Boys buzzing wood.</unittitle>
-            <unitid>(negative no. 78)</unitid>
+            <unitid>negative no. 78</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 18)</p>
@@ -1161,7 +1161,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Grandma and child in yard.</unittitle>
-            <unitid>(negative no. 79)</unitid>
+            <unitid>negative no. 79</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -1171,7 +1171,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>The fields and ditch.</unittitle>
-            <unitid>(negative no. 80)</unitid>
+            <unitid>negative no. 80</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 9)</p>
@@ -1181,7 +1181,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Fuller barnyard, winter.</unittitle>
-            <unitid>(negative no. 80a)</unitid>
+            <unitid>negative no. 80a</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 10)</p>
@@ -1191,7 +1191,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Ditch, with two men.</unittitle>
-            <unitid>(negative no. 81)</unitid>
+            <unitid>negative no. 81</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 9)</p>
@@ -1201,7 +1201,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Father on the swing, Derbyshire barn.</unittitle>
-            <unitid>(negative no. 82)</unitid>
+            <unitid>negative no. 82</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -1211,7 +1211,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Quarrying.</unittitle>
-            <unitid>(negative no. 83)</unitid>
+            <unitid>negative no. 83</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 9)</p>
@@ -1221,7 +1221,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Interior with portrait and fancy pillow, Mr. Fletcher's parlor.</unittitle>
-            <unitid>(negative no. 84)</unitid>
+            <unitid>negative no. 84</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 15)</p>
@@ -1231,7 +1231,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 85)</unitid>
+            <unitid>negative no. 85</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -1241,7 +1241,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 86)</unitid>
+            <unitid>negative no. 86</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -1251,7 +1251,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Derbyshire house with fir trees.</unittitle>
-            <unitid>(negative no. 87)</unitid>
+            <unitid>negative no. 87</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 7)</p>
@@ -1261,7 +1261,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Couple in apple trees.</unittitle>
-            <unitid>(negative no. 88)</unitid>
+            <unitid>negative no. 88</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 3)</p>
@@ -1271,7 +1271,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Charles Newton and Ira Fuller in apple wagon-woman standing beside it.</unittitle>
-            <unitid>(negative no. 89)</unitid>
+            <unitid>negative no. 89</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 3)</p>
@@ -1281,7 +1281,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>A house-woman on side steps.</unittitle>
-            <unitid>(negative no. 90)</unitid>
+            <unitid>negative no. 90</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 14)</p>
@@ -1291,7 +1291,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Apple craters-seated</unittitle>
-            <unitid>(negative no. 91)</unitid>
+            <unitid>negative no. 91</unitid>
           </did>
           <odd>
             <p>(no contact print)</p>
@@ -1301,7 +1301,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Woman and child with potted plant before house.</unittitle>
-            <unitid>(negative no. 92)</unitid>
+            <unitid>negative no. 92</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 14)</p>
@@ -1311,7 +1311,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 93)</unitid>
+            <unitid>negative no. 93</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -1321,7 +1321,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Distant view of cattle and barnyard.</unittitle>
-            <unitid>(negative no. 94)</unitid>
+            <unitid>negative no. 94</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 8)</p>
@@ -1331,7 +1331,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Laurel Ebusole Newton in Derbyshire house interior.</unittitle>
-            <unitid>(negative no. 95)</unitid>
+            <unitid>negative no. 95</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 16)</p>
@@ -1341,7 +1341,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Mr. Newton (?) at desk.</unittitle>
-            <unitid>(negative no. 96)</unitid>
+            <unitid>negative no. 96</unitid>
           </did>
           <odd>
             <p>(see also 59; contact print in envelope no. 1)</p>
@@ -1351,7 +1351,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Man, cow, and calf in barnyard.</unittitle>
-            <unitid>(negative no. 97)</unitid>
+            <unitid>negative no. 97</unitid>
           </did>
           <odd>
             <p>(see also 34; contact print in envelope no. 8)</p>
@@ -1361,7 +1361,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Cattle, barn, silo, and hayrick.</unittitle>
-            <unitid>(negative no. 98)</unitid>
+            <unitid>negative no. 98</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 8)</p>
@@ -1371,7 +1371,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Boy with bicycle (Albert Arbogast?)</unittitle>
-            <unitid>(negative no. 99)</unitid>
+            <unitid>negative no. 99</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -1381,7 +1381,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>The old and the young-Ira Fuller's grandmothers Raymond and Fuller in yard with children.</unittitle>
-            <unitid>(negative no. 100)</unitid>
+            <unitid>negative no. 100</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -1391,7 +1391,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>The music room.</unittitle>
-            <unitid>(negative no. 101)</unitid>
+            <unitid>negative no. 101</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 15)</p>
@@ -1401,7 +1401,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Fuller barnyard.</unittitle>
-            <unitid>(negative no. 102)</unitid>
+            <unitid>negative no. 102</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 10)</p>
@@ -1411,7 +1411,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Group of men by the barnyard.</unittitle>
-            <unitid>(negative no. 103)</unitid>
+            <unitid>negative no. 103</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 18)</p>
@@ -1421,7 +1421,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 104)</unitid>
+            <unitid>negative no. 104</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -1431,7 +1431,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Interior of home-doctor with art object.</unittitle>
-            <unitid>(negative no. 105)</unitid>
+            <unitid>negative no. 105</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 17)</p>
@@ -1441,7 +1441,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Lowden, McIntyre, Doss House-Greek Revival.</unittitle>
-            <unitid>(negative no. 106)</unitid>
+            <unitid>negative no. 106</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 17)</p>
@@ -1451,7 +1451,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 107)</unitid>
+            <unitid>negative no. 107</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -1461,7 +1461,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 108)</unitid>
+            <unitid>negative no. 108</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -1471,7 +1471,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 109)</unitid>
+            <unitid>negative no. 109</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -1481,7 +1481,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 110)</unitid>
+            <unitid>negative no. 110</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -1491,7 +1491,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Two men with horses in barnyard.</unittitle>
-            <unitid>(negative no. 111)</unitid>
+            <unitid>negative no. 111</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 4)</p>
@@ -1501,7 +1501,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Horse and buggy in front of Fuller house, horse and wagon and one driver.</unittitle>
-            <unitid>(negative no. 112a)</unitid>
+            <unitid>negative no. 112a</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 10)</p>
@@ -1511,7 +1511,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Buggy by the Fuller house (blur) two men in buggy.</unittitle>
-            <unitid>(negative no. 112)</unitid>
+            <unitid>negative no. 112</unitid>
           </did>
           <odd>
             <p>(b; contact print in envelope no. 10)</p>
@@ -1521,7 +1521,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Men buzzing wood.</unittitle>
-            <unitid>(negative no. 113)</unitid>
+            <unitid>negative no. 113</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 18)</p>
@@ -1531,7 +1531,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unknown</unittitle>
-            <unitid>(negative no. 114)</unitid>
+            <unitid>negative no. 114</unitid>
           </did>
           <odd>
             <p>(not received)</p>
@@ -1541,7 +1541,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Girl with gramophone.</unittitle>
-            <unitid>(negative no. 115)</unitid>
+            <unitid>negative no. 115</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -1551,7 +1551,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Little Indians and black woman.</unittitle>
-            <unitid>(negative no. 116)</unitid>
+            <unitid>negative no. 116</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -1561,7 +1561,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Fuller farm turkeys and woodpile.</unittitle>
-            <unitid>(negative no. 117)</unitid>
+            <unitid>negative no. 117</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 2)</p>
@@ -1571,7 +1571,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Ditch digging with horses.</unittitle>
-            <unitid>(negative no. 118)</unitid>
+            <unitid>negative no. 118</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 8)</p>
@@ -1581,7 +1581,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Man with two horses.</unittitle>
-            <unitid>(negative no. 119)</unitid>
+            <unitid>negative no. 119</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 4)</p>
@@ -1591,7 +1591,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Farming-binder and wheat sheaves.</unittitle>
-            <unitid>(negative no. 120)</unitid>
+            <unitid>negative no. 120</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 8)</p>
@@ -1601,7 +1601,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Barnyard (Fuller farm), man with pig.</unittitle>
-            <unitid>(negative no. 121)</unitid>
+            <unitid>negative no. 121</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 10)</p>
@@ -1611,7 +1611,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Picnic.</unittitle>
-            <unitid>(negative no. 122)</unitid>
+            <unitid>negative no. 122</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -1621,7 +1621,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Young people with swing.</unittitle>
-            <unitid>(negative no. 123)</unitid>
+            <unitid>negative no. 123</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -1631,7 +1631,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Young people in barn with swing, cavorting.</unittitle>
-            <unitid>(negative no. 124)</unitid>
+            <unitid>negative no. 124</unitid>
           </did>
           <odd>
             <p>(contact prints in envelopes nos. 4 &amp; 11)</p>
@@ -1641,7 +1641,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Boy and girl by steps.</unittitle>
-            <unitid>(negative no. 125)</unitid>
+            <unitid>negative no. 125</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -1651,7 +1651,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Apple wagon with horses and four men.</unittitle>
-            <unitid>(negative no. 126)</unitid>
+            <unitid>negative no. 126</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 3)</p>
@@ -1661,7 +1661,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Girl on horse held by man, near trees.</unittitle>
-            <unitid>(negative no. 127)</unitid>
+            <unitid>negative no. 127</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -1671,7 +1671,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Old couple (Mr. and Mrs. Samuel Ballard),.she on floor.</unittitle>
-            <unitid>(negative no. 128)</unitid>
+            <unitid>negative no. 128</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -1681,7 +1681,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Three old women in chairs in yard.</unittitle>
-            <unitid>(negative no. 129)</unitid>
+            <unitid>negative no. 129</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -1691,7 +1691,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Two women at mailbox.</unittitle>
-            <unitid>(negative no. 130)</unitid>
+            <unitid>negative no. 130</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -1701,7 +1701,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Man with dog.</unittitle>
-            <unitid>(negative no. 131)</unitid>
+            <unitid>negative no. 131</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 1)</p>
@@ -1711,7 +1711,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Ella Fuller by woodpile.</unittitle>
-            <unitid>(negative no. 132)</unitid>
+            <unitid>negative no. 132</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 10)</p>
@@ -1721,7 +1721,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Burlie Fuller with backdrop</unittitle>
-            <unitid>(negative no. 133)</unitid>
+            <unitid>negative no. 133</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 16)</p>
@@ -1731,7 +1731,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Group with horse cart.</unittitle>
-            <unitid>(negative no. 134)</unitid>
+            <unitid>negative no. 134</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 5)</p>
@@ -1741,7 +1741,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Black girl (Nora Johnston).</unittitle>
-            <unitid>(negative no. 135)</unitid>
+            <unitid>negative no. 135</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -1751,7 +1751,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Bearded man (Charles Newton) and little girl holding cat.</unittitle>
-            <unitid>(negative no. 136)</unitid>
+            <unitid>negative no. 136</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -1761,7 +1761,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Woman in bonnet-seated outdoors.</unittitle>
-            <unitid>(negative no. 137)</unitid>
+            <unitid>negative no. 137</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 1)</p>
@@ -1771,7 +1771,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Another house.</unittitle>
-            <unitid>(negative no. 138)</unitid>
+            <unitid>negative no. 138</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 14)</p>
@@ -1781,7 +1781,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Dense, blurred: woman holding horse's bridle.</unittitle>
-            <unitid>(negative no. 139)</unitid>
+            <unitid>negative no. 139</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 5)</p>
@@ -1791,7 +1791,7 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Woman with large plant</unittitle>
-            <unitid>(negative no. 140)</unitid>
+            <unitid>negative no. 140</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 1)</p>
@@ -1801,7 +1801,7 @@
           <did>
             <container label="Box" type="box">3</container>
             <unittitle>House with large cannas, couple on porch.</unittitle>
-            <unitid>(negative no. 141)</unitid>
+            <unitid>negative no. 141</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -1811,7 +1811,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Man in rocker, Ballard parlor.</unittitle>
-            <unitid>(negative no. 142)</unitid>
+            <unitid>negative no. 142</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 1)</p>
@@ -1821,7 +1821,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Woman in chemise.</unittitle>
-            <unitid>(negative no. 143)</unitid>
+            <unitid>negative no. 143</unitid>
           </did>
           <odd>
             <p>(contact prints in envelopes nos. 1 &amp; 16)</p>
@@ -1831,7 +1831,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Ralph (?) with drum on ground.</unittitle>
-            <unitid>(negative no. 144)</unitid>
+            <unitid>negative no. 144</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 16)</p>
@@ -1841,7 +1841,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Child at mirror, Fuller house.</unittitle>
-            <unitid>(negative no. 145)</unitid>
+            <unitid>negative no. 145</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -1851,7 +1851,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Old couple standing, Quaker minister and wife, he with book.</unittitle>
-            <unitid>(negative no. 146)</unitid>
+            <unitid>negative no. 146</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -1861,7 +1861,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Group frolic on lawn, sitting.</unittitle>
-            <unitid>(negative no. 147)</unitid>
+            <unitid>negative no. 147</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -1871,7 +1871,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Frolic in apple orchard, girl lying down.</unittitle>
-            <unitid>(negative no. 148)</unitid>
+            <unitid>negative no. 148</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 3)</p>
@@ -1881,7 +1881,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Ralph Juckett with drum by pump.</unittitle>
-            <unitid>(negative no. 149)</unitid>
+            <unitid>negative no. 149</unitid>
           </did>
           <odd>
             <p>(contact prints in envelopes nos. 6 &amp; 16)</p>
@@ -1891,7 +1891,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Little girl (Cora McCartnie) seated in yard holding flowers.</unittitle>
-            <unitid>(negative no. 150)</unitid>
+            <unitid>negative no. 150</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -1901,7 +1901,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Barnyard.</unittitle>
-            <unitid>(negative no. 151)</unitid>
+            <unitid>negative no. 151</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 2)</p>
@@ -1911,7 +1911,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Two couples in parlor, women seated.</unittitle>
-            <unitid>(negative no. 152)</unitid>
+            <unitid>negative no. 152</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -1921,7 +1921,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Couple with baby girl before bookcase.</unittitle>
-            <unitid>(negative no. 153)</unitid>
+            <unitid>negative no. 153</unitid>
           </did>
           <odd>
             <p>(see also 7; contact print in envelope no. 11)</p>
@@ -1931,7 +1931,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Little girl (Crystal Frisbie), foot on watering pot.</unittitle>
-            <unitid>(negative no. 154)</unitid>
+            <unitid>negative no. 154</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -1941,7 +1941,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Boy by table before drop.</unittitle>
-            <unitid>(negative no. 155)</unitid>
+            <unitid>negative no. 155</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -1951,7 +1951,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Girl by table.</unittitle>
-            <unitid>(negative no. 156)</unitid>
+            <unitid>negative no. 156</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -1961,7 +1961,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Family on steps.</unittitle>
-            <unitid>(negative no. 157)</unitid>
+            <unitid>negative no. 157</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -1971,7 +1971,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Two women in bonnets; woodpile beyond.</unittitle>
-            <unitid>(negative no. 158)</unitid>
+            <unitid>negative no. 158</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no 12.)</p>
@@ -1981,7 +1981,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Seated woman with baby.</unittitle>
-            <unitid>(negative no. 159)</unitid>
+            <unitid>negative no. 159</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -1991,7 +1991,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Two women.</unittitle>
-            <unitid>(negative no. 160)</unitid>
+            <unitid>negative no. 160</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -2001,7 +2001,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Young man and dog on steps (hat) Burlie or Frank Fuller.</unittitle>
-            <unitid>(negative no. 161)</unitid>
+            <unitid>negative no. 161</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 16)</p>
@@ -2011,7 +2011,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Young man on steps holding satchel and raising hat-Burlie or Frank Fuller.</unittitle>
-            <unitid>(negative no. 162)</unitid>
+            <unitid>negative no. 162</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 16)</p>
@@ -2021,7 +2021,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Mother with little girl at organ (thin).</unittitle>
-            <unitid>(negative no. 163)</unitid>
+            <unitid>negative no. 163</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -2031,7 +2031,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Dense: Ira Fuller and Bird Heath on steps.</unittitle>
-            <unitid>(negative no. 164)</unitid>
+            <unitid>negative no. 164</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 16)</p>
@@ -2041,7 +2041,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Two men on steps, with hats on knees, Ira Fuller and Bird Heath.</unittitle>
-            <unitid>(negative no. 164a)</unitid>
+            <unitid>negative no. 164a</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 16)</p>
@@ -2051,7 +2051,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Thin: Ballard house interior, blurred man [Samuel Ballard], seated, lamp.</unittitle>
-            <unitid>(negative no. 165)</unitid>
+            <unitid>negative no. 165</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 1)</p>
@@ -2061,7 +2061,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Woman with child in lap.</unittitle>
-            <unitid>(negative no. 166)</unitid>
+            <unitid>negative no. 166</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -2071,7 +2071,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Dense: Pigs in barnyard.</unittitle>
-            <unitid>(negative no. 167)</unitid>
+            <unitid>negative no. 167</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 4)</p>
@@ -2081,7 +2081,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Dense: Old woman and two bearded men, Ballard house, interior with pictures.</unittitle>
-            <unitid>(negative no. 168)</unitid>
+            <unitid>negative no. 168</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -2091,7 +2091,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Ira Fuller in Derbyshire house, interior.</unittitle>
-            <unitid>(negative no. 168a)</unitid>
+            <unitid>negative no. 168a</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 16)</p>
@@ -2101,7 +2101,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Young people cavorting in orchard.</unittitle>
-            <unitid>(negative no. 169)</unitid>
+            <unitid>negative no. 169</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -2111,7 +2111,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Horse. (2 copies)</unittitle>
-            <unitid>(negative no. 170)</unitid>
+            <unitid>negative no. 170</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 2)</p>
@@ -2121,7 +2121,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Little girl with doll in rocker.</unittitle>
-            <unitid>(negative no. 171)</unitid>
+            <unitid>negative no. 171</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -2131,7 +2131,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Family in interior (girl in background).</unittitle>
-            <unitid>(negative no. 171a)</unitid>
+            <unitid>negative no. 171a</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -2141,7 +2141,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Drummer (Ralph Juckett).</unittitle>
-            <unitid>(negative no. 172)</unitid>
+            <unitid>negative no. 172</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 16)</p>
@@ -2151,7 +2151,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Family before small house (at lake).</unittitle>
-            <unitid>(negative no. 173)</unitid>
+            <unitid>negative no. 173</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 14)</p>
@@ -2161,7 +2161,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Three children on steps (dense).</unittitle>
-            <unitid>(negative no. 174)</unitid>
+            <unitid>negative no. 174</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -2171,7 +2171,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Family by Derbyshire house.</unittitle>
-            <unitid>(negative no. 175)</unitid>
+            <unitid>negative no. 175</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 7)</p>
@@ -2181,7 +2181,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Three boys and dog in interior.</unittitle>
-            <unitid>(negative no. 176)</unitid>
+            <unitid>negative no. 176</unitid>
           </did>
           <odd>
             <p>(no contact print)</p>
@@ -2191,7 +2191,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Baby with bottle, drinking (dense).</unittitle>
-            <unitid>(negative no. 177)</unitid>
+            <unitid>negative no. 177</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -2201,7 +2201,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Baby standing on chair by table with bottle (dense).</unittitle>
-            <unitid>(negative no. 178)</unitid>
+            <unitid>negative no. 178</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -2211,7 +2211,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Bearded man seated (Charles Newton), interior with flowers.</unittitle>
-            <unitid>(negative no. 179)</unitid>
+            <unitid>negative no. 179</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 16)</p>
@@ -2221,7 +2221,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Barn interior, sheep shearing, Hewens farm.</unittitle>
-            <unitid>(negative no. 180)</unitid>
+            <unitid>negative no. 180</unitid>
           </did>
           <odd>
             <p>(see also 60; contact print in envelope no. 13)</p>
@@ -2231,7 +2231,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Boy and girl (blurred).</unittitle>
-            <unitid>(negative no. 181)</unitid>
+            <unitid>negative no. 181</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -2241,7 +2241,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Young man in long coat by fence.</unittitle>
-            <unitid>(negative no. 182)</unitid>
+            <unitid>negative no. 182</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 16)</p>
@@ -2251,7 +2251,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Woman with chicken, plucked, two boys.</unittitle>
-            <unitid>(negative no. 183)</unitid>
+            <unitid>negative no. 183</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -2261,7 +2261,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Two horses, ditch digging.</unittitle>
-            <unitid>(negative no. 184)</unitid>
+            <unitid>negative no. 184</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 9)</p>
@@ -2271,7 +2271,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Child with dog on chair.</unittitle>
-            <unitid>(negative no. 185)</unitid>
+            <unitid>negative no. 185</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -2281,7 +2281,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Baby on bed by window.</unittitle>
-            <unitid>(negative no. 186)</unitid>
+            <unitid>negative no. 186</unitid>
           </did>
           <odd>
             <p>(no contact print)</p>
@@ -2291,7 +2291,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Baby on bed by window-blurred.</unittitle>
-            <unitid>(negative no. 186a)</unitid>
+            <unitid>negative no. 186a</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 16)</p>
@@ -2301,7 +2301,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Baby on bed by window.</unittitle>
-            <unitid>(negative no. 187)</unitid>
+            <unitid>negative no. 187</unitid>
           </did>
           <odd>
             <p>(no contact print)</p>
@@ -2311,7 +2311,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Baby on bed by window.</unittitle>
-            <unitid>(negative no. 187a)</unitid>
+            <unitid>negative no. 187a</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -2321,7 +2321,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Quarry.</unittitle>
-            <unitid>(negative no. 188)</unitid>
+            <unitid>negative no. 188</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 9)</p>
@@ -2331,7 +2331,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Man and four women.</unittitle>
-            <unitid>(negative no. 189)</unitid>
+            <unitid>negative no. 189</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -2341,7 +2341,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Two couples on porch, Fuller farm.</unittitle>
-            <unitid>(negative no. 190)</unitid>
+            <unitid>negative no. 190</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -2351,7 +2351,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Old lady in rocking chair, Derbyshire house.</unittitle>
-            <unitid>(negative no. 191)</unitid>
+            <unitid>negative no. 191</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 1)</p>
@@ -2361,7 +2361,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Dense: mother and two boys on steps.</unittitle>
-            <unitid>(negative no. 192)</unitid>
+            <unitid>negative no. 192</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -2371,7 +2371,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Couple seated in parlor (he with beard).</unittitle>
-            <unitid>(negative no. 193)</unitid>
+            <unitid>negative no. 193</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 15)</p>
@@ -2381,7 +2381,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Old couple, Quaker minister and wife, seated under conifer.</unittitle>
-            <unitid>(negative no. 194)</unitid>
+            <unitid>negative no. 194</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -2391,7 +2391,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Two young men in dark hats, on bench.</unittitle>
-            <unitid>(negative no. 195)</unitid>
+            <unitid>negative no. 195</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -2401,7 +2401,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Leutie Bemis and class.</unittitle>
-            <unitid>(negative no. 196)</unitid>
+            <unitid>negative no. 196</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -2411,7 +2411,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Couple with two children, hat on table</unittitle>
-            <unitid>(negative no. 197)</unitid>
+            <unitid>negative no. 197</unitid>
           </did>
           <odd>
             <p>(see also 204; contact print in envelope no. 11)</p>
@@ -2421,7 +2421,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Family of adults on front steps. Hadley-Norton family. Ella Fuller at right.</unittitle>
-            <unitid>(negative no. 198)</unitid>
+            <unitid>negative no. 198</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -2431,7 +2431,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Three older women in interior, seated.</unittitle>
-            <unitid>(negative no. 199)</unitid>
+            <unitid>negative no. 199</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -2441,7 +2441,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Couple beside large canna.</unittitle>
-            <unitid>(negative no. 200)</unitid>
+            <unitid>negative no. 200</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -2451,7 +2451,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Boy by a table, arm on table.</unittitle>
-            <unitid>(negative no. 201)</unitid>
+            <unitid>negative no. 201</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -2461,7 +2461,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Little girl from rear, approaching table.</unittitle>
-            <unitid>(negative no. 202)</unitid>
+            <unitid>negative no. 202</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -2471,7 +2471,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Little girl with doll-very dense.</unittitle>
-            <unitid>(negative no. 203)</unitid>
+            <unitid>negative no. 203</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -2481,7 +2481,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Couple with two children, hat on table</unittitle>
-            <unitid>(negative no. 204)</unitid>
+            <unitid>negative no. 204</unitid>
           </did>
           <odd>
             <p>(see also 197; contact print in envelope no. 11)</p>
@@ -2491,14 +2491,14 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>House (Rose Arbogast on porch). (negative no. 205; contact print in envelope no. 14)</unittitle>
-            <unitid>(negative no. 205)</unitid>
+            <unitid>negative no. 205</unitid>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Man in derby before Derbyshire house.</unittitle>
-            <unitid>(negative no. 206)</unitid>
+            <unitid>negative no. 206</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 16)</p>
@@ -2508,7 +2508,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Group on ladder.</unittitle>
-            <unitid>(negative no. 207)</unitid>
+            <unitid>negative no. 207</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -2518,7 +2518,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Three boys and girl with cat.</unittitle>
-            <unitid>(negative no. 208)</unitid>
+            <unitid>negative no. 208</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -2528,7 +2528,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Geese.</unittitle>
-            <unitid>(negative no. 209)</unitid>
+            <unitid>negative no. 209</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 2)</p>
@@ -2538,7 +2538,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Double exposure with sheep and woman with horse.</unittitle>
-            <unitid>(negative no. 210)</unitid>
+            <unitid>negative no. 210</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 2)</p>
@@ -2548,7 +2548,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Ditch, snow on bank.</unittitle>
-            <unitid>(negative no. 211)</unitid>
+            <unitid>negative no. 211</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 9)</p>
@@ -2558,7 +2558,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Girl sitting on watering can.</unittitle>
-            <unitid>(negative no. 212)</unitid>
+            <unitid>negative no. 212</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -2568,7 +2568,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Ditch with horses pulling.</unittitle>
-            <unitid>(negative no. 213)</unitid>
+            <unitid>negative no. 213</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 9)</p>
@@ -2578,7 +2578,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Baby girl (Ethel Ballard) seated before backdrop.</unittitle>
-            <unitid>(negative no. 214)</unitid>
+            <unitid>negative no. 214</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -2588,7 +2588,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Woman in striped blouse, interior.</unittitle>
-            <unitid>(negative no. 215)</unitid>
+            <unitid>negative no. 215</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 1)</p>
@@ -2598,7 +2598,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Bonneted woman (double exposure?).</unittitle>
-            <unitid>(negative no. 216)</unitid>
+            <unitid>negative no. 216</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 1)</p>
@@ -2608,7 +2608,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Toddler, milk can, on porch.</unittitle>
-            <unitid>(negative no. 217)</unitid>
+            <unitid>negative no. 217</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -2618,7 +2618,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Watermelon feast.</unittitle>
-            <unitid>(negative no. 218)</unitid>
+            <unitid>negative no. 218</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -2628,7 +2628,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Woman in hat and child in fur M [blurred].</unittitle>
-            <unitid>(negative no. 219)</unitid>
+            <unitid>negative no. 219</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -2638,7 +2638,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Three elderly women in yard-seated.</unittitle>
-            <unitid>(negative no. 220)</unitid>
+            <unitid>negative no. 220</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -2648,7 +2648,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Man in derby with horse and buggy.</unittitle>
-            <unitid>(negative no. 221)</unitid>
+            <unitid>negative no. 221</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 5)</p>
@@ -2658,7 +2658,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Three elderly women standing in yard.</unittitle>
-            <unitid>(negative no. 222)</unitid>
+            <unitid>negative no. 222</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -2668,7 +2668,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Geese.</unittitle>
-            <unitid>(negative no. 223)</unitid>
+            <unitid>negative no. 223</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 1)</p>
@@ -2678,7 +2678,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Man and dog by stove.</unittitle>
-            <unitid>(negative no. 224)</unitid>
+            <unitid>negative no. 224</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 15)</p>
@@ -2688,7 +2688,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Baby on blanket-outdoors.</unittitle>
-            <unitid>(negative no. 225)</unitid>
+            <unitid>negative no. 225</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 6)</p>
@@ -2698,7 +2698,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Geese-blurred.</unittitle>
-            <unitid>(negative no. 226)</unitid>
+            <unitid>negative no. 226</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 2)</p>
@@ -2708,7 +2708,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Interior with chairs.</unittitle>
-            <unitid>(negative no. 227)</unitid>
+            <unitid>negative no. 227</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 15)</p>
@@ -2718,7 +2718,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Group before house at lake.</unittitle>
-            <unitid>(negative no. 228)</unitid>
+            <unitid>negative no. 228</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 11)</p>
@@ -2728,7 +2728,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Charles Newton and Rose Arbogast seated in field.</unittitle>
-            <unitid>(negative no. 229)</unitid>
+            <unitid>negative no. 229</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -2738,7 +2738,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Horse, nose out of picture.</unittitle>
-            <unitid>(negative no. 230)</unitid>
+            <unitid>negative no. 230</unitid>
           </did>
           <odd>
             <p>(no contact print)</p>
@@ -2748,7 +2748,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Mustached man in interior</unittitle>
-            <unitid>(negative no. 231)</unitid>
+            <unitid>negative no. 231</unitid>
           </did>
           <odd>
             <p>(no contact print; deteriorated)</p>
@@ -2758,7 +2758,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Two women, man with horse.</unittitle>
-            <unitid>(negative no. 232)</unitid>
+            <unitid>negative no. 232</unitid>
           </did>
           <odd>
             <p>(no contact print)</p>
@@ -2768,7 +2768,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Couple, Mr. and Mrs. Calvin G. Hadley.</unittitle>
-            <unitid>(negative no. 233)</unitid>
+            <unitid>negative no. 233</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -2778,7 +2778,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Man in Derby with letter and another in straw?, hat clowning, Frank (left?) and Burlie Fuller?</unittitle>
-            <unitid>(negative no. 234)</unitid>
+            <unitid>negative no. 234</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 12)</p>
@@ -2788,7 +2788,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Farm and farmyard</unittitle>
-            <unitid>(negative no. 235)</unitid>
+            <unitid>negative no. 235</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 7)</p>
@@ -2798,7 +2798,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Old woman in rocker with book (grandmother Fannie Post Raymond).</unittitle>
-            <unitid>(negative no. 236)</unitid>
+            <unitid>negative no. 236</unitid>
           </did>
           <odd>
             <p>(contact print in envelope no. 16)</p>
@@ -2808,7 +2808,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Seated woman in striped shirt.</unittitle>
-            <unitid>(negative no. 237)</unitid>
+            <unitid>negative no. 237</unitid>
           </did>
           <odd>
             <p>(no contact print)</p>
@@ -2818,7 +2818,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Two little girls, very dense.</unittitle>
-            <unitid>(negative no. 238)</unitid>
+            <unitid>negative no. 238</unitid>
           </did>
           <odd>
             <p>(no contact print)</p>
@@ -2828,7 +2828,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Ditch digging-horses pulling.</unittitle>
-            <unitid>(negative no. 239)</unitid>
+            <unitid>negative no. 239</unitid>
           </did>
           <odd>
             <p>(no contact print)</p>
@@ -2838,7 +2838,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Lady with pipe.</unittitle>
-            <unitid>(negative no. 240)</unitid>
+            <unitid>negative no. 240</unitid>
           </did>
           <odd>
             <p>(no contact print)</p>
@@ -2848,7 +2848,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Two elders.</unittitle>
-            <unitid>(negative no. 241)</unitid>
+            <unitid>negative no. 241</unitid>
           </did>
           <odd>
             <p>(no contact print)</p>
@@ -2858,7 +2858,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Horse and carriage in distance.</unittitle>
-            <unitid>(negative no. 242)</unitid>
+            <unitid>negative no. 242</unitid>
           </did>
           <odd>
             <p>(no contact print)</p>
@@ -2868,7 +2868,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Cows in field.</unittitle>
-            <unitid>(negative no. 243)</unitid>
+            <unitid>negative no. 243</unitid>
           </did>
           <odd>
             <p>(no contact print)</p>
@@ -2878,7 +2878,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>House.</unittitle>
-            <unitid>(negative no. 244)</unitid>
+            <unitid>negative no. 244</unitid>
           </did>
           <odd>
             <p>(no contact print)</p>
@@ -2888,7 +2888,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Shed in barnyard.</unittitle>
-            <unitid>(negative no. 245)</unitid>
+            <unitid>negative no. 245</unitid>
           </did>
           <odd>
             <p>(no contact print)</p>
@@ -2898,7 +2898,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Pig in barnyard.</unittitle>
-            <unitid>(negative no. 246)</unitid>
+            <unitid>negative no. 246</unitid>
           </did>
           <odd>
             <p>(no contact print)</p>
@@ -2908,7 +2908,7 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Two men and a woman in orchard.</unittitle>
-            <unitid>(negative no. 247)</unitid>
+            <unitid>negative no. 247</unitid>
           </did>
           <odd>
             <p>(no contact print)</p>

--- a/Real_Masters_all/gehringc.xml
+++ b/Real_Masters_all/gehringc.xml
@@ -649,7 +649,7 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>1)</unitid>
+            <unitid>1</unitid>
             <unittitle>A Program of Robert Frost, Songs / music by Carl Gehring--WNYC-New York City <unitdate type="inclusive" normal="1960-04-06">April 6, 1960</unitdate></unittitle>
             <physdesc>
               <physfacet>7" reel; 7 1/2 ips</physfacet>
@@ -659,7 +659,7 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>2)</unitid>
+            <unitid>2</unitid>
             <unittitle>Ten Songs by Carl Gehring / Marilyn Krimm, soprano: Elaine Jacobson, accompanist. <unitdate type="inclusive" normal="1961-10-02">October 2, 1961</unitdate></unittitle>
             <physdesc>
               <physfacet>7" reel; 7 1/2 ips</physfacet>
@@ -672,7 +672,7 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>3)</unitid>
+            <unitid>3</unitid>
             <unittitle>The Readers' Almanac : Songs by Carl Gehring, based on Poems by American Negro Authors.--WNYC-New York City <unitdate type="inclusive" normal="1962-05-05">May 5, 1962</unitdate></unittitle>
             <physdesc>
               <physfacet>7" reel; 7 1/2 ips</physfacet>
@@ -682,7 +682,7 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>4)</unitid>
+            <unitid>4</unitid>
             <unittitle>Rameau/Gehring/Bach : Two-Piano program broadcast <unitdate type="inclusive" normal="1963-03-21">March 21, 1963</unitdate></unittitle>
             <physdesc>
               <physfacet>7" reel; 7 1/2 ips</physfacet>
@@ -695,7 +695,7 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>5)</unitid>
+            <unitid>5</unitid>
             <unittitle>Piano Pieces in a Program of American Music / Barbara Holmquist, pianist <unitdate type="inclusive" normal="1963-12-31">December 31, 1963</unitdate></unittitle>
             <physdesc>
               <physfacet>5" reel; 7 1/2 ips</physfacet>
@@ -708,7 +708,7 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>6)</unitid>
+            <unitid>6</unitid>
             <unittitle>Studio Showcase : Gehring, Sonqs / Reah Sadowsky, Pianist,--WUOM-Ann Arbor, Mich. <unitdate type="inclusive" normal="1964-04-28">April 28, 1964</unitdate></unittitle>
             <physdesc>
               <physfacet>7" reel; 7 1/2 ips</physfacet>
@@ -721,7 +721,7 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>7)</unitid>
+            <unitid>7</unitid>
             <unittitle>Studio Showcase : Gehring Songs Based on Poems by Emily Dickinson / Marilyn Krimm, soprano; Elaine Jacobson, Pianist <unitdate type="inclusive" normal="1964-05-28">May 28, 1964</unitdate></unittitle>
             <physdesc>
               <physfacet>7" reel; 7 1/2 ips</physfacet>
@@ -734,7 +734,7 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>8)</unitid>
+            <unitid>8</unitid>
             <unittitle>Studio Showcase : Gehring Songs Based on Poems by Emily Dickinson (revised for broadcast) <unitdate type="inclusive" normal="1964-05-28">May 28, 1964</unitdate></unittitle>
             <physdesc>
               <physfacet>7" reel; 7 1/2 ips</physfacet>
@@ -747,7 +747,7 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>9)</unitid>
+            <unitid>9</unitid>
             <unittitle>The Readers' Almanac [broadcast]: Emily Dickinson Songs. Music by Carl Gehring (contents unknown)--WNYC-New York City <unitdate type="inclusive" normal="1964-10-26">October 26, 1964</unitdate></unittitle>
             <physdesc>
               <physfacet>7" reel; 7 1/2 ips</physfacet>
@@ -757,7 +757,7 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>10)</unitid>
+            <unitid>10</unitid>
             <unittitle>WUOM Studio Showcase / Frances Felbeck. Pianist, November 3 ? <unitdate type="inclusive" normal="1964">1964</unitdate></unittitle>
             <physdesc>
               <physfacet>7" reel; 7 1/2 ips</physfacet>
@@ -770,7 +770,7 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>11)</unitid>
+            <unitid>11</unitid>
             <unittitle>WUOM Studio Showcase: Ten Songs by Carl Gehring / Soprano, Carolyn Austin; accompanist, E. Jacobson <unitdate type="inclusive" normal="1965" certainty="approximate">circa 1965</unitdate></unittitle>
             <physdesc>
               <physfacet>7" reel; 7 1/2 ips</physfacet>
@@ -783,7 +783,7 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>12)</unitid>
+            <unitid>12</unitid>
             <unittitle>Eight Songs Based on Poems by Robert Frost / Carolyn Austin;: E. Jacobson <unitdate type="inclusive">undated</unitdate></unittitle>
             <physdesc>
               <physfacet>7" reel; 7 1/2 ips</physfacet>
@@ -796,7 +796,7 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>13)</unitid>
+            <unitid>13</unitid>
             <unittitle>The Readers' Almanac: Songs by Edna St. Vincent Millay, Music by Carl Gehring.---WNYC-New York City <unitdate type="inclusive" normal="1964-02-23">February 23, 1964</unitdate></unittitle>
             <physdesc>
               <physfacet>7" reel; 7 1/2 ips</physfacet>
@@ -809,7 +809,7 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>14)</unitid>
+            <unitid>14</unitid>
             <unittitle>WUOM Studio Showcase: Suite for Piano Solo Music by Carl Gehring) / pianist, Lydia Court <unitdate type="inclusive">undated</unitdate></unittitle>
           </did>
           <odd>
@@ -819,7 +819,7 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>15)</unitid>
+            <unitid>15</unitid>
             <unittitle>(Gehring Songs) / Carolyn Austin; E. Jacobson <unitdate type="inclusive">undated</unitdate></unittitle>
           </did>
           <odd>
@@ -829,7 +829,7 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>16)</unitid>
+            <unitid>16</unitid>
             <unittitle>[Gehring Songs Based on Poems by Edna St. Vincent Millay] / Mary Matfeld Burdette, contralto; E. Jacobson, accompanist <unitdate type="inclusive">undated</unitdate></unittitle>
             <physdesc>
               <physfacet>10" reel; 7 1/2 ips</physfacet>

--- a/Real_Masters_all/laporte.xml
+++ b/Real_Masters_all/laporte.xml
@@ -273,112 +273,112 @@ Otto Laporte papers, Bentley Historical Library, University of Michigan</p>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>1)</unitid>
+            <unitid>1</unitid>
             <unittitle>Lectures on Classical Mechanics</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>2)</unitid>
+            <unitid>2</unitid>
             <unittitle>Miscellaneous Notes on Minimal Surfaces</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>3)</unitid>
+            <unitid>3</unitid>
             <unittitle>Whirling Arm</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>4)</unitid>
+            <unitid>4</unitid>
             <unittitle>Directional Equations, Integrals</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>5)</unitid>
+            <unitid>5</unitid>
             <unittitle>E &amp; M Mechanics Problems</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>6)</unitid>
+            <unitid>6</unitid>
             <unittitle>Miscellaneous Notes to 451-452</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>7)</unitid>
+            <unitid>7</unitid>
             <unittitle>Aero 15 (Class Notes)</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>8)</unitid>
+            <unitid>8</unitid>
             <unittitle>Calculations on Tenor of Rigid Body Rotation</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>9)</unitid>
+            <unitid>9</unitid>
             <unittitle>Miscellaneous Equations</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>10)</unitid>
+            <unitid>10</unitid>
             <unittitle>Schrodinger Equation w/Periodic Potential</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>11)</unitid>
+            <unitid>11</unitid>
             <unittitle>On the Wave Mechanics of Mobius</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>12)</unitid>
+            <unitid>12</unitid>
             <unittitle>Notes on Fluid Mechanics &amp; Quantum Mechanics</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>13)</unitid>
+            <unitid>13</unitid>
             <unittitle>Quantum Mechanics II</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>14)</unitid>
+            <unitid>14</unitid>
             <unittitle>Quantum Mechanics III</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>15)</unitid>
+            <unitid>15</unitid>
             <unittitle>Theoretical Mechanics I</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>16)</unitid>
+            <unitid>16</unitid>
             <unittitle>Theoretical Mechanics Addenda</unittitle>
           </did>
           <odd>
@@ -388,154 +388,154 @@ Otto Laporte papers, Bentley Historical Library, University of Michigan</p>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>17)</unitid>
+            <unitid>17</unitid>
             <unittitle>Theoretical Mechanics II</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>18)</unitid>
+            <unitid>18</unitid>
             <unittitle>Theoretical Mechanics III</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>19)</unitid>
+            <unitid>19</unitid>
             <unittitle>Mirror Problem I</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>20)</unitid>
+            <unitid>20</unitid>
             <unittitle>Mirror Problem II</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>21)</unitid>
+            <unitid>21</unitid>
             <unittitle>Polyhedral Harmonics, Raleigh Ritz Method I</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>22)</unitid>
+            <unitid>22</unitid>
             <unittitle>Raleigh Ritz Method II &amp; Slit Problem I</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>23)</unitid>
+            <unitid>23</unitid>
             <unittitle>Slit Problem II</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>24)</unitid>
+            <unitid>24</unitid>
             <unittitle>Slit Problem III</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>25)</unitid>
+            <unitid>25</unitid>
             <unittitle>More Ritz Method Examples</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>26)</unitid>
+            <unitid>26</unitid>
             <unittitle>Theory of Atomic Spectra</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>27)</unitid>
+            <unitid>27</unitid>
             <unittitle>Rubinowitz's Diffraction Problem, Vol. II</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>28)</unitid>
+            <unitid>28</unitid>
             <unittitle>Diffraction Problem, Vol. III</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>29)</unitid>
+            <unitid>29</unitid>
             <unittitle>Diffraction Problem, Vol. IV</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>30)</unitid>
+            <unitid>30</unitid>
             <unittitle>Diffraction Problem, Vol. V</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>31)</unitid>
+            <unitid>31</unitid>
             <unittitle>Integral Equations, Vol. I</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>32)</unitid>
+            <unitid>32</unitid>
             <unittitle>Integral Equations, Vol. II</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>33)</unitid>
+            <unitid>33</unitid>
             <unittitle>Integral Equations, Vol. III</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>34)</unitid>
+            <unitid>34</unitid>
             <unittitle>Integral Equations, Vol. IV (w/notes on Vortex ring)</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>35)</unitid>
+            <unitid>35</unitid>
             <unittitle>Integral Equations, Vol. V (w/notes on Vortex ring)</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>36)</unitid>
+            <unitid>36</unitid>
             <unittitle>Integral Equations, Vol. VI (w/notes on Vortex ring)</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>37)</unitid>
+            <unitid>37</unitid>
             <unittitle>Integral Equations, Vol. VII (w/notes on Vortex ring)</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>38)</unitid>
+            <unitid>38</unitid>
             <unittitle>Dipole and Screen with Hole</unittitle>
           </did>
         </c02>

--- a/Real_Masters_all/lefavour.xml
+++ b/Real_Masters_all/lefavour.xml
@@ -562,7 +562,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>1-3)</unitid>
+            <unitid>1-3</unitid>
             <unittitle>James Shearer House, Bay City -- Interiors</unittitle>
             <physdesc>
               <physfacet>8 1/2" x 6 1/2"</physfacet>
@@ -575,7 +575,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>4)</unitid>
+            <unitid>4</unitid>
             <unittitle>Surveying Photograph-University of Michigan Campus, View of East University Street and Elementary School</unittitle>
             <physdesc>
               <physfacet>5" x 8"</physfacet>
@@ -588,7 +588,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>5-9)</unitid>
+            <unitid>5-9</unitid>
             <unittitle>Surveying Photograph-University of Michigan Campus</unittitle>
             <physdesc>
               <physfacet>5" x 8"</physfacet>
@@ -601,7 +601,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>10)</unitid>
+            <unitid>10</unitid>
             <unittitle>City Building, Bay City <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -611,7 +611,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>11)</unitid>
+            <unitid>11</unitid>
             <unittitle>Hospitals, University of Michigan</unittitle>
           </did>
           <odd>
@@ -621,7 +621,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>12)</unitid>
+            <unitid>12</unitid>
             <unittitle>F.P. Graves</unittitle>
           </did>
           <odd>
@@ -631,7 +631,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>13)</unitid>
+            <unitid>13</unitid>
             <unittitle>Presbyterian Church, Bay City</unittitle>
           </did>
           <odd>
@@ -641,7 +641,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>14)</unitid>
+            <unitid>14</unitid>
             <unittitle>Masonic Temple, Bay City</unittitle>
           </did>
           <odd>
@@ -651,7 +651,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>15)</unitid>
+            <unitid>15</unitid>
             <unittitle>Episcopal Church, Bay City <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -661,7 +661,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>16)</unitid>
+            <unitid>16</unitid>
             <unittitle>High School, Bay City <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -671,7 +671,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>17)</unitid>
+            <unitid>17</unitid>
             <unittitle>Elm Lawn Cemetery, Bay City <unitdate type="inclusive" normal="1895-09">September 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -681,7 +681,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>18)</unitid>
+            <unitid>18</unitid>
             <unittitle>James vanDucusin (?), Bay City <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -691,7 +691,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>19)</unitid>
+            <unitid>19</unitid>
             <unittitle>James Shearer House, Bay City-Interior <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -701,7 +701,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>20)</unitid>
+            <unitid>20</unitid>
             <unittitle>James Shearer House, Bay City-Interior <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -711,7 +711,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>21)</unitid>
+            <unitid>21</unitid>
             <unittitle>G. Henry Shearer House, Bay City-Exterior <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -721,7 +721,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>22)</unitid>
+            <unitid>22</unitid>
             <unittitle>Chauncey H. Shearer, Bay City-Exterior <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -731,14 +731,14 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>23)</unitid>
+            <unitid>23</unitid>
             <unittitle>H.M.K. at McCormicks</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>24)</unitid>
+            <unitid>24</unitid>
             <unittitle>Michigan Central Railroad Station, Bay City <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -748,7 +748,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>25)</unitid>
+            <unitid>25</unitid>
             <unittitle>Observatory, University of Michigan</unittitle>
           </did>
           <odd>
@@ -758,14 +758,14 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>26)</unitid>
+            <unitid>26</unitid>
             <unittitle>H.M.K. at McCormicks</unittitle>
           </did>
         </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>27)</unitid>
+            <unitid>27</unitid>
             <unittitle>McEwan House, Bay City-Exterior <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -775,7 +775,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>28)</unitid>
+            <unitid>28</unitid>
             <unittitle>Amelise and Alfred (Shearer), Bay City <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -785,7 +785,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>29)</unitid>
+            <unitid>29</unitid>
             <unittitle>Woodland Pond, Windfall Timber (with fisherman and boater)</unittitle>
           </did>
           <odd>
@@ -795,7 +795,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>30)</unitid>
+            <unitid>30</unitid>
             <unittitle>Engineers and Tent (group)</unittitle>
           </did>
           <odd>
@@ -805,7 +805,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>31)</unitid>
+            <unitid>31</unitid>
             <unittitle>Engineer and Tent (individual)</unittitle>
           </did>
           <odd>
@@ -815,7 +815,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>32)</unitid>
+            <unitid>32</unitid>
             <unittitle>Tent and Equipment (?)</unittitle>
           </did>
           <odd>
@@ -825,7 +825,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>33)</unitid>
+            <unitid>33</unitid>
             <unittitle>Campsite</unittitle>
           </did>
           <odd>
@@ -835,7 +835,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>34)</unitid>
+            <unitid>34</unitid>
             <unittitle>Lakeshore</unittitle>
           </did>
           <odd>
@@ -845,7 +845,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>35)</unitid>
+            <unitid>35</unitid>
             <unittitle>Engineering class (group)</unittitle>
           </did>
           <odd>
@@ -855,7 +855,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>36)</unitid>
+            <unitid>36</unitid>
             <unittitle>Couple with baby and carriage</unittitle>
           </did>
           <odd>
@@ -865,7 +865,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>37)</unitid>
+            <unitid>37</unitid>
             <unittitle>Engineer and Tent (individual)</unittitle>
           </did>
           <odd>
@@ -875,7 +875,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>38)</unitid>
+            <unitid>38</unitid>
             <unittitle>Boat, "The SALLIE," with engineers</unittitle>
           </did>
           <odd>
@@ -885,7 +885,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>39)</unitid>
+            <unitid>39</unitid>
             <unittitle>Engineers (group) at campsite</unittitle>
           </did>
           <odd>
@@ -895,7 +895,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>40)</unitid>
+            <unitid>40</unitid>
             <unittitle>Engineers (group) and Tent</unittitle>
           </did>
           <odd>
@@ -905,7 +905,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>41)</unitid>
+            <unitid>41</unitid>
             <unittitle>Building</unittitle>
           </did>
           <odd>
@@ -915,7 +915,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>42)</unitid>
+            <unitid>42</unitid>
             <unittitle>City Street</unittitle>
           </did>
           <odd>
@@ -925,7 +925,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>43)</unitid>
+            <unitid>43</unitid>
             <unittitle>Engineer and Tent</unittitle>
           </did>
           <odd>
@@ -935,7 +935,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>44)</unitid>
+            <unitid>44</unitid>
             <unittitle>Fraternity House</unittitle>
           </did>
           <odd>
@@ -945,7 +945,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>45)</unitid>
+            <unitid>45</unitid>
             <unittitle>Alfred Shearer, Bay City <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -955,7 +955,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>46)</unitid>
+            <unitid>46</unitid>
             <unittitle>Campsite, Boat Landing <unitdate type="inclusive" normal="1895-06">June, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -965,7 +965,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>47)</unitid>
+            <unitid>47</unitid>
             <unittitle>Engineers (group) at roll call <unitdate type="inclusive" normal="1895-06">June, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -975,7 +975,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>48)</unitid>
+            <unitid>48</unitid>
             <unittitle>Baseball game at Sutton's Bay <unitdate type="inclusive" normal="1895-06">June, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -985,7 +985,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>49)</unitid>
+            <unitid>49</unitid>
             <unittitle>Campsite, Building a Landing (swampwork) <unitdate type="inclusive" normal="1895-06">June, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -995,7 +995,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>50)</unitid>
+            <unitid>50</unitid>
             <unittitle>Engineers, starting out for Sutton's Bay <unitdate type="inclusive" normal="1895-06">June, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1005,7 +1005,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>51)</unitid>
+            <unitid>51</unitid>
             <unittitle>Women (group), Helen, Margaret, and Jack (?) <unitdate type="inclusive" normal="1895-07">July, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1015,7 +1015,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>52)</unitid>
+            <unitid>52</unitid>
             <unittitle>Main Building</unittitle>
           </did>
           <odd>
@@ -1025,7 +1025,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>53)</unitid>
+            <unitid>53</unitid>
             <unittitle>Unidentified Women <unitdate type="inclusive" normal="1895-07">July, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1035,7 +1035,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>54)</unitid>
+            <unitid>54</unitid>
             <unittitle>Unidentified Building</unittitle>
           </did>
           <odd>
@@ -1045,7 +1045,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>55)</unitid>
+            <unitid>55</unitid>
             <unittitle>Mr. Carter (Maltby Carter), Bay City <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1055,7 +1055,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>56)</unitid>
+            <unitid>56</unitid>
             <unittitle>C.A. Eddy House, Bay City-Exterior <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1065,7 +1065,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>57)</unitid>
+            <unitid>57</unitid>
             <unittitle>Engineers, Clifford Moses Pritchard and David LeFavour <unitdate type="inclusive" normal="1895-06">June, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1075,7 +1075,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>58)</unitid>
+            <unitid>58</unitid>
             <unittitle>Engineers (group) with instruments <unitdate type="inclusive" normal="1895-06">June, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1085,7 +1085,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>59)</unitid>
+            <unitid>59</unitid>
             <unittitle>Surveying Camp <unitdate type="inclusive" normal="1895-06">June, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1095,7 +1095,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
-            <unitid>60)</unitid>
+            <unitid>60</unitid>
             <unittitle>Alfred Shearer, Bay City <unitdate type="inclusive" normal="1895-08">August, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1105,7 +1105,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>61)</unitid>
+            <unitid>61</unitid>
             <unittitle>Alfred Shearer, Bay City <unitdate type="inclusive" normal="1895-08">August, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1115,7 +1115,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>62)</unitid>
+            <unitid>62</unitid>
             <unittitle>Helen and Alfred Shearer <unitdate type="inclusive" normal="1895-08">August, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1125,7 +1125,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>63)</unitid>
+            <unitid>63</unitid>
             <unittitle>Miss Beckwith and Bicycle <unitdate type="inclusive" normal="1895-07">July, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1135,7 +1135,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>64)</unitid>
+            <unitid>64</unitid>
             <unittitle>Women (group), Helen, Margaret, and Jack M. <unitdate type="inclusive" normal="1895-07">July, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1145,7 +1145,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>65)</unitid>
+            <unitid>65</unitid>
             <unittitle>Women (group), Helen, Margaret, and Jack (?) <unitdate type="inclusive" normal="1895-07">July, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1155,7 +1155,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>66)</unitid>
+            <unitid>66</unitid>
             <unittitle>Engineers (group)</unittitle>
           </did>
           <odd>
@@ -1165,7 +1165,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>67)</unitid>
+            <unitid>67</unitid>
             <unittitle>Tappan Hall, University of Michigan</unittitle>
           </did>
           <odd>
@@ -1175,7 +1175,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>68)</unitid>
+            <unitid>68</unitid>
             <unittitle>Children (unidentified) with laundry basket</unittitle>
           </did>
           <odd>
@@ -1185,7 +1185,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>69)</unitid>
+            <unitid>69</unitid>
             <unittitle>Women (group)</unittitle>
           </did>
           <odd>
@@ -1195,7 +1195,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>70)</unitid>
+            <unitid>70</unitid>
             <unittitle>Student room, University of Michigan (Alpha Delta Phi?)</unittitle>
           </did>
           <odd>
@@ -1205,7 +1205,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>71)</unitid>
+            <unitid>71</unitid>
             <unittitle>Huron River at Ann Arbor</unittitle>
           </did>
           <odd>
@@ -1215,7 +1215,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>72)</unitid>
+            <unitid>72</unitid>
             <unittitle>Curtice (?) House, Bay City-Exterior <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1225,7 +1225,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>73)</unitid>
+            <unitid>73</unitid>
             <unittitle>Fraternity House (group)</unittitle>
           </did>
           <odd>
@@ -1235,7 +1235,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>74)</unitid>
+            <unitid>74</unitid>
             <unittitle>Sunday Walk (group)</unittitle>
           </did>
           <odd>
@@ -1245,7 +1245,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>75)</unitid>
+            <unitid>75</unitid>
             <unittitle>Alpha Delta Phi Fraternity (group)</unittitle>
           </did>
           <odd>
@@ -1255,7 +1255,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>76)</unitid>
+            <unitid>76</unitid>
             <unittitle>Fraternity House (group) <unitdate type="inclusive" normal="1895">1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1265,7 +1265,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>77)</unitid>
+            <unitid>77</unitid>
             <unittitle>Fraternity House (group) <unitdate type="inclusive" normal="1895">1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1275,7 +1275,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>78)</unitid>
+            <unitid>78</unitid>
             <unittitle>Alpha Delta Phi Fraternity (group)</unittitle>
           </did>
           <odd>
@@ -1285,7 +1285,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>79)</unitid>
+            <unitid>79</unitid>
             <unittitle>James Shearer House, Bay City-Exterior <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1295,7 +1295,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>80)</unitid>
+            <unitid>80</unitid>
             <unittitle>Lane Building, University of Michigan</unittitle>
           </did>
           <odd>
@@ -1305,7 +1305,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>81)</unitid>
+            <unitid>81</unitid>
             <unittitle>Medical Building, University of Michigan</unittitle>
           </did>
           <odd>
@@ -1315,7 +1315,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>82)</unitid>
+            <unitid>82</unitid>
             <unittitle>Professor Joseph B. Davis (Geodesy and Surveying), at Campsite <unitdate type="inclusive" normal="1895-06">June, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1325,7 +1325,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>83)</unitid>
+            <unitid>83</unitid>
             <unittitle>The Whitfield Family (at campsite)</unittitle>
           </did>
           <odd>
@@ -1335,7 +1335,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>84)</unitid>
+            <unitid>84</unitid>
             <unittitle>F.E.E. (unknown woman) and bicycle <unitdate type="inclusive" normal="1895-08">August, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1345,7 +1345,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>85)</unitid>
+            <unitid>85</unitid>
             <unittitle>Harriet E. M and bicycle <unitdate type="inclusive" normal="1895-08">August, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1355,7 +1355,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>86)</unitid>
+            <unitid>86</unitid>
             <unittitle>F.E.E. (unknown woman) <unitdate type="inclusive" normal="1895-08">August, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1365,7 +1365,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>87)</unitid>
+            <unitid>87</unitid>
             <unittitle>F.E.E., N.J.D., and Harriet E. (?) <unitdate type="inclusive" normal="1895-08">August, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1375,7 +1375,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>88)</unitid>
+            <unitid>88</unitid>
             <unittitle>N.J.D. (unknown woman) and bicycle <unitdate type="inclusive" normal="1895-08">August, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1385,7 +1385,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>89)</unitid>
+            <unitid>89</unitid>
             <unittitle>Women (group) on fence (man in background) <unitdate type="inclusive" normal="1895-08">August, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1395,7 +1395,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>90)</unitid>
+            <unitid>90</unitid>
             <unittitle>Harriet E. (?) and Elaine</unittitle>
           </did>
           <odd>
@@ -1405,7 +1405,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>91)</unitid>
+            <unitid>91</unitid>
             <unittitle>Harriet E. M and Elaine</unittitle>
           </did>
           <odd>
@@ -1415,7 +1415,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>92)</unitid>
+            <unitid>92</unitid>
             <unittitle>Miss Beckwith <unitdate type="inclusive" normal="1895-07">July, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1425,7 +1425,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>93)</unitid>
+            <unitid>93</unitid>
             <unittitle>James Shearer House, Bay City-Exterior <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1435,7 +1435,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>94)</unitid>
+            <unitid>94</unitid>
             <unittitle>Government Building, Bay City <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1445,7 +1445,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>95)</unitid>
+            <unitid>95</unitid>
             <unittitle>Spencer O. Fisher House, Bay City Exterior <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1455,7 +1455,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>96)</unitid>
+            <unitid>96</unitid>
             <unittitle>Alpha Delta Phi Fraternity House Interior, group at piano</unittitle>
           </did>
           <odd>
@@ -1465,7 +1465,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>97)</unitid>
+            <unitid>97</unitid>
             <unittitle>University of Michigan Track Team (two members)</unittitle>
           </did>
           <odd>
@@ -1475,7 +1475,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>98)</unitid>
+            <unitid>98</unitid>
             <unittitle>University of Michigan Track Team (individual)</unittitle>
           </did>
           <odd>
@@ -1485,7 +1485,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>99)</unitid>
+            <unitid>99</unitid>
             <unittitle>University of Michigan Track Team (individual)</unittitle>
           </did>
           <odd>
@@ -1495,7 +1495,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>100)</unitid>
+            <unitid>100</unitid>
             <unittitle>University of Michigan Track Team (cyclist and assistant)</unittitle>
           </did>
           <odd>
@@ -1505,7 +1505,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>101)</unitid>
+            <unitid>101</unitid>
             <unittitle>University of Michigan Track Team (individual)</unittitle>
           </did>
           <odd>
@@ -1515,7 +1515,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>102)</unitid>
+            <unitid>102</unitid>
             <unittitle>Football game</unittitle>
           </did>
           <odd>
@@ -1525,7 +1525,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>103)</unitid>
+            <unitid>103</unitid>
             <unittitle>Engineers (group)</unittitle>
           </did>
           <odd>
@@ -1535,7 +1535,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>104)</unitid>
+            <unitid>104</unitid>
             <unittitle>Huron River at Ann Arbor</unittitle>
           </did>
           <odd>
@@ -1545,7 +1545,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>105)</unitid>
+            <unitid>105</unitid>
             <unittitle>University Hall, University of Michigan</unittitle>
           </did>
           <odd>
@@ -1555,7 +1555,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>106)</unitid>
+            <unitid>106</unitid>
             <unittitle>Three young men (unidentified)</unittitle>
           </did>
           <odd>
@@ -1565,7 +1565,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>107)</unitid>
+            <unitid>107</unitid>
             <unittitle>Students (group), on a cattle guard, Ann Arbor <unitdate type="inclusive" normal="1895">1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1575,7 +1575,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>108)</unitid>
+            <unitid>108</unitid>
             <unittitle>F.P. Graves</unittitle>
           </did>
           <odd>
@@ -1585,7 +1585,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>109)</unitid>
+            <unitid>109</unitid>
             <unittitle>Alpha Delta Phi Fraternity House (group), Commencement Week <unitdate type="inclusive" normal="1895" certainty="approximate">1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1595,7 +1595,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>110)</unitid>
+            <unitid>110</unitid>
             <unittitle>A.H. Wrigt (outside Alpha Delta Phi Fraternity House) <unitdate type="inclusive" normal="1895">1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1605,7 +1605,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>111)</unitid>
+            <unitid>111</unitid>
             <unittitle>Alpha Delta Phi Fraternity (group?) <unitdate type="inclusive" normal="1895-10">October, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1615,7 +1615,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>112)</unitid>
+            <unitid>112</unitid>
             <unittitle>Physical Lab, University of Michigan</unittitle>
           </did>
           <odd>
@@ -1625,7 +1625,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>113)</unitid>
+            <unitid>113</unitid>
             <unittitle>Alpha Delta Phi Fraternity House, Class of <unitdate type="inclusive" normal="1897">1897</unitdate>, <unitdate type="inclusive" normal="1895-10">October, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1635,7 +1635,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>114)</unitid>
+            <unitid>114</unitid>
             <unittitle>University of Michigan Track Team (individual)</unittitle>
           </did>
           <odd>
@@ -1645,7 +1645,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>115)</unitid>
+            <unitid>115</unitid>
             <unittitle>Alpha Delta Phi Fraternity House, Class of <unitdate type="inclusive" normal="1898">1898</unitdate>, <unitdate type="inclusive" normal="1895-10">October, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1655,7 +1655,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>116)</unitid>
+            <unitid>116</unitid>
             <unittitle>Alpha Delta Phi Fraternity House, unidentified group</unittitle>
           </did>
           <odd>
@@ -1665,7 +1665,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>117)</unitid>
+            <unitid>117</unitid>
             <unittitle>Alpha Delta Phi Fraternity House-Interior, room of D. LeFavour and Robert Clark Stephens</unittitle>
           </did>
           <odd>
@@ -1675,7 +1675,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>118)</unitid>
+            <unitid>118</unitid>
             <unittitle>Alpha Delta Phi Fraternity House-Interior, group at formal celebration</unittitle>
           </did>
           <odd>
@@ -1685,7 +1685,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>119)</unitid>
+            <unitid>119</unitid>
             <unittitle>Alpha Delta Phi Fraternity House-Interior, group at formal celebration</unittitle>
           </did>
           <odd>
@@ -1695,7 +1695,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>120)</unitid>
+            <unitid>120</unitid>
             <unittitle>Alpha Delta Phi Fraternity House-Interior, group at formal celebration</unittitle>
           </did>
           <odd>
@@ -1705,7 +1705,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>121)</unitid>
+            <unitid>121</unitid>
             <unittitle>Bay City, Center Avenue west of Jefferson Avenue</unittitle>
           </did>
           <odd>
@@ -1715,7 +1715,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>122)</unitid>
+            <unitid>122</unitid>
             <unittitle>Bay City, Center Avenue east of Madison Avenue</unittitle>
           </did>
           <odd>
@@ -1725,7 +1725,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>123)</unitid>
+            <unitid>123</unitid>
             <unittitle>Waterman Gymnasium, University of Michigan</unittitle>
           </did>
           <odd>
@@ -1735,7 +1735,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>124)</unitid>
+            <unitid>124</unitid>
             <unittitle>Delta Kappa Epsilon Fraternity, University of Michigan</unittitle>
           </did>
           <odd>
@@ -1745,7 +1745,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>125)</unitid>
+            <unitid>125</unitid>
             <unittitle>Huron River at Ann Arbor</unittitle>
           </did>
           <odd>
@@ -1755,7 +1755,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>126)</unitid>
+            <unitid>126</unitid>
             <unittitle>Huron River at Ann Arbor</unittitle>
           </did>
           <odd>
@@ -1765,7 +1765,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>127)</unitid>
+            <unitid>127</unitid>
             <unittitle>Huron River at Ann Arbor</unittitle>
           </did>
           <odd>
@@ -1775,7 +1775,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>128)</unitid>
+            <unitid>128</unitid>
             <unittitle>Football</unittitle>
           </did>
           <odd>
@@ -1785,7 +1785,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>129)</unitid>
+            <unitid>129</unitid>
             <unittitle>Football</unittitle>
           </did>
           <odd>
@@ -1795,7 +1795,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>130)</unitid>
+            <unitid>130</unitid>
             <unittitle>Football</unittitle>
           </did>
           <odd>
@@ -1805,7 +1805,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>131)</unitid>
+            <unitid>131</unitid>
             <unittitle>Michigan Central Railroad Station, Ann Arbor</unittitle>
           </did>
           <odd>
@@ -1815,7 +1815,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>132)</unitid>
+            <unitid>132</unitid>
             <unittitle>"Lower Town" Ann Arbor</unittitle>
           </did>
           <odd>
@@ -1825,7 +1825,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>133)</unitid>
+            <unitid>133</unitid>
             <unittitle>Huron River at Ann Arbor</unittitle>
           </did>
           <odd>
@@ -1835,7 +1835,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>134)</unitid>
+            <unitid>134</unitid>
             <unittitle>Margaret (Shearer), Bay City <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1845,7 +1845,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>135)</unitid>
+            <unitid>135</unitid>
             <unittitle>Helen LeFavour (sister) and Margaret Shearer (cousin), Bay City <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1855,7 +1855,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>136)</unitid>
+            <unitid>136</unitid>
             <unittitle>Alfred Shearer, Bay City <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1865,7 +1865,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>137)</unitid>
+            <unitid>137</unitid>
             <unittitle>The three boys, Bay City <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1875,7 +1875,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>138)</unitid>
+            <unitid>138</unitid>
             <unittitle>Helen (LeFavour), Bay City <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1885,7 +1885,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>139)</unitid>
+            <unitid>139</unitid>
             <unittitle>Alfred Shearer, Bay City <unitdate type="inclusive" normal="1895-09">September, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1895,7 +1895,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>140)</unitid>
+            <unitid>140</unitid>
             <unittitle>Engineers (group) with instruments <unitdate type="inclusive" normal="1895-06">June, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1905,7 +1905,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>141)</unitid>
+            <unitid>141</unitid>
             <unittitle>Three Instructors, at engineers' camp <unitdate type="inclusive" normal="1895-06">June, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1915,7 +1915,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>142)</unitid>
+            <unitid>142</unitid>
             <unittitle>Fountain, engineers' camp <unitdate type="inclusive" normal="1895-06">June, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1925,7 +1925,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>143)</unitid>
+            <unitid>143</unitid>
             <unittitle>Bridge, engineers' camp <unitdate type="inclusive" normal="1895-06">June, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1935,7 +1935,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>144)</unitid>
+            <unitid>144</unitid>
             <unittitle>Professor Davis and Tent <unitdate type="inclusive" normal="1895-06">June, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1945,7 +1945,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>145)</unitid>
+            <unitid>145</unitid>
             <unittitle>Baseball at Sutton's Bay <unitdate type="inclusive" normal="1895-06">June, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1955,7 +1955,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>146)</unitid>
+            <unitid>146</unitid>
             <unittitle>Engineers, Boat landing <unitdate type="inclusive" normal="1895-06">June, 1895</unitdate></unittitle>
           </did>
           <odd>
@@ -1965,7 +1965,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>147)</unitid>
+            <unitid>147</unitid>
             <unittitle>Mechanical Lab, University of Michigan</unittitle>
           </did>
           <odd>
@@ -1975,7 +1975,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>148)</unitid>
+            <unitid>148</unitid>
             <unittitle>Broken Down House (near engineers' camp)</unittitle>
           </did>
           <odd>
@@ -1985,7 +1985,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>149)</unitid>
+            <unitid>149</unitid>
             <unittitle>Football</unittitle>
           </did>
           <odd>
@@ -1995,7 +1995,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>150)</unitid>
+            <unitid>150</unitid>
             <unittitle>Football <unitdate type="inclusive" normal="1894">1894</unitdate></unittitle>
           </did>
           <odd>
@@ -2005,7 +2005,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>151)</unitid>
+            <unitid>151</unitid>
             <unittitle>Library, University of Michigan</unittitle>
           </did>
           <odd>
@@ -2015,7 +2015,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>152)</unitid>
+            <unitid>152</unitid>
             <unittitle>"Semaphore Group" <unitdate type="inclusive" normal="1894-10">October, 1894</unitdate></unittitle>
           </did>
           <odd>
@@ -2025,7 +2025,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>153)</unitid>
+            <unitid>153</unitid>
             <unittitle>Ann Street, Ann Arbor</unittitle>
           </did>
           <odd>
@@ -2035,7 +2035,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>154)</unitid>
+            <unitid>154</unitid>
             <unittitle>Main Street, Ann Arbor (taken from Liberty Street)</unittitle>
           </did>
           <odd>
@@ -2045,7 +2045,7 @@ David LeFavour photographs, Bentley Historical Library, University of Michigan</
         <c02 level="file">
           <did>
             <container type="box" label="Box">3</container>
-            <unitid>155)</unitid>
+            <unitid>155</unitid>
             <unittitle>Unidentified Road, Ann Arbor</unittitle>
           </did>
           <odd>

--- a/Real_Masters_all/maynardb.xml
+++ b/Real_Masters_all/maynardb.xml
@@ -109,7 +109,7 @@ Bernice G. Maynard photographs, Bentley Historical Library, University of Michig
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>1)</unitid>
+              <unitid>1</unitid>
               <unittitle>Palmer's Drugstore, S. State Street, Ann Arbor, Michigan between <unitdate normal="1896/1898" type="inclusive">1896-1898</unitdate>. Sign for A.H. Holmes (Livery) in foreground.</unittitle>
             </did>
             <odd>
@@ -119,63 +119,63 @@ Bernice G. Maynard photographs, Bentley Historical Library, University of Michig
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>2)</unitid>
+              <unitid>2</unitid>
               <unittitle>Woodward Avenue, Detroit. Street Scene showing C.H. Mills Furniture Store, Overman Wheel and Beals, Selkirk &amp; Co. (trunks and bags).</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>3)</unitid>
+              <unitid>3</unitid>
               <unittitle>Palmer's Drugstore, S. State Street (No. 46) <unitdate type="inclusive" normal="1896">1896</unitdate> or <unitdate type="inclusive" normal="1897">1897</unitdate>. Window display with large bottle of "Pabst Malt Extract."</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>4)</unitid>
+              <unitid>4</unitid>
               <unittitle>Palmer's Pharmacy, 46 S. State Street <unitdate type="inclusive" normal="1896/1897">1896-1897</unitdate>. Window display with large bottle of "Pabst Malt Extract"</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>5)</unitid>
+              <unitid>5</unitid>
               <unittitle>Resort Hotel or large Queen Anne home with wrap-around porch, with cupola and strollers</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>6)</unitid>
+              <unitid>6</unitid>
               <unittitle>Man playing banjo, dressed in uniform; perhaps the interior of the Palmer Pharmacy</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>7)</unitid>
+              <unitid>7</unitid>
               <unittitle>Man in apron pouring liquid into flask-perhaps interior of Palmer Pharmacy</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>8)</unitid>
+              <unitid>8</unitid>
               <unittitle>Interior of steam plant (?) showing machinery labeled A. Harvey and Sons, Detroit, Michigan</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>9)</unitid>
+              <unitid>9</unitid>
               <unittitle>Interior of steam plant (?) with four women and two men before tunnel</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>10)</unitid>
+              <unitid>10</unitid>
               <unittitle>Man in derby hat sitting by a telephone and rolls of paper. A framed notice on the wall reads "Ann Arbor and Ypsilanti Railway...A.L. Noble"</unittitle>
             </did>
           </c03>
@@ -187,56 +187,56 @@ Bernice G. Maynard photographs, Bentley Historical Library, University of Michig
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>11)</unitid>
+              <unitid>11</unitid>
               <unittitle>Rear view of man walking towards a barbed wire fence</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>12)</unitid>
+              <unitid>12</unitid>
               <unittitle>Two women standing on roof of shed behind a house Homeopathic Hospital</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>13)</unitid>
+              <unitid>13</unitid>
               <unittitle>University of Michigan: Homeopathic Medical School (on North University Ave.)</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>14)</unitid>
+              <unitid>14</unitid>
               <unittitle>Sailboat and motor boat on lake</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>15)</unitid>
+              <unitid>15</unitid>
               <unittitle>Man standing with bicycle next to large rock</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>16)</unitid>
+              <unitid>16</unitid>
               <unittitle>Two women, one on a horse, the other standing next to her bicycle</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>17)</unitid>
+              <unitid>17</unitid>
               <unittitle>Woman standing amidst many trees, hammock in background</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>18)</unitid>
+              <unitid>18</unitid>
               <unittitle>Two women seated on front steps of house</unittitle>
             </did>
             <odd>
@@ -246,42 +246,42 @@ Bernice G. Maynard photographs, Bentley Historical Library, University of Michig
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>19)</unitid>
+              <unitid>19</unitid>
               <unittitle>Old woman seated indoors, large portrait (framed) on table to her right</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>20)</unitid>
+              <unitid>20</unitid>
               <unittitle>Two women and man in horse and buggy in front of house</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>21)</unitid>
+              <unitid>21</unitid>
               <unittitle>Six men posing casually in a field</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>22)</unitid>
+              <unitid>22</unitid>
               <unittitle>Two men and two women standing indoors, one woman laughing</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>23)</unitid>
+              <unitid>23</unitid>
               <unittitle>Woman reading to her daughter <unitdate type="inclusive" normal="1890/1899" certainty="approximate">circa 1890s</unitdate></unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>24)</unitid>
+              <unitid>24</unitid>
               <unittitle>Young men (team?) huddled in group</unittitle>
             </did>
           </c03>
@@ -293,70 +293,70 @@ Bernice G. Maynard photographs, Bentley Historical Library, University of Michig
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>25)</unitid>
+              <unitid>25</unitid>
               <unittitle>Marching Band</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>26)</unitid>
+              <unitid>26</unitid>
               <unittitle>Soldiers standing with rifles; wearing tall helmets</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>27)</unitid>
+              <unitid>27</unitid>
               <unittitle>Marching band in field</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>28)</unitid>
+              <unitid>28</unitid>
               <unittitle>American flag and army tents</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>29)</unitid>
+              <unitid>29</unitid>
               <unittitle>Soldiers standing around horses</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>30)</unitid>
+              <unitid>30</unitid>
               <unittitle>Soldiers marching across field, U.S. flag in background</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>31)</unitid>
+              <unitid>31</unitid>
               <unittitle>Soldiers standing with rifles</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>32)</unitid>
+              <unitid>32</unitid>
               <unittitle>Soldiers standing around tents, some in line</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>33)</unitid>
+              <unitid>33</unitid>
               <unittitle>Large group of soldiers lined up at attention, American flags present</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>34)</unitid>
+              <unitid>34</unitid>
               <unittitle>General on horse parades before soldiers at attention</unittitle>
             </did>
           </c03>
@@ -368,147 +368,147 @@ Bernice G. Maynard photographs, Bentley Historical Library, University of Michig
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>35)</unitid>
+              <unitid>35</unitid>
               <unittitle>Men sitting around a dining room table</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>36)</unitid>
+              <unitid>36</unitid>
               <unittitle>Two children (teens?) with bicycles, standing in front of buildings</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>37)</unitid>
+              <unitid>37</unitid>
               <unittitle>Two young men peering out from a bedroom. An Ann Arbor calendar is on the wall, dated <unitdate type="inclusive" normal="1891" certainty="approximate">1891</unitdate></unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>38)</unitid>
+              <unitid>38</unitid>
               <unittitle>Interior: man jokingly asking for a lady's hand while friends peer out from behind a curtain</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>39)</unitid>
+              <unitid>39</unitid>
               <unittitle>Two women strumming guitars, standing on wooden sidewalk.</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>40)</unitid>
+              <unitid>40</unitid>
               <unittitle>Family seated indoors, looking at an album</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>41)</unitid>
+              <unitid>41</unitid>
               <unittitle>Interior-two men and two women sitting on a sofa</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>42)</unitid>
+              <unitid>42</unitid>
               <unittitle>Interior-group of 10 people gathered around a potbellied stove</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>43)</unitid>
+              <unitid>43</unitid>
               <unittitle>Interior-two young women and young child seated informally, talking to each other</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>44)</unitid>
+              <unitid>44</unitid>
               <unittitle>Man in hat standing sideways to camera, looking upwards at a building behind him</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>45)</unitid>
+              <unitid>45</unitid>
               <unittitle>Woman leaning against water pump, smiling at camera</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>46)</unitid>
+              <unitid>46</unitid>
               <unittitle>Man in bowler hat posing with bicycle</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>47)</unitid>
+              <unitid>47</unitid>
               <unittitle>Woman with back to camera in prow of rowboat, fishing gear sticking out from under her skirt</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>48)</unitid>
+              <unitid>48</unitid>
               <unittitle>Man playing a flute sitting on front stoop. A large bottle labeled "Corkscrew Jamoca Ginger" is held between his knees</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>49)</unitid>
+              <unitid>49</unitid>
               <unittitle>Girl wearing knickers posing with bicycle</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>50)</unitid>
+              <unitid>50</unitid>
               <unittitle>Young girl and young man in backyard, smiling at each other</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>51)</unitid>
+              <unitid>51</unitid>
               <unittitle>Interior-two men and two women sitting at table having tea</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>52)</unitid>
+              <unitid>52</unitid>
               <unittitle>Lady and young woman with umbrella strolling through a yard</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>53)</unitid>
+              <unitid>53</unitid>
               <unittitle>Interior-two men and a woman inside a parlor</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>54)</unitid>
+              <unitid>54</unitid>
               <unittitle>Interior-man with saw and pliers pretending to be a dentist; friend in chair grimaces in mock agony</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>55)</unitid>
+              <unitid>55</unitid>
               <unittitle>Interior-woman in underwear (long stockings and camisole)</unittitle>
             </did>
             <odd>
@@ -518,14 +518,14 @@ Bernice G. Maynard photographs, Bentley Historical Library, University of Michig
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>56)</unitid>
+              <unitid>56</unitid>
               <unittitle>Two women behind barn pretending to be fighting; one holds scythe</unittitle>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitid>57)</unitid>
+              <unitid>57</unitid>
               <unittitle>"Khozzy Rhoost"-picnickers in front on tents <unitdate type="inclusive" normal="1890" certainty="approximate">circa 1890</unitdate></unittitle>
             </did>
             <odd>

--- a/Real_Masters_all/odellfc.xml
+++ b/Real_Masters_all/odellfc.xml
@@ -50,9 +50,8 @@
       </origination>
       <unittitle encodinganalog="245">Frederick C. O'Dell Papers <unitdate type="inclusive" encodinganalog="245$f" normal="1918/1919">1918-1919</unitdate></unittitle>
       <abstract>Master engineer of 1st Battalion, 310th U.S. Army Engineers, in charge of the Army Topographical Office in Archangel, Russia during the Allied intervention in Russia, 1918-1920, the "Polar Bear Expedition." Collection includes maps, architectural drawings, photographs, and miscellanea relating to the work of the 310th Engineers in Russia. Architectural drawings include plans for buildings and fortifications.</abstract>
-      <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">93830;Aa;2;UAl (photographs and papers)</unitid>
+      <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">93830;Aa;2;UAl (photographs and papers) ; M;7063;.A7;1918;O3 (maps and drawings)</unitid>
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
-      <unitid>M;7063;.A7;1918;O3 (maps and drawings)</unitid>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">185 maps</extent>
       </physdesc>


### PR DESCRIPTION
DLXS adds parens around component level unitids, so no need for us to include them.
