### PR TITLE
wrapping unitdates

### DIFF
--- a/Real_Masters_all/aayoungm.xml
+++ b/Real_Masters_all/aayoungm.xml
@@ -178,20 +178,20 @@ Ann Arbor Young Men’s - Young Women's Christian Association (Mich.) records, B
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitdate type="inclusive" normal="1902-01/1914">January 1902-1914</unitdate>
-            </did>
+              <unittitle><unitdate type="inclusive" normal="1902-01/1914">January 1902-1914</unitdate>
+            </unittitle></did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitdate type="inclusive" normal="1914-12/1921-12">December 1914-December 1921</unitdate>
-            </did>
+              <unittitle><unitdate type="inclusive" normal="1914-12/1921-12">December 1914-December 1921</unitdate>
+            </unittitle></did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitdate type="inclusive" normal="1922/1933">1922-1933</unitdate>
-            </did>
+              <unittitle><unitdate type="inclusive" normal="1922/1933">1922-1933</unitdate>
+            </unittitle></did>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/brewercl.xml
+++ b/Real_Masters_all/brewercl.xml
@@ -306,8 +306,8 @@ Clarence E. Brewer papers, Bentley Historical Library, University of Michigan</p
           <c03 level="file">
             <did>
               <container type="box" label="Box">2</container>
-              <unitdate type="inclusive" normal="1918/1925">1918-1925</unitdate>
-            </did>
+              <unittitle><unitdate type="inclusive" normal="1918/1925">1918-1925</unitdate>
+            </unittitle></did>
             <odd>
               <p>(include pamphlets, song books, and war memorial tributes)</p>
             </odd>
@@ -315,8 +315,8 @@ Clarence E. Brewer papers, Bentley Historical Library, University of Michigan</p
           <c03 level="file">
             <did>
               <container type="box" label="Box">2</container>
-              <unitdate type="inclusive" normal="1919/1921">1919-1921</unitdate>
-            </did>
+              <unittitle><unitdate type="inclusive" normal="1919/1921">1919-1921</unitdate>
+            </unittitle></did>
             <odd>
               <p>(include special bulletins, policy statements, and organizational procedures)</p>
             </odd>

--- a/Real_Masters_all/burrowsf.xml
+++ b/Real_Masters_all/burrowsf.xml
@@ -732,8 +732,8 @@ Burrows family papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">3</container>
-              <unitdate type="inclusive" normal="1914-07/1914-12">July-December 1914</unitdate>
-            </did>
+              <unittitle><unitdate type="inclusive" normal="1914-07/1914-12">July-December 1914</unitdate>
+            </unittitle></did>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/churchm.xml
+++ b/Real_Masters_all/churchm.xml
@@ -149,26 +149,26 @@ Michael P. Church papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitdate type="inclusive" normal="1933/1972">1933-1972</unitdate>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">43 folders</extent>
               </physdesc>
-            </did>
+            <unittitle><unitdate type="inclusive" normal="1933/1972">1933-1972</unitdate>
+              </unittitle></did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">2</container>
-              <unitdate type="inclusive" normal="1973/1975">1973-1975</unitdate>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
-            </did>
+            <unittitle><unitdate type="inclusive" normal="1973/1975">1973-1975</unitdate>
+              </unittitle></did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">2</container>
-              <unitdate type="inclusive">undated</unitdate>
-            </did>
+              <unittitle><unitdate type="inclusive">undated</unitdate>
+            </unittitle></did>
             <odd>
               <p>(filed alphabetically by correspondent)</p>
             </odd>

--- a/Real_Masters_all/davenfrd.xml
+++ b/Real_Masters_all/davenfrd.xml
@@ -172,8 +172,8 @@ Fred M. Davenport papers, Bentley Historical Library, University of Michigan</p>
           <c03 level="file">
             <did>
               <container type="box" label="Box">9</container>
-              <unitdate type="inclusive" normal="1969/1972">1969-1972</unitdate>
-            </did>
+              <unittitle><unitdate type="inclusive" normal="1969/1972">1969-1972</unitdate>
+            </unittitle></did>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/fbaptaa.xml
+++ b/Real_Masters_all/fbaptaa.xml
@@ -1485,14 +1485,14 @@ First Baptist Church (Ann Arbor, Mich.) records, Bentley Historical Library, Uni
             <c04 level="file">
               <did>
                 <container type="box" label="Box">14</container>
-                <unitdate type="inclusive" normal="1970/1974">1970-1974</unitdate>
-              </did>
+                <unittitle><unitdate type="inclusive" normal="1970/1974">1970-1974</unitdate>
+              </unittitle></did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">14</container>
-                <unitdate type="inclusive" normal="1975/1981">1975-1981</unitdate>
-              </did>
+                <unittitle><unitdate type="inclusive" normal="1975/1981">1975-1981</unitdate>
+              </unittitle></did>
             </c04>
           </c03>
           <c03 level="file">
