### PR TITLE
removing parens from extents

### DIFF
--- a/Real_Masters_all/a2twnshp.xml
+++ b/Real_Masters_all/a2twnshp.xml
@@ -391,7 +391,7 @@
             <unittitle>Record of roads</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
-              <extent altrender="carrier">(in 1 folder)</extent>
+              <extent altrender="carrier">in 1 folder</extent>
             </physdesc>
           </did>
           <odd>

--- a/Real_Masters_all/aafilmfs.xml
+++ b/Real_Masters_all/aafilmfs.xml
@@ -47,7 +47,7 @@
       <abstract>The Ann Arbor Film Festival is the longest-running independent and experimental film festival in North America. The collection consists of programs, posters and flyers, news clippings and articles about the yearly festival.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">4 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes and 1 oversize folder)</extent>
+        <extent altrender="carrier">in 5 boxes and 1 oversize folder</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/aafiredp.xml
+++ b/Real_Masters_all/aafiredp.xml
@@ -43,7 +43,7 @@
       <abstract>Minute books of the Fire Department and of related voluntary fire companies; also other administrative records, including records of expenditures and salaries, and records detailing individual fires; and record books, 1876-1899, of city poor relief (then administered by the Fire Department); also photograph.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">8 oversize volumes</extent>

--- a/Real_Masters_all/aapsch.xml
+++ b/Real_Masters_all/aapsch.xml
@@ -54,7 +54,7 @@
       <abstract>The records of the Ann Arbor Public Schools, cover the numerous districts and schools that developed and then gradually merged into an area school system which today encompasses twenty-one elementary schools, five middle schools, and three high schools with a school population of 16,724 (as of May 17, 2005).</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">25 linear feet</extent>
-        <extent altrender="carrier">(in 26 boxes.)</extent>
+        <extent altrender="carrier">in 26 boxes.</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">231 oversize volumes</extent>

--- a/Real_Masters_all/aarotary.xml
+++ b/Real_Masters_all/aarotary.xml
@@ -377,7 +377,7 @@ Ann Arbor Rotary Club records, Bentley Historical Library, University of Michiga
             <unittitle>History <unitdate type="inclusive" normal="1964/1970">1964-1970</unitdate>, <unitdate type="inclusive" normal="1970/1980">1970-1980</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 items</extent>
-              <extent altrender="carrier">(in 1 folder)</extent>
+              <extent altrender="carrier">in 1 folder</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/aasaf.xml
+++ b/Real_Masters_all/aasaf.xml
@@ -46,7 +46,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2.8 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">10 oversize volumes</extent>

--- a/Real_Masters_all/aathrift.xml
+++ b/Real_Masters_all/aathrift.xml
@@ -43,7 +43,7 @@
       <abstract>Philanthropic organization established to aid the needy through the resale of merchandise. Minutes of board and general meetings, financial records, constitution and by-laws, history, and photographs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/aayoungm.xml
+++ b/Real_Masters_all/aayoungm.xml
@@ -178,20 +178,17 @@ Ann Arbor Young Men’s - Young Women's Christian Association (Mich.) records, B
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitdate type="inclusive" normal="1902-01/1914">January 1902-1914</unitdate>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitdate type="inclusive" normal="1914-12/1921-12">December 1914-December 1921</unitdate>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitdate type="inclusive" normal="1922/1933">1922-1933</unitdate>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/abramsae.xml
+++ b/Real_Masters_all/abramsae.xml
@@ -50,7 +50,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/actonh.xml
+++ b/Real_Masters_all/actonh.xml
@@ -43,7 +43,7 @@
       <abstract>Hugh Acton (1925-), the "Cowboy-Designer," was a furniture designer, specializing in mid-century modern furniture, and artist in Augusta, Mich. He is best-known for his 1973 Acton Stacker chair for American Seating, as well as for his 1954 Suspended Beam Bench. This collection includes a brief history of the designer through articles and resumes, with a primary focus on his designs--including photographs (with negatives, transparencies, and online), catalog information, sketches, and design boards for his various furniture designs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/aitonasp.xml
+++ b/Real_Masters_all/aitonasp.xml
@@ -43,7 +43,7 @@
       <abstract>Professor of Latin American history at the University of Michigan. Reprints of journal articles and other writings.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.3 linear feet</extent>
-        <extent altrender="carrier">(in 1 box)</extent>
+        <extent altrender="carrier">in 1 box</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/albright.xml
+++ b/Real_Masters_all/albright.xml
@@ -50,7 +50,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">52 linear feet</extent>
-        <extent altrender="carrier">(in 83 boxes)</extent>
+        <extent altrender="carrier">in 83 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/alexandm.xml
+++ b/Real_Masters_all/alexandm.xml
@@ -43,7 +43,7 @@
       <abstract>Michael T. Alexander was a member of the research staff of the University of Michigan's Computing Center and Information Technology Division Research Systems from 1965 to 1996. Collection contains records of Alexander's duties as well as extensive documentation for the Michigan Terminal System, including manuals and systems reports.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">8 linear feet</extent>
-        <extent altrender="carrier">(in 10 boxes)</extent>
+        <extent altrender="carrier">in 10 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/amcalch.xml
+++ b/Real_Masters_all/amcalch.xml
@@ -50,7 +50,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 linear feet</extent>
-        <extent altrender="carrier">(in 9 boxes)</extent>
+        <extent altrender="carrier">in 9 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/amculfkl.xml
+++ b/Real_Masters_all/amculfkl.xml
@@ -47,7 +47,7 @@
       <abstract>Archives of folklore collected by students in the course "Survey of American Folklore" offered by the University of Michigan Program in American Culture and first taught by Bruce Conforth in 2005. Collected folklore reports compiled by students in American Folklore course based on oral interviews with informants. (Interviews are included on a variety of physical formats--cassettes, microcassettes, CDs, VHS tapes). Reports include essays, transcripts on topics ranging from popular folklore to campus legends and traditions.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">13.5 linear feet</extent>
-        <extent altrender="carrier">(in 31 boxes)</extent>
+        <extent altrender="carrier">in 31 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/amlegaux.xml
+++ b/Real_Masters_all/amlegaux.xml
@@ -43,7 +43,7 @@
       <abstract>Sister organization to the American Legion organization for Michigan veterans. The record group documents the Department’s administrative functions, its publications, and involvement with the Girls State government simulation program.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">25 linear feet</extent>
-        <extent altrender="carrier">(in 26 boxes)</extent>
+        <extent altrender="carrier">in 26 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 oversize volumes</extent>

--- a/Real_Masters_all/anatdept.xml
+++ b/Real_Masters_all/anatdept.xml
@@ -58,7 +58,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/anatdona.xml
+++ b/Real_Masters_all/anatdona.xml
@@ -61,7 +61,7 @@
       <abstract>Unit of the University of Michigan concerned with the procurement of cadavers for anatomical instruction, includes registers and permits detailing the acquisition and tracking of cadavers for medical instruction at the University of Michigan</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3.5 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/angelljb.xml
+++ b/Real_Masters_all/angelljb.xml
@@ -59,7 +59,7 @@
       <abstract>Papers of James Burrill Angell, the third President of the University of Michigan (1871-1909).</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">16.5 linear feet</extent>
-        <extent altrender="carrier">(in 17 boxes)</extent>
+        <extent altrender="carrier">in 17 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/annarbor.xml
+++ b/Real_Masters_all/annarbor.xml
@@ -55,7 +55,7 @@
       <abstract>The records of the city of Ann Arbor, Michigan include council proceedings (1834-1919); assessment rolls (1830, 1839, and 1958-1959); scrapbooks relating to city government (1904-1951); and records and photographs detailing the city’s waste management and recycling program beginning in the 1980s. Miscellaneous materials include plats of the wards, 1912; election returns, 1847-1852; records of the former city of East Ann Arbor and the Village of Ann Arbor (Lower Town); and minutes of the Ann Arbor Park Commission (1905-1956). Also of interest are files concerning the Ann Arbor Railroad and the city’s street railway and interurban system.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">13 linear feet</extent>
-        <extent altrender="carrier">(in 14 boxes)</extent>
+        <extent altrender="carrier">in 14 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">37 oversize volumes</extent>

--- a/Real_Masters_all/aprillth.xml
+++ b/Real_Masters_all/aprillth.xml
@@ -322,8 +322,6 @@ Theophil Aprill papers, Bentley Historical Library, University of Michigan</p>
             <unittitle>WPAG Live Recording of Zion Church Service <unitdate type="inclusive" normal="1948-03-08">March 8, 1948</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">8 phonograph records</extent>
-            </physdesc>
-            <physdesc>
               <physfacet>33 1/3 rpm</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/aprillth.xml
+++ b/Real_Masters_all/aprillth.xml
@@ -47,7 +47,7 @@
       <abstract>Lifelong member of Zion Lutheran Church, Ann Arbor, Michigan, Aprill served for several years in the 1990s as a member of the Church’s Executive Board. Papers include files relating to the history of Zion Lutheran Church, including a conflict within the church in the mid-1990s.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/arcmich.xml
+++ b/Real_Masters_all/arcmich.xml
@@ -476,7 +476,7 @@ Arc Michigan records, Bentley Historical Library, University of Michigan</p>
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">39 reports</extent>
-                  <extent altrender="carrier">(in 1 expandable folder)</extent>
+                  <extent altrender="carrier">in 1 expandable folder</extent>
                 </physdesc>
               </did>
             </c04>

--- a/Real_Masters_all/armstron.xml
+++ b/Real_Masters_all/armstron.xml
@@ -43,7 +43,7 @@
       <abstract>Hillsdale, Michigan, Singer Sewing Machine Company representative in central China, 1911-1917; wife, Elsa F. Armstrong of Northfield, Minnesota, Evangelical Lutheran missionary in China, 1911-1917. Correspondence between Arthur and Elsa Armstrong, Elsa Armstrong's family, and other missionaries, concerning life in China; also photographs and Arthur and Elsa Armstrong's reminiscences of China.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/arnoldtr.xml
+++ b/Real_Masters_all/arnoldtr.xml
@@ -43,7 +43,7 @@
       <abstract>The Arnold Transit Company is the longest operating ferry line on the straits of Mackinac. Founded in 1878 by George T. Arnold, the line continues to transport thousands of passengers and tons of freight every year. The record group consists primarily of early financial records, various property interests of Arnold Transit, and the estates of the Arnold family.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">14.8 linear feet</extent>
-        <extent altrender="carrier">(in 16 boxes)</extent>
+        <extent altrender="carrier">in 16 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">24 oversize volumes</extent>

--- a/Real_Masters_all/artscitz.xml
+++ b/Real_Masters_all/artscitz.xml
@@ -372,7 +372,7 @@ Arts of Citizenship Program (University of Michigan) records, Bentley Historical
                 <unittitle>Interviews</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">59 audiocassettes</extent>
-                  <extent altrender="carrier">(in case)</extent>
+                  <extent altrender="carrier">in case</extent>
                 </physdesc>
               </did>
             </c04>

--- a/Real_Masters_all/asstpres.xml
+++ b/Real_Masters_all/asstpres.xml
@@ -50,7 +50,7 @@
       <abstract>Files concerning honorary degree recipients, University commencements, the Honors Convocations, and various University fellowships and scholarships; topical files of Frank E. Robbins, Erich Walter, Robert N. Cross, Herbert Hildebrandt, Richard L. Kennedy, William Cash, Jr., and James Shortt; and photographs</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">44 linear feet</extent>
-        <extent altrender="carrier">(in 58 boxes)</extent>
+        <extent altrender="carrier">in 58 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/athdept.xml
+++ b/Real_Masters_all/athdept.xml
@@ -91,7 +91,7 @@
       <physloc>Films and videotapes are stored offsite, prior notice required for retrieval.  Consult the reference archivist to arrange viewing or duplication.</physloc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">298 linear feet</extent>
-        <extent altrender="carrier">(in 318 boxes, approximate)</extent>
+        <extent altrender="carrier">in 318 boxes, approximate</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">15 oversize boxes</extent>
@@ -33196,7 +33196,7 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   <unittitle>2003/2004</unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 volumes</extent>
-                    <extent altrender="carrier">(in cd case)</extent>
+                    <extent altrender="carrier">in cd case</extent>
                     <physfacet>binder and CDs</physfacet>
                   </physdesc>
                 </did>

--- a/Real_Masters_all/bachbarb.xml
+++ b/Real_Masters_all/bachbarb.xml
@@ -43,7 +43,7 @@
       <abstract>Barbara Bach first worked as a Boston area schoolteacher and creator of television documentaries. After receiving a Master's degree in Education in 1969, she became an Ann Arbor, Mich. businesswoman, networking facilitator, fundraiser, and lifelong educator/mentor to individuals and organizations. The collection includes business records, association newsletters, campaign literature, photographs, and correspondence representing her multiple careers as an entrepreneur, legislative aide, community activist, and executive director in a policy environment promoting economic development in Michigan.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">9.3 linear feet</extent>
-        <extent altrender="carrier">(in 10 boxes)</extent>
+        <extent altrender="carrier">in 10 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/bachfp.xml
+++ b/Real_Masters_all/bachfp.xml
@@ -46,7 +46,7 @@
       <abstract>Frank and Peggy Bach were involved with the counterculture in Detroit and Ann Arbor beginning in the 1960s as musicians, performers, graphic designers, promoters, and activists for area jazz, blues, and pop acts. Frank Bach was also involved in community organizations supporting housing and economic development activities in Detroit. The collection documents the Bach's numerous professional activities and organizations, groups, and individuals with whom they were associated, including Rainbow Corporation and Rainbow Multi-media, Allied Artists Association of America, Strata Associates, Detroit Jazz Center, Grande Graphics, Morda-Sinclair &amp; Associates, and John Sinclair. Detroit community organizations documented in the collection include the Creekside Community Development Corporation, the Jefferson-Chalmers Citizens' District Council, and the Jefferson East Business Association.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">9 linear feet</extent>
-        <extent altrender="carrier">(in 10 boxes)</extent>
+        <extent altrender="carrier">in 10 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 oversize folders</extent>

--- a/Real_Masters_all/balchnat.xml
+++ b/Real_Masters_all/balchnat.xml
@@ -227,7 +227,7 @@ Nathaniel A. Balch papers, Bentley Historical Library, University of Michigan</p
             <unittitle><genreform normal="Diaries">Diaries</genreform> and account books, <unitdate type="inclusive" normal="1852/1884">1852-1884</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">21 volumes</extent>
-              <extent altrender="carrier">(in box)</extent>
+              <extent altrender="carrier">in box</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/barretta.xml
+++ b/Real_Masters_all/barretta.xml
@@ -43,7 +43,7 @@
       <abstract>Physician, early specialist in the treatment of mental illness; correspondence; topical files; lectures and publications; casework; and photographs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/bartlehh.xml
+++ b/Real_Masters_all/bartlehh.xml
@@ -57,7 +57,7 @@
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">13 film reels</extent>
-        <extent altrender="carrier">(in 4)</extent>
+        <extent altrender="carrier">in 4</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/bartletl.xml
+++ b/Real_Masters_all/bartletl.xml
@@ -445,7 +445,7 @@ Lynn M. Bartlett papers, Bentley Historical Library, University of Michigan</p>
             <unittitle>Photographs</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">4 envelopes</extent>
-              <extent altrender="carrier">(in 1 folder)</extent>
+              <extent altrender="carrier">in 1 folder</extent>
             </physdesc>
           </did>
           <odd>

--- a/Real_Masters_all/bassettl.xml
+++ b/Real_Masters_all/bassettl.xml
@@ -46,7 +46,7 @@
       <abstract>Leslie Bassett is a composer and professor of music at the University of Michigan. Bassett’s papers, consisting of correspondence, collected memorabilia, photographs, lectures, scrapbooks, and music, document his career as a composer and professor of music.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">35 linear feet</extent>
-        <extent altrender="carrier">(in 47 boxes and various sizes)</extent>
+        <extent altrender="carrier">in 47 boxes and various sizes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">5 oversize volumes</extent>

--- a/Real_Masters_all/bcsanit.xml
+++ b/Real_Masters_all/bcsanit.xml
@@ -42,7 +42,7 @@
       <abstract>Publications produced by or for the Battle Creek Sanitarium founded by John Harvey Kellogg in Battle Creek Michigan.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/beachwme.xml
+++ b/Real_Masters_all/beachwme.xml
@@ -43,7 +43,7 @@
       <abstract>William E. Beach was an amateur photographer whose photographs document his hometown of Howell, Michigan and historical sites in other Michigan communities. His collection consists of photographic negatives (with some prints) and albums with prints of historic plaques and markers, statues of famous statesmen and their gravesites, early school buildings, historic houses, gristmills, sawmills, and county courthouses.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/beardsly.xml
+++ b/Real_Masters_all/beardsly.xml
@@ -49,7 +49,7 @@
       </note>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">5.5 linear feet</extent>
-        <extent altrender="carrier">(in 6 boxes)</extent>
+        <extent altrender="carrier">in 6 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/beekman.xml
+++ b/Real_Masters_all/beekman.xml
@@ -43,7 +43,7 @@
       <abstract>Collection of correspondence, records of committees and organizations, legislation drafts, and research material on the subject of Special Education programs and services, created and used by Lynwood Beekman in his law practice and in drafting of the Michigan Special Education legislation.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">9.25 linear feet</extent>
-        <extent altrender="carrier">(in 10 boxes)</extent>
+        <extent altrender="carrier">in 10 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/beggvic.xml
+++ b/Real_Masters_all/beggvic.xml
@@ -47,7 +47,7 @@
       <abstract>Collection of records, correspondence, memoranda, issued official statements, and architectural drawings of The Muslim Unity Center of Bloomfield Hills, Michigan, the Council of Islamic Organizations of Michigan and other Islamic organizations in Michigan and the U.S.; correspondence and memoranda, statements and articles written by and about interfaith organizations and projects in Michigan; also correspondence, conference presentations, speeches, and newspaper articles written by and about Victor Begg; reports and articles about Muslim communities in Michigan and in the U.S., politics in the Middle East, interfaith dialogue, and terrorism.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.6 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/benzf.xml
+++ b/Real_Masters_all/benzf.xml
@@ -43,7 +43,7 @@
       <abstract>Amateur photographer; sixty-two reels of film shot by Benz on various trips.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">62 reels</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/bethelro.xml
+++ b/Real_Masters_all/bethelro.xml
@@ -58,7 +58,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">10 linear feet</extent>
-        <extent altrender="carrier">(in 11 boxes)</extent>
+        <extent altrender="carrier">in 11 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/bimedcom.xml
+++ b/Real_Masters_all/bimedcom.xml
@@ -47,7 +47,7 @@
       <abstract>BMC Media Services (formerly Biomedical Communications) is an in-house graphics and marketing production service for the University of Michigan. The collection is comprised of visual materials, including photographic prints, negatives, slides, and contact sheets, as well as videotapes, a few films, and digital files. The records reflect BMC's biomedical origins and document the history of the medical school, health science, hospitals, and related departments at the University of Michigan.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">31.6 linear feet</extent>
-        <extent altrender="carrier">(in 35 boxes)</extent>
+        <extent altrender="carrier">in 35 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 films, oversize rolled materials and oversize folders</extent>
@@ -13461,7 +13461,7 @@ Thiele, Maria, Technology Transfer Office <unitdate type="inclusive" normal="199
               </physdesc>
               <physdesc altrender="part">
                 <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>
-                <extent altrender="carrier">(in drawer 230)</extent>
+                <extent altrender="carrier">in drawer 230</extent>
               </physdesc>
               <physdesc>
                 <physfacet>prints and negatives</physfacet>

--- a/Real_Masters_all/binkodon.xml
+++ b/Real_Masters_all/binkodon.xml
@@ -58,7 +58,7 @@
       <abstract>District judge from Warren, Michigan. Correspondence, campaign materials, and other papers concerning his work as delegate to Michigan Constitutional Convention, 1961-1962, as Warren city councilman, and as attorney and judge; papers concerning local and state Democratic politics, and his activities with Polish-American organizations and his interest in Polish American history and personages. Also includes digital images.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">11 linear feet</extent>
-        <extent altrender="carrier">(in 12 boxes)</extent>
+        <extent altrender="carrier">in 12 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/birkertg.xml
+++ b/Real_Masters_all/birkertg.xml
@@ -49,7 +49,7 @@
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1912 drawings</extent>
-        <extent altrender="carrier">(in 11 drawers)</extent>
+        <extent altrender="carrier">in 11 drawers</extent>
         <physfacet>architectural drawings</physfacet>
       </physdesc>
       <repository>

--- a/Real_Masters_all/blanchjj.xml
+++ b/Real_Masters_all/blanchjj.xml
@@ -7263,7 +7263,7 @@
                 <unittitle>Briefing p on Policy Issues <unitdate type="inclusive" normal="1983-01/1983-03">January-March 1983</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 volumes</extent>
-                  <extent altrender="carrier">(in expandable folder)</extent>
+                  <extent altrender="carrier">in expandable folder</extent>
                 </physdesc>
               </did>
             </c04>

--- a/Real_Masters_all/blanfam.xml
+++ b/Real_Masters_all/blanfam.xml
@@ -43,11 +43,11 @@
       <abstract>The Blanchard family papers document the lives and careers of several members of the Blanchard, Cobb, and Proctor families from the mid-nineteenth century through the late twentieth century. Includes visual materials, publications, personal writings, and extensive correspondence files.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">49.5 linear feet</extent>
-        <extent altrender="carrier">(in 50 boxes)</extent>
+        <extent altrender="carrier">in 50 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1400 glass photographic plates</extent>
-        <extent altrender="carrier">(in 10 boxes)</extent>
+        <extent altrender="carrier">in 10 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/bldgrds.xml
+++ b/Real_Masters_all/bldgrds.xml
@@ -50,7 +50,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3.5 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>
@@ -637,7 +637,7 @@
             <unittitle>Health Service PWA Project No. Mich. 1691-F Photo Album <unitdate type="inclusive" normal="1938/1940">1938-1940</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">28 prints</extent>
-              <extent altrender="carrier">(in 1 bound album; no negatives)</extent>
+              <extent altrender="carrier">in 1 bound album; no negatives</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/bolcom.xml
+++ b/Real_Masters_all/bolcom.xml
@@ -74,7 +74,7 @@
       <abstract>William Bolcom is a composer and pianist. Joan Morris is a mezzo-soprano. They are both members of the University of Michigan School of Music faculty. Bolcom and Morris have given numerous performances since 1971. They have also recorded albums of classical and popular songs. Performance files include programs, itineraries, newspaper articles and reviews of each performance, and contracts. There are also files relating to University of Michigan student production of Mina &amp; Colossus; original scores to Bolcom's compositions, including McTeague, Casino Paradise, and A View from the Bridge; and topical files relating to awards, competitions, and other activities and interests.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">60.5 linear feet</extent>
-        <extent altrender="carrier">(in 73 boxes including oversize)</extent>
+        <extent altrender="carrier">in 73 boxes including oversize</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">31 bundles</extent>

--- a/Real_Masters_all/bonistee.xml
+++ b/Real_Masters_all/bonistee.xml
@@ -54,7 +54,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">13 linear feet</extent>
-        <extent altrender="carrier">(in 14 boxes)</extent>
+        <extent altrender="carrier">in 14 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/boyneusa.xml
+++ b/Real_Masters_all/boyneusa.xml
@@ -51,7 +51,7 @@
       <abstract>Michigan-based ski and golf corporation, operating twelve major resorts in North America; records consists of photographs, slides, video cassettes, films, sound recordings, promotional materials, biographical information on the corporation’s founder Everett F. Kircher, and miscellaneous office and topical files.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">51 linear feet</extent>
-        <extent altrender="carrier">(in 54 boxes)</extent>
+        <extent altrender="carrier">in 54 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">19 oversize volumes</extent>

--- a/Real_Masters_all/bratere.xml
+++ b/Real_Masters_all/bratere.xml
@@ -47,7 +47,7 @@
       <abstract>Member of the Michigan State Senate, House of Representatives, Ann Arbor City Council, and Mayor of Ann Arbor; records include handwritten notes on policy issues, collected research materials, and news clippings related to Brater’s service as a member of the Michigan State Senate and House of Representatives.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">19.75 linear feet</extent>
-        <extent altrender="carrier">(in 20 boxes)</extent>
+        <extent altrender="carrier">in 20 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/brewercl.xml
+++ b/Real_Masters_all/brewercl.xml
@@ -306,8 +306,7 @@ Clarence E. Brewer papers, Bentley Historical Library, University of Michigan</p
           <c03 level="file">
             <did>
               <container type="box" label="Box">2</container>
-              <unitdate type="inclusive" normal="1918/1925">1918-1925</unitdate>
-            </did>
+              </did>
             <odd>
               <p>(include pamphlets, song books, and war memorial tributes)</p>
             </odd>
@@ -315,8 +314,7 @@ Clarence E. Brewer papers, Bentley Historical Library, University of Michigan</p
           <c03 level="file">
             <did>
               <container type="box" label="Box">2</container>
-              <unitdate type="inclusive" normal="1919/1921">1919-1921</unitdate>
-            </did>
+              </did>
             <odd>
               <p>(include special bulletins, policy statements, and organizational procedures)</p>
             </odd>

--- a/Real_Masters_all/brownhen.xml
+++ b/Real_Masters_all/brownhen.xml
@@ -43,7 +43,7 @@
       <abstract>Historian and manuscript curator; collected historical materials and various activities files.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/brownjam.xml
+++ b/Real_Masters_all/brownjam.xml
@@ -43,7 +43,7 @@
       <abstract>Papers of the Rev. James A. Brown, Michigan Methodist minister, and his wife Winifred Croel Brown. Correspondence, diaries, sermons, photographs and other materials relating in part to their pastorate in Elsie, Michigan, life during the depression; include comments on farming conditions, politics, and the effects of prohibition.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3.5 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/brownpre.xml
+++ b/Real_Masters_all/brownpre.xml
@@ -50,7 +50,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">28 linear feet</extent>
-        <extent altrender="carrier">(in 29 boxes)</extent>
+        <extent altrender="carrier">in 29 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 oversize folders</extent>

--- a/Real_Masters_all/burrowsf.xml
+++ b/Real_Masters_all/burrowsf.xml
@@ -42,7 +42,7 @@
       <abstract>Burrows-Avery-Smith families of New York, Connecticut, and Michigan. Correspondence and business papers of Lorenzo Burrows, New York Congressman, 1849-1853; George L. Burrows, Saginaw, Michigan, banker and speculator; material concerning the Whig Party and New York state politics, 1848-1860. Correspondents include: Millard Fillmore, Washington Hunt, and John Young.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">6 linear feet</extent>
-        <extent altrender="carrier">(in 7 boxes)</extent>
+        <extent altrender="carrier">in 7 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/burrowsf.xml
+++ b/Real_Masters_all/burrowsf.xml
@@ -732,8 +732,7 @@ Burrows family papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">3</container>
-              <unitdate type="inclusive" normal="1914-07/1914-12">July-December 1914</unitdate>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/bussosc.xml
+++ b/Real_Masters_all/bussosc.xml
@@ -46,7 +46,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">700 photographs</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
         <physfacet>approximate</physfacet>
       </physdesc>
       <repository encodinganalog="852">

--- a/Real_Masters_all/butterfi.xml
+++ b/Real_Masters_all/butterfi.xml
@@ -57,7 +57,7 @@
       </note>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">10 linear feet</extent>
-        <extent altrender="carrier">(in 11 boxes)</extent>
+        <extent altrender="carrier">in 11 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/byrddav.xml
+++ b/Real_Masters_all/byrddav.xml
@@ -46,7 +46,7 @@
       <abstract>David R. Byrd (1921-1987) was an African-American architect of churches, residential homes, offices, and schools in Washington, D.C. and Ann Arbor, Michigan. He served on the Board of Commissioners of Washtenaw County (1968-1972), and was an advocate for civil rights and affordable housing for the poor. This collection includes architectural drawings, reports, photographs, and personal and professional correspondence.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3.5 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 portfolios</extent>

--- a/Real_Masters_all/cacioppo.xml
+++ b/Real_Masters_all/cacioppo.xml
@@ -47,7 +47,7 @@
       <abstract>This collection contains sketches, manuscripts, printed music and writings by George Cacioppo, American composer, founder of the ONCE group, and faculty member at the University of Michigan.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">12 linear feet</extent>