@@ -1596,20 +1596,20 @@ First Baptist Church (Ann Arbor, Mich.) records, Bentley Historical Library, Uni
           <c03 level="file">
             <did>
               <container type="box" label="Box">15</container>
-              <unitdate type="inclusive" normal="1874/1880">1874-1880</unitdate>
-            </did>
+              <unittitle><unitdate type="inclusive" normal="1874/1880">1874-1880</unitdate>
+            </unittitle></did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">15</container>
-              <unitdate type="inclusive" normal="1881/1914">1881-1914</unitdate>
-            </did>
+              <unittitle><unitdate type="inclusive" normal="1881/1914">1881-1914</unitdate>
+            </unittitle></did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">15</container>
-              <unitdate type="inclusive">undated</unitdate>
-            </did>
+              <unittitle><unitdate type="inclusive">undated</unitdate>
+            </unittitle></did>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/gbassoc.xml
+++ b/Real_Masters_all/gbassoc.xml
@@ -22069,13 +22069,13 @@
             </c04>
             <c04 level="file">
               <did>
-                <unitdate type="inclusive" normal="1975-01-21/1976-01-21">1/21/75-1/21/76</unitdate>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">50 prints</extent>
                   <physfacet>black and white</physfacet>
                   <dimensions>8x10-inch</dimensions>
                 </physdesc>
-              </did>
+              <unittitle><unitdate type="inclusive" normal="1975-01-21/1976-01-21">1/21/75-1/21/76</unitdate>
+                </unittitle></did>
             </c04>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/inreform.xml
+++ b/Real_Masters_all/inreform.xml
@@ -305,14 +305,14 @@ International Reform Federation records, Bentley Historical Library, University 
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitdate type="inclusive" normal="1928/1936">1928-1936</unitdate>
-            </did>
+              <unittitle><unitdate type="inclusive" normal="1928/1936">1928-1936</unitdate>
+            </unittitle></did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">1</container>
-              <unitdate type="inclusive" normal="1937/1949">1937-1949</unitdate>
-            </did>
+              <unittitle><unitdate type="inclusive" normal="1937/1949">1937-1949</unitdate>
+            </unittitle></did>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/physics.xml
+++ b/Real_Masters_all/physics.xml
@@ -840,17 +840,17 @@ Programs <unitdate type="inclusive" normal="1984">1984</unitdate></unittitle>
               </did>
               <c05 level="file">
                 <did>
-                  <unitdate type="inclusive" normal="1954-10/1966-07">October 1954-July 1966</unitdate>
                   <physdesc>
                     <extent>3 folders</extent>
                   </physdesc>
-                </did>
+                <unittitle><unitdate type="inclusive" normal="1954-10/1966-07">October 1954-July 1966</unitdate>
+                  </unittitle></did>
               </c05>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">11</container>
-                  <unitdate type="inclusive" normal="1973/1978">1973-1978</unitdate>
-                </did>
+                  <unittitle><unitdate type="inclusive" normal="1973/1978">1973-1978</unitdate>
+                </unittitle></did>
               </c05>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/washmeds.xml
+++ b/Real_Masters_all/washmeds.xml
@@ -173,8 +173,8 @@ Washtenaw County Medical Society records, Bentley Historical Library, University
           </did>
           <c03 level="file">
             <did>
-              <unitdate type="inclusive" normal="1866/1883">1866-1883</unitdate>
-            </did>
+              <unittitle><unitdate type="inclusive" normal="1866/1883">1866-1883</unitdate>
+            </unittitle></did>
             <odd>
               <p>(include constitution and by-laws)</p>
             </odd>
@@ -182,14 +182,14 @@ Washtenaw County Medical Society records, Bentley Historical Library, University
           <c03 level="file">
             <did>
               <container type="box" label="Box">4</container>
-              <unitdate type="inclusive" normal="1911/1931">1911-1931</unitdate>
-            </did>
+              <unittitle><unitdate type="inclusive" normal="1911/1931">1911-1931</unitdate>
+            </unittitle></did>
           </c03>
           <c03 level="file">
             <did>
               <container type="box" label="Box">4</container>
-              <unitdate type="inclusive" normal="1937/1940">1937-1940</unitdate>
-            </did>
+              <unittitle><unitdate type="inclusive" normal="1937/1940">1937-1940</unitdate>
+            </unittitle></did>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/whithar.xml
+++ b/Real_Masters_all/whithar.xml
@@ -294,8 +294,8 @@ Harlow Olin Whittemore Papers, Bentley Historical Library, University of Michiga
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">1</container>
-                  <unitdate type="inclusive" normal="1962">1962</unitdate>
-                </did>
+                  <unittitle><unitdate type="inclusive" normal="1962">1962</unitdate>
+                </unittitle></did>
                 <odd>
                   <p>includes some drawings and sketches</p>
                 </odd>


### PR DESCRIPTION
Somehow we have some components that just have unitdates. I don't think this is something we did, and it won't matter post-migration, but since we now know for sure that DLXS does not handle just unitdates, I wrapped these in unittitle tags.