-        <extent altrender="carrier">(in 22 boxes)</extent>
+        <extent altrender="carrier">in 22 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
@@ -624,7 +624,7 @@ George Cacioppo papers, Bentley Historical Library, University of Michigan</p>
             <unittitle>Cacioppo's Programs <unitdate type="inclusive" normal="1949/1985">1949-1985</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">70 items</extent>
-              <extent altrender="carrier">(in 2 folders)</extent>
+              <extent altrender="carrier">in 2 folders</extent>
             </physdesc>
           </did>
           <odd>
@@ -636,7 +636,7 @@ George Cacioppo papers, Bentley Historical Library, University of Michigan</p>
             <unittitle>Cacioppo's Program Notes for His Own Music</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">21 items</extent>
-              <extent altrender="carrier">(in 2 folders)</extent>
+              <extent altrender="carrier">in 2 folders</extent>
             </physdesc>
           </did>
           <odd>
@@ -709,7 +709,7 @@ George Cacioppo papers, Bentley Historical Library, University of Michigan</p>
             <unittitle>Other Programs and Notes <unitdate type="inclusive" normal="1949/1983">1949-1983</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">116 items</extent>
-              <extent altrender="carrier">(in 3 folders)</extent>
+              <extent altrender="carrier">in 3 folders</extent>
             </physdesc>
           </did>
           <odd>
@@ -2214,7 +2214,7 @@ George Cacioppo papers, Bentley Historical Library, University of Michigan</p>
             <unittitle>Mother-Chronological <unitdate type="inclusive" normal="1946/1971">1946-1971</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">361 items</extent>
-              <extent altrender="carrier">(in 19 folders)</extent>
+              <extent altrender="carrier">in 19 folders</extent>
             </physdesc>
           </did>
           <odd>
@@ -2227,7 +2227,7 @@ George Cacioppo papers, Bentley Historical Library, University of Michigan</p>
             <unittitle>Other Family Letters-Chronological <unitdate type="inclusive" normal="1939/1981">1939-1981</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">65 items</extent>
-              <extent altrender="carrier">(in 3 folders)</extent>
+              <extent altrender="carrier">in 3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2495,7 +2495,7 @@ George Cacioppo papers, Bentley Historical Library, University of Michigan</p>
             <unittitle>Archive inventory, Crosstalk Intermedia, fliers, programs, Dramatic Arts Center material and WUOM program guides</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">62 items</extent>
-              <extent altrender="carrier">(in 7 folders)</extent>
+              <extent altrender="carrier">in 7 folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/calendum.xml
+++ b/Real_Masters_all/calendum.xml
@@ -46,7 +46,7 @@
       <abstract>Wall and engagement calendars produced and published by Ann Arbor, Mich. firms such as George Wahr, Sheehan and Co., and designer Almira F. Lovell. Calendars feature contemporary photographs and drawings of the University of Michigan campus, people, and environs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/campbelj.xml
+++ b/Real_Masters_all/campbelj.xml
@@ -50,7 +50,7 @@
       <abstract>University of Michigan professor of law, Detroit, Michigan, attorney, Michigan Supreme Court justice. Family correspondence, journal of trip to Sandusky, Ohio, in 1844, and lecture materials; also papers of Valeria Campbell, corresponding secretary of the Soldiers' Aid Society of Detroit, U. S. Sanitary Commission, concerning the society, the Detroit Soldiers' Home, and other relief agencies; and University student letters, 1872-1876, of Henry M. Campbell.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4.2 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize volumes</extent>

--- a/Real_Masters_all/carpppub.xml
+++ b/Real_Masters_all/carpppub.xml
@@ -42,7 +42,7 @@
       <abstract>Publications produced by the University of Michigan's office of Career Planning and Placement, includes miscellaneous annual reports, brochures, and newsletters. Also includes printed materials regarding the Public Service Intern Program and the Washington Summer Intern Program.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.6 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/carywilm.xml
+++ b/Real_Masters_all/carywilm.xml
@@ -184,7 +184,7 @@
               <unittitle>Walled Lake (student papers) <unitdate type="inclusive" normal="1984">1984</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">11 reports</extent>
-                <extent altrender="carrier">(in 1 expandable folder)</extent>
+                <extent altrender="carrier">in 1 expandable folder</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/caseemc.xml
+++ b/Real_Masters_all/caseemc.xml
@@ -43,7 +43,7 @@
       <abstract>Ermine Cowles Case was a prolific paleontologist and geologist, and a well respected professor of historical geology and paleontology at the University of Michigan. He was instrumental in the discovery and naming of several dinosaurs, and did considerable research on prehistoric vertebrates. The collection includes professional and person files that contain correspondence, organizational activities, recognitions, research, speeches, biographical records, and photographs. Inclusive dates span from 1805-1956, but most fall in the 1902s-1940s.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3.5 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/cassidyj.xml
+++ b/Real_Masters_all/cassidyj.xml
@@ -47,7 +47,7 @@
       <abstract>Jay Cassidy was a student photographer for <title render="italic">The Michigan Daily</title> from 1967 to 1970. The collection contains an inventory, background notes, negatives, a printed catalogue containing an image thumbnail and metadata for each image in the collection, and 4,882 digitized images of Cassidy's photography while at the University of Michigan. Subjects include student protests and anti-war demonstrations in Ann Arbor, Poor Peoples March/Resurrection City in Washington, D.C., Democratic primary campaigns of Robert Kennedy, Eugene McCarthy and George Wallace, 1968 Democratic Party National Convention, 1969 Ann Arbor Blues Festival and a wide variety of campus activities. Cassidy digitized the images and created the printed catalogue in 2010.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-        <extent altrender="carrier">(in 10 boxes)</extent>
+        <extent altrender="carrier">in 10 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4882 digital images</extent>

--- a/Real_Masters_all/caupstup.xml
+++ b/Real_Masters_all/caupstup.xml
@@ -47,7 +47,7 @@
       <abstract>Student papers written for courses in architectural history research, mainly about Michigan architects, buildings and communities.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">70 volumes</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
         <physfacet>approximate</physfacet>
       </physdesc>
       <repository>

--- a/Real_Masters_all/ccmich.xml
+++ b/Real_Masters_all/ccmich.xml
@@ -50,7 +50,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">16.75 linear feet</extent>
-        <extent altrender="carrier">(in 17 boxes)</extent>
+        <extent altrender="carrier">in 17 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/cew.xml
+++ b/Real_Masters_all/cew.xml
@@ -42,7 +42,7 @@
       <abstract>Minutes, correspondence, audiovisual materials, and other records documenting the founding, public programs, research projects, day-to-day administrative activities, and individual staff members of the University of Michigan's Center for the Education of Women.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">42 linear feet</extent>
-        <extent altrender="carrier">(in 43 boxes)</extent>
+        <extent altrender="carrier">in 43 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/cewpub.xml
+++ b/Real_Masters_all/cewpub.xml
@@ -48,7 +48,7 @@
 include miscellaneous bibliographies, brochures, calendars, flyers, journals, and proceedings. Also includes newsletters such as <title render="italic">Cornerstone</title> and <title render="italic">Newsletter: Center for Continuing Education of Women</title>; reports documenting the history of CEW such as Center for the Education of Women: 30 Year Anniversary Report, 1964-1994 and publications describing CEW library holdings and materials from the Women in Science Program.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/cglas.xml
+++ b/Real_Masters_all/cglas.xml
@@ -1626,7 +1626,7 @@
               <unittitle>Inland Seas <unitdate type="inclusive" normal="1962">1962</unitdate>, <unitdate type="inclusive" normal="1964/1971">1964-1971</unitdate>, <unitdate type="inclusive" normal="1973">1973</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">10 volumes</extent>
-                <extent altrender="carrier">(in 2 folders)</extent>
+                <extent altrender="carrier">in 2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1645,7 +1645,7 @@
               <unittitle>Mysis <unitdate type="inclusive" normal="1964/1970">1964-1970</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">13 volumes</extent>
-                <extent altrender="carrier">(in 2 folders)</extent>
+                <extent altrender="carrier">in 2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1655,7 +1655,7 @@
               <unittitle>Naiad <unitdate type="inclusive" normal="1957/1964">1957-1964</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">10 volumes</extent>
-                <extent altrender="carrier">(in 2 folders)</extent>
+                <extent altrender="carrier">in 2 folders</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/chapinlu.xml
+++ b/Real_Masters_all/chapinlu.xml
@@ -184,7 +184,7 @@ Lucy E. Chapin papers, Bentley Historical Library, University of Michigan</p>
             <unittitle>Scrapbook of clippings <genreform normal="Photographs">photographs</genreform>, postcards, etc. relating to Ann Arbor buildings, residents, and events</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 volumes</extent>
-              <extent altrender="carrier">(in 3 folders)</extent>
+              <extent altrender="carrier">in 3 folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/chapinrd.xml
+++ b/Real_Masters_all/chapinrd.xml
@@ -62,7 +62,7 @@
       <abstract>Lansing, Michigan businessman, founder of the Hudson Motor car Company, Secretary of Commerce in the Hoover Administration, leader of the "good roads movement" and the Lincoln Highway Association. Collection includes correspondence, speeches, business papers, clippings and scrapbooks and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">32 linear feet</extent>
-        <extent altrender="carrier">(in 33 boxes)</extent>
+        <extent altrender="carrier">in 33 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 oversize volumes</extent>

--- a/Real_Masters_all/charnetski.xml
+++ b/Real_Masters_all/charnetski.xml
@@ -43,7 +43,7 @@
       <abstract>Papers of Clark J. Charnetski (1942- ), a physicist who specialized in holographic research and development at Conductron Corporation in Ann Arbor, Mich., where he was the Associate Research Physicist and Chief Holographer. This collection contains materials relating to the administrative background of Conductron Corporation, materials relating to holography in Michigan collected by Charnetski, papers and presentations given by Charnetski and Conductron Corporation, notes, drawings, information relating to patents of Charnetski and others at Conductron, as well as detailed papers regarding the projects that Charnetski conducted while at Conductron.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3.1 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/chasmear.xml
+++ b/Real_Masters_all/chasmear.xml
@@ -43,7 +43,7 @@
       <abstract>Ludington, Michigan lumber company; business records, including day books, inventories, time books, and ledgers.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">12 volumes</extent>
-        <extent altrender="carrier">(in 1 box)</extent>
+        <extent altrender="carrier">in 1 box</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">8 oversize volumes</extent>

--- a/Real_Masters_all/chavisj.xml
+++ b/Real_Masters_all/chavisj.xml
@@ -43,7 +43,7 @@
       <abstract>Historian and administrator at University of Michigan and Tuskegee Institute. Minutes, reports and correspondence relating primarily to enrollment of black students at University of Michigan, including material concerning his work with the Steering Committee for the Development of Academic Opportunities, the Opportunity Award Program, and the Exchange Program with Tuskegee Institute.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.25 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/chfundmi.xml
+++ b/Real_Masters_all/chfundmi.xml
@@ -46,7 +46,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">23 linear feet</extent>
-        <extent altrender="carrier">(in 24 boxes)</extent>
+        <extent altrender="carrier">in 24 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4 oversize volumes</extent>

--- a/Real_Masters_all/chgdshep.xml
+++ b/Real_Masters_all/chgdshep.xml
@@ -42,7 +42,7 @@
       <abstract>Church of the Good Shepherd (Episcopal) in Dearborn Heights, Michigan was established in 1954. In 1990, the church building was sold; and in 1998, the congregation officially disbanded. The records include a complete register of church vital records, parochial reports, and annual reports.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3.3 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/choffman.xml
+++ b/Real_Masters_all/choffman.xml
@@ -17052,7 +17052,7 @@
           <unittitle>Scrapbooks <unitdate normal="1935/1962">1935-1962</unitdate></unittitle>
           <physdesc altrender="whole">
             <extent altrender="materialtype spaceoccupied">20 volumes</extent>
-            <extent altrender="carrier">(in 5 boxes)</extent>
+            <extent altrender="carrier">in 5 boxes</extent>
           </physdesc>
         </did>
         <scopecontent>

--- a/Real_Masters_all/churchm.xml
+++ b/Real_Masters_all/churchm.xml
@@ -149,7 +149,6 @@ Michael P. Church papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitdate type="inclusive" normal="1933/1972">1933-1972</unitdate>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">43 folders</extent>
               </physdesc>
@@ -158,7 +157,6 @@ Michael P. Church papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">2</container>
-              <unitdate type="inclusive" normal="1973/1975">1973-1975</unitdate>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
@@ -167,8 +165,7 @@ Michael P. Church papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">2</container>
-              <unitdate type="inclusive">undated</unitdate>
-            </did>
+              </did>
             <odd>
               <p>(filed alphabetically by correspondent)</p>
             </odd>

--- a/Real_Masters_all/civileng.xml
+++ b/Real_Masters_all/civileng.xml
@@ -47,7 +47,7 @@
       <abstract>The Department of Civil and Environmental Engineering is a unit within the College of Engineering at the University of Michigan. The records span from 1853 to 2001 with the bulk of the material being from 1960-1998. The records cover a variety of topics, including documentation from the Alumni Association, Chi Epsilon chapter, faculty meeting minutes, and annual reports from the administration.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">5.7 linear feet</extent>
-        <extent altrender="carrier">(7 boxes)</extent>
+        <extent altrender="carrier">7 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/cjsumpub.xml
+++ b/Real_Masters_all/cjsumpub.xml
@@ -54,7 +54,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/claspost.xml
+++ b/Real_Masters_all/claspost.xml
@@ -47,7 +47,7 @@
       <abstract>Posters and broadsides concerning competition between freshman and sophomore classes at the University of Michigan</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">37 items</extent>
-        <extent altrender="carrier">(in 2 oversize folders)</extent>
+        <extent altrender="carrier">in 2 oversize folders</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/classalb.xml
+++ b/Real_Masters_all/classalb.xml
@@ -58,7 +58,7 @@
       <abstract>The Class Albums collection consists of photograph albums compiled by University of Michigan students. The albums include individual and group portraits of class members, faculty portraits, and views of university buildings, the campus, and Ann Arbor scenes.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">16 linear feet</extent>
-        <extent altrender="carrier">(in 46 boxes)</extent>
+        <extent altrender="carrier">in 46 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/claussju.xml
+++ b/Real_Masters_all/claussju.xml
@@ -948,7 +948,7 @@ Julius A. Clauss papers
             <unittitle>Steelmaking process</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 film reels</extent>
-              <extent altrender="carrier">(in 1 can)</extent>
+              <extent altrender="carrier">in 1 can</extent>
             </physdesc>
           </did>
           <odd>

--- a/Real_Masters_all/claybour.xml
+++ b/Real_Masters_all/claybour.xml
@@ -47,7 +47,7 @@
       <physloc>Offsite storage in part; prior notification required for access to this portion</physloc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">5.5 linear feet</extent>
-        <extent altrender="carrier">(in 7 boxes)</extent>
+        <extent altrender="carrier">in 7 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/cleagemf.xml
+++ b/Real_Masters_all/cleagemf.xml
@@ -43,7 +43,7 @@
       <abstract>Detroit, Michigan clergyman, pastor at St. Mark's Presbyterian Church, which later became Central Congregational Church. In the 1960s, Cleage and his congregation began restructuring the church's rituals, programs, and theology to conform to the Black Christian Nationalist philosophy. In 1970, the church was renamed the Shrine of the Black Madonna. The collection contains correspondence, sermons, and writings of Albert B. Cleage, Jr. (his name would later be changed to Jaramogi Abebe Agyeman); records of the shrine of the Black Madonna; papers of individuals within the church who assisted Cleage; and records of the National Office of the Shrine.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">11 linear feet</extent>
-        <extent altrender="carrier">(on 19 microfilm rolls)</extent>
+        <extent altrender="carrier">on 19 microfilm rolls</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/clementh.xml
+++ b/Real_Masters_all/clementh.xml
@@ -47,7 +47,7 @@
       </repository>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">318 drawings</extent>
-        <extent altrender="carrier">(in 11 tubes)</extent>
+        <extent altrender="carrier">in 11 tubes</extent>
         <physfacet>architectural drawings</physfacet>
       </physdesc>
       <physdesc altrender="part">

--- a/Real_Masters_all/clockjp.xml
+++ b/Real_Masters_all/clockjp.xml
@@ -105,7 +105,7 @@
             <unittitle>Digitized sound recording of interview</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">4 digital files</extent>
-              <extent altrender="carrier">(in 1 zip file)</extent>
+              <extent altrender="carrier">in 1 zip file</extent>
               <physfacet>MP3 files</physfacet>
             </physdesc>
             <dao show="new" actuate="onrequest" href="clock0001">

--- a/Real_Masters_all/commence.xml
+++ b/Real_Masters_all/commence.xml
@@ -43,7 +43,7 @@
       <abstract>Programs for University of Michigan commencement week activities, issued for each school and college, and usually have embossed limp leather covers.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes.)</extent>
+        <extent altrender="carrier">in 3 boxes.</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/communic.xml
+++ b/Real_Masters_all/communic.xml
@@ -47,7 +47,7 @@
       <abstract>Formerly called the Department of Journalism; includes administrative files, records of sponsored workshops, conferences, and lectures; faculty personnel files; and records of internship programs, including reports from students interning at local Michigan newspapers.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">9.3 linear feet</extent>
-        <extent altrender="carrier">(in 10 boxes)</extent>
+        <extent altrender="carrier">in 10 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/conger.xml
+++ b/Real_Masters_all/conger.xml
@@ -42,7 +42,7 @@
       <abstract>The Lucile B. Conger Alumnae Chapter was established in 1947 as an offshoot of the Junior Michigan Alumnae Group. The Conger Chapter provides financial support and mentorship to women attending the University of Michigan through annual fundraising and social events. Materials include officer records, newsletters, membership directories, and scrapbooks.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/connable.xml
+++ b/Real_Masters_all/connable.xml
@@ -389,7 +389,7 @@
             <unittitle>Republican State Convention <unitdate type="inclusive" normal="1949">1949</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 volumes</extent>
-              <extent altrender="carrier">(in folder)</extent>
+              <extent altrender="carrier">in folder</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/cooleych.xml
+++ b/Real_Masters_all/cooleych.xml
@@ -54,7 +54,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 linear feet</extent>
-        <extent altrender="carrier">(in 9 boxes)</extent>
+        <extent altrender="carrier">in 9 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/coolmary.xml
+++ b/Real_Masters_all/coolmary.xml
@@ -43,7 +43,7 @@
       <abstract>Assistant to the director of the Hopwood Awards program at the University of Michigan; correspondence relating in part to her research into the life and career of American admiral and explorer, Charles Wilkes.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.5 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/coonsdh.xml
+++ b/Real_Masters_all/coonsdh.xml
@@ -43,7 +43,7 @@
       <abstract>Gerontologist at the Institute of Gerontology of the University of Michigan, specializing in Alzheimer's Disease and the training and education of people working with the elderly. Professional papers, including correspondence, subject files, papers and reports, and files relating to workshops and symposia attended; Alzheimer's Disease research files; photographs; and other audio-visual materials.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/copehelg.xml
+++ b/Real_Masters_all/copehelg.xml
@@ -43,7 +43,7 @@
       <abstract>Collection of papers related to Jones-McDonald-Gibson-Cope families of Macomb County, Michigan. Genealogical chart, marriage certificate, high school diploma, photographic scrapbook, family correspondence and two different drafts of a compiled history for James Jones and his family descendants, spanning the years 1867 -- 1987. This collection is related to the James Henry McDonald family collection, which is also held at Bentley Historical Library.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.0 linear foot</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/cowleshc.xml
+++ b/Real_Masters_all/cowleshc.xml
@@ -43,7 +43,7 @@
       <abstract>The Henry Chandler Cowles photograph collection is comprised primarily of lantern slides. As a botany professor at the University of Chicago, Cowles led several field trips to observe ecological environments during the years from 1898 to 1934. The lantern slides in this collection cover the geographic areas of Michigan, Colorado, Indiana, Wisconsin, and Illinois and include photographic subjects such as dunes, plant life, forests, landscapes, and class group pictures.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">104 slides</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/cramtonl.xml
+++ b/Real_Masters_all/cramtonl.xml
@@ -433,7 +433,7 @@
               <unittitle>Travel logs <unitdate type="inclusive" normal="1918">1918</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 volumes</extent>
-                <extent altrender="carrier">(in 1 folder)</extent>
+                <extent altrender="carrier">in 1 folder</extent>
                 <physfacet>bound manuscripts</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/cromwell.xml
+++ b/Real_Masters_all/cromwell.xml
@@ -43,7 +43,7 @@
       <abstract>Artist for the Detroit Times. Editorial cartoons and sketches relating to local political and social issues.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">570 items</extent>
-        <extent altrender="carrier">(in 40 folders)</extent>
+        <extent altrender="carrier">in 40 folders</extent>
         <physfacet>approximate</physfacet>
       </physdesc>
       <repository>

--- a/Real_Masters_all/crossbrad.xml
+++ b/Real_Masters_all/crossbrad.xml
@@ -43,7 +43,7 @@
       <abstract>Papers of Bradley Cross, Ann Arbor, Mich. environmental activist and businessman. The bulk of the collection includes material related to the Kimberly Hills Neighborhood Association (KHNA) in Pittsfield Township in Ann Arbor, Mich. and its fight to preserve neighborhood natural area by preventing it from commercial development. The legal case filed by KHNA went to the Michigan Supreme Court but was overturned in 1983. This material is dated between 1977 and 1983 and includes correspondence, court documents, maps and plans, position papers, publications, articles and newspaper clippings covering the case, photographs, and audiovisual material. Collection also includes a small number of collected materials related to anti-Vietnam war protests in Michigan and across the country, and Michigan politics, all dated in the 1960s. Included here are publications, campaign signs, and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.3 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 oversize folders</extent>

--- a/Real_Masters_all/crouserb.xml
+++ b/Real_Masters_all/crouserb.xml
@@ -42,7 +42,7 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 microfilms</extent>

--- a/Real_Masters_all/culvermm.xml
+++ b/Real_Masters_all/culvermm.xml
@@ -43,7 +43,7 @@
       <abstract>Papers of Washtenaw County, Mich. architectural historian and preservation activist Mary M. Culver. Collection includes records of Washtenaw County, Mich. historic preservation organizations, Culver's research files and presentations, and images of Michigan historic buildings.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.3 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/currtop.xml
+++ b/Real_Masters_all/currtop.xml
@@ -47,7 +47,7 @@
       <abstract>Constitution and bylaws, correspondence, minutes, photographs, and programs; minutes describe presentation by Raoul Wallenberg about Sweden and Swedish architecture.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/cushgeo.xml
+++ b/Real_Masters_all/cushgeo.xml
@@ -50,7 +50,7 @@
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">230 audiotapes</extent>
-        <extent altrender="carrier">(in 9 boxes)</extent>
+        <extent altrender="carrier">in 9 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/cwuchel.xml
+++ b/Real_Masters_all/cwuchel.xml
@@ -43,7 +43,7 @@
       <abstract>Records of Chelsea, Michigan chapter of Church Women United, an interdenominational church women's organization. Minutes of meetings, reports, memoranda, scrapbooks, and collected printed materials relating to activities and interests.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.65 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/dalglfam.xml
+++ b/Real_Masters_all/dalglfam.xml
@@ -43,7 +43,7 @@
       <abstract>Records of car dealerships owned by the Dalgleish family of Detroit, Michigan. Advertising and customer service material, photographs, selected business records, and artifacts. The collection is of special interest to researchers of Detroit business community and to the U.S. automobile industry and trade historians. Collection is especially rich with material related to auto advertising, particularly, the Cadillac.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.3 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes including oversize)</extent>
+        <extent altrender="carrier">in 2 boxes including oversize</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/daugherm.xml
+++ b/Real_Masters_all/daugherm.xml
@@ -59,7 +59,7 @@
       <abstract>Michael Daugherty is an internationally renowned composer and Professor of Composition at the University of Michigan School of Music, Theatre &amp; Dance. Papers include compositions and original scores, correspondence, reviews, previews, programs and brochures for performances of Daugherty’s work, and notes and collected materials documenting Daugherty’s education, awards, and grants.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">38.5 linear feet</extent>
-        <extent altrender="carrier">(in 55 boxes and 1 oversize folder)</extent>
+        <extent altrender="carrier">in 55 boxes and 1 oversize folder</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/davenfrd.xml
+++ b/Real_Masters_all/davenfrd.xml
@@ -172,8 +172,7 @@ Fred M. Davenport papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">9</container>
-              <unitdate type="inclusive" normal="1969/1972">1969-1972</unitdate>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/davisde.xml
+++ b/Real_Masters_all/davisde.xml
@@ -47,7 +47,7 @@
       <abstract>Automotive enthusiast writer who edited <title render="italic">Car and Driver</title> and founded <title render="italic">Automobile Magazine.</title> Also worked for advertising agencies and served as an industry consultant. Material include correspondence, business files, text of speeches, publicity items, photographs, bound issues of <title render="italic">Automobile Magazine</title> and audio-visual material.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">21 linear feet</extent>
-        <extent altrender="carrier">(in 22 boxes including 1 oversize box)</extent>
+        <extent altrender="carrier">in 22 boxes including 1 oversize box</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">6 film reels</extent>

--- a/Real_Masters_all/davisjl.xml
+++ b/Real_Masters_all/davisjl.xml
@@ -1348,7 +1348,7 @@ Joe Lee Davis papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Novel <title render="italic">: Julia Farnum</title></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 versions</extent>
-                <extent altrender="carrier">(in 4 boxes)</extent>
+                <extent altrender="carrier">in 4 boxes</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/davislor.xml
+++ b/Real_Masters_all/davislor.xml
@@ -43,7 +43,7 @@
       <abstract>Washtenaw County, Michigan minister, local historian and public official; correspondence, sermons, and collected papers relating to the history of Ann Arbor and Washtenaw County, Michigan.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.6 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/dedijer.xml
+++ b/Real_Masters_all/dedijer.xml
@@ -370,7 +370,7 @@ Vladimir Dedijer papers, Bentley Historical Library, University of Michigan</p>
             <unittitle>Passports, address books, etc.</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">19 items</extent>
-              <extent altrender="carrier">(in 1 expandable folder)</extent>
+              <extent altrender="carrier">in 1 expandable folder</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/delanghe.xml
+++ b/Real_Masters_all/delanghe.xml
@@ -43,7 +43,7 @@
       <abstract>Performer and professor of modern dance at the University of Michigan. Collection contains subject files relating to Delanghe's activities as a choreographer, dancer, teacher and department chair. Collection also contains photographs and audiovisual material documenting productions with which Delanghe was involved.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">10 linear feet</extent>
-        <extent altrender="carrier">(in 13 boxes)</extent>
+        <extent altrender="carrier">in 13 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/demparty.xml
+++ b/Real_Masters_all/demparty.xml
@@ -51,7 +51,7 @@
       <abstract>Files of state chairs, Neil Staebler, John J. Collins, Zolton Ferency, Sander Levin, James McNeely, Morley Winograd, Olivia Maynard, Richard Wiener, F. Thomas LeWand, and Gary Corbin; files of deputy state chair, Billie S. Farnum, vice chairs Adelaide Hart and Olivia Maynard, and vice chair Robert Mitchell; files relating to state constitutional convention, and to state and national political campaigns, since 1950; sound recordings and visual materials.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">97 linear feet</extent>
-        <extent altrender="carrier">(in 99 boxes)</extent>
+        <extent altrender="carrier">in 99 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 film reels</extent>
@@ -23553,7 +23553,7 @@ Democratic Party of Michigan records, Bentley Historical Library, University of 
               <unittitle>Michigan Democratic Committee <unitdate type="inclusive" normal="1968-06-05">June 5, 1968</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 reels</extent>
-                <extent altrender="carrier">(in 1 canister)</extent>
+                <extent altrender="carrier">in 1 canister</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/denbleyk.xml
+++ b/Real_Masters_all/denbleyk.xml
@@ -43,7 +43,7 @@
       <abstract>Paulus den Bleyker family of Kalamazoo, Michigan. Papers of Paulus den Bleyker, his son John, John's wife, Anna Balch den Bleyker, and other family members relating to family and business affairs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">9 linear feet</extent>
-        <extent altrender="carrier">(in 10 boxes)</extent>
+        <extent altrender="carrier">in 10 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/dentsch.xml
+++ b/Real_Masters_all/dentsch.xml
@@ -54,7 +54,7 @@
       <abstract>The School of Dentistry is a teaching and research unit of the University of Michigan. Records include administrative files, faculty meeting minutes, curriculum and education, subject files relating to dentistry and to the professional interests of the school's faculty; and photographs and films.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">34.5 linear feet</extent>
-        <extent altrender="carrier">(in 35 boxes)</extent>
+        <extent altrender="carrier">in 35 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize volumes</extent>

--- a/Real_Masters_all/detnewir.xml
+++ b/Real_Masters_all/detnewir.xml
@@ -43,7 +43,7 @@
       <abstract>Files of Detroit News conservation editor Albert Stoll and director of public relations Lee A. White. Correspondence, newspaper clippings, photographs, and miscellaneous papers relating to the Detroit News' campaign to make Isle Royale a national park and to secure land for it; manuscript and notes of an article by Martha M. Bigelow, 1955.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/detroitnews.xml
+++ b/Real_Masters_all/detroitnews.xml
@@ -61,7 +61,7 @@ Detroit News records
 </unittitle>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">164.5 linear feet</extent>
-        <extent altrender="carrier">(in 180 boxes)</extent>
+        <extent altrender="carrier">in 180 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">33.4 GB</extent>

--- a/Real_Masters_all/diceleer.xml
+++ b/Real_Masters_all/diceleer.xml
@@ -281,7 +281,7 @@ The papers are organized of the following series: Professional Correspondence; I
             </physdesc>
             <physdesc altrender="part">
               <extent altrender="materialtype spaceoccupied">8 envelopes</extent>
-              <extent altrender="carrier">(in 1 folder)</extent>
+              <extent altrender="carrier">in 1 folder</extent>
             </physdesc>
             <physdesc>
               <physfacet>(photocopies</physfacet>

--- a/Real_Masters_all/donahuew.xml
+++ b/Real_Masters_all/donahuew.xml
@@ -54,7 +54,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">26 linear feet</extent>
-        <extent altrender="carrier">(in 27 boxes)</extent>
+        <extent altrender="carrier">in 27 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/donermfr.xml
+++ b/Real_Masters_all/donermfr.xml
@@ -51,7 +51,7 @@
       </repository>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">6 linear feet</extent>
-        <extent altrender="carrier">(in 7 boxes)</extent>
+        <extent altrender="carrier">in 7 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 oversize volumes</extent>

--- a/Real_Masters_all/downst.xml
+++ b/Real_Masters_all/downst.xml
@@ -329,7 +329,7 @@ The collection is organized in the following series: Political and other activit
             <unittitle>Miscellaneous cassettes</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">32 audiocassettes</extent>
-              <extent altrender="carrier">(in 2 cassette boxes)</extent>
+              <extent altrender="carrier">in 2 cassette boxes</extent>
             </physdesc>
           </did>
           <odd>

--- a/Real_Masters_all/dsigmad.xml
+++ b/Real_Masters_all/dsigmad.xml
@@ -732,7 +732,7 @@ Delta Sigma Delta records, Bentley Historical Library, University of Michigan</p
             <unittitle>Jackie Jungman Party <unitdate type="inclusive" normal="1934" certainty="approximate">circa 1934</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
-              <extent altrender="carrier">(in 1 envelope)</extent>
+              <extent altrender="carrier">in 1 envelope</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/duderst.xml
+++ b/Real_Masters_all/duderst.xml
@@ -6093,7 +6093,7 @@
               <unittitle>1986-1997 Strategy</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">63 digital files</extent>
-                <extent altrender="carrier">(on 1 CD-ROM)</extent>
+                <extent altrender="carrier">on 1 CD-ROM</extent>
               </physdesc>
             </did>
             <accessrestrict>

--- a/Real_Masters_all/dudleyam.xml
+++ b/Real_Masters_all/dudleyam.xml
@@ -43,7 +43,7 @@
       <abstract>Electrical engineer; professional papers relating to his career at Westinghouse.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.6 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/dunnejim.xml
+++ b/Real_Masters_all/dunnejim.xml
@@ -43,7 +43,7 @@
       <abstract>Jim Dunne is known for his work as a pioneer in automotive spy photography. He is also an established journalist and author, and conducted automotive performance tests and reviews of new vehicles for many years. The collection, spanning 1969-2011, includes his book <title render="italic">Car Spy: Secret Cars Exposed by the Industry's Most Notorious Photographer</title>, magazines containing his photographic work, articles written by him, and awards and recognitions. A large portion of the collection is made up of visual materials, which consists of photographs, slides, negatives, CDs containing images of automobiles he included in his book, and a digital slideshow presentation featuring his work.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/eadensmo.xml
+++ b/Real_Masters_all/eadensmo.xml
@@ -43,7 +43,7 @@
       <abstract>Dansville, Michigan, general store. Ledgers, daybooks, cash books, and other business records.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">14 volumes</extent>
-        <extent altrender="carrier">(in 1 box)</extent>
+        <extent altrender="carrier">in 1 box</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 oversize volumes</extent>

--- a/Real_Masters_all/engcoll.xml
+++ b/Real_Masters_all/engcoll.xml
@@ -7735,7 +7735,7 @@
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 sets</extent>
-                  <extent altrender="carrier">(in 4 volumes)</extent>
+                  <extent altrender="carrier">in 4 volumes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -11407,7 +11407,7 @@
                 <unittitle>Individual Portraits <unitdate type="inclusive" normal="1950/1989" certainty="approximate">circa 1950s-1980s</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">50 portraits</extent>
-                  <extent altrender="carrier">(in 2 folders)</extent>
+                  <extent altrender="carrier">in 2 folders</extent>
                   <physfacet>black and white</physfacet>
                 </physdesc>
               </did>
@@ -11419,7 +11419,7 @@
               <unittitle>Laboratories and Equipment <unitdate type="inclusive" normal="1910/1929" certainty="approximate">circa 1910s-1920s</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">38 prints</extent>
-                <extent altrender="carrier">(in 2 folders)</extent>
+                <extent altrender="carrier">in 2 folders</extent>
                 <physfacet>black and white</physfacet>
               </physdesc>
             </did>
@@ -11430,7 +11430,7 @@
               <unittitle>Laboratory and Library Scenes <unitdate type="inclusive" normal="1920/1929" certainty="approximate">circa 1920s</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">17 prints</extent>
-                <extent altrender="carrier">(in 1 binder)</extent>
+                <extent altrender="carrier">in 1 binder</extent>
                 <physfacet>black and white</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/englerj.xml
+++ b/Real_Masters_all/englerj.xml
@@ -38859,7 +38859,7 @@ Topics extensively documented include state welfare and school funding reform, r
               <unittitle>Audiocassettes <unitdate type="inclusive" normal="1991/2000">1991-2000</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">400 audiocassettes</extent>
-                <extent altrender="carrier">(in 6 boxes)</extent>
+                <extent altrender="carrier">in 6 boxes</extent>
                 <physfacet>approximate</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/episwest.xml
+++ b/Real_Masters_all/episwest.xml
@@ -12613,7 +12613,7 @@
               <unittitle>Register of church services <unitdate type="inclusive" normal="1966/1992">1966-1992</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 volumes</extent>
-                <extent altrender="carrier">(in 1 folder)</extent>
+                <extent altrender="carrier">in 1 folder</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/esgeorge.xml
+++ b/Real_Masters_all/esgeorge.xml
@@ -43,7 +43,7 @@
       <abstract>Records of the Edwin S. George Reserve, Livingston County, Michigan, operated by the University of Michigan as a natural area for scientific study. Collection includes administrative records, history, publications, research, photographs, maps, and other records relating to Reserve activities.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">15 linear feet</extent>
-        <extent altrender="carrier">(in 16 boxes)</extent>
+        <extent altrender="carrier">in 16 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">12 oversize folders</extent>

--- a/Real_Masters_all/eskimo.xml
+++ b/Real_Masters_all/eskimo.xml
@@ -46,7 +46,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/facwclub.xml
+++ b/Real_Masters_all/facwclub.xml
@@ -47,7 +47,7 @@
       <abstract>Proceedings, treasurer's reports, committee reports, scrapbooks, and various administrative records.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">14.5 linear feet</extent>
-        <extent altrender="carrier">(in 15 boxes)</extent>
+        <extent altrender="carrier">in 15 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize volumes</extent>

--- a/Real_Masters_all/faethgm.xml
+++ b/Real_Masters_all/faethgm.xml
@@ -43,7 +43,7 @@
       <abstract>Gerard Faeth (1936-2005) professor of aerospace engineering and mechanical engineering was a world-renowned scholar, researcher, and NASA advisor on theoretical and experimental research on combustion, heat transfer, fluid dynamics, and instrumentation. The collection includes correspondence, teaching materials, research proposals, presentations and publications, photographs and other visual materials reflecting his academic, research, and consulting career. The collection covers the years 1964-2005, but primarily documents 1985-2005.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">12 linear feet</extent>
-        <extent altrender="carrier">(in 13 boxes)</extent>
+        <extent altrender="carrier">in 13 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/favorite.xml
+++ b/Real_Masters_all/favorite.xml
@@ -185,7 +185,7 @@ William P. Favorite Papers, Bentley Historical Library, University of Michigan</
             <unittitle>Sturgis, Michigan</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
-              <extent altrender="carrier">(in folders)</extent>
+              <extent altrender="carrier">in folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/fbaptaa.xml
+++ b/Real_Masters_all/fbaptaa.xml
@@ -1485,14 +1485,12 @@ First Baptist Church (Ann Arbor, Mich.) records, Bentley Historical Library, Uni
             <c04 level="file">
               <did>
                 <container type="box" label="Box">14</container>
-                <unitdate type="inclusive" normal="1970/1974">1970-1974</unitdate>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">14</container>
-                <unitdate type="inclusive" normal="1975/1981">1975-1981</unitdate>
-              </did>
+                </did>
             </c04>
           </c03>
           <c03 level="file">
@@ -1596,20 +1594,17 @@ First Baptist Church (Ann Arbor, Mich.) records, Bentley Historical Library, Uni
           <c03 level="file">
             <did>
               <container type="box" label="Box">15</container>
-              <unitdate type="inclusive" normal="1874/1880">1874-1880</unitdate>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">15</container>
-              <unitdate type="inclusive" normal="1881/1914">1881-1914</unitdate>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">15</container>
-              <unitdate type="inclusive">undated</unitdate>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/felcha.xml
+++ b/Real_Masters_all/felcha.xml
@@ -2632,7 +2632,7 @@
               <unittitle>Land grants, appointments, etc.</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">6 items</extent>
-                <extent altrender="carrier">(in oversize folder)</extent>
+                <extent altrender="carrier">in oversize folder</extent>
               </physdesc>
             </did>
           </c03>
@@ -2739,7 +2739,7 @@
               <unittitle>Manuscript map of the United States drawn while student at Bowdoin College</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 items</extent>
-                <extent altrender="carrier">(in oversize folder)</extent>
+                <extent altrender="carrier">in oversize folder</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/ferguson.xml
+++ b/Real_Masters_all/ferguson.xml
@@ -4340,7 +4340,7 @@
             <unittitle>Statements taken for Wayne County graft grand jury <unitdate type="inclusive" normal="1939/1941">1939-1941</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">35 phonograph records</extent>
-              <extent altrender="carrier">(in carrying case)</extent>
+              <extent altrender="carrier">in carrying case</extent>
             </physdesc>
           </did>
           <odd>

--- a/Real_Masters_all/ferrydm.xml
+++ b/Real_Masters_all/ferrydm.xml
@@ -62,7 +62,7 @@
       <abstract>A pioneer Detroit, Michigan family, established the Ferry Seed Company and other business enterprises, active in civic and cultural affairs. Papers document the family and its business, cultural, political and philanthropic activities.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">23.5 linear feet</extent>
-        <extent altrender="carrier">(in 25 boxes)</extent>
+        <extent altrender="carrier">in 25 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 oversize volumes</extent>

--- a/Real_Masters_all/festing.xml
+++ b/Real_Masters_all/festing.xml
@@ -46,7 +46,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3.5 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/flemingr.xml
+++ b/Real_Masters_all/flemingr.xml
@@ -55,7 +55,7 @@
       <abstract>Ninth president of the University of Michigan, 1967-1978, later president of the Corporation for Public Broadcasting, chairman of the National Institute for Dispute Resolution, and member of the boards of the MacArthur and Johnson Foundations. Personal files, including general and family correspondence, papers detailing service with the U. S. Army military police in Europe during World War II, records concerning activities as labor arbitrator, topical files relating to work at universities of Illinois, Wisconsin, and Michigan; files relating to activities with the Corporation for Public Broadcasting concerning in part the Annenberg/CPB project; and photographs relating to his life and career.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">51 linear feet</extent>
-        <extent altrender="carrier">(in 52 boxes)</extent>
+        <extent altrender="carrier">in 52 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/fmohp.xml
+++ b/Real_Masters_all/fmohp.xml
@@ -47,7 +47,7 @@
       <abstract>Transcripts of oral interviews conducted by University of Michigan history professor Sidney Fine in cooperation with the Michigan Historical Collections with individuals on the subject of the life and times of Michigan governor and U.S. Supreme Court Justice, Frank Murphy; and sound recordings of the interviews.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/fullerel.xml
+++ b/Real_Masters_all/fullerel.xml
@@ -50,7 +50,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">240 glass negatives</extent>
-        <extent altrender="carrier">(approximate; in 2 boxes)</extent>
+        <extent altrender="carrier">approximate; in 2 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.5 linear feet</extent>

--- a/Real_Masters_all/fultond.xml
+++ b/Real_Masters_all/fultond.xml
@@ -51,7 +51,7 @@
       <abstract>Outdoor writer and photographer for The Ann Arbor News, advocate of environment issues, author of local interest and music review columns; articles written and photographs taken by Fulton, personal correspondence and documentation of awards received.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">13.3 linear feet</extent>
-        <extent altrender="carrier">(in 15 boxes)</extent>
+        <extent altrender="carrier">in 15 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/gablercl.xml
+++ b/Real_Masters_all/gablercl.xml
@@ -174,11 +174,11 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
               <unittitle>Wake Island</unittitle>
               <physdesc altrender="part">
                 <extent altrender="materialtype spaceoccupied">43 slides</extent>
-                <extent altrender="carrier">(in folder)</extent>
+                <extent altrender="carrier">in folder</extent>
               </physdesc>
               <physdesc altrender="part">
                 <extent altrender="materialtype spaceoccupied">19 slides</extent>
-                <extent altrender="carrier">(in box)</extent>
+                <extent altrender="carrier">in box</extent>
               </physdesc>
             </did>
             <odd>
@@ -191,11 +191,11 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
               <unittitle>Majuro/Mille</unittitle>
               <physdesc altrender="part">
                 <extent altrender="materialtype spaceoccupied">4 slides</extent>
-                <extent altrender="carrier">(in folder)</extent>
+                <extent altrender="carrier">in folder</extent>
               </physdesc>
               <physdesc altrender="part">
                 <extent altrender="materialtype spaceoccupied">24 slides</extent>
-                <extent altrender="carrier">(in box)</extent>
+                <extent altrender="carrier">in box</extent>
               </physdesc>
             </did>
             <odd>
@@ -208,7 +208,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
               <unittitle>Wotje</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">9 slides</extent>
-                <extent altrender="carrier">(in box)</extent>
+                <extent altrender="carrier">in box</extent>
               </physdesc>
             </did>
             <odd>
@@ -221,11 +221,11 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
               <unittitle>Jaluit</unittitle>
               <physdesc altrender="part">
                 <extent altrender="materialtype spaceoccupied">6 slides</extent>
-                <extent altrender="carrier">(in folder)</extent>
+                <extent altrender="carrier">in folder</extent>
               </physdesc>
               <physdesc altrender="part">
                 <extent altrender="materialtype spaceoccupied">18 slides</extent>
-                <extent altrender="carrier">(in box)</extent>
+                <extent altrender="carrier">in box</extent>
               </physdesc>
             </did>
             <odd>
@@ -238,11 +238,11 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
               <unittitle>Laura</unittitle>
               <physdesc altrender="part">
                 <extent altrender="materialtype spaceoccupied">13 slides</extent>
-                <extent altrender="carrier">(in folder)</extent>
+                <extent altrender="carrier">in folder</extent>
               </physdesc>
               <physdesc altrender="part">
                 <extent altrender="materialtype spaceoccupied">3 slides</extent>
-                <extent altrender="carrier">(in box)</extent>
+                <extent altrender="carrier">in box</extent>
               </physdesc>
             </did>
             <odd>
@@ -255,11 +255,11 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
               <unittitle>Rabaul</unittitle>
               <physdesc altrender="part">
                 <extent altrender="materialtype spaceoccupied">34 slides</extent>
-                <extent altrender="carrier">(in folder)</extent>
+                <extent altrender="carrier">in folder</extent>
               </physdesc>
               <physdesc altrender="part">
                 <extent altrender="materialtype spaceoccupied">26 slides</extent>
-                <extent altrender="carrier">(in box)</extent>
+                <extent altrender="carrier">in box</extent>
               </physdesc>
             </did>
             <odd>
@@ -285,7 +285,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
             <unittitle>Code C-burials in battlefield cemetery</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 slides</extent>
-              <extent altrender="carrier">(in folder)</extent>
+              <extent altrender="carrier">in folder</extent>
               <physfacet>black and white</physfacet>
             </physdesc>
           </did>
@@ -296,7 +296,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
             <unittitle>Code CP-Cherry Point, N.C <unitdate type="inclusive" normal="1945">1945</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">29 slides</extent>
-              <extent altrender="carrier">(in folder)</extent>
+              <extent altrender="carrier">in folder</extent>
               <physfacet>color</physfacet>
             </physdesc>
           </did>
@@ -307,7 +307,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
             <unittitle>Code D-Japanese dead</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">13 slides</extent>
-              <extent altrender="carrier">(in folder)</extent>
+              <extent altrender="carrier">in folder</extent>
               <physfacet>black and white</physfacet>
             </physdesc>
           </did>
@@ -318,7 +318,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
             <unittitle>Code ED-combat scenes</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 slides</extent>
-              <extent altrender="carrier">(in folder)</extent>
+              <extent altrender="carrier">in folder</extent>
               <physfacet>black and white</physfacet>
             </physdesc>
           </did>
@@ -329,7 +329,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
             <unittitle>Code G-combat scenes</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">12 slides</extent>
-              <extent altrender="carrier">(in folder)</extent>
+              <extent altrender="carrier">in folder</extent>
               <physfacet>black and white</physfacet>
             </physdesc>
           </did>
@@ -340,12 +340,12 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
             <unittitle>Code H-of Hawaii <unitdate type="inclusive" normal="1945" certainty="approximate">circa 1945</unitdate></unittitle>
             <physdesc altrender="part">
               <extent altrender="materialtype spaceoccupied">18 slides</extent>
-              <extent altrender="carrier">(in folder)</extent>
+              <extent altrender="carrier">in folder</extent>
               <physfacet>color</physfacet>
             </physdesc>
             <physdesc altrender="part">
               <extent altrender="materialtype spaceoccupied">2 slides</extent>
-              <extent altrender="carrier">(in box)</extent>
+              <extent altrender="carrier">in box</extent>
             </physdesc>
           </did>
         </c02>
@@ -355,7 +355,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
             <unittitle>Code M-aerial views of an island</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">8 slides</extent>
-              <extent altrender="carrier">(in folder)</extent>
+              <extent altrender="carrier">in folder</extent>
               <physfacet>black and white</physfacet>
             </physdesc>
           </did>
@@ -366,7 +366,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
             <unittitle>Code N scenery</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">4 slides</extent>
-              <extent altrender="carrier">(in folder)</extent>
+              <extent altrender="carrier">in folder</extent>
               <physfacet>black and white</physfacet>
             </physdesc>
           </did>
@@ -377,7 +377,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
             <unittitle>Code NC-of military scene</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 slides</extent>
-              <extent altrender="carrier">(in folder)</extent>
+              <extent altrender="carrier">in folder</extent>
               <physfacet>black and white</physfacet>
             </physdesc>
           </did>
@@ -388,7 +388,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
             <unittitle>code NP-river</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 slides</extent>
-              <extent altrender="carrier">(in folder)</extent>
+              <extent altrender="carrier">in folder</extent>
               <physfacet>black and white</physfacet>
             </physdesc>
           </did>
@@ -399,7 +399,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
             <unittitle>Code P-U.S. personnel, mixed with slides of Japanese prisoners</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">14 slides</extent>
-              <extent altrender="carrier">(in folder)</extent>
+              <extent altrender="carrier">in folder</extent>
               <physfacet>black and white</physfacet>
             </physdesc>
           </did>
@@ -410,7 +410,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
             <unittitle>Code PAB-puppy</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 slides</extent>
-              <extent altrender="carrier">(in folder)</extent>
+              <extent altrender="carrier">in folder</extent>
               <physfacet>black and white</physfacet>
             </physdesc>
           </did>
@@ -421,7 +421,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
             <unittitle>Code PAN-native village and people</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">8 slides</extent>
-              <extent altrender="carrier">(in folder)</extent>
+              <extent altrender="carrier">in folder</extent>
               <physfacet>black and white</physfacet>
             </physdesc>
           </did>
@@ -432,7 +432,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
             <unittitle>Code R-radar installation?</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">7 slides</extent>
-              <extent altrender="carrier">(in folder)</extent>
+              <extent altrender="carrier">in folder</extent>
               <physfacet>black and white</physfacet>
             </physdesc>
           </did>
@@ -443,7 +443,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
             <unittitle>Code T-military camp</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 slides</extent>
-              <extent altrender="carrier">(in folder)</extent>
+              <extent altrender="carrier">in folder</extent>
               <physfacet>black and white</physfacet>
             </physdesc>
           </did>
@@ -454,11 +454,11 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
             <unittitle>Uncoded</unittitle>
             <physdesc altrender="part">
               <extent altrender="materialtype spaceoccupied">22 slides</extent>
-              <extent altrender="carrier">(in folder)</extent>
+              <extent altrender="carrier">in folder</extent>
             </physdesc>
             <physdesc altrender="part">
               <extent altrender="materialtype spaceoccupied">125 slides</extent>
-              <extent altrender="carrier">(in box)</extent>
+              <extent altrender="carrier">in box</extent>
             </physdesc>
           </did>
         </c02>
@@ -468,7 +468,7 @@ Cornelius L. T. Gabler papers, Bentley Historical Library, University of Michiga
             <unittitle>Marine recruiting-construction of Detroit Marine recruiting station <unitdate type="inclusive" normal="1942">1942</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">29 slides</extent>
-              <extent altrender="carrier">(in folder)</extent>
+              <extent altrender="carrier">in folder</extent>
               <physfacet>color and black and white</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/galbraij.xml
+++ b/Real_Masters_all/galbraij.xml
@@ -49,7 +49,7 @@
 The D. James Galbraith Photographic Collection is significant for its extensive photographic evidence of rural Michigan, particularly its emphasis on families, communities, and local institutions such as churches and schools. The collection is useful as a visual representation of late twentieth-century Michigan, capturing a wide array of social and cultural activities that highlight the daily experiences of Michigan residents.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">16 linear feet</extent>
-        <extent altrender="carrier">(in 10 boxes)</extent>
+        <extent altrender="carrier">in 10 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">6 oversize boxes</extent>

--- a/Real_Masters_all/gbassoc.xml
+++ b/Real_Masters_all/gbassoc.xml
@@ -22069,7 +22069,6 @@
             </c04>
             <c04 level="file">
               <did>
-                <unitdate type="inclusive" normal="1975-01-21/1976-01-21">1/21/75-1/21/76</unitdate>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">50 prints</extent>
                   <physfacet>black and white</physfacet>

--- a/Real_Masters_all/gbassoc.xml
+++ b/Real_Masters_all/gbassoc.xml
@@ -45581,7 +45581,7 @@
               <unittitle>Photographs of drawings, models, construction, exterior and interior by unknown photographer, Balthazar Korab and Daniel Bartush, as stamped</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">467 slides</extent>
-                <extent altrender="carrier">(in 3 folders)</extent>
+                <extent altrender="carrier">in 3 folders</extent>
                 <physfacet>color</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/gentvnet.xml
+++ b/Real_Masters_all/gentvnet.xml
@@ -43,7 +43,7 @@
       <abstract>Television production and post-production company located in Oak Park, Michigan. The record group consists primarily of albums containing photographs, correspondence, clippings and other materials documenting GTN, its facilities, staff, and projects.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">11 linear feet</extent>
-        <extent altrender="carrier">(in 12 boxes)</extent>
+        <extent altrender="carrier">in 12 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 oversize volumes</extent>

--- a/Real_Masters_all/geoum.xml
+++ b/Real_Masters_all/geoum.xml
@@ -47,7 +47,7 @@
       <abstract>Legally-certified collective bargaining agent for the graduate student teaching and staff assistants at the University of Michigan. Includes minutes of meetings, announcements, newsletters and other materials concerning, in part, its activities to gain recognition and its strike against the University in 1975. Also includes material related to the organization's bargaining and negotiations with the University.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">23.8 linear feet</extent>
-        <extent altrender="carrier">(in 25 boxes)</extent>
+        <extent altrender="carrier">in 25 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.2 MB</extent>

--- a/Real_Masters_all/goldbergst.xml
+++ b/Real_Masters_all/goldbergst.xml
@@ -43,7 +43,7 @@
       <abstract>Papers of Stanley B. Goldberg, president of the Wayne County, Mich., chapter of Mothers Against Drunk Driving. Collection includes correspondence, newspaper clippings, and videotapes.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.5 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/goldmane.xml
+++ b/Real_Masters_all/goldmane.xml
@@ -54,7 +54,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/gossette.xml
+++ b/Real_Masters_all/gossette.xml
@@ -43,7 +43,7 @@
       <abstract>Volunteer in local and national community and professional organizations and resident of Bloomfield Hills, Michigan from 1947-1981; records include photographs, correspondence, articles, newspaper clippings, and notes related to Gossett’s personal life and volunteer activities.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.6 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/grandhot.xml
+++ b/Real_Masters_all/grandhot.xml
@@ -70,7 +70,7 @@
       <abstract>The Grand Hotel records comprise documents, photographs, audio and videographic material collected about the hotel by its management. The strength of the collection is in its documentation of the guest experience at the hotel, and the evolution of amenities offered by the hotel during the mid-to-late 20th century. A small number of items also provide a glimpse of the hotel’s earliest days as a summer resort.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">25.5 linear feet</extent>
-        <extent altrender="carrier">(in 27 boxes)</extent>
+        <extent altrender="carrier">in 27 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 oversize folders</extent>
@@ -740,7 +740,7 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">62 prints</extent>
-                  <extent altrender="carrier">(in 2 envelopes)</extent>
+                  <extent altrender="carrier">in 2 envelopes</extent>
                 </physdesc>
                 <physdesc>
                   <physfacet>bulk b/w prints</physfacet>
@@ -821,7 +821,7 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>"This Time For Keeps" Movie Shoot <unitdate type="inclusive" normal="1946">1946</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">77 prints</extent>
-                <extent altrender="carrier">(in 2 envelopes)</extent>
+                <extent altrender="carrier">in 2 envelopes</extent>
               </physdesc>
               <physdesc>
                 <physfacet>8"x10" b/w prints</physfacet>
@@ -948,7 +948,7 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>100th Anniversary Party <unitdate type="inclusive" normal="1987">1987</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">235 prints</extent>
-                <extent altrender="carrier">(in 3 envelopes)</extent>
+                <extent altrender="carrier">in 3 envelopes</extent>
               </physdesc>
               <physdesc>
                 <physfacet>5"x7" color prints</physfacet>
@@ -1287,7 +1287,7 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">135 prints</extent>
-                  <extent altrender="carrier">(in 3 envelopes)</extent>
+                  <extent altrender="carrier">in 3 envelopes</extent>
                 </physdesc>
                 <physdesc>
                   <physfacet>color snapshots</physfacet>
@@ -1305,7 +1305,7 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">94 prints</extent>
-                  <extent altrender="carrier">(in 2 envelopes)</extent>
+                  <extent altrender="carrier">in 2 envelopes</extent>
                 </physdesc>
                 <physdesc>
                   <physfacet>color snapshots</physfacet>

--- a/Real_Masters_all/grandval.xml
+++ b/Real_Masters_all/grandval.xml
@@ -42,7 +42,7 @@
       <abstract>Oral history project undertaken by Professor John Tevebaugh of Grand Valley State Colleges in 1976. The focus of the interviews was the history of Grand Rapids, Michigan.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">61 audiotapes</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
         <physfacet>reel-to-reel tapes</physfacet>
       </physdesc>
       <repository>

--- a/Real_Masters_all/granholm.xml
+++ b/Real_Masters_all/granholm.xml
@@ -47,7 +47,7 @@
       <abstract>Granholm was the Democratic governor of Michigan from 2003 to 2010. Records are primarily arranged by office of origin and staff member and document Granholm's service as governor. The series in the collection are: Transition 2002, Legal Division, Policy Division, Executive Office, Communications Division, Economic Recovery Office, Northern Michigan Office, Other Executive Divisions, Office of the Lieutenant Governor, Office of the First Gentleman, Archived Websites, and Memorabilia. The collection includes paper and electronic files and audio-visual materials. Extensively documented topics include economic diversification, renewable energy, environmental issues, education, Michigan's response to the 2008 financial crisis, the Governor's Hearing on the Removal of Kwame Kilpatrick from the office of Mayor of Detroit, and Michigan soldiers killed in Iraq and Afghanistan.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">225 linear feet</extent>
-        <extent altrender="carrier">(in 227 boxes)</extent>
+        <extent altrender="carrier">in 227 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/greenfrd.xml
+++ b/Real_Masters_all/greenfrd.xml
@@ -43,7 +43,7 @@
       <abstract>Republican Governor of Michigan, 1927-1930, from Ionia. Correspondence and other papers, 1898-1936, concerning the Spanish-American War, Republican politics, and personal affairs; and scrapbooks, 1896-1929, covering his political career and election campaigns; and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4 oversize volumes</extent>

--- a/Real_Masters_all/greenman.xml
+++ b/Real_Masters_all/greenman.xml
@@ -49,7 +49,7 @@
       </note>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">7 linear feet</extent>
-        <extent altrender="carrier">(in 8 boxes)</extent>
+        <extent altrender="carrier">in 8 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/grimmjoe.xml
+++ b/Real_Masters_all/grimmjoe.xml
@@ -43,7 +43,7 @@
       <abstract>University of Michigan student photographer for the Michiganensian; photographs of images used in the yearbook.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.6 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/gswms.xml
+++ b/Real_Masters_all/gswms.xml
@@ -66,7 +66,7 @@
       <abstract>Ann Arbor, Michigan based hydraulic engineer known for his multiple arch dams, hydroelectric plants, and for developing the Hazen-Williams hydraulic tables, designed and consulted on numerous water power and dam projects. Papers include biographical files, material relating to construction of dams and power plants on the Huron River and elsewhere, and papers relating to Michigan Engineering Society.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 linear feet</extent>
-        <extent altrender="carrier">(in 8 boxes)</extent>
+        <extent altrender="carrier">in 8 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 oversize folders</extent>

--- a/Real_Masters_all/hammondf.xml
+++ b/Real_Masters_all/hammondf.xml
@@ -43,7 +43,7 @@
       <abstract>Collection consists of photographs taken by photographer Fred Hammond for use by the Michigan Department of Transportation and personal photos.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.5 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
         <physfacet>boxes 2 and 3 are oversize</physfacet>
       </physdesc>
       <repository>

--- a/Real_Masters_all/hankinst.xml
+++ b/Real_Masters_all/hankinst.xml
@@ -55,7 +55,7 @@
       </repository>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">8 linear feet</extent>
-        <extent altrender="carrier">(in 10 boxes)</extent>
+        <extent altrender="carrier">in 10 boxes</extent>
       </physdesc>
       <physloc>Portions located in offsite storage; prior notification required for access.</physloc>
     </did>

--- a/Real_Masters_all/harbourj.xml
+++ b/Real_Masters_all/harbourj.xml
@@ -261,7 +261,7 @@ James E. Harbour papers, Bentley Historical Library, University of Michigan</p>
             <unittitle>Reviews, articles, press releases, interviews</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">40 folders</extent>
-              <extent altrender="carrier">(in 1 expandable folder)</extent>
+              <extent altrender="carrier">in 1 expandable folder</extent>
             </physdesc>
           </did>
         </c02>
@@ -298,7 +298,7 @@ James E. Harbour papers, Bentley Historical Library, University of Michigan</p>
             </physdesc>
             <physdesc altrender="part">
               <extent altrender="materialtype spaceoccupied">10 folders</extent>
-              <extent altrender="carrier">(in 1 expandable folder)</extent>
+              <extent altrender="carrier">in 1 expandable folder</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/harriman.xml
+++ b/Real_Masters_all/harriman.xml
@@ -46,7 +46,7 @@
       <abstract>William L. Clements Library staff member, collector of posters; event posters and announcements flyers advertising University of Michigan and Ann Arbor and other Michigan community events and activities.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 oversize folders</extent>

--- a/Real_Masters_all/harrisgb.xml
+++ b/Real_Masters_all/harrisgb.xml
@@ -124,7 +124,7 @@
             <unittitle>World War I (India and Mesopotamia) <unitdate type="inclusive" normal="1914/1918">1914-1918</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">6 volumes</extent>
-              <extent altrender="carrier">(in 3 folders)</extent>
+              <extent altrender="carrier">in 3 folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/hartjane.xml
+++ b/Real_Masters_all/hartjane.xml
@@ -47,7 +47,7 @@
       <abstract>Aviator and wife of the late Senator Philip A. Hart. Scrapbooks, photographs, clippings, and papers documenting her life as wife of Senator Philip A. Hart, her family life, and to a lesser extent, her aviation activities.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">4 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes and 11 oversize volumes)</extent>
+        <extent altrender="carrier">in 3 boxes and 11 oversize volumes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/heinemn.xml
+++ b/Real_Masters_all/heinemn.xml
@@ -43,7 +43,7 @@
       <abstract>Detroit, Michigan, merchant and attorney, state legislator from Wayne County, Michigan, later Detroit city councilman; scrapbooks, photographs, and miscellanea.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">18 volumes</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/hilbish.xml
+++ b/Real_Masters_all/hilbish.xml
@@ -47,7 +47,7 @@
       <abstract>Professor at the University of Michigan (1965-1988). Director of Choirs, and respected conductor of choral music, well-known for his extensive repertoire and new interpretations of 20th century choral music. The collection includes photographs, video, press clippings, writings, correspondence, and programs documenting Hilbish's work as an instructor and conductor from 1948 to 2004.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/hillchas.xml
+++ b/Real_Masters_all/hillchas.xml
@@ -354,7 +354,7 @@
               </unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 parts</extent>
-                <extent altrender="carrier">(in 3 volumes)</extent>
+                <extent altrender="carrier">in 3 volumes</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/hofdavid.xml
+++ b/Real_Masters_all/hofdavid.xml
@@ -42,7 +42,7 @@
       <abstract>D. C. Allen was a Three Oaks, Michigan book dealer and collector of material on the House of David, an adventist cult founded in England. The leader of this cult was Benjamin Purnell who made Benton Harbor his home and the site of his follower’s business activities. The Allen collection (formerly housed at the Wyoming American Heritage Center) consists of most of the publications by and about the Israelite House of David, scattered manuscript materials mainly documenting the colony's business operations and court cases involving Purnell and the colony, and photographs and postcards depicting activities of the colony.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">22 linear feet</extent>
-        <extent altrender="carrier">(in 24 boxes)</extent>
+        <extent altrender="carrier">in 24 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">69 volumes</extent>

--- a/Real_Masters_all/holljeep.xml
+++ b/Real_Masters_all/holljeep.xml
@@ -43,7 +43,7 @@
       <abstract>Hugh "Jeep" Holland was the founder of the A-Square Record label in Ann Arbor in 1967, and consequently became an integral part of the southeast Michigan music scene in the late 1960s and early 1970s. The collection documents, in papers, photographs and sound recordings, Jeep’s personal life, interests, and career.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">12 linear feet</extent>
-        <extent altrender="carrier">(in 13 boxes)</extent>
+        <extent altrender="carrier">in 13 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/housing.xml
+++ b/Real_Masters_all/housing.xml
@@ -47,7 +47,7 @@
 also files concerning the occupational status and treatment of Japanese-Americans working for the University during World War II, and concerning the housing and training of military personnel on campus during the war.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">43 linear feet</extent>
-        <extent altrender="carrier">(in 44 boxes)</extent>
+        <extent altrender="carrier">in 44 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize volumes</extent>

--- a/Real_Masters_all/hubbardb.xml
+++ b/Real_Masters_all/hubbardb.xml
@@ -46,7 +46,7 @@
       <abstract>Pioneer Michigan geologist, assistant to state geologist Douglas Houghton on the Michigan Geological Survey, 1837-1842, completed portions of U.S. Land Survey of the Upper Peninsula begun by Douglas Houghton, 1845-1846. Later active in family's land business and lumber trade. Papers consist of notebooks containing field notes, sketches and maps; private journals covering Michigan geological expeditions and other trips, including the peninsula coast survey, Lake Superior and Upper Peninsula surveys and surveys of Wayne, Monroe and other counties; also weather memoranda, 1835-1864; miscellaneous accounts; and other papers largely relating to geology.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.75 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/hubbfam.xml
+++ b/Real_Masters_all/hubbfam.xml
@@ -42,7 +42,7 @@
       <abstract>Benzonia and Ann Arbor, Michigan; papers of individual family members, detailing in part activities in the Philippines, 1907-1912. The collection also contains photographs and albums of images from the period when they lived in the Philippines.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/icc.xml
+++ b/Real_Masters_all/icc.xml
@@ -59,7 +59,7 @@
       <abstract>Organization established to coordinate activities of cooperative houses founded and operated by University of Michigan students. Minutes, office files, and newsletters, also records of student cooperative, the Socialist House.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">47.5 linear feet</extent>
-        <extent altrender="carrier">(in 48 boxes)</extent>
+        <extent altrender="carrier">in 48 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 oversize volumes</extent>

--- a/Real_Masters_all/inaugs.xml
+++ b/Real_Masters_all/inaugs.xml
@@ -177,7 +177,7 @@ Presidential Inaugurations (University of Michigan) Collection, Bentley Historic
             <unittitle>Greetings and Certificates</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">5 folders</extent>
-              <extent altrender="carrier">(in oversize folder)</extent>
+              <extent altrender="carrier">in oversize folder</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/inreform.xml
+++ b/Real_Masters_all/inreform.xml
@@ -305,14 +305,12 @@ International Reform Federation records, Bentley Historical Library, University 
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitdate type="inclusive" normal="1928/1936">1928-1936</unitdate>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitdate type="inclusive" normal="1937/1949">1937-1949</unitdate>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/insgloba.xml
+++ b/Real_Masters_all/insgloba.xml
@@ -761,7 +761,7 @@ Institute for Global Education records, Bentley Historical Library, University o
             </unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 volumes</extent>
-              <extent altrender="carrier">(in 4 folders)</extent>
+              <extent altrender="carrier">in 4 folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/insthum.xml
+++ b/Real_Masters_all/insthum.xml
@@ -50,7 +50,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">5 linear feet</extent>
-        <extent altrender="carrier">(in 11 boxes)</extent>
+        <extent altrender="carrier">in 11 boxes</extent>
       </physdesc>
       <repository encodinganalog="852">
         <corpname><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/interloc.xml
+++ b/Real_Masters_all/interloc.xml
@@ -58,7 +58,7 @@
       </repository>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">86.4 linear feet</extent>
-        <extent altrender="carrier">(in 92 boxes)</extent>
+        <extent altrender="carrier">in 92 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">51 volumes</extent>
@@ -27687,7 +27687,7 @@ Interlochen Center for The Arts Records, Bentley Historical Library, University 
                 <unittitle>Mozart at Lincoln Center</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
-                  <extent altrender="carrier">(in a vinyl case)</extent>
+                  <extent altrender="carrier">in a vinyl case</extent>
                 </physdesc>
               </did>
             </c04>

--- a/Real_Masters_all/intermed.xml
+++ b/Real_Masters_all/intermed.xml
@@ -47,7 +47,7 @@
       </repository>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">27.3 linear feet</extent>
-        <extent altrender="carrier">(in 28 boxes)</extent>
+        <extent altrender="carrier">in 28 boxes</extent>
       </physdesc>
       <physloc>Portions located in offsite storage; prior notification required for access.</physloc>
     </did>

--- a/Real_Masters_all/intraneg.xml
+++ b/Real_Masters_all/intraneg.xml
@@ -289,7 +289,7 @@ Institute of Transportation Engineers, Michigan Section Records, Bentley Histori
             <unittitle><unitdate type="inclusive" normal="1984/1985">1984-1985</unitdate> (Record book of director and secretary, Joseph Marson)</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 volumes</extent>
-              <extent altrender="carrier">(in 1 folder)</extent>
+              <extent altrender="carrier">in 1 folder</extent>
             </physdesc>
           </did>
         </c02>
@@ -299,7 +299,7 @@ Institute of Transportation Engineers, Michigan Section Records, Bentley Histori
             <unittitle><unitdate type="inclusive" normal="1984/1988">1984-1988</unitdate> (Records of officers, Donald Wiertella and Joseph Marson)</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
-              <extent altrender="carrier">(in 7 folders)</extent>
+              <extent altrender="carrier">in 7 folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/irwinfam.xml
+++ b/Real_Masters_all/irwinfam.xml
@@ -43,7 +43,7 @@
       <abstract>James and Sybil (Hunter) Irwin were early setters of Washtenaw County, Michigan. Their two sons, John E. and (James) Leman Irwin, fought in the Civil War as volunteer members of the 20th Michigan Infantry. Correspondence, diaries, and ledgers from these and other branches of the family are preserved in the Irwin family papers.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">6.3 linear feet</extent>
-        <extent altrender="carrier">(in 8 boxes)</extent>
+        <extent altrender="carrier">in 8 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
@@ -1179,7 +1179,7 @@ James and Sybil Irwin family papers, Bentley Historical Library, University of M
               </unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">9 volumes</extent>
-                <extent altrender="carrier">(in 5 folders)</extent>
+                <extent altrender="carrier">in 5 folders</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/ivoryph.xml
+++ b/Real_Masters_all/ivoryph.xml
@@ -506,7 +506,7 @@
                 <unittitle>R.T. Brokaw and planes <unitdate type="inclusive" normal="1967-09-06">September 6, 1967</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">6 negatives</extent>
-                  <extent altrender="carrier">(in 4 envelope)</extent>
+                  <extent altrender="carrier">in 4 envelope</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3164,7 +3164,7 @@
                     <unittitle>2280 -- Wedemeyer <unitdate type="inclusive" normal="1971-04-26">April 26, 1971</unitdate></unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">3 negatives</extent>
-                      <extent altrender="carrier">(in 2 envelope)</extent>
+                      <extent altrender="carrier">in 2 envelope</extent>
                     </physdesc>
                   </did>
                   <odd>
@@ -3306,7 +3306,7 @@
                     <unittitle>1426 -- Alton Floyd house interior <unitdate type="inclusive" normal="1969-12-16">December 16, 1969</unitdate></unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">8 negatives</extent>
-                      <extent altrender="carrier">(in 1 envelope)</extent>
+                      <extent altrender="carrier">in 1 envelope</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -4098,7 +4098,7 @@
                       </unittitle>
                       <physdesc altrender="whole">
                         <extent altrender="materialtype spaceoccupied">12 negatives</extent>
-                        <extent altrender="carrier">(in 3 envelope)</extent>
+                        <extent altrender="carrier">in 3 envelope</extent>
                       </physdesc>
                     </did>
                   </c07>
@@ -4210,7 +4210,7 @@
                     <unittitle>1200 -- AAA (American Automobile Association) building and vicinity <unitdate type="inclusive" normal="1970-07-22">July 22, 1970</unitdate></unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">14 negatives</extent>
-                      <extent altrender="carrier">(in 9 envelope)</extent>
+                      <extent altrender="carrier">in 9 envelope</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -4377,7 +4377,7 @@
                     <unittitle>1110 -- house <unitdate type="inclusive" normal="1953">1953</unitdate></unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">2 negatives</extent>
-                      <extent altrender="carrier">(in 1 envelope)</extent>
+                      <extent altrender="carrier">in 1 envelope</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -4779,7 +4779,7 @@
                       <unittitle>Exterior and interior with people <unitdate type="inclusive" normal="1967-10-05">October 5, 1967</unitdate></unittitle>
                       <physdesc altrender="whole">
                         <extent altrender="materialtype spaceoccupied">5 negatives</extent>
-                        <extent altrender="carrier">(in 3 envelope)</extent>
+                        <extent altrender="carrier">in 3 envelope</extent>
                       </physdesc>
                     </did>
                   </c07>
@@ -5584,7 +5584,7 @@
                   <unittitle>Vesper -- 912 -- house, 1953</unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">3 negatives</extent>
-                    <extent altrender="carrier">(in 2 envelope)</extent>
+                    <extent altrender="carrier">in 2 envelope</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -5610,7 +5610,7 @@
                     <unittitle>114 -- Bimbo's Pizza -- exterior and interior with band and patrons <unitdate type="inclusive" normal="1965" certainty="approximate">circa 1965</unitdate></unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">11 negatives</extent>
-                      <extent altrender="carrier">(in 9 envelope)</extent>
+                      <extent altrender="carrier">in 9 envelope</extent>
                     </physdesc>
                   </did>
                   <odd>
@@ -6328,7 +6328,7 @@
                       <unittitle>Huron River Valley Estates-site <unitdate type="inclusive" normal="1969-08-11">August 11, 1969</unitdate></unittitle>
                       <physdesc altrender="whole">
                         <extent altrender="materialtype spaceoccupied">3 negatives</extent>
-                        <extent altrender="carrier">(in 2 envelope)</extent>
+                        <extent altrender="carrier">in 2 envelope</extent>
                       </physdesc>
                     </did>
                   </c07>
@@ -6598,7 +6598,7 @@
                     </unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">6 negatives</extent>
-                      <extent altrender="carrier">(in 3 envelope)</extent>
+                      <extent altrender="carrier">in 3 envelope</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -6855,7 +6855,7 @@
                     <unittitle>Exterior <unitdate type="inclusive" normal="1952">1952</unitdate></unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">2 negatives</extent>
-                      <extent altrender="carrier">(in 1 envelope)</extent>
+                      <extent altrender="carrier">in 1 envelope</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -7350,7 +7350,7 @@
                     <unittitle>Safety campaign -- Ann Arbor Public Schools and Automobile Club of Michigan <unitdate type="inclusive" normal="1969-08-20">August 20, 1969</unitdate></unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">2 negatives</extent>
-                      <extent altrender="carrier">(in 1 envelope)</extent>
+                      <extent altrender="carrier">in 1 envelope</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -7629,7 +7629,7 @@
                   <unittitle>I-94 <unitdate type="inclusive" normal="1960/1969" certainty="approximate">circa 1960s</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 negatives</extent>
-                    <extent altrender="carrier">(in 1 envelope)</extent>
+                    <extent altrender="carrier">in 1 envelope</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -7778,7 +7778,7 @@
                     <unittitle>at Madison and Division <unitdate type="inclusive" normal="1960/1969" certainty="approximate">circa 1960s</unitdate></unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">4 negatives</extent>
-                      <extent altrender="carrier">(in 2 envelope)</extent>
+                      <extent altrender="carrier">in 2 envelope</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -7887,7 +7887,7 @@
                     <unittitle>at Liberty <unitdate type="inclusive" normal="1970" certainty="approximate">circa 1970</unitdate></unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">6 negatives</extent>
-                      <extent altrender="carrier">(in 3 envelope)</extent>
+                      <extent altrender="carrier">in 3 envelope</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -8384,7 +8384,7 @@
                   <unittitle>Building exterior; plant floor, assembly line; men at work <unitdate type="inclusive" normal="1969-08-22">August 22, 1969</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">10 negatives</extent>
-                    <extent altrender="carrier">(in 9 envelope)</extent>
+                    <extent altrender="carrier">in 9 envelope</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9598,7 +9598,7 @@
                     <unittitle>Ivory Photo interior and personnel</unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">4 negatives</extent>
-                      <extent altrender="carrier">(in 3 envelope)</extent>
+                      <extent altrender="carrier">in 3 envelope</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -9608,7 +9608,7 @@
                     <unittitle>Mel Ivory as Santa Claus</unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">6 negatives</extent>
-                      <extent altrender="carrier">(in 3 envelope)</extent>
+                      <extent altrender="carrier">in 3 envelope</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -9731,7 +9731,7 @@
                     <unittitle>Staff party</unittitle>
                     <physdesc altrender="whole">
                       <extent altrender="materialtype spaceoccupied">6 negatives</extent>
-                      <extent altrender="carrier">(in 3 envelope)</extent>
+                      <extent altrender="carrier">in 3 envelope</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -9926,7 +9926,7 @@
                   <unittitle>Exterior <unitdate type="inclusive" normal="1960/1969" certainty="approximate">1960s</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 negatives</extent>
-                    <extent altrender="carrier">(in 1 envelope)</extent>
+                    <extent altrender="carrier">in 1 envelope</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -10249,7 +10249,7 @@
                   <unittitle>People and display; waste treatment plant 49 <unitdate type="inclusive" normal="1970" certainty="approximate">circa 1970</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">4 negatives</extent>
-                    <extent altrender="carrier">(in 3 envelope)</extent>
+                    <extent altrender="carrier">in 3 envelope</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -11743,7 +11743,7 @@
                   <unittitle>Accident Prevention <unitdate type="inclusive" normal="1971-08-25">August 25, 1971</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">3 negatives</extent>
-                    <extent altrender="carrier">(in 2 envelope)</extent>
+                    <extent altrender="carrier">in 2 envelope</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -11997,7 +11997,7 @@
                 <unittitle>Brownies -- dancing in gym <unitdate>Undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">18 negatives</extent>
-                  <extent altrender="carrier">(in 1 envelope)</extent>
+                  <extent altrender="carrier">in 1 envelope</extent>
                 </physdesc>
               </did>
             </c04>
@@ -12145,7 +12145,7 @@
                 <unittitle>Figure Skating Club -- Female Skaters; Male Skaters; Child Skaters <unitdate type="inclusive" normal="1940" certainty="approximate">circa 1940</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">13 negatives</extent>
-                  <extent altrender="carrier">(in 11 envelope)</extent>
+                  <extent altrender="carrier">in 11 envelope</extent>
                 </physdesc>
               </did>
             </c04>
@@ -12307,7 +12307,7 @@
                   <unittitle>Social Services for Crippled Children; Group Shots (Adults and Youths); Officers <unitdate type="inclusive" normal="1940" certainty="approximate">circa 1940</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">7 negatives</extent>
-                    <extent altrender="carrier">(in 5 envelope)</extent>
+                    <extent altrender="carrier">in 5 envelope</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -15644,7 +15644,7 @@
                   <unittitle>Musicians' Local 625 -- Winter Jamboree <unitdate type="inclusive" normal="1968-02-16">February 16, 1968</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">24 negatives</extent>
-                    <extent altrender="carrier">(in 11 envelope)</extent>
+                    <extent altrender="carrier">in 11 envelope</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -15719,7 +15719,7 @@
                   <unittitle>Hunting trip <unitdate type="inclusive" normal="1952">1952</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">30 negatives</extent>
-                    <extent altrender="carrier">(in 20 envelope)</extent>
+                    <extent altrender="carrier">in 20 envelope</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -25505,7 +25505,7 @@
               <unittitle>Blaess Elevator <unitdate type="inclusive" normal="1971-08-20">August 20, 1971</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">7 negatives</extent>
-                <extent altrender="carrier">(in 4 envelope)</extent>
+                <extent altrender="carrier">in 4 envelope</extent>
               </physdesc>
             </did>
           </c03>
@@ -25677,7 +25677,7 @@
               <unittitle>Holmes General Store and road scenes <unitdate type="inclusive" normal="1970" certainty="approximate">circa 1970</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">7 negatives</extent>
-                <extent altrender="carrier">(in 4 envelope)</extent>
+                <extent altrender="carrier">in 4 envelope</extent>
               </physdesc>
             </did>
           </c03>
@@ -26083,7 +26083,7 @@
                 <unittitle>Schultz, Raymond, farm (?) -- 10090 Martz Road, late <unitdate type="inclusive" normal="1960/1969" certainty="approximate">1960s</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">4 negatives</extent>
-                  <extent altrender="carrier">(in 2 envelope)</extent>
+                  <extent altrender="carrier">in 2 envelope</extent>
                 </physdesc>
               </did>
             </c04>
@@ -27056,7 +27056,7 @@
                 <unittitle>I-94 <unitdate type="inclusive" normal="1960/1969" certainty="approximate">1960s</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">6 negatives</extent>
-                  <extent altrender="carrier">(in 3 envelope)</extent>
+                  <extent altrender="carrier">in 3 envelope</extent>
                 </physdesc>
               </did>
             </c04>
@@ -27106,7 +27106,7 @@
                 <unittitle>Demaris house -- aerial <unitdate type="inclusive" normal="1968">1968</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 negatives</extent>
-                  <extent altrender="carrier">(in 2 envelope)</extent>
+                  <extent altrender="carrier">in 2 envelope</extent>
                 </physdesc>
               </did>
             </c04>
@@ -30033,7 +30033,7 @@
               <unittitle>Washtenaw County Library -- Santa Claus and children <unitdate type="inclusive" normal="1970" certainty="approximate">circa 1970</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 negatives</extent>
-                <extent altrender="carrier">(in 1 envelope)</extent>
+                <extent altrender="carrier">in 1 envelope</extent>
               </physdesc>
             </did>
           </c03>
@@ -30043,7 +30043,7 @@
               <unittitle>Whitmore Lake houses <unitdate type="inclusive" normal="1960/1969" certainty="approximate">1960s</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">8 negatives</extent>
-                <extent altrender="carrier">(in 1 envelope)</extent>
+                <extent altrender="carrier">in 1 envelope</extent>
               </physdesc>
             </did>
           </c03>
@@ -30883,7 +30883,7 @@
                   <unittitle>Third Street -- 518 -- house interiors <unitdate type="inclusive" normal="1960/1969" certainty="approximate">circa 1960s</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">18 negatives</extent>
-                    <extent altrender="carrier">(in 1 envelope)</extent>
+                    <extent altrender="carrier">in 1 envelope</extent>
                   </physdesc>
                 </did>
               </c05>

--- a/Real_Masters_all/jarocki.xml
+++ b/Real_Masters_all/jarocki.xml
@@ -46,11 +46,11 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2265 negatives</extent>
-        <extent altrender="carrier">(in 3 boxes; number approximate)</extent>
+        <extent altrender="carrier">in 3 boxes; number approximate</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 prints</extent>
-        <extent altrender="carrier">(in oversize folder)</extent>
+        <extent altrender="carrier">in oversize folder</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/jeffsoc.xml
+++ b/Real_Masters_all/jeffsoc.xml
@@ -43,7 +43,7 @@
       <abstract>Student debating society of the University of Michigan Law School; records include Minutes, and secretary’s book containing lists of members and fellows in addition to constitutions and by-laws</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">6 volumes</extent>
-        <extent altrender="carrier">(in 1 box)</extent>
+        <extent altrender="carrier">in 1 box</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/jensenj.xml
+++ b/Real_Masters_all/jensenj.xml
@@ -78,11 +78,11 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">93 folders</extent>
-        <extent altrender="carrier">(in 15 flat drawers)</extent>
+        <extent altrender="carrier">in 15 flat drawers</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/joneslol.xml
+++ b/Real_Masters_all/joneslol.xml
@@ -43,7 +43,7 @@
       <abstract>Producer of local Ann Arbor, Michigan, cable television programs highlighting achievements of African Americans in the Ann Arbor-Ypsilanti area. Videocassette copies of television program, "Another Ann Arbor" that featured interviews with local area and national African American public figures.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">96 videotapes</extent>
-        <extent altrender="carrier">(in 8 boxes)</extent>
+        <extent altrender="carrier">in 8 boxes</extent>
         <physfacet>U-matic and VHS</physfacet>
       </physdesc>
       <repository>

--- a/Real_Masters_all/joneslv.xml
+++ b/Real_Masters_all/joneslv.xml
@@ -40,7 +40,7 @@
       <unittitle encodinganalog="245">LaVerne Jones Collection <unitdate type="inclusive" encodinganalog="245$f" normal="1878/1966">1878-1966</unitdate>, <unitdate type="bulk" encodinganalog="245$g" normal="1900/1944">1900-1944</unitdate></unittitle>
       <physdesc altrender="whole">
         <extent encodinganalog="300" altrender="materialtype spaceoccupied">1.4 linear feet</extent>
-        <extent encodinganalog="300" altrender="carrier">(in 2 boxes)</extent>
+        <extent encodinganalog="300" altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">2014073 Aa 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>

--- a/Real_Masters_all/kahnalb.xml
+++ b/Real_Masters_all/kahnalb.xml
@@ -85,7 +85,7 @@
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7417 drawings</extent>
-        <extent altrender="carrier">(in 32 drawers)</extent>
+        <extent altrender="carrier">in 32 drawers</extent>
         <physfacet>architectural drawings</physfacet>
       </physdesc>
       <physdesc altrender="part">
@@ -2265,7 +2265,7 @@
           <unittitle>Photographs of Completed Buildings in Leather Portfolios</unittitle>
           <physdesc altrender="part">
             <extent altrender="materialtype spaceoccupied">1326 prints</extent>
-            <extent altrender="carrier">(in 85 volumes)</extent>
+            <extent altrender="carrier">in 85 volumes</extent>
           </physdesc>
           <physdesc altrender="part">
             <extent altrender="materialtype spaceoccupied">1 boxes</extent>

--- a/Real_Masters_all/kalmbach.xml
+++ b/Real_Masters_all/kalmbach.xml
@@ -47,7 +47,7 @@
       <abstract>Staff photographer for University of Michigan News and Information Services and contract photographer for the University of Michigan Athletic Department. Includes negatives and contact prints of game action photos of UM athletic competitions, 1978-2000 and some personal and family photos.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">27 linear feet</extent>
-        <extent altrender="carrier">(in 62 boxes)</extent>
+        <extent altrender="carrier">in 62 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/katzdl.xml
+++ b/Real_Masters_all/katzdl.xml
@@ -43,7 +43,7 @@
       <abstract>Professor of chemical engineering at the University of Michigan. Tapes and transcript of tapes of oral interviews with Donald Katz talking about his life and professional activities; reprints of his writings; files relating to his Ann Arbor Council of Churches activities; and files of his investigation of the Port Huron Water Tunnel explosion, 1971.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/kavanjhn.xml
+++ b/Real_Masters_all/kavanjhn.xml
@@ -47,7 +47,7 @@
       <abstract>Detroit social activist involved in GLBT organizations and activities. The collection consists of correspondence, essays and articles, e-mails, conference materials, organizational records, publications and articles on the subjects of GLBT history, gay civil rights, gay marriage, interracial and interfaith marriage, GLBT families, sexual and gender equality, violence against GLBT persons, religion and homosexuality, gay clergy, clergy with AIDS, and violence against GLBT persons. The collection also includes materials related to the development of public transportation in the Detroit Metropolitan area; election campaigns and vote suppression of ethnic minorities; and U.S. and international politics and economy.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">718 MB</extent>
@@ -654,7 +654,7 @@ John L. Kavanaugh papers, Bentley Historical Library, University of Michigan</p>
             <unittitle>My Documents Folder</unittitle>
             <physdesc altrender="part">
               <extent altrender="materialtype spaceoccupied">235 files</extent>
-              <extent altrender="carrier">(in 6 folders)</extent>
+              <extent altrender="carrier">in 6 folders</extent>
             </physdesc>
             <physdesc altrender="part">
               <extent altrender="materialtype spaceoccupied">448 MB</extent>

--- a/Real_Masters_all/kelloggj.xml
+++ b/Real_Masters_all/kelloggj.xml
@@ -54,7 +54,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English; some documents in French and German.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">19.3 linear feet</extent>
-        <extent altrender="carrier">(in 21 boxes)</extent>
+        <extent altrender="carrier">in 21 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">30.5 GB</extent>
@@ -1120,7 +1120,7 @@
               </dao>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">13 lectures</extent>
-                <extent altrender="carrier">(in 2 folders)</extent>
+                <extent altrender="carrier">in 2 folders</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/kelseymu.xml
+++ b/Real_Masters_all/kelseymu.xml
@@ -51,7 +51,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">131.5 linear feet</extent>
-        <extent altrender="carrier">(in 244 boxes)</extent>
+        <extent altrender="carrier">in 244 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/kendricp.xml
+++ b/Real_Masters_all/kendricp.xml
@@ -271,7 +271,7 @@
               <unittitle>Journals and Accounts</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 volumes</extent>
-                <extent altrender="carrier">(in 1 folder)</extent>
+                <extent altrender="carrier">in 1 folder</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/kennedyg.xml
+++ b/Real_Masters_all/kennedyg.xml
@@ -54,7 +54,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">6 linear feet</extent>
-        <extent altrender="carrier">(in 7 boxes)</extent>
+        <extent altrender="carrier">in 7 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">14 oversize volumes</extent>

--- a/Real_Masters_all/kentca.xml
+++ b/Real_Masters_all/kentca.xml
@@ -42,7 +42,7 @@
       <abstract>Professor of law at University of Michigan. Papers include a report of his faculty activities for the period 1876-1877, and correspondence relating to his study of Michigan jurist, Thomas M. Cooley, including letters from James B. Angell, Henry Carter Adams, Charles Horton Cooley, Norman Geddes and Benjamin L. Baxter.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">13 items</extent>
-        <extent altrender="carrier">(in 1 folder)</extent>
+        <extent altrender="carrier">in 1 folder</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/kentchar.xml
+++ b/Real_Masters_all/kentchar.xml
@@ -43,7 +43,7 @@
       <abstract>Charles Edwin Kent, a resident of Ann Arbor, Michigan, worked as an engineer, solving complex technological problems for Bendix Corporation for most of his career, first in the Systems Division, and later in the Aerospace Systems Division. Kent worked on automotive, communications, weaponry, and space research, as well as a number of other subjects. The collection encompasses material primarily from his college years through his career. The series in the collection are Personal Files and Professional Files. Papers primarily include research notes, internal company memorandums, and research reports.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">7.5 linear feet</extent>
-        <extent altrender="carrier">(in 8 boxes including oversize)</extent>
+        <extent altrender="carrier">in 8 boxes including oversize</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/kermanc.xml
+++ b/Real_Masters_all/kermanc.xml
@@ -47,7 +47,7 @@
       <abstract>Biographer of Kenneth E. Boulding. Collected information about life and career of Kenneth E. Boulding; tapes and transcripts of interviews with Kenneth E. Boulding and his family and associates; copies of Boulding articles; and photographs used in the biography.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.3 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/kikuchi.xml
+++ b/Real_Masters_all/kikuchi.xml
@@ -1251,7 +1251,7 @@
             <unittitle>Slides: To accompany lectures on Ruby Maser and Nuclear Power Issues</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">205 slides</extent>
-              <extent altrender="carrier">(in 8 boxes)</extent>
+              <extent altrender="carrier">in 8 boxes</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/kingemer.xml
+++ b/Real_Masters_all/kingemer.xml
@@ -43,7 +43,7 @@
       <abstract>Oral history interviews relating to the National Negro Labor Council (NNLC) and to unions at the Ford Rouge River Plant in Dearborn, Mich., taken during production of the 1994 documentary <title render="italic">The Freedom Train</title>. Also includes digital video of both <title render="italic">The Freedom Train</title> and <title render="italic">The Rouge</title> documentaries.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">68 videotapes</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
         <physfacet>Betacam (TM)</physfacet>
       </physdesc>
       <physdesc altrender="part">

--- a/Real_Masters_all/kleinera.xml
+++ b/Real_Masters_all/kleinera.xml
@@ -47,7 +47,7 @@
       <physloc>offsite storage; prior notification required for access</physloc>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">15.5 linear feet</extent>
-        <extent altrender="carrier">(in 16 boxes)</extent>
+        <extent altrender="carrier">in 16 boxes</extent>
       </physdesc>
       <repository encodinganalog="852">
         <corpname><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/korab.xml
+++ b/Real_Masters_all/korab.xml
@@ -212,7 +212,7 @@
             <unittitle>Folio 1. Upper Peninsula, Michigan</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">77 sheets</extent>
-              <extent altrender="carrier">(in 2 folders)</extent>
+              <extent altrender="carrier">in 2 folders</extent>
             </physdesc>
           </did>
           <odd>
@@ -224,7 +224,7 @@
             <unittitle>Folio 2. Trees</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">90 sheets</extent>
-              <extent altrender="carrier">(in 2 folders)</extent>
+              <extent altrender="carrier">in 2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -244,7 +244,7 @@
             <unittitle>Folio 4. Monroe, Michigan</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">73 sheets</extent>
-              <extent altrender="carrier">(in 2 folders)</extent>
+              <extent altrender="carrier">in 2 folders</extent>
             </physdesc>
           </did>
           <odd>
@@ -256,7 +256,7 @@
             <unittitle>Folio 5. Kalamazoo, Michigan</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">63 sheets</extent>
-              <extent altrender="carrier">(in 2 folders)</extent>
+              <extent altrender="carrier">in 2 folders</extent>
             </physdesc>
           </did>
           <odd>

--- a/Real_Masters_all/kuplanlo.xml
+++ b/Real_Masters_all/kuplanlo.xml
@@ -51,7 +51,7 @@
       </repository>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">142 audiotapes</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
         <physfacet>reel-to-reel tapes</physfacet>
       </physdesc>
       <physloc>Portions located in offsite storage; prior notification required for access.</physloc>

--- a/Real_Masters_all/ladlitcl.xml
+++ b/Real_Masters_all/ladlitcl.xml
@@ -46,7 +46,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">6 linear feet</extent>
-        <extent altrender="carrier">(in 7 boxes)</extent>
+        <extent altrender="carrier">in 7 boxes</extent>
       </physdesc>
       <repository encodinganalog="852">
         <corpname><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/lanecw.xml
+++ b/Real_Masters_all/lanecw.xml
@@ -47,7 +47,7 @@
       <abstract>Architect based in Ann Arbor, Michigan. Project files relate to work with George Brigham and his system of constructing prefabricated homes, 1944-1947; files relating to design and construction of Huron High School in Ann Arbor; other projects concern design of mobile home parks and other Michigan school buildings.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4.5 linear feet</extent>
-        <extent altrender="carrier">(in 6 boxes)</extent>
+        <extent altrender="carrier">in 6 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 oversize folders</extent>

--- a/Real_Masters_all/larsonct.xml
+++ b/Real_Masters_all/larsonct.xml
@@ -46,7 +46,7 @@
       <abstract>Professor of architecture at the University of Michigan. The series in the collection are: Architectural Research, 1932-1983; College of Architecture and Urban Planning, 1967-1985; Correspondence, 1962-1972; Development Index, 1947-1984; and Published Materials, 1930-1982.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">4 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/lased.xml
+++ b/Real_Masters_all/lased.xml
@@ -62,7 +62,7 @@
       <abstract>Latino social service organization active in southwest Detroit, Michigan; records, primarily assembled by board member Lucy Gajec, include administrative files, correspondence, and publicity material</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.5 linear foot</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/lawart.xml
+++ b/Real_Masters_all/lawart.xml
@@ -47,7 +47,7 @@
       <abstract>Portraits, photographs, and artwork previously displayed in the University of Michigan Law School, featuring prominent alumni, faculty, notable figures in the legal profession, and images of the Law School grounds. Also, records concerning art owned by the Law School, including surveys, inventories, reports, and scattered information on specific portraits.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.0 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 items</extent>

--- a/Real_Masters_all/lawsch.xml
+++ b/Real_Masters_all/lawsch.xml
@@ -15872,7 +15872,7 @@
                 <unittitle>Digital files</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">86 digital files</extent>
-                  <extent altrender="carrier">(on 3 CDs)</extent>
+                  <extent altrender="carrier">on 3 CDs</extent>
                 </physdesc>
               </did>
               <odd>

--- a/Real_Masters_all/leachjam.xml
+++ b/Real_Masters_all/leachjam.xml
@@ -46,7 +46,7 @@
       <abstract>Ann Arbor, Michigan photographer. Photonegatives of Ann Arbor area businesses, service and fraternal organizations, school and other youth groups.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">227 folders</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/lemmerv.xml
+++ b/Real_Masters_all/lemmerv.xml
@@ -2401,7 +2401,7 @@
             <unittitle>W.P.A. History of Gogebic County</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 manuscript bound</extent>
-              <extent altrender="carrier">(in 3 volumes)</extent>
+              <extent altrender="carrier">in 3 volumes</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/lewiswma.xml
+++ b/Real_Masters_all/lewiswma.xml
@@ -291,7 +291,7 @@ William Augustus Lewis Papers, Bentley Historical Library, University of Michiga
           <unittitle><genreform normal="Diaries">Diaries</genreform>, <unitdate type="inclusive" normal="1854/1917">1854-1917</unitdate></unittitle>
           <physdesc altrender="whole">
             <extent altrender="materialtype spaceoccupied">46 volumes</extent>
-            <extent altrender="carrier">(in 5 expanding files)</extent>
+            <extent altrender="carrier">in 5 expanding files</extent>
           </physdesc>
         </did>
         <scopecontent>

--- a/Real_Masters_all/livingst.xml
+++ b/Real_Masters_all/livingst.xml
@@ -47,7 +47,7 @@
       <abstract>Livingstone was a Detroit, Michigan businessman, banker, and newspaper publisher. He was an advocate of improving shipping on the Great Lakes, helping to found the Lake Carriers' Association. Livingstone successfully lobbied Congress for funds to construct a channel in the lower Detroit River (the Livingstone Channel). The collection consists of manuscript and visual materials, some of which were collected by later family members. Included are diaries and account books, 1871-1882 (scattered) and 1925; correspondence and newspaper clippings; subject files pertaining to the Dime Savings Bank and the Lake Carriers' Association; and a speech book containing draft of speech written for James G. Blaine, presidential candidate in 1884. Visual materials include photographs and drawings.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 reels</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize volumes</extent>

--- a/Real_Masters_all/lombardw.xml
+++ b/Real_Masters_all/lombardw.xml
@@ -43,7 +43,7 @@
       <abstract>Professor of physiology at the University of Michigan; correspondence, speeches, and other materials concerning U-M Medical School activities, the Ann Arbor Red Cross, the Ann Arbor Art Association, and Lombard’s interest in art and etching.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/loughray.xml
+++ b/Real_Masters_all/loughray.xml
@@ -43,7 +43,7 @@
       <abstract>John J. Loughray's collection of materials relating to the history of Northern Michigan, particularly Roscommon County and logging activity.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.1 linear feet</extent>
-        <extent altrender="carrier">(1 box and 1 oversize folder)</extent>
+        <extent altrender="carrier">1 box and 1 oversize folder</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/lowelldn.xml
+++ b/Real_Masters_all/lowelldn.xml
@@ -43,7 +43,7 @@
       <abstract>University of Michigan graduate, 1867, and lawyer in Macomb County, Michigan. Collection of pamphlets and other printed material relating to history of the university, the legal profession and other matters.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">60 items</extent>
-        <extent altrender="carrier">(in 6 bound volumes)</extent>
+        <extent altrender="carrier">in 6 bound volumes</extent>
         <physfacet>approximate</physfacet>
       </physdesc>
       <repository>

--- a/Real_Masters_all/ludwigfp.xml
+++ b/Real_Masters_all/ludwigfp.xml
@@ -54,10 +54,10 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">6 linear feet</extent>
-        <extent altrender="carrier">(in 7 boxes)</extent>
+        <extent altrender="carrier">in 7 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent altrender="carrier">(in 7 boxes)</extent>
+        <extent altrender="carrier">in 7 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/luthcams.xml
+++ b/Real_Masters_all/luthcams.xml
@@ -43,7 +43,7 @@
       <abstract>President's correspondence, executive committee minutes, and minutes of annual conventions; also files on individual churches in the Synod, including clippings, reports, church histories and programs; and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">42 linear feet</extent>
-        <extent altrender="carrier">(in 46 boxes)</extent>
+        <extent altrender="carrier">in 46 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 oversize volumes</extent>

--- a/Real_Masters_all/lwva2.xml
+++ b/Real_Masters_all/lwva2.xml
@@ -46,7 +46,7 @@
       <unittitle encodinganalog="245">League of Women Voters of the Ann Arbor Area records <unitdate type="inclusive" encodinganalog="245$f" normal="1920/2009">1920-2009</unitdate></unittitle>
       <physdesc altrender="whole">
         <extent encodinganalog="300" altrender="materialtype spaceoccupied">14.5 linear feet</extent>
-        <extent altrender="carrier">(in 15 boxes)</extent>
+        <extent altrender="carrier">in 15 boxes</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">851657 Bm 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>

--- a/Real_Masters_all/lwvgp.xml
+++ b/Real_Masters_all/lwvgp.xml
@@ -43,7 +43,7 @@
       <abstract>Records of the League of Women Voters Grosse Pointe, Mich. chapter includes administrative, annual meetings and issues materials, and publications.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.3 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/macdnldk.xml
+++ b/Real_Masters_all/macdnldk.xml
@@ -42,7 +42,7 @@
       <abstract>Owner and operator of a network of Michigan radio stations, including WSAM in Saginaw, Michigan. Biographical files relating in part to his Ann Arbor and Saginaw, Michigan, civic activities; scrapbooks, advertisements and other materials relating to WSAM radio station; files detailing his involvement with the National Association of Broadcasters; scrapbooks documenting career activities, and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 oversize volumes</extent>

--- a/Real_Masters_all/madd.xml
+++ b/Real_Masters_all/madd.xml
@@ -46,7 +46,7 @@
       <abstract>Records of the MADD's state coordinating council, files from the various county chapters, bulletins from the national headquarters of MADD, and programs and clippings describing state activities; also videotapes relating to the work of the organization, and audio-tapes promoting the organization and its aims.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">9 linear feet</extent>
-        <extent altrender="carrier">(in 10 boxes)</extent>
+        <extent altrender="carrier">in 10 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/mannrich.xml
+++ b/Real_Masters_all/mannrich.xml
@@ -43,7 +43,7 @@
       <abstract>Professor of psychology at the University of Michigan, and an organizer of the teach-ins on the Vietnam War in Ann Arbor, Michigan, and elsewhere, 1965-1966. Autobiographical papers; files on the protest against the Vietnam War; and materials on Program for Educational and Social Change, an effort to open university courses to the local community.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">5 linear inches</extent>
-        <extent altrender="carrier">(in 1 box)</extent>
+        <extent altrender="carrier">in 1 box</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/martindale.xml
+++ b/Real_Masters_all/martindale.xml
@@ -52,7 +52,7 @@ AC</unitid>
       <abstract>Materials documenting the business transactions and personal communications of the Edward Ingraham family of Bay City, Michigan and Old Saybrook, Connecticut between the years of 1852 and 1881. The collection is particularly strong in legal documentation of the time periods covered, including deeds, agreements, insurance policies, permits and certifications Family and professional correspondence also account for a large portion of the collection.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.75 linear feet</extent>
-        <extent altrender="carrier">(in 1 box)</extent>
+        <extent altrender="carrier">in 1 box</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize volumes</extent>

--- a/Real_Masters_all/martined.xml
+++ b/Real_Masters_all/martined.xml
@@ -47,7 +47,7 @@
       <abstract>Collector of materials documenting Michigan Polish-American individuals and organizations, especially in Detroit and Hamtramck. Included are records of the Detroit Board of Water Commissioners, the Polish Army Veterans Association, and the Polish Sea League. The collection also contains photographs from various Polish photography studios in Detroit and Michigan, including portraits and topical photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">14 linear feet</extent>
-        <extent altrender="carrier">(in 22 boxes)</extent>
+        <extent altrender="carrier">in 22 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 oversize volumes</extent>

--- a/Real_Masters_all/martinju.xml
+++ b/Real_Masters_all/martinju.xml
@@ -47,7 +47,7 @@
       <abstract>The Slatford Bird families were residents of Ann Arbor, Michigan. Correspondence and family papers, including letters, 1851-1853, of John Slatford written from the California gold fields describing his activities.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/masonst.xml
+++ b/Real_Masters_all/masonst.xml
@@ -42,7 +42,7 @@
       <abstract>First governor of Michigan; correspondence, drafts of letters to Andrew Jackson and to Secretary of State John Forsyth; draft of his inaugural address, 1838 and of other messages to the Legislature; topics covered include the Toledo War and the dispute arising from his appointment as Secretary of the Michigan Territory.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.6 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/massab.xml
+++ b/Real_Masters_all/massab.xml
@@ -2854,7 +2854,7 @@ courses Maassab taught in the Department of Epidemiology. are divided into six s
                 <unittitle>Books I-XI and XN <unitdate type="inclusive" normal="1962/1983">1962-1983</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">7 volumes</extent>
-                  <extent altrender="carrier">(in 5 folders)</extent>
+                  <extent altrender="carrier">in 5 folders</extent>
                 </physdesc>
               </did>
               <accessrestrict>

--- a/Real_Masters_all/mattern.xml
+++ b/Real_Masters_all/mattern.xml
@@ -43,7 +43,7 @@
       <abstract>Professor of music education at University of Michigan. Correspondence relating to his work in music education; also programs relating to music education, particularly the Summer Conference on Music Education; and photographs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3.5 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/mccauley.xml
+++ b/Real_Masters_all/mccauley.xml
@@ -43,7 +43,7 @@
       <abstract>Newsletters and minutes of executive committee of the Dav-Joy-Lin-Dex Community Council; newsletters of area block clubs; files relating to her community and organizational involvement; published materials; and photographs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/mccreery.xml
+++ b/Real_Masters_all/mccreery.xml
@@ -62,7 +62,7 @@
       <abstract>The McCreery and Fenton families were prominent Genesee county, Michigan residents some of whose members distinguished themselves in local and state government, as soldiers during the Civil War, and in the United States diplomatic service. Papers include diaries, correspondence and other material relating to the Civil War, local and state politics and aspects of diplomatic service in Central and South America.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">12 linear feet</extent>
-        <extent altrender="carrier">(in 13 boxes)</extent>
+        <extent altrender="carrier">in 13 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>
@@ -1354,7 +1354,7 @@
             <unittitle>Notebooks, diary fragments, etc.</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">8 volumes</extent>
-              <extent altrender="carrier">(in 1 expandable folder folders)</extent>
+              <extent altrender="carrier">in 1 expandable folder folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/mcintirs.xml
+++ b/Real_Masters_all/mcintirs.xml
@@ -42,7 +42,7 @@
       <abstract>Michigan State Police officer, later mayor of Mackinac Island, Michigan, and owner of the Iroquois Hotel on Mackinac Island. Scattered correspondence and miscellanea; largely photographs, prints, and slides, some of which had been collected by S. Alicia Poole, of views of Mackinac Island, the Straits of Mackinac, and Great Lakes ships and passenger ferries; also personal photographs relating in part to his association with Michigan governor G. Mennen Williams and his Michigan State Police activities.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/mcnamedh.xml
+++ b/Real_Masters_all/mcnamedh.xml
@@ -43,7 +43,7 @@
       <abstract>Papers of Edward H. McNamara (1926-2006), Democratic southeastern Michigan politician, served as Wayne county executive (1987-2002), Mayor of Livonia (1970-1986), and Livonia city councilman (1962-1968). The collection includes newspaper clippings, biographical materials, miscellaneous from his political career, and visual materials.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/mcook.xml
+++ b/Real_Masters_all/mcook.xml
@@ -46,7 +46,7 @@
       <abstract>The records of the Martha Cook Building at the University of Michigan (women's dormitory) contains administrative files and historical information about the construction of the building.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">7.25 linear feet</extent>
-        <extent altrender="carrier">(in 8 boxes)</extent>
+        <extent altrender="carrier">in 8 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
@@ -1164,7 +1164,7 @@ Martha Cook Building (University of Michigan) Records, Bentley Historical Librar
             <unittitle>Negatives by U-M News Service <unitdate type="inclusive" normal="1965-10">October 1965</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">109 negatives</extent>
-              <extent altrender="carrier">(in 20 strips)</extent>
+              <extent altrender="carrier">in 20 strips</extent>
             </physdesc>
           </did>
           <odd>

--- a/Real_Masters_all/mcrrc.xml
+++ b/Real_Masters_all/mcrrc.xml
@@ -47,7 +47,7 @@
       <abstract>Letter books, 1883-1921, of company president and general manager (outgoing only); administrative records, including contracts, financial papers, and miscellanea; manuscript and printed agreements between MCR and other railway lines; volumes of letters received, 1846 and 1860 (fragmentary); time books, 1853-1872, detailing hours and wages on the Detroit-Chicago section of the railroad; and miscellaneous scattered correspondence of Alpheus Felch, James F. Joy, and William Woodbridge.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">25.3 linear feet</extent>
-        <extent altrender="carrier">(in 26 boxes)</extent>
+        <extent altrender="carrier">in 26 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/medillus.xml
+++ b/Real_Masters_all/medillus.xml
@@ -46,7 +46,7 @@
       <abstract>This record group contains original artwork, administrative materials, and audiovisual materials produced by the University of Michigan Graduate Program of Medical and Biological Illustration. The records represent the work of approximately 35 medical illustrators spanning the years 1902-1991. With circa 670 illustrations, the material documents the work of the faculty of the program and other prominent illustrators.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">8 linear feet</extent>
-        <extent altrender="carrier">(in 21 boxes)</extent>
+        <extent altrender="carrier">in 21 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4 film reels</extent>

--- a/Real_Masters_all/medrecs.xml
+++ b/Real_Masters_all/medrecs.xml
@@ -47,7 +47,7 @@
       <abstract>The <title render="italic">Middle English Dictionary</title> (MED) is a comprehensive dictionary of the English language as it was used between 1100 and 1500. The <title render="italic">MED</title> was in production at the University of Michigan from 1930 to 2001. The collection contains correspondence of the chief editors, administrative records, files on editorial matters, and miscellaneous files and production material.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">61 linear feet</extent>
-        <extent altrender="carrier">(in 91 boxes)</extent>
+        <extent altrender="carrier">in 91 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 items</extent>

--- a/Real_Masters_all/medstp.xml
+++ b/Real_Masters_all/medstp.xml
@@ -54,7 +54,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/methaa.xml
+++ b/Real_Masters_all/methaa.xml
@@ -43,7 +43,7 @@
       <abstract>Methodist church established in Ann Arbor, Michigan in 1827; proceedings and minutes of various church boards and committees; baptism and marriage records, topical files relating to church activities and personalities; and photographs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">5.5 linear feet</extent>
-        <extent altrender="carrier">(in 7 boxes)</extent>
+        <extent altrender="carrier">in 7 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/mhctopph.xml
+++ b/Real_Masters_all/mhctopph.xml
@@ -50,7 +50,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.5 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize boxes</extent>

--- a/Real_Masters_all/mhpn.xml
+++ b/Real_Masters_all/mhpn.xml
@@ -46,7 +46,7 @@
       <abstract>Statewide organization established in part to create an awareness of Michigan's cultural heritage and architectural history and to encourage the preservation and stewardship of important state historic resources. Records document the administration and programs of the Network, including conferences, publications, training sessions, and awards given for local preservation achievements.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">9 linear feet</extent>
-        <extent altrender="carrier">(in 17 boxes)</extent>
+        <extent altrender="carrier">in 17 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/michacap.xml
+++ b/Real_Masters_all/michacap.xml
@@ -331,7 +331,7 @@ Michigan Interfaith Council on Alcohol Problems records, Bentley Historical Libr
             </unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">12 volumes</extent>
-              <extent altrender="carrier">(in 2 expandable folders)</extent>
+              <extent altrender="carrier">in 2 expandable folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/michbell.xml
+++ b/Real_Masters_all/michbell.xml
@@ -50,7 +50,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">63 linear feet</extent>
-        <extent altrender="carrier">(in 93 boxes)</extent>
+        <extent altrender="carrier">in 93 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/michcitizen.xml
+++ b/Real_Masters_all/michcitizen.xml
@@ -40,7 +40,7 @@
       <unittitle encodinganalog="245"> Michigan Citizen Records<unitdate type="inclusive" encodinganalog="245$f"> 1933-2015 </unitdate> <unitdate type="bulk" encodinganalog="245$g"> 1990-2010 </unitdate></unittitle>
       <physdesc altrender="part">
         <extent encodinganalog="300">30 linear feet</extent>
-        <extent altrender="carrier">(in 57 boxes; including oversize)</extent>
+        <extent altrender="carrier">in 57 boxes; including oversize</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent encodinganalog="300">5 microfilms</extent>

--- a/Real_Masters_all/microbio.xml
+++ b/Real_Masters_all/microbio.xml
@@ -50,7 +50,7 @@
       <abstract>Collected historical information, including record of faculty research, 1890-1970, history of the department, and faculty bibliography; and correspondence and memoranda of chairmen, Walter J. Nungester and Frederick C. Neidhardt; also administrative files concerning faculty activities, fellowships, research projects, and student affairs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/midengl.xml
+++ b/Real_Masters_all/midengl.xml
@@ -47,7 +47,7 @@
       </repository>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">582 linear feet</extent>
-        <extent altrender="carrier">(in 1164 boxes)</extent>
+        <extent altrender="carrier">in 1164 boxes</extent>
       </physdesc>
       <physloc>Portions located in offsite storage; prior notification required for access.</physloc>
     </did>

--- a/Real_Masters_all/migardcl.xml
+++ b/Real_Masters_all/migardcl.xml
@@ -47,7 +47,7 @@
       <abstract>The Michigan Garden Clubs was formed in 1931 as an organization of separate Michigan gardening groups. The record group includes administrative and historical files, activities files, awards, correspondence, yearbooks, and photographs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">7.3 linear feet</extent>
-        <extent altrender="carrier">(in 8 boxes)</extent>
+        <extent altrender="carrier">in 8 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/milanahs.xml
+++ b/Real_Masters_all/milanahs.xml
@@ -54,7 +54,7 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">9 linear feet</extent>
-        <extent altrender="carrier">(in 11 boxes)</extent>
+        <extent altrender="carrier">in 11 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4 oversize volumes</extent>

--- a/Real_Masters_all/millardf.xml
+++ b/Real_Masters_all/millardf.xml
@@ -42,7 +42,7 @@
       <abstract>Republican attorney general of Michigan, 1951-1954, general counsel of the Department of the Army. World War I letters, papers detailing work as chairman of the committee on emerging problems of the Michigan Constitutional Convention; miscellaneous genealogical material, and diaries and memoranda books; scrapbooks concerning political career, especially his service as state attorney general; and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4 linear feet</extent>
-        <extent altrender="carrier">(in 6 boxes)</extent>
+        <extent altrender="carrier">in 6 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 oversize volumes</extent>

--- a/Real_Masters_all/millerca.xml
+++ b/Real_Masters_all/millerca.xml
@@ -54,7 +54,7 @@
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 folders</extent>
-        <extent altrender="carrier">(in 19 boxes)</extent>
+        <extent altrender="carrier">in 19 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 oversize volumes</extent>

--- a/Real_Masters_all/millswl.xml
+++ b/Real_Masters_all/millswl.xml
@@ -42,7 +42,7 @@
       <abstract>Dearborn, Michigan newspaper publisher; candidate for mayor of Dearborn in 1957. Papers relating to the Dearborn Independent newspaper; collected materials detailing the career of Dearborn mayor Orville Hubbard; campaign files documenting Mills' unsuccessful bid to unseat Hubbard in 1957; and photographs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.3 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/mipolhis.xml
+++ b/Real_Masters_all/mipolhis.xml
@@ -54,7 +54,7 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">28 optical disks</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
         <physfacet>DVDs</physfacet>
       </physdesc>
       <repository>

--- a/Real_Masters_all/mireform.xml
+++ b/Real_Masters_all/mireform.xml
@@ -47,7 +47,7 @@
       <abstract>Special commission appointed by Governor Frank Murphy and headed by Professor J. Ralston Hayden of University of Michigan. Correspondence, news releases and drafts of the report.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/mohr.xml
+++ b/Real_Masters_all/mohr.xml
@@ -72,7 +72,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">13 linear feet</extent>
-        <extent altrender="carrier">(in 14 boxes)</extent>
+        <extent altrender="carrier">in 14 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/monroeco.xml
+++ b/Real_Masters_all/monroeco.xml
@@ -47,7 +47,7 @@
       <abstract>Miscellaneous county records.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.6 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">5 oversize volumes</extent>

--- a/Real_Masters_all/moodyb.xml
+++ b/Real_Masters_all/moodyb.xml
@@ -54,7 +54,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">27.5 linear feet</extent>
-        <extent altrender="carrier">(in 29 boxes)</extent>
+        <extent altrender="carrier">in 29 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">29 film reels</extent>

--- a/Real_Masters_all/mooreev.xml
+++ b/Real_Masters_all/mooreev.xml
@@ -54,7 +54,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/mosaicjk.xml
+++ b/Real_Masters_all/mosaicjk.xml
@@ -114,7 +114,7 @@ Mosaic Club (Jackson, Mich.) records, Bentley Historical Library, University of 
             </unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
-              <extent altrender="carrier">(in 1 folder)</extent>
+              <extent altrender="carrier">in 1 folder</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/mtheater.xml
+++ b/Real_Masters_all/mtheater.xml
@@ -47,7 +47,7 @@
       <abstract>Michigan Theater Foundation was formed in 1979 when it purchased the Michigan Theater in Ann Arbor, Mich., a historic landmark built in 1928 and restored by the fundraising efforts of the Foundation. The record group comprises administrative records, including files of the Executive Director, Board of Trustees and administrative committees; grant proposals, materials related to fundraising, theater restoration, renovation, and membership campaigns; descriptions of programs, series, and individual events taken place at the theater; publicity photographs, audio- and video (VHS) recordings, and outsize posters and calendars of events.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">4.5 linear feet</extent>
-        <extent altrender="carrier">(in 6 boxes)</extent>
+        <extent altrender="carrier">in 6 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/mufflygr.xml
+++ b/Real_Masters_all/mufflygr.xml
@@ -43,7 +43,7 @@
       <abstract>Member of University of Michigan Class of 1932. Negatives made in spring and summer, 1931, by Gary Muffly; include University of Michigan campus and buildings, construction of the Law Building, tug-of-war, and other student activities.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">43 items</extent>
-        <extent altrender="carrier">(in 1 folder)</extent>
+        <extent altrender="carrier">in 1 folder</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
@@ -96,7 +96,7 @@ Gary Muffly photographic negatives, Bentley Historical Library, University of Mi
           </unittitle>
           <physdesc altrender="whole">
             <extent altrender="materialtype spaceoccupied">43 negatives</extent>
-            <extent altrender="carrier">(in 1 folder)</extent>
+            <extent altrender="carrier">in 1 folder</extent>
           </physdesc>
         </did>
         <c02 level="item">

--- a/Real_Masters_all/mullinsr.xml
+++ b/Real_Masters_all/mullinsr.xml
@@ -50,7 +50,7 @@
       <abstract>Ypsilanti, Michigan attorney active in community affairs, particularly in areas of civil rights and minority education. President of National Association for the Advancement of Colored People Ypsilanti-Willow Run Branch, 1981-1982 and 1987 to 1998. Correspondence, papers associated with his involvement in NAACP activities, documents relating to judgeship candidacy in 1992, printed material culled from Martin Luther King, Jr. Day celebrations, and papers documenting service to Brown Chapel A.M.E. Church.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4.75 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">842 KB</extent>

--- a/Real_Masters_all/muncyr.xml
+++ b/Real_Masters_all/muncyr.xml
@@ -43,7 +43,7 @@
       <abstract>Socialist Labor Party member, later member of the League for Socialist Reconstruction. Correspondence, campaign files, audio-tapes, and other materials largely concerning his work with the State Central Committee of the Socialist Labor Party and Socialist Reconstruction, 1928-1992; and collected family materials including letters and memoirs of Levi Muncy, soldier during the Civil War; also photographs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">15.5 linear feet</extent>
-        <extent altrender="carrier">(in 16 boxes)</extent>
+        <extent altrender="carrier">in 16 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/murphyf.xml
+++ b/Real_Masters_all/murphyf.xml
@@ -74,7 +74,7 @@
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">23 linear feet</extent>
-        <extent altrender="carrier">(in 103 boxes, not microfilmed)</extent>
+        <extent altrender="carrier">in 103 boxes, not microfilmed</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 oversize volumes</extent>

--- a/Real_Masters_all/muschba.xml
+++ b/Real_Masters_all/muschba.xml
@@ -74,7 +74,7 @@
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3081 drawings</extent>
-        <extent altrender="carrier">(in Avery Library Collection)</extent>
+        <extent altrender="carrier">in Avery Library Collection</extent>
         <physfacet>architectural drawings</physfacet>
       </physdesc>
       <physdesc altrender="part">
@@ -82,7 +82,7 @@
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">58 oversize folders</extent>
-        <extent altrender="carrier">(in Bentley Library Collection)</extent>
+        <extent altrender="carrier">in Bentley Library Collection</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/muschen.xml
+++ b/Real_Masters_all/muschen.xml
@@ -54,7 +54,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">13.5 linear feet</extent>
-        <extent altrender="carrier">(in 15 boxes)</extent>
+        <extent altrender="carrier">in 15 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 folders</extent>

--- a/Real_Masters_all/nabeelabr.xml
+++ b/Real_Masters_all/nabeelabr.xml
@@ -43,7 +43,7 @@
       <abstract>Nabeel Abraham was a professor of anthropology and director of the Honors Program at Henry Ford Community College and an Arab American activist. Nabeel Abraham papers primarily document his focus on Arab American and Middle East issues.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">29 linear feet</extent>
-        <extent altrender="carrier">(in 27 boxes)</extent>
+        <extent altrender="carrier">in 27 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/netzorgf.xml
+++ b/Real_Masters_all/netzorgf.xml
@@ -51,7 +51,7 @@
       <abstract>Papers of Morton Isadore and Katherine Smit Netzorg; their son Morton Jacob Netzorg and his wife Petra Fuld Netzorg; Petra Netzorg's mother Charlotte Fuld, and Petra's younger sister Bracha Fuld. The collection chronicles the history of the Philippine Islands in the 20th century, specifically during the Second World War; life of German Jewry on the eve of World War II; Zionist Insurgency in the British Mandate Palestine; developments in the scholarly field of South East Asian Studies and international publishing and book trade industries related to the region. The collection is a rich source of bibliographic material related to the Pacific Islands, primarily the Philippines, as well as the entire South East Asian region.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">30 linear feet</extent>
-        <extent altrender="carrier">(in 35 boxes, 1 oversize box, and 1 audio cassette box)</extent>
+        <extent altrender="carrier">in 35 boxes, 1 oversize box, and 1 audio cassette box</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/nicksalv.xml
+++ b/Real_Masters_all/nicksalv.xml
@@ -49,7 +49,7 @@
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">117 audiocassettes</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/nisserd.xml
+++ b/Real_Masters_all/nisserd.xml
@@ -51,7 +51,7 @@
       <abstract>The University of Michigan News and Information Services functions as the university's media relations office. It disseminates information and images about university programs, research, events, and faculty and staff activities. This series of News and Information Services photographs is comprised of portraits of more than 4,000 individual faculty and staff members spanning the years 1946-2006 (bulk 1950-1990).</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">7.5 linear feet</extent>
-        <extent altrender="carrier">(in 15 boxes)</extent>
+        <extent altrender="carrier">in 15 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/noblealf.xml
+++ b/Real_Masters_all/noblealf.xml
@@ -300,7 +300,7 @@
                 <unittitle>Oversize items</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 items</extent>
-                  <extent altrender="carrier">(in oversize folder)</extent>
+                  <extent altrender="carrier">in oversize folder</extent>
                 </physdesc>
               </did>
               <odd>

--- a/Real_Masters_all/nomads.xml
+++ b/Real_Masters_all/nomads.xml
@@ -43,7 +43,7 @@
       <abstract>Detroit, Mich. based travel group which toured destinations throughout the world. Records include tour files arranged by destination. These files consist of description of the proposed tour, itineraries of events, and list of tour members. The collection also has organization newsletter <title render="italic">Nomad Notes</title> and <title render="italic">The Nomad</title>; and photographs from the social activities of the group.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">22 linear feet</extent>
-        <extent altrender="carrier">(in 40 boxes)</extent>
+        <extent altrender="carrier">in 40 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">14 oversize volumes</extent>

--- a/Real_Masters_all/nursescc.xml
+++ b/Real_Masters_all/nursescc.xml
@@ -43,7 +43,7 @@
       <abstract>Professional nursing association chapter established in 1982. Subject files relating to chapter activities; include chapter board and committee files.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/obgynum.xml
+++ b/Real_Masters_all/obgynum.xml
@@ -43,7 +43,7 @@
       <abstract>Records include registers; annual reports; administrative files; departmental minutes; admissions books containing details on admission, births, treatment, and disposition of patients; and photographs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">6.5 linear feet</extent>
-        <extent altrender="carrier">(in 8 boxes)</extent>
+        <extent altrender="carrier">in 8 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/ohioalco.xml
+++ b/Real_Masters_all/ohioalco.xml
@@ -675,7 +675,7 @@ Ohio Council on Alcohol Problems records, Bentley Historical Library, University
             <unittitle>Glass slides <unitdate type="inclusive" normal="1901/1921">1901-1921</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">200 slides</extent>
-              <extent altrender="carrier">(in 3 file boxes)</extent>
+              <extent altrender="carrier">in 3 file boxes</extent>
               <physfacet>approximate</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/oiapum.xml
+++ b/Real_Masters_all/oiapum.xml
@@ -50,7 +50,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">5.8 linear feet</extent>
-        <extent altrender="carrier">(in 7 boxes)</extent>
+        <extent altrender="carrier">in 7 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/onealjoe.xml
+++ b/Real_Masters_all/onealjoe.xml
@@ -42,7 +42,7 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/orderksd.xml
+++ b/Real_Masters_all/orderksd.xml
@@ -64,7 +64,7 @@ tagging.</item>
       <abstract>Minutes, correspondence, reports, programs, financial records and photographs documenting statewide service activities and programs of various county circles; also photograph albums and scrapbooks.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7.3 linear feet</extent>
-        <extent altrender="carrier">(in 8 boxes)</extent>
+        <extent altrender="carrier">in 8 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">8 oversize volumes</extent>

--- a/Real_Masters_all/oslerdav.xml
+++ b/Real_Masters_all/oslerdav.xml
@@ -55,7 +55,7 @@
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.3 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
         <physfacet>textual and photographic material</physfacet>
       </physdesc>
       <repository>

--- a/Real_Masters_all/ouradnik.xml
+++ b/Real_Masters_all/ouradnik.xml
@@ -47,7 +47,7 @@
       <abstract>Official photographer for the University Players (formerly Play Production) at the University of Michigan starting in 1928; photographic negatives of cast (in costume) from various student productions.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">420 negatives</extent>
-        <extent altrender="carrier">(in 2 boxes; number approximate)</extent>
+        <extent altrender="carrier">in 2 boxes; number approximate</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/ozone.xml
+++ b/Real_Masters_all/ozone.xml
@@ -46,7 +46,7 @@
       <abstract>Shelter in Ann Arbor, Michigan, for runaway young people. The Ozone House records have been divided into seven series: Meeting Minutes; Grants and Funding; Worker Training; Publicity and Outreach; Topical Files; Drug Helpline; and Visual Materials. The records document the administration and various counseling, training, fundraising and outreach activities of the Ozone House.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">10.5 linear feet</extent>
-        <extent altrender="carrier">(in 11 boxes)</extent>
+        <extent altrender="carrier">in 11 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/pacoszch.xml
+++ b/Real_Masters_all/pacoszch.xml
@@ -51,7 +51,7 @@
       <abstract>Widely published American Polish poet whose life is at the heart of her poetry; diaries and publications.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">7 linear feet</extent>
-        <extent altrender="carrier">(in 7 boxes)</extent>
+        <extent altrender="carrier">in 7 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/palazzl.xml
+++ b/Real_Masters_all/palazzl.xml
@@ -47,7 +47,7 @@
       <abstract>Research materials used by Laurie Palazzolo in writing of her book <title render="italic">Horn Man: the Polish-American Musician in Twentieth-Century Detroit</title> (Detroit, Mich.: American-Polish Music Society, 2003). The collection sheds light on the history of 20th century Polish-American musical landscape of greater Detroit.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">10 linear feet</extent>
-        <extent altrender="carrier">(in 13 boxes)</extent>
+        <extent altrender="carrier">in 13 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/parsonsj.xml
+++ b/Real_Masters_all/parsonsj.xml
@@ -43,7 +43,7 @@
       <abstract>Jeffrey R. Parsons was Curator of Latin American Archaeology and Director of the Museum of Anthropology at the University of Michigan. He was a professor at the same institution for over forty years starting in 1966 and carried out extensive research on settlement patterns in the basin of Mexico, in Peru, and in many other countries. Parsons is known for his role in the development of systematic settlement survey methods in archaeology, a methodology which has become common in archaeological work around the world. Material includes papers, maps, site surveys, photo negatives, aerial photographs and digital scans of the negatives.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">70 linear feet</extent>
-        <extent altrender="carrier">(in 59 boxes)</extent>
+        <extent altrender="carrier">in 59 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/pattersf.xml
+++ b/Real_Masters_all/pattersf.xml
@@ -43,7 +43,7 @@
       <abstract>New York State and Ann Arbor, Michigan family; family correspondence, business papers, student notebooks, photograph albums.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/pattersj.xml
+++ b/Real_Masters_all/pattersj.xml
@@ -274,7 +274,7 @@ John C. Patterson papers, Bentley Historical Library, University of Michigan</p>
             </unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">59 volumes</extent>
-              <extent altrender="carrier">(in 3 letter boxes)</extent>
+              <extent altrender="carrier">in 3 letter boxes</extent>
             </physdesc>
           </did>
         </c02>
@@ -508,7 +508,7 @@ John C. Patterson papers, Bentley Historical Library, University of Michigan</p>
             <unittitle>University of Albany Law School notes <unitdate type="inclusive" normal="1864/1865">1864-1865</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">6 volumes</extent>
-              <extent altrender="carrier">(in 2 expandable folders)</extent>
+              <extent altrender="carrier">in 2 expandable folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/peacewrk.xml
+++ b/Real_Masters_all/peacewrk.xml
@@ -47,7 +47,7 @@
       <abstract>Michigan Peaceworks (MPW) was an Ann Arbor based grassroots organization dedicated to peace, social justice, and human rights that was founded in 2001 following the September 11th attacks. The collection includes material related to their public events and outreach activities in Ann Arbor. These events and activities are well represented in posters, fliers, and photographs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">4.5 linear feet</extent>
-        <extent altrender="carrier">(in 6 boxes)</extent>
+        <extent altrender="carrier">in 6 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/perazza.xml
+++ b/Real_Masters_all/perazza.xml
@@ -44,7 +44,7 @@
       <unittitle encodinganalog="245">Julio Perazza visual materials <unitdate type="inclusive" encodinganalog="245$f" normal="1934/2004" certainty="approximate">1934-2004</unitdate></unittitle>
       <physdesc altrender="whole">
         <extent encodinganalog="300" altrender="materialtype spaceoccupied">6 linear feet</extent>
-        <extent altrender="carrier">(in 7 boxes)</extent>
+        <extent altrender="carrier">in 7 boxes</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">2009180 Aa 2</unitid>
       <langmaterial>The material is in Material is mostly in <language langcode="eng" encodinganalog="041">English</language> English; there are a few interviews in <language langcode="esp" encodinganalog="041">Spanish</language>  on DVD.</langmaterial>

--- a/Real_Masters_all/pharmpub.xml
+++ b/Real_Masters_all/pharmpub.xml
@@ -58,7 +58,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2.8 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.2 MB</extent>

--- a/Real_Masters_all/phoenix.xml
+++ b/Real_Masters_all/phoenix.xml
@@ -54,7 +54,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">51 linear feet</extent>
-        <extent altrender="carrier">(in 54 boxes)</extent>
+        <extent altrender="carrier">in 54 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/photoser.xml
+++ b/Real_Masters_all/photoser.xml
@@ -43,7 +43,7 @@
       <abstract>The University of Michigan Photo and Campus Services is a comprehensive photographic unit established to meet the needs of the schools, colleges, departments, and other units within the university as well as individuals within the university community. In existence since 1948, the unit officially became part of News and Information Services in 1997. Services include photographic reproduction and studio and location photography.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.25 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/physics.xml
+++ b/Real_Masters_all/physics.xml
@@ -840,7 +840,6 @@ Programs <unitdate type="inclusive" normal="1984">1984</unitdate></unittitle>
               </did>
               <c05 level="file">
                 <did>
-                  <unitdate type="inclusive" normal="1954-10/1966-07">October 1954-July 1966</unitdate>
                   <physdesc>
                     <extent>3 folders</extent>
                   </physdesc>
@@ -849,8 +848,7 @@ Programs <unitdate type="inclusive" normal="1984">1984</unitdate></unittitle>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">11</container>
-                  <unitdate type="inclusive" normal="1973/1978">1973-1978</unitdate>
-                </did>
+                  </did>
               </c05>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/pinkush.xml
+++ b/Real_Masters_all/pinkush.xml
@@ -51,7 +51,7 @@
       <abstract>Hermann Pinkus and Hilde Hensel Pinkus were German immigrants who worked as dermatologists and allergists in the greater Detroit area. The collection includes records from the Detroit Dermatological Society and material related to the Pinkus’s participation in professional societies and their research interests, including thorium X and amino acids.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/pionband.xml
+++ b/Real_Masters_all/pionband.xml
@@ -40,7 +40,7 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">8 linear feet</extent>
-        <extent altrender="carrier">(in 10 boxes)</extent>
+        <extent altrender="carrier">in 10 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize volumes</extent>

--- a/Real_Masters_all/pittsfld.xml
+++ b/Real_Masters_all/pittsfld.xml
@@ -43,7 +43,7 @@
       <abstract>The Pittsfield Township (Washtenaw County, Mich.) records contain school district records for districts 1 through 8 and 8 fractional from 1860-1930, with occasional records dating back to 1830. The collection also contains a wide range of types of township records dealing with assessments, elections, finance, and legal activities, dating from 1832 to 1980. Township Board proceedings (1834-1965, with some gaps) and road records (1835-1887) are also available in digitized versions.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 linear feet</extent>
-        <extent altrender="carrier">(in 8 boxes)</extent>
+        <extent altrender="carrier">in 8 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">121 oversize volumes</extent>

--- a/Real_Masters_all/pollackp.xml
+++ b/Real_Masters_all/pollackp.xml
@@ -49,7 +49,7 @@
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">13 folders</extent>
-        <extent altrender="carrier">(in 2 drawers)</extent>
+        <extent altrender="carrier">in 2 drawers</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4 digital files</extent>

--- a/Real_Masters_all/pondfam.xml
+++ b/Real_Masters_all/pondfam.xml
@@ -46,7 +46,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">9.6 linear feet</extent>
-        <extent altrender="carrier">(in 13 boxes)</extent>
+        <extent altrender="carrier">in 13 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 oversize drawers</extent>

--- a/Real_Masters_all/pontaul.xml
+++ b/Real_Masters_all/pontaul.xml
@@ -42,7 +42,7 @@
       <abstract>Pontiac, Michigan, chapter of the National Urban League. The record group includes scattered minutes and annual reports, clippings and scrapbooks, publications, subject files relating to chapter activities, and photographs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.7 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/postcard.xml
+++ b/Real_Masters_all/postcard.xml
@@ -50,7 +50,7 @@
       <abstract>Postcard views of Michigan cities and the University of Michigan.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">10.5 linear feet</extent>
-        <extent altrender="carrier">(in 12 boxes)</extent>
+        <extent altrender="carrier">in 12 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/powrie.xml
+++ b/Real_Masters_all/powrie.xml
@@ -47,7 +47,7 @@
       <abstract>Papers of Emerson F. Powrie, Ann Arbor, MI public schools teacher (1945-1948), principal (1948-1971), and Central Administration employee (1972-1977); and his wife Gwendolyn Sutton Powrie, teacher for the hearing-impaired children.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/ppldet.xml
+++ b/Real_Masters_all/ppldet.xml
@@ -54,7 +54,7 @@
       <abstract>Detroit, Michigan chapter of the Planned Parenthood Federation of America, founded in 1932 as the Detroit Chapter of the Michigan Birth Control League. Minutes, correspondence, reports, surveys, newsletters, and printed material document the efforts of the Planned Parenthood League to provide birth control information and services to residents of the Detroit area</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">8.5 linear feet</extent>
-        <extent altrender="carrier">(in 9 boxes)</extent>
+        <extent altrender="carrier">in 9 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/ppolicy.xml
+++ b/Real_Masters_all/ppolicy.xml
@@ -62,7 +62,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">17 linear feet</extent>
-        <extent altrender="carrier">(in 18 boxes)</extent>
+        <extent altrender="carrier">in 18 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3.97 GB</extent>

--- a/Real_Masters_all/prayff.xml
+++ b/Real_Masters_all/prayff.xml
@@ -46,7 +46,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.7 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/pricejac.xml
+++ b/Real_Masters_all/pricejac.xml
@@ -47,7 +47,7 @@
       <abstract>History professor at the University of Michigan (1956-1990) specializing in the early modern Atlantic economy, particularly the trade of tobacco and sugar between Europe and North America in the 17th and 18th centuries. Price served with the Army Air Force in China during World War II and twice served as chairman of the history department. Collection includes letters written during his military service, extensive correspondence with colleagues and scholars, material on the Francis Lowenheim case involving access to research material, and Price's research files and index cards detailing his research into colonial American and British merchants.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">8.5 linear feet</extent>
-        <extent altrender="carrier">(in 13 boxes)</extent>
+        <extent altrender="carrier">in 13 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/psycdept.xml
+++ b/Real_Masters_all/psycdept.xml
@@ -48,7 +48,7 @@
       <unittitle encodinganalog="245">Department of Psychology (University of Michigan) records <unitdate type="inclusive" encodinganalog="245$f" normal="1903/1998">1903-1998</unitdate>, <unitdate type="bulk" encodinganalog="245$g" normal="1960/1990">1960-1990</unitdate></unittitle>
       <physdesc altrender="part">
         <extent encodinganalog="300" altrender="materialtype spaceoccupied">10.25 linear feet</extent>
-        <extent encodinganalog="300" altrender="carrier">(in 10 boxes)</extent>
+        <extent encodinganalog="300" altrender="carrier">in 10 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent encodinganalog="300" altrender="materialtype spaceoccupied">437 KB</extent>

--- a/Real_Masters_all/rackhamg.xml
+++ b/Real_Masters_all/rackhamg.xml
@@ -707,7 +707,7 @@
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 microfilms</extent>
-                    <extent altrender="carrier">(located in microfilm cabinet)</extent>
+                    <extent altrender="carrier">located in microfilm cabinet</extent>
                     <physfacet>positive and negative</physfacet>
                   </physdesc>
                 </did>
@@ -720,7 +720,7 @@
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 microfilms</extent>
-                    <extent altrender="carrier">(located in microfilm cabinet)</extent>
+                    <extent altrender="carrier">located in microfilm cabinet</extent>
                     <physfacet>positive and negative</physfacet>
                   </physdesc>
                 </did>
@@ -733,7 +733,7 @@
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 microfilms</extent>
-                    <extent altrender="carrier">(located in microfilm cabinet)</extent>
+                    <extent altrender="carrier">located in microfilm cabinet</extent>
                     <physfacet>positive and negative</physfacet>
                   </physdesc>
                 </did>
@@ -746,7 +746,7 @@
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 microfilms</extent>
-                    <extent altrender="carrier">(located in microfilm cabinet)</extent>
+                    <extent altrender="carrier">located in microfilm cabinet</extent>
                     <physfacet>positive and negative</physfacet>
                   </physdesc>
                 </did>

--- a/Real_Masters_all/radumilo.xml
+++ b/Real_Masters_all/radumilo.xml
@@ -47,7 +47,7 @@
       <abstract>Air Force Lieutenant accused of being a security risk during the era of Senator Joseph McCarthy; records include biographical information, correspondence, scrapbooks, audio-visual materials, and other documents pertaining to the case and to the movie "Good Night, and Good Luck."</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">6 oversize volumes</extent>

--- a/Real_Masters_all/randallh.xml
+++ b/Real_Masters_all/randallh.xml
@@ -43,7 +43,7 @@
       <abstract>Renowned physicist who studied, conducted research, and taught at the University of Michigan from the late 1800s until the 1960s; Dr. Harrison M. Randall helped develop the atomic and nuclear components of the physics program, and conducted research on infrared spectroscopy. Materials include correspondence, photos, postcards, research data, progress and final research reports, grant proposals, and reprints.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/ransomfm.xml
+++ b/Real_Masters_all/ransomfm.xml
@@ -47,7 +47,7 @@
       <abstract>Eugene Ransom was director of the Wesley Foundation at the University of Michigan (1951-1968). Jeanne Bailey Ransom was a teacher, writer, and family historian. The collection consists largely of binders of materials (photographs, clippings, and other memorabilia) relating to Eugene's service with the Civilian Public Service during World War II, to his work with the Wesley Foundation, and to the couples' involvement in issues of peace and justice. In addition, the collection includes collected genealogical materials and family documents pertaining to the Bailey family.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">7 linear feet</extent>
-        <extent altrender="carrier">(in 8 boxes)</extent>
+        <extent altrender="carrier">in 8 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/ranville.xml
+++ b/Real_Masters_all/ranville.xml
@@ -43,7 +43,7 @@
       <abstract>Author and political consultant from Charlotte, Michigan who wrote a book on the Milo Radulovich Case; records include interviews, correspondence, newspaper clippings, Radulovich military records, research notes, and documentation relating to the writing and publication of <title render="italic">To Strike at a King: The Turning Point in the McCarthy Witch-Hunt</title>.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3.5 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 oversize items</extent>

--- a/Real_Masters_all/raschc.xml
+++ b/Real_Masters_all/raschc.xml
@@ -50,7 +50,7 @@
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4 linear feet</extent>
-        <extent altrender="carrier">(in 6 boxes)</extent>
+        <extent altrender="carrier">in 6 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/realestat.xml
+++ b/Real_Masters_all/realestat.xml
@@ -47,7 +47,7 @@
       <abstract>New World State Wide V’s Realty’s collection of Michigan real estate data and sales books for Albion County (1997-2003), Hillsdale County (1995-1999), Jackson County (1994-2009), Lenawee County (1993-2007, and 2010), Monroe (1988, 1993-1994, and 1996-2009), Washtenaw County (1973-2011), and Wayne County (1976-1982, 1985, and 1988-2004).</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">21.3 linear feet</extent>
-        <extent altrender="carrier">(in 22 boxes)</extent>
+        <extent altrender="carrier">in 22 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/redfordp.xml
+++ b/Real_Masters_all/redfordp.xml
@@ -47,7 +47,7 @@
       <abstract>Detroit, Michigan Presbyterian Church; organizational records, publications, baptismal and membership records, scrapbooks, files of the women’s organization.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">13 linear feet</extent>
-        <extent altrender="carrier">(in 16 boxes)</extent>
+        <extent altrender="carrier">in 16 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 oversize volumes</extent>

--- a/Real_Masters_all/redstone.xml
+++ b/Real_Masters_all/redstone.xml
@@ -1851,7 +1851,7 @@ Louis G. Redstone Photograph Collection, Bentley Historical Library, University 
             <unittitle>K-Numbered Jobs</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">0.6 linear feet</extent>
-              <extent altrender="carrier">(in 76 folders)</extent>
+              <extent altrender="carrier">in 76 folders</extent>
             </physdesc>
           </did>
           <c03 level="file">

--- a/Real_Masters_all/regispub.xml
+++ b/Real_Masters_all/regispub.xml
@@ -58,7 +58,7 @@
       <abstract>Publications produced by the University of Michigan registrar’s office including course descriptions and time schedules, statistics and reports on enrollment, and a variety of brochures, manuals and handbooks.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">8.5 linear feet</extent>
-        <extent altrender="carrier">(in 13 boxes)</extent>
+        <extent altrender="carrier">in 13 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">353 MB</extent>

--- a/Real_Masters_all/rentschp.xml
+++ b/Real_Masters_all/rentschp.xml
@@ -53,7 +53,7 @@
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">600 negatives</extent>
-        <extent altrender="carrier">(in 8 boxes)</extent>
+        <extent altrender="carrier">in 8 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/rescoll.xml
+++ b/Real_Masters_all/rescoll.xml
@@ -48,7 +48,7 @@
       <unittitle encodinganalog="245">Residential College (University of Michigan) records <unitdate type="inclusive" encodinganalog="245$f" normal="1957/2011">1957-2011</unitdate></unittitle>
       <physdesc>
         <extent encodinganalog="300">30 linear feet</extent>
-        <extent altrender="carrier">(in 31 boxes)</extent>
+        <extent altrender="carrier">in 31 boxes</extent>
       </physdesc>
       <physdesc>
         <extent encodinganalog="300">1 oversize folders</extent>

--- a/Real_Masters_all/revelliw.xml
+++ b/Real_Masters_all/revelliw.xml
@@ -62,7 +62,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">9 linear feet</extent>
-        <extent altrender="carrier">(in 10 boxes)</extent>
+        <extent altrender="carrier">in 10 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/robbinsp.xml
+++ b/Real_Masters_all/robbinsp.xml
@@ -42,7 +42,7 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">15 items</extent>
-        <extent altrender="carrier">(in 1 box)</extent>
+        <extent altrender="carrier">in 1 box</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/robydf.xml
+++ b/Real_Masters_all/robydf.xml
@@ -47,7 +47,7 @@
       <abstract>Douglas Fergusson Roby was a member of the International Olympic Committee from 1952-1985 and president of the United States Olympic Committee from 1965 to 1969. The collection includes materials related to his professional activities and interests and contains personal files, national and international Olympic and athletic organizations' files and photographs, as well as Roby's personal files and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">8.3 linear feet</extent>
-        <extent altrender="carrier">(in 9 boxes)</extent>
+        <extent altrender="carrier">in 9 boxes</extent>
         <physfacet>including oversize</physfacet>
       </physdesc>
       <physdesc altrender="part">

--- a/Real_Masters_all/rowefam.xml
+++ b/Real_Masters_all/rowefam.xml
@@ -50,11 +50,11 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.7 linear feet</extent>
-        <extent altrender="carrier">(on 2 rolls of microfilm)</extent>
+        <extent altrender="carrier">on 2 rolls of microfilm</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.3 linear feet</extent>
-        <extent altrender="carrier">(in 1 box)</extent>
+        <extent altrender="carrier">in 1 box</extent>
       </physdesc>
       <repository encodinganalog="852">
         <corpname><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/russlect.xml
+++ b/Real_Masters_all/russlect.xml
@@ -53,7 +53,7 @@
       <abstract>University of Michigan committee which selects the annual Henry Russell Lecturer, the highest faculty award and the nominee for the Henry Russell Award recognizing a junior faculty member for superior scholarship and teaching ability.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-        <extent altrender="carrier">(in 2.4 boxes)</extent>
+        <extent altrender="carrier">in 2.4 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/ruthvenp.xml
+++ b/Real_Masters_all/ruthvenp.xml
@@ -43,7 +43,7 @@
       <abstract>President of the University of Michigan, commencement speeches, addresses, articles and miscellaneous publications on academic and administrative issue at the University of Michigan and higher education generally.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">46 items</extent>
-        <extent altrender="carrier">(in 1 box)</extent>
+        <extent altrender="carrier">in 1 box</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/sandersw.xml
+++ b/Real_Masters_all/sandersw.xml
@@ -43,7 +43,7 @@
       <abstract>Architect, professor of architecture at the University of Michigan. Biographical information; subject files relating to his professional activities, his involvement with the International Congress for Modern Architecture, his interest in architectural education, and his own design work; photographs and architectural drawings. The collection includes correspondence exchanged with Buckminster Fuller and Walter Gropius. There is also a letter from Lewis Mumford.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.3 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/sareini.xml
+++ b/Real_Masters_all/sareini.xml
@@ -43,7 +43,7 @@
       <abstract>Arab-American Politician and businesswoman from Dearborn, Michigan, and first Arab American elected to Dearborn City Council. Personal materials related to her political campaigns, community involvement, and city council service, as well as restaurant business papers and menus, and menu's from the Dearborn restaurant community.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 oversize boxes</extent>

--- a/Real_Masters_all/schimp.xml
+++ b/Real_Masters_all/schimp.xml
@@ -47,7 +47,7 @@
       <abstract>The Albert J. Schimpke collection consists of photographs, audio-tapes, and other materials collected by Mr. Schimpke relating to Manistee, Michigan, especially the activities of one of its most prominent local lumbermen, Richard G. Peters.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4 linear feet</extent>
-        <extent altrender="carrier">(in 6 boxes)</extent>
+        <extent altrender="carrier">in 6 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/schmidtc.xml
+++ b/Real_Masters_all/schmidtc.xml
@@ -43,7 +43,7 @@
       <abstract>Detroit German-American business; scrapbooks containing a variety of printed material, photographs, handwritten accounts of sentiments and occasions, and hand-drawn ink illustrations.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">15 volumes</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize volumes</extent>

--- a/Real_Masters_all/schneid.xml
+++ b/Real_Masters_all/schneid.xml
@@ -43,7 +43,7 @@
       <abstract>Richard Schneidewind’s collection of photographs, stereographs, newspaper articles and advertising materials about the Igorot peoples of the Philippines, and "Igorot Villages" traveling exhibits in the U.S., Canada and Europe that his company, the Filipino Exhibition Company, organized and managed between 1905 and 1913; also photographs of locations in the Philippines and Hawaii taken ca. 1899.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.25 linear feet</extent>
-        <extent altrender="carrier">(in 1 box)</extent>
+        <extent altrender="carrier">in 1 box</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 oversize volumes</extent>

--- a/Real_Masters_all/schofed.xml
+++ b/Real_Masters_all/schofed.xml
@@ -54,7 +54,7 @@
       <abstract>School records consisting of executive committee and faculty meeting minutes, subject files concerning in part promotion and tenure decisions, teacher certification, programs in Detroit Public Schools, the School's accreditation review in 1973-1974, and the University's review of the School in 1982-1984. Topical files of various deans and administrative officers, notably James B. Edmonson, Willard Olson, Carl F. Berger, Frederick W. Bertolaet, Joan Stark, and Charles F. Lehmann; and information on programs and departments at one time administered by the School, including Department of Physical Education, Fresh Air Camp, Bureau of School Services, and vocational education.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">54.25 linear feet</extent>
-        <extent altrender="carrier">(in 55 boxes)</extent>
+        <extent altrender="carrier">in 55 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">184 MB</extent>

--- a/Real_Masters_all/schulers.xml
+++ b/Real_Masters_all/schulers.xml
@@ -42,7 +42,7 @@
       <abstract>Historic restaurant based in Marshall, Michigan, specializing in American home-style cuisine. Since 1909, the Schuler family has owned and operated this Michigan institution. Records include administrative files, menus, advertising and publicity materials, slides, photographs, videotapes and scrapbooks.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">18 linear feet</extent>
-        <extent altrender="carrier">(in 20 boxes)</extent>
+        <extent altrender="carrier">in 20 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">9 oversize volumes</extent>

--- a/Real_Masters_all/sesqcent.xml
+++ b/Real_Masters_all/sesqcent.xml
@@ -51,7 +51,7 @@
       </repository>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">13 linear feet</extent>
-        <extent altrender="carrier">(in 14 boxes)</extent>
+        <extent altrender="carrier">in 14 boxes</extent>
       </physdesc>
       <physloc>Portions located in offsite storage; prior notification required for access.</physloc>
     </did>

--- a/Real_Masters_all/sharkeyr.xml
+++ b/Real_Masters_all/sharkeyr.xml
@@ -43,7 +43,7 @@
       <abstract>Conservationist from Petoskey, Michigan who wrote columns and served as an environmental reporter for several regional newspapers; records include published newspaper columns and articles, drafts, photographs and negatives, and documentation relating to his conservation work.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4.5 linear feet</extent>
-        <extent altrender="carrier">(in 6 boxes)</extent>
+        <extent altrender="carrier">in 6 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/shawwb.xml
+++ b/Real_Masters_all/shawwb.xml
@@ -54,7 +54,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7 linear feet</extent>
-        <extent altrender="carrier">(in 12 boxes)</extent>
+        <extent altrender="carrier">in 12 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/shepherdgw.xml
+++ b/Real_Masters_all/shepherdgw.xml
@@ -46,7 +46,7 @@
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 maps</extent>
-        <extent altrender="carrier">(in 1 tube)</extent>
+        <extent altrender="carrier">in 1 tube</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/sheppard.xml
+++ b/Real_Masters_all/sheppard.xml
@@ -43,7 +43,7 @@
       <abstract>The Glen Sheppard Papers document the research and writing undertaken by Sheppard during his 40-year tenure as editor, publisher, and writer for the <title render="italic">North Woods Call</title>, a small conservation newspaper dedicated to the stewardship and protection of Northern Michigan's natural resources. The collection's three series contain Sheppard's articles and writings, press releases and newspaper articles written by others, government reports and publications, audio and visual materials.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">35.5 linear feet</extent>
-        <extent altrender="carrier">(in 36 boxes)</extent>
+        <extent altrender="carrier">in 36 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/sherzera.xml
+++ b/Real_Masters_all/sherzera.xml
@@ -47,7 +47,7 @@
       <abstract>Professor of mechanical engineering at the University of Michigan, First Lieutenant 301st Field Artillery during World War I; Visual and other materials of Allen Sherzer and members of the Sherzer family, including film footage of University of Michigan campus ca. 1928.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.3 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/showers.xml
+++ b/Real_Masters_all/showers.xml
@@ -50,7 +50,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 oversize folders</extent>

--- a/Real_Masters_all/siglind.xml
+++ b/Real_Masters_all/siglind.xml
@@ -55,7 +55,7 @@
       <abstract>Program Director at the Ark, Ann Arbor, Michigan music club; administrative records relating to the management of the Ark, including artists’ contracts and financial records, printed materials such as concert calendars, flyers, and posters, and photographs of Ark performances, informal snapshots and publicity photos of performers.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 oversize volumes</extent>

--- a/Real_Masters_all/sincljl.xml
+++ b/Real_Masters_all/sincljl.xml
@@ -71,7 +71,7 @@
       <unittitle encodinganalog="245">John and Leni Sinclair papers <unitdate type="inclusive" encodinganalog="245$f" normal="1957/2003">1957-2003</unitdate></unittitle>
       <physdesc altrender="part">
         <extent encodinganalog="300" altrender="materialtype spaceoccupied">66.5 linear feet</extent>
-        <extent altrender="carrier">(in 82 boxes)</extent>
+        <extent altrender="carrier">in 82 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent encodinganalog="300" altrender="materialtype spaceoccupied">1 oversize folders</extent>
@@ -8186,7 +8186,7 @@
                 <container type="box" label="Box">28b</container>
                 <unittitle>Larry Monroe interview with John and Leni Sinclair <unitdate type="inclusive" normal="1971-12-18">December 18, 1971</unitdate></unittitle>
                 <physdesc>
-                  <extent>2 cassettes)</extent>
+                  <extent>2 cassettes</extent>
                 </physdesc>
               </did>
               <odd>

--- a/Real_Masters_all/singerjd.xml
+++ b/Real_Masters_all/singerjd.xml
@@ -55,7 +55,7 @@
       <abstract>University of Michigan professor of political science, research scientist at the Mental Health Research Institute, and pioneer in the interdisciplinary and quantitative approach to conflict resolution. Administrative papers of Center for Research on Conflict Resolution, Correlates of War Project, and the Journal of Conflict Resolution, topical files on numerous organizations and subjects, and research papers from disarmament negotiations study.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">21.3 linear feet</extent>
-        <extent altrender="carrier">(in 23 boxes)</extent>
+        <extent altrender="carrier">in 23 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/sinkauto.xml
+++ b/Real_Masters_all/sinkauto.xml
@@ -47,7 +47,7 @@
       <abstract>Charles A. Sink was president of University Musical Society. Photographs (mainly autographed portraits) of musical performers, many of whom appeared in performances of the University Musical Society.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">568 photographs</extent>
-        <extent altrender="carrier">(in 6 boxes)</extent>
+        <extent altrender="carrier">in 6 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/slaytonf.xml
+++ b/Real_Masters_all/slaytonf.xml
@@ -43,7 +43,7 @@
       <abstract>Hillsdale, Michigan family; papers relating to participation of family members in the Civil War, farming in Kent County, Hillsdale College, religion, and daily activities.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">10.5 linear feet</extent>
-        <extent altrender="carrier">(in 11 boxes)</extent>
+        <extent altrender="carrier">in 11 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
@@ -256,7 +256,7 @@ The collection has been arranged by family and family member name. The series in
               <unittitle><genreform normal="Diaries">Diaries</genreform>, <unitdate type="inclusive" normal="1857/1879">1857-1879</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">20 volumes</extent>
-                <extent altrender="carrier">(in 2 expandable folders)</extent>
+                <extent altrender="carrier">in 2 expandable folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -266,7 +266,7 @@ The collection has been arranged by family and family member name. The series in
               <unittitle><genreform normal="Diaries">Diaries</genreform>, <unitdate type="inclusive" normal="1880/1897">1880-1897</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">17 volumes</extent>
-                <extent altrender="carrier">(in 2 expandable folders)</extent>
+                <extent altrender="carrier">in 2 expandable folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -492,7 +492,7 @@ The collection has been arranged by family and family member name. The series in
               <unittitle>Diaries <unitdate type="inclusive" normal="1899/1918">1899-1918</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">9 volumes</extent>
-                <extent altrender="carrier">(in 1 expandable folder)</extent>
+                <extent altrender="carrier">in 1 expandable folder</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/sligh.xml
+++ b/Real_Masters_all/sligh.xml
@@ -70,7 +70,7 @@
       <abstract>Grand Rapids, Michigan family, involved in furniture making and other businesses, also active in local state and Republican Party politics and businessmen's associations. Papers include family papers and correspondence, business records, scrapbooks and visual materials.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">36 linear feet</extent>
-        <extent altrender="carrier">(in 41 boxes)</extent>
+        <extent altrender="carrier">in 41 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">31 oversize volumes</extent>

--- a/Real_Masters_all/slusserr.xml
+++ b/Real_Masters_all/slusserr.xml
@@ -43,7 +43,7 @@
       <abstract>Professor of Russian and Soviet history at Michigan State University. Research and bibliographic note cards used in his study and teaching of Russian history, particularly relating to the study of the Soviet Union; also publications and dissertation.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">13 linear feet</extent>
-        <extent altrender="carrier">(in 21 boxes)</extent>
+        <extent altrender="carrier">in 21 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/smithhaz.xml
+++ b/Real_Masters_all/smithhaz.xml
@@ -1046,7 +1046,7 @@
               </unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">13 volumes</extent>
-                <extent altrender="carrier">(in 1 folder)</extent>
+                <extent altrender="carrier">in 1 folder</extent>
               </physdesc>
             </did>
             <c04 level="file">

--- a/Real_Masters_all/smithhigr.xml
+++ b/Real_Masters_all/smithhigr.xml
@@ -47,7 +47,7 @@
       <abstract>Architectural and engineering firm established in 1853 and headquartered in Detroit, Mich. with offices throughout the United States. Collection contains architectural drawings of five Michigan projects located in Ann Arbor, Detroit, and Flint.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">211 drawings</extent>
-        <extent altrender="carrier">(in 4 oversize folders)</extent>
+        <extent altrender="carrier">in 4 oversize folders</extent>
         <physfacet>architectural drawings</physfacet>
       </physdesc>
       <physdesc altrender="part">

--- a/Real_Masters_all/snre.xml
+++ b/Real_Masters_all/snre.xml
@@ -9670,7 +9670,7 @@
                   </physdesc>
                   <physdesc altrender="part">
                     <extent altrender="materialtype spaceoccupied">1 oversize photographs</extent>
-                    <extent altrender="carrier">(located in box 76)</extent>
+                    <extent altrender="carrier">located in box 76</extent>
                   </physdesc>
                 </did>
                 <odd>
@@ -9710,7 +9710,7 @@
                   </physdesc>
                   <physdesc altrender="part">
                     <extent altrender="materialtype spaceoccupied">1 oversize photographs</extent>
-                    <extent altrender="carrier">(located in box 76)</extent>
+                    <extent altrender="carrier">located in box 76</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9867,7 +9867,7 @@
                   </physdesc>
                   <physdesc altrender="part">
                     <extent altrender="materialtype spaceoccupied">1 oversize photographs</extent>
-                    <extent altrender="carrier">(located in box 76)</extent>
+                    <extent altrender="carrier">located in box 76</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -10549,7 +10549,7 @@
                   </physdesc>
                   <physdesc altrender="part">
                     <extent altrender="materialtype spaceoccupied">1 oversize photographs</extent>
-                    <extent altrender="carrier">(located in box 76)</extent>
+                    <extent altrender="carrier">located in box 76</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -11951,7 +11951,7 @@
               <unittitle>Tree Species</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">11 slides</extent>
-                <extent altrender="carrier">(in plastic bag)</extent>
+                <extent altrender="carrier">in plastic bag</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/spedhist.xml
+++ b/Real_Masters_all/spedhist.xml
@@ -43,7 +43,7 @@
       <abstract>Records of the organization as well as collections of records received from individuals and organization relating to the development and history of special education in Michigan.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">17 linear feet</extent>
-        <extent altrender="carrier">(in 24 boxes)</extent>
+        <extent altrender="carrier">in 24 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
@@ -109,7 +109,7 @@ Society for the Preservation of Michigan Special Education History collection, B
             <unittitle>Early record <unitdate type="inclusive" normal="1988/1989">1988-1989</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">27 folders</extent>
-              <extent altrender="carrier">(in 1 expandable folder)</extent>
+              <extent altrender="carrier">in 1 expandable folder</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/sphum.xml
+++ b/Real_Masters_all/sphum.xml
@@ -63,7 +63,7 @@
       <unittitle encodinganalog="245">School of Public Health (University of Michigan) records <unitdate type="inclusive" encodinganalog="245$f" normal="1909/2015">1909-2015</unitdate> <unitdate type="bulk" encodinganalog="245$g" normal="1941/2004">1941-2004</unitdate></unittitle>
       <physdesc altrender="part">
         <extent encodinganalog="300">97 linear feet</extent>
-        <extent altrender="carrier">(in 98 boxes)</extent>
+        <extent altrender="carrier">in 98 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent encodinganalog="300">8.74 GB</extent>

--- a/Real_Masters_all/stanleya.xml
+++ b/Real_Masters_all/stanleya.xml
@@ -43,7 +43,7 @@
       <abstract>Professor of music and director of the University Musical Society at University of Michigan. Correspondence, articles, lectures, speeches, autobiography, and photographs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/stellafr.xml
+++ b/Real_Masters_all/stellafr.xml
@@ -51,7 +51,7 @@
       <abstract>Detroit businessman, active in many civic and philanthropic activities, a founder and president of the National Italian American Foundation and a founding director of Legatus, an organization of Catholic business leaders. The Frank D. Stella collection documents the career of a Detroit businessman, who devoted much of his time and energy to many philanthropic, cultural, and civic endeavors. The collection consists of his files from a selection of his organizational responsibilities relating to Italian American organizations and causes, to state and national Republican Party fund raising and campaigns, to Roman Catholic schools and organizations, and to the betterment of life (cultural, health services, etc.) of the greater Detroit area.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">49 linear feet</extent>
-        <extent altrender="carrier">(in 51 boxes)</extent>
+        <extent altrender="carrier">in 51 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">12 oversize volumes</extent>

--- a/Real_Masters_all/stewartf.xml
+++ b/Real_Masters_all/stewartf.xml
@@ -198,7 +198,7 @@ Stewart family papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Reminiscences and reflections <unitdate type="inclusive" normal="1918/1989">1918-1989</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 volumes</extent>
-                <extent altrender="carrier">(in 2 folders)</extent>
+                <extent altrender="carrier">in 2 folders</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/stewfam.xml
+++ b/Real_Masters_all/stewfam.xml
@@ -43,7 +43,7 @@
       <abstract>Papers of the Stewart, Van Akin, and Seymour families, of Flint, Michigan. Includes correspondence, genealogies, newspaper clippings, family memorabilia and photographs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.25 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/stlandof.xml
+++ b/Real_Masters_all/stlandof.xml
@@ -50,7 +50,7 @@
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">69 oversize folders</extent>
-        <extent altrender="carrier">(in 20 boxes)</extent>
+        <extent altrender="carrier">in 20 boxes</extent>
       </physdesc>
       <physloc>Portions located in offsite storage; prior notification required for access.</physloc>
     </did>

--- a/Real_Masters_all/stockton.xml
+++ b/Real_Masters_all/stockton.xml
@@ -46,7 +46,7 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/stonerct.xml
+++ b/Real_Masters_all/stonerct.xml
@@ -46,7 +46,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">9 linear feet</extent>
-        <extent altrender="carrier">(in 13 boxes)</extent>
+        <extent altrender="carrier">in 13 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/stthomas.xml
+++ b/Real_Masters_all/stthomas.xml
@@ -50,7 +50,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/studleyw.xml
+++ b/Real_Masters_all/studleyw.xml
@@ -41,7 +41,7 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.6 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/swaingr.xml
+++ b/Real_Masters_all/swaingr.xml
@@ -54,7 +54,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">20 linear feet</extent>
-        <extent altrender="carrier">(in 34 boxes)</extent>
+        <extent altrender="carrier">in 34 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/swainson.xml
+++ b/Real_Masters_all/swainson.xml
@@ -56,7 +56,7 @@
       <physloc>Stored offsite except for oversize folder and volume; two days notice required for retrieval of materials.</physloc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">71.5 linear feet</extent>
-        <extent altrender="carrier">(in 73 boxes)</extent>
+        <extent altrender="carrier">in 73 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/tappanhp.xml
+++ b/Real_Masters_all/tappanhp.xml
@@ -47,7 +47,7 @@
       <abstract>First president of University of Michigan. Correspondence, essays, sermons, lectures, poetry, and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 oversize folders</extent>

--- a/Real_Masters_all/taubmana.xml
+++ b/Real_Masters_all/taubmana.xml
@@ -47,7 +47,7 @@
       <abstract>A. Alfred Taubman is an entrepreneur, real estate developer and philanthropist. The Taubman collection consists of business and personal records documenting his development of retail and mixed-use real estate projects, his role as a leader in the real estate industry in Michigan and nationally, his transformation of Sotheby’s, his investments and business interests, his contributions to the arts, to American educational institutions, and to the city of Detroit.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">220 linear feet</extent>
-        <extent altrender="carrier">(approximate; in 247 boxes)</extent>
+        <extent altrender="carrier">approximate; in 247 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 tubes</extent>
@@ -2658,7 +2658,7 @@ A. Alfred Taubman papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Restructuring and Refinancing <unitdate type="inclusive" normal="1989-03">March 1989</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 volumes</extent>
-                <extent altrender="carrier">(in 3 portfolios)</extent>
+                <extent altrender="carrier">in 3 portfolios</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/taylorho.xml
+++ b/Real_Masters_all/taylorho.xml
@@ -58,7 +58,7 @@
       </repository>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">23.1 linear feet</extent>
-        <extent altrender="carrier">(in 25 boxes)</extent>
+        <extent altrender="carrier">in 25 boxes</extent>
       </physdesc>
       <physloc>Portions located in offsite storage; prior notification required for access.</physloc>
     </did>

--- a/Real_Masters_all/teachout.xml
+++ b/Real_Masters_all/teachout.xml
@@ -42,7 +42,7 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">67 phonograph records</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/terhorstj.xml
+++ b/Real_Masters_all/terhorstj.xml
@@ -51,7 +51,7 @@
       <abstract>Jerald terHorst was a political reporter for the <title render="italic">Detroit News</title> and served as President Ford's first press secretary, before resigning in protest of the pardon of Richard Nixon. He also wrote a biography Gerald Ford and a history of Air Force One. The collection includes correspondence, speeches, newspaper articles by terHorst and about him, audiotapes, and video documenting his role in the Gerald Ford administration and his later literary and public career.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3.5 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>
@@ -516,7 +516,7 @@ Jerald F. terHorst papers, Bentley Historical Library, University of Michigan</p
               <unittitle>Berlin color slides special by Press and Information Office of the Federal Government of Germany <unitdate type="inclusive" normal="1963" certainty="approximate">1963</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">28 slides</extent>
-                <extent altrender="carrier">(in 1 box)</extent>
+                <extent altrender="carrier">in 1 box</extent>
               </physdesc>
             </did>
           </c03>
@@ -526,7 +526,7 @@ Jerald F. terHorst papers, Bentley Historical Library, University of Michigan</p
               <unittitle>Jimmy Carter in Africa <unitdate type="inclusive" normal="1978-05">May 1978</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">32 slides</extent>
-                <extent altrender="carrier">(in 2 boxes)</extent>
+                <extent altrender="carrier">in 2 boxes</extent>
               </physdesc>
             </did>
           </c03>
@@ -571,7 +571,7 @@ Jerald F. terHorst papers, Bentley Historical Library, University of Michigan</p
               <unittitle>John F. Kennedy in Berlin <unitdate type="inclusive" normal="1963-06">June 1963</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">73 slides</extent>
-                <extent altrender="carrier">(in 2 boxes)</extent>
+                <extent altrender="carrier">in 2 boxes</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/thomasc.xml
+++ b/Real_Masters_all/thomasc.xml
@@ -1341,7 +1341,7 @@
             <unittitle><corpname>Community Development Center (CDC)</corpname>, <unitdate type="inclusive" normal="1970/1975" certainty="approximate">circa early 1970s</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">11 photographs</extent>
-              <extent altrender="carrier">(in 2 folders)</extent>
+              <extent altrender="carrier">in 2 folders</extent>
               <physfacet>black and white</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/thomasna.xml
+++ b/Real_Masters_all/thomasna.xml
@@ -42,7 +42,7 @@
       <abstract>Quaker abolitionist and physician in Mt. Pleasant, Ohio, and Schoolcraft, Michigan. Correspondence of Thomas, his wife Pamela S. Brown Thomas, and their children; addresses, autobiography, financial ledgers, and files relating to business activities, medical practice, and anti-slavery activities.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">2 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/thomrobt.xml
+++ b/Real_Masters_all/thomrobt.xml
@@ -42,7 +42,7 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">25 photographs</extent>
-        <extent altrender="carrier">(in 1 folder)</extent>
+        <extent altrender="carrier">in 1 folder</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/ticecarol.xml
+++ b/Real_Masters_all/ticecarol.xml
@@ -47,7 +47,7 @@
       <abstract>Art teacher in Ann Arbor, Mich. Public schools and the founder of the Teaching-Learning Communities program and Lifespan Resources, Inc., an educational non-profit organization. Administrative papers, correspondence, news clippings, photographs, reports, grant proposals, and personal speeches and publications related to intergenerational education and related initiatives from the early 1970s until 2000.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">8.5 linear feet</extent>
-        <extent altrender="carrier">(in 9 boxes)</extent>
+        <extent altrender="carrier">in 9 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize boxes</extent>

--- a/Real_Masters_all/toyjim.xml
+++ b/Real_Masters_all/toyjim.xml
@@ -62,7 +62,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">27.5 linear feet</extent>
-        <extent altrender="carrier">(in 30 boxes)</extent>
+        <extent altrender="carrier">in 30 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/tsaoonce.xml
+++ b/Real_Masters_all/tsaoonce.xml
@@ -43,7 +43,7 @@
       <abstract>Posters, programs, and flyers advertising events of the ONCE Festival, collected by Makepeace Uho Tsao.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.3 linear feet</extent>
-        <extent altrender="carrier">(in 2 oversize folders)</extent>
+        <extent altrender="carrier">in 2 oversize folders</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/ucellar.xml
+++ b/Real_Masters_all/ucellar.xml
@@ -47,7 +47,7 @@
       <abstract>Student-controlled bookstore at the University of Michigan (established 1970, ceased operation in 1987.) Minutes and memoranda of board of directors, financial records, labor negotiation files, and other subject files; and photographs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">5 linear feet</extent>
-        <extent altrender="carrier">(in 6 boxes)</extent>
+        <extent altrender="carrier">in 6 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/umarchdr.xml
+++ b/Real_Masters_all/umarchdr.xml
@@ -50,7 +50,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">17 oversize folders</extent>
-        <extent altrender="carrier">(in 3 blueprint cabinet drawers)</extent>
+        <extent altrender="carrier">in 3 blueprint cabinet drawers</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 blueprints</extent>

--- a/Real_Masters_all/umgass.xml
+++ b/Real_Masters_all/umgass.xml
@@ -43,7 +43,7 @@
       <abstract>University of Michigan group established in 1946 devoted to production of Gilbert and Sullivan operettas. Records include production files with programs, photographs, reviews and newspaper clippings, and scattered production notes and memoranda; topical files relating to the Society, its friends organization, and its publication; slides of productions; Society newsletter, "Gasbag"; posters; phonorecords, tapes, and videos of productions.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">22.5 linear feet</extent>
-        <extent altrender="carrier">(in 26 boxes)</extent>
+        <extent altrender="carrier">in 26 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">9 oversize volumes</extent>

--- a/Real_Masters_all/umhillel.xml
+++ b/Real_Masters_all/umhillel.xml
@@ -47,7 +47,7 @@
       <abstract>The University of Michigan Hillel records cover the student organization's contribution to Jewish campus life. The collection consists primarily of calendar of events, newsletters, some correspondence, newspaper clippings, board minutes, brochures, programs, and posters.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/ummanthr.xml
+++ b/Real_Masters_all/ummanthr.xml
@@ -49,7 +49,7 @@
       </note>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/umnap.xml
+++ b/Real_Masters_all/umnap.xml
@@ -46,7 +46,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/umstport.xml
+++ b/Real_Masters_all/umstport.xml
@@ -46,7 +46,7 @@
       <abstract>Portraits of University of Michigan students, ca. 1860-ca.1950, gathered from a number of sources.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2000 photographs</extent>
-        <extent altrender="carrier">(in 10 boxes.)</extent>
+        <extent altrender="carrier">in 10 boxes.</extent>
         <physfacet>approximate</physfacet>
       </physdesc>
       <repository>

--- a/Real_Masters_all/unistrut.xml
+++ b/Real_Masters_all/unistrut.xml
@@ -46,7 +46,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">2.5 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <repository encodinganalog="852">
         <corpname><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/upatnieks.xml
+++ b/Real_Masters_all/upatnieks.xml
@@ -55,7 +55,7 @@
       <abstract>Papers of Juris Upatnieks, a University of Michigan scientist who helped to lay the foundations of holography, a photography technique that recreates the recorded objects with all of their three-dimensional optical properties. Collection includes Upatnieks correspondence with American and international scientists and companies, scientific papers, proposals and technical reports, sometimes prepared in collaboration with other scientists, as well as digitized laboratory notebooks and lantern slides illustrating his research on various subjects.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">7.25 linear feet</extent>
-        <extent altrender="carrier">(in 7 boxes)</extent>
+        <extent altrender="carrier">in 7 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/vanbroek.xml
+++ b/Real_Masters_all/vanbroek.xml
@@ -47,7 +47,7 @@
       <abstract>Professor of mechanical engineering at University of Michigan. Correspondence concerning University and departmental business, World War II research projects, the American Society of Civil Engineering, and research projects of the Hamilton Watch Company and Hayes Wheel Company.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.5 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/vandenba.xml
+++ b/Real_Masters_all/vandenba.xml
@@ -71,7 +71,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">8 linear feet</extent>
-        <extent altrender="carrier">(on 11 microfilm rolls)</extent>
+        <extent altrender="carrier">on 11 microfilm rolls</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">25 volumes</extent>

--- a/Real_Masters_all/vantynej.xml
+++ b/Real_Masters_all/vantynej.xml
@@ -55,7 +55,7 @@
       </repository>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
-        <extent altrender="carrier">(in 5 boxes)</extent>
+        <extent altrender="carrier">in 5 boxes</extent>
       </physdesc>
       <physloc>Portions located in offsite storage; prior notification required for access.</physloc>
     </did>

--- a/Real_Masters_all/vargasg.xml
+++ b/Real_Masters_all/vargasg.xml
@@ -47,7 +47,7 @@
       <abstract>Artist and art historian with an emphasis in Latino art; artwork, research, teaching, and professional materials.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 oversize folders</extent>

--- a/Real_Masters_all/vpsaff.xml
+++ b/Real_Masters_all/vpsaff.xml
@@ -54,7 +54,7 @@
       <abstract>University of Michigan administrative office, established as the Dean of Student Affairs in 1921, responsible for overseeing many aspects of non-academic student services and activities including at various times: counseling, financial aid, student housing, student activities and organizations, the health service, student discipline, and fraternities and sororities. Records provide extensive documentation of student life.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">41.5 linear feet</extent>
-        <extent altrender="carrier">(in 42 boxes)</extent>
+        <extent altrender="carrier">in 42 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/waitclar.xml
+++ b/Real_Masters_all/waitclar.xml
@@ -43,7 +43,7 @@
       <abstract>Member of the Michigan Daughters of the American Revolution; scrapbooks, journals, and photograph albums.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">16 volumes</extent>
-        <extent altrender="carrier">(in 1 box)</extent>
+        <extent altrender="carrier">in 1 box</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/wascohs.xml
+++ b/Real_Masters_all/wascohs.xml
@@ -55,7 +55,7 @@
       <abstract>Local historical society for Washtenaw County, Michigan Organizational records and collected historical materials.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">17.5 linear feet</extent>
-        <extent altrender="carrier">(in 18 boxes)</extent>
+        <extent altrender="carrier">in 18 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/washcoun.xml
+++ b/Real_Masters_all/washcoun.xml
@@ -43,7 +43,7 @@
       <abstract>Correspondence files of the county clerk, register of deeds, county treasurer, and other county offices; also township poll lists, political party enrollment books, list of Civil War volunteers, record of county soldiers and sailors during World War I, and miscellaneous welfare records.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">14 linear feet</extent>
-        <extent altrender="carrier">(in 16 boxes)</extent>
+        <extent altrender="carrier">in 16 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">16 oversize volumes</extent>

--- a/Real_Masters_all/washmeds.xml
+++ b/Real_Masters_all/washmeds.xml
@@ -173,8 +173,7 @@ Washtenaw County Medical Society records, Bentley Historical Library, University
           </did>
           <c03 level="file">
             <did>
-              <unitdate type="inclusive" normal="1866/1883">1866-1883</unitdate>
-            </did>
+              </did>
             <odd>
               <p>(include constitution and by-laws)</p>
             </odd>
@@ -182,14 +181,12 @@ Washtenaw County Medical Society records, Bentley Historical Library, University
           <c03 level="file">
             <did>
               <container type="box" label="Box">4</container>
-              <unitdate type="inclusive" normal="1911/1931">1911-1931</unitdate>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">4</container>
-              <unitdate type="inclusive" normal="1937/1940">1937-1940</unitdate>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/wctumi.xml
+++ b/Real_Masters_all/wctumi.xml
@@ -67,7 +67,7 @@
       <abstract>State chapter of national temperance organization founded in 1874; records include correspondence of early W.C.T.U. workers, Alice E. H. Peters and Ella Eaton Kellogg; also minutes, scrapbooks, and other records of individual Michigan W.C.T.U. districts and chapters.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">16 linear feet</extent>
-        <extent altrender="carrier">(in 17 boxes)</extent>
+        <extent altrender="carrier">in 17 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3 oversize volumes</extent>

--- a/Real_Masters_all/weberw.xml
+++ b/Real_Masters_all/weberw.xml
@@ -58,7 +58,7 @@
       <abstract>Detroit, Michigan businessman and civic leader. Business correspondence relating to Weber's activities as a dealer in timber lands, his role as a member of the Art Commission in the development of Detroit, Michigan's Cultural Center, his involvement in the construction of the Detroit-Windsor bridge and tunnel and his activities during World War I; and correspondence and class notes of his sons, Harry B. and Erwin W. Weber, while attending University of Michigan; also photographs, including family portraits, aerial views of Windsor, Ontario, and Detroit, photographs of the construction of the Detroit-Windsor Tunnel and Ambassador Bridge, and glass negatives of family vacations in Upper Michigan, Ontario, and Quebec; and maps of land and timber holdings</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">28 linear feet</extent>
-        <extent altrender="carrier">(in 30 boxes)</extent>
+        <extent altrender="carrier">in 30 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">15 oversize volumes</extent>

--- a/Real_Masters_all/wedemeyr.xml
+++ b/Real_Masters_all/wedemeyr.xml
@@ -47,7 +47,7 @@
       <abstract>Ann Arbor, Michigan attorney, American consul in British Guiana in 1905, and U.S. Congressman, 1911-1913. Political and business correspondence, notes and addresses, and other materials relating to his business interests and political career; also papers concerning his trips to Alaska, British Guiana, and Panama.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">1.3 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/weinsteina.xml
+++ b/Real_Masters_all/weinsteina.xml
@@ -43,7 +43,7 @@
       <abstract>Papers of Arnold Weinstein, American poet, playwright, librettist, and translator. Material in both paper and digital formats includes manuscript drafts and final versions of libretti, music scores with Weinstein's lyrics, manuscript and published literary works; research and background material related to individual works and projects, as well as programs, publicity material and reviews of shows. Also commercially produced and non-commercial audio and video recordings.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">12.3 linear feet</extent>
-        <extent altrender="carrier">(in 13 boxes including oversize)</extent>
+        <extent altrender="carrier">in 13 boxes including oversize</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize volumes</extent>

--- a/Real_Masters_all/weissert.xml
+++ b/Real_Masters_all/weissert.xml
@@ -43,7 +43,7 @@
       <abstract>Journalist, historical researcher from Kalamazoo, Michigan; Correspondence, research articles and notes, and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3.3 linear feet</extent>
-        <extent altrender="carrier">(in 4 boxes)</extent>
+        <extent altrender="carrier">in 4 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/welchken.xml
+++ b/Real_Masters_all/welchken.xml
@@ -50,7 +50,7 @@
       <langmaterial>The materials are in <language encodinganalog="041" langcode="eng">English.</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">13.6 linear feet</extent>
-        <extent altrender="carrier">(in 15 boxes)</extent>
+        <extent altrender="carrier">in 15 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>

--- a/Real_Masters_all/westmeth.xml
+++ b/Real_Masters_all/westmeth.xml
@@ -43,7 +43,7 @@
       <abstract>Church originally established by German immigrant families to Ann Arbor, Michigan. Quarterly and annual reports of the church, records of church boards and commissions, Sunday School minutes and reports, subject files, publications, visual materials, and sound recordings.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">16 linear feet</extent>
-        <extent altrender="carrier">(in 17 boxes)</extent>
+        <extent altrender="carrier">in 17 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/whithar.xml
+++ b/Real_Masters_all/whithar.xml
@@ -46,7 +46,7 @@
       <abstract>Landscape architect, professor of landscape architecture at the University of Michigan. Files relating to various Michigan projects, notably in Ann Arbor, Hartland, Hillsdale, and Highland Park; subject files on professional activities; and photographs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">5.5 linear feet</extent>
-        <extent altrender="carrier">(in 7 boxes)</extent>
+        <extent altrender="carrier">in 7 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
@@ -1650,7 +1650,7 @@ Harlow Olin Whittemore Papers, Bentley Historical Library, University of Michiga
             <unittitle>Battle Creek-Miscellaneous <unitdate type="inclusive" normal="1927-10-16">October 16, 1927</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">25 prints</extent>
-              <extent altrender="carrier">(in 3 folders)</extent>
+              <extent altrender="carrier">in 3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1765,7 +1765,7 @@ Harlow Olin Whittemore Papers, Bentley Historical Library, University of Michiga
             <unittitle>Grand Ledge-Riverside Park and Grand River <unitdate type="inclusive" normal="1939-05/1939-07">May-July, 1939</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">46 prints</extent>
-              <extent altrender="carrier">(in 2 folders)</extent>
+              <extent altrender="carrier">in 2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1919,7 +1919,7 @@ Harlow Olin Whittemore Papers, Bentley Historical Library, University of Michiga
               <unittitle>Street Scenes <unitdate type="inclusive" normal="1949/1952" certainty="approximate">circa 1949-1952</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">39 prints</extent>
-                <extent altrender="carrier">(in 4 folders)</extent>
+                <extent altrender="carrier">in 4 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2153,7 +2153,7 @@ Harlow Olin Whittemore Papers, Bentley Historical Library, University of Michiga
               <unittitle>Munising <unitdate type="inclusive" normal="1930-09">September, 1930</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">28 prints</extent>
-                <extent altrender="carrier">(in 2 folders)</extent>
+                <extent altrender="carrier">in 2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2357,7 +2357,7 @@ Harlow Olin Whittemore Papers, Bentley Historical Library, University of Michiga
                 <unittitle>Street Scenes, circa <unitdate type="inclusive" normal="1949/1952">1949-1952</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">36 negatives</extent>
-                  <extent altrender="carrier">(in 2 folders)</extent>
+                  <extent altrender="carrier">in 2 folders</extent>
                 </physdesc>
               </did>
               <odd>

--- a/Real_Masters_all/whithar.xml
+++ b/Real_Masters_all/whithar.xml
@@ -294,8 +294,7 @@ Harlow Olin Whittemore Papers, Bentley Historical Library, University of Michiga
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">1</container>
-                  <unitdate type="inclusive" normal="1962">1962</unitdate>
-                </did>
+                  </did>
                 <odd>
                   <p>includes some drawings and sketches</p>
                 </odd>

--- a/Real_Masters_all/whittfam.xml
+++ b/Real_Masters_all/whittfam.xml
@@ -864,7 +864,7 @@ Whittemore Family Papers
             </physdesc>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">23 items</extent>
-              <extent altrender="carrier">(in 2 folders)</extent>
+              <extent altrender="carrier">in 2 folders</extent>
             </physdesc>
           </did>
           <odd>

--- a/Real_Masters_all/wickliff.xml
+++ b/Real_Masters_all/wickliff.xml
@@ -43,7 +43,7 @@
       <abstract>Teacher; Ann Arbor, Michigan, community activist; member of the North Central Property Owners Association in Ann Arbor. Articles written for the local newspaper, awards, scattered correspondence, biographical information, and photographs.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.5 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/wilkwarr.xml
+++ b/Real_Masters_all/wilkwarr.xml
@@ -47,7 +47,7 @@
       <abstract>Scrapbooks of Warren S. Wilkinson, member of the board of the Evening News Association, publisher of the <title render="italic">Detroit News</title>. Scrapbooks relate to the life and work of James E. Scripps, founder of the <title render="italic">Detroit News</title>, and to the struggle over the sale of the newspaper to Gannett Company in 1985.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">5 oversize volumes</extent>

--- a/Real_Masters_all/willekel.xml
+++ b/Real_Masters_all/willekel.xml
@@ -47,7 +47,7 @@
       <abstract>Cincinnati and Detroit based architect. Major commissions include the Grosse Pointe Shores, Michigan residence for Oscar Webber, the Fordson Village Development, and the Goulburn Avenue and Dresden Avenue Defense Houses in Detroit. The collection consists primarily of project files, correspondence, personal diaries, photographs, commission accounts, and architectural drawings.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">9.5 linear feet</extent>
-        <extent altrender="carrier">(in 11 boxes)</extent>
+        <extent altrender="carrier">in 11 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">26 tubes</extent>

--- a/Real_Masters_all/winchell.xml
+++ b/Real_Masters_all/winchell.xml
@@ -62,7 +62,7 @@
       <abstract>Professor of geology and paleontology at the University of Michigan, director of the Michigan Geological Survey, and chancellor of Syracuse University, popular lecturer and writer on scientific topics and as a Methodist layman who worked to reconcile traditional religious beliefs to nineteenth-century developments in the fields of evolutionary biology, cosmology, geology, and paleontology. Papers include extensive diaries, field notes and maps from travels and geological expeditions, correspondence, speeches, articles and other publications and photographs.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">23.5 linear feet</extent>
-        <extent altrender="carrier">(in 25 boxes)</extent>
+        <extent altrender="carrier">in 25 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>
@@ -4070,7 +4070,7 @@
               <unittitle>Student registers <unitdate type="inclusive" normal="1861/1870">1861-1870</unitdate>, <unitdate type="inclusive" normal="1881/1890">1881-1890</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 volumes</extent>
-                <extent altrender="carrier">(in 2 folders)</extent>
+                <extent altrender="carrier">in 2 folders</extent>
               </physdesc>
             </did>
             <odd>

--- a/Real_Masters_all/wineberg.xml
+++ b/Real_Masters_all/wineberg.xml
@@ -67,7 +67,7 @@
       <abstract>Susan Wineberg is a historian of Ann Arbor, Mich., and historic preservationist. She became involved in historic preservation in 1974 and has served as a commissioner on the Ann Arbor Historic District Commission (1982, 1984-1988) and as a member on its committees since 1977. Wineberg also has authored books and articles on historic buildings in Ann Arbor and been active in other local organizations. The collection includes correspondence, articles, brochures, clippings, printed ephemera and realia, photographs, and subject files relating mostly to Ann Arbor, Detroit, and Michigan historic properties and businesses.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">68 linear feet</extent>
-        <extent altrender="carrier">(in 69 boxes)</extent>
+        <extent altrender="carrier">in 69 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/winesher.xml
+++ b/Real_Masters_all/winesher.xml
@@ -51,7 +51,7 @@
       <abstract>Sherwin T. Wine was the iconoclastic founder of Humanistic Judaism and an openly gay rabbi who established the Birmingham Temple and formed the Society for Humanistic Judaism, the Center for New Thinking (a community forum for discussion of current events and issues), and various groups devoted to free thought and humanism. Papers include biographical content, correspondence, writings, educational and worship materials, sound recordings, visual materials, and various organizational records.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">36.5 linear feet</extent>
-        <extent altrender="carrier">(in 42 boxes)</extent>
+        <extent altrender="carrier">in 42 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>
@@ -4567,7 +4567,7 @@ Sherwin T. Wine papers, Bentley Historical Library, University of Michigan</p>
             <unittitle><genreform normal="Compact discs">Compact Discs</genreform>: lectures and a memorial service</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 optical disks</extent>
-              <extent altrender="carrier">(in 1 folder)</extent>
+              <extent altrender="carrier">in 1 folder</extent>
               <physfacet>CDs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/wittedge.xml
+++ b/Real_Masters_all/wittedge.xml
@@ -43,7 +43,7 @@
       <abstract>Lawrence L. Witt was a Detroit native who served in the Army Air Force during World War II and was a prisoner of war (POW) for eleven months after getting shot down over Nazi Germany. His daughter Laura A. Edge later researched her father's story and wrote a book about his and other airmen's experiences as prisoners of war in WWII. Correspondence, various documents relating to military and prisoner of war experience, and audio-visual materials including oral histories of several WWII veterans.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1.5 linear feet</extent>
-        <extent altrender="carrier">(in 2 boxes)</extent>
+        <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">30.9 GB</extent>

--- a/Real_Masters_all/womenstd.xml
+++ b/Real_Masters_all/womenstd.xml
@@ -50,7 +50,7 @@
       <abstract>The collection of the Women's Studies Program at the University of Michigan contains administrative files, correspondence, historical information, curriculum information, and meeting minutes. The collection documents the founding of the program and the 1979 review of the program.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">8.5 linear feet</extent>
-        <extent altrender="carrier">(in 10 boxes)</extent>
+        <extent altrender="carrier">in 10 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>

--- a/Real_Masters_all/woodjcp.xml
+++ b/Real_Masters_all/woodjcp.xml
@@ -42,7 +42,7 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">42 items</extent>
-        <extent altrender="carrier">(in 1 box)</extent>
+        <extent altrender="carrier">in 1 box</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/worthjea.xml
+++ b/Real_Masters_all/worthjea.xml
@@ -154,7 +154,7 @@ Jean Worth Papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Negatives <unitdate type="inclusive">undated</unitdate>, <unitdate type="inclusive" normal="1906" certainty="approximate">circa 1906</unitdate>, <unitdate type="inclusive" normal="1914/1915">1914-1915</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">40 negatives</extent>
-                <extent altrender="carrier">(in 2 folders)</extent>
+                <extent altrender="carrier">in 2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -172,7 +172,7 @@ Jean Worth Papers, Bentley Historical Library, University of Michigan</p>
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">33 prints</extent>
-                  <extent altrender="carrier">(in 2 folders)</extent>
+                  <extent altrender="carrier">in 2 folders</extent>
                 </physdesc>
               </did>
             </c04>

--- a/Real_Masters_all/yatesp.xml
+++ b/Real_Masters_all/yatesp.xml
@@ -42,7 +42,7 @@
       <abstract>Ann Arbor, Michigan photographer. Photographic images taken to accompany articles in the Ann Arbor Observer. Images include Ann Arbor businesses, buildings, neighborhoods, parks, landmarks; also photos of local personalities, politicians, business people, and University of Michigan faculty and staff members.</abstract>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">5200 35mm negative strips</extent>
-        <extent altrender="carrier">(in 3 boxes)</extent>
+        <extent altrender="carrier">in 3 boxes</extent>
         <physfacet>approximate</physfacet>
       </physdesc>
       <repository>

--- a/Real_Masters_all/ymcadet.xml
+++ b/Real_Masters_all/ymcadet.xml
@@ -59,7 +59,7 @@
       <abstract>Branch of the YMCA; Annual reports, clippings, correspondence, financial records, minutes of meetings, photographs, press releases, published materials, rosters, and scrapbooks; also includes collected branch records for the Railroad branch, 1877-1890, and the Downtown branch, 1890-1909; and publication, Detroit Young Men, 1911-1922.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">11 linear feet</extent>
-        <extent altrender="carrier">(in 13 boxes)</extent>
+        <extent altrender="carrier">in 13 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">21 oversize volumes</extent>

--- a/Real_Masters_all/yodertho.xml
+++ b/Real_Masters_all/yodertho.xml
@@ -1187,7 +1187,7 @@ Thomas Yoder papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Recordings of conference talks and prayer meetings <unitdate type="inclusive" normal="1969/1972">1969-1972</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">103 audiocassettes</extent>
-                <extent altrender="carrier">(in 8 card file boxes)</extent>
+                <extent altrender="carrier">in 8 card file boxes</extent>
               </physdesc>
             </did>
           </c03>
@@ -1197,7 +1197,7 @@ Thomas Yoder papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Recordings of conference talks and prayer meetings <unitdate type="inclusive" normal="1969/1972">1969-1972</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">37 audiocassettes</extent>
-                <extent altrender="carrier">(in 1 card file box)</extent>
+                <extent altrender="carrier">in 1 card file box</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/yostfh.xml
+++ b/Real_Masters_all/yostfh.xml
@@ -42,7 +42,7 @@
       <abstract>Football coach and athletic director of University of Michigan, 1901-1940. Correspondence, addresses, scrapbooks, photographs and other papers relating to his interest in sports and family affairs; also papers of his wife Eunice Josephine (Fite) Yost.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">8 linear feet</extent>
-        <extent altrender="carrier">(in 9 boxes)</extent>
+        <extent altrender="carrier">in 9 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">4 oversize volumes</extent>

--- a/Real_Masters_all/ypsitown.xml
+++ b/Real_Masters_all/ypsitown.xml
@@ -46,7 +46,7 @@
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">30 items</extent>
-        <extent altrender="carrier">(in 1 box)</extent>
+        <extent altrender="carrier">in 1 box</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>
@@ -175,7 +175,7 @@ Ypsilanti (Mich. : Township) records, Bentley Historical Library, University of 
               <unittitle>District No. 8 records <unitdate type="inclusive" normal="1837">1837</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 items</extent>
-                <extent altrender="carrier">(in oversize folder)</extent>
+                <extent altrender="carrier">in oversize folder</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/zollerp.xml
+++ b/Real_Masters_all/zollerp.xml
@@ -42,7 +42,7 @@
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">78 items</extent>
-        <extent altrender="carrier">(in 1 box)</extent>
+        <extent altrender="carrier">in 1 box</extent>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/ztgergan.xml
+++ b/Real_Masters_all/ztgergan.xml
@@ -43,7 +43,7 @@
       <abstract>Architectural drawings of the firm of Z.T. Gerganoff, of Ypsilanti, Michigan, (and predecessor firms of R.S. Gerganoff and S.T. Gerganoff). Drawings and specifications for various area churches, service stations and auto dealerships, the Washtenaw County Building, the Ypsi-Ann Building, and miscellaneous businesses and private residences.</abstract>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">27 oversize folders</extent>
-        <extent altrender="carrier">(in 6 drawers)</extent>
+        <extent altrender="carrier">in 6 drawers</extent>
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 linear feet</extent>


### PR DESCRIPTION
1. DLXS wraps extents in parens, so including parens in container summaries causes them to be wrapped up twice
2. We'll be exporting extents formatted how we want them, anyway, so we can add any necessary parens at that point

@walkerdb just FYI, I wanted to do another test import/export for DLXS so I went ahead and took care of this
