### PR TITLE
merging some physdescs

### DIFF
--- a/Real_Masters_all/acadwc.xml
+++ b/Real_Masters_all/acadwc.xml
@@ -1057,9 +1057,7 @@ Academic Women’s Caucus (University of Michigan) records, Bentley Historical L
             </unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">22 videotapes</extent>
-            </physdesc>
-            <physdesc>
-              <physfacet>(Betacam SP</physfacet>
+              <physfacet>Betacam SP</physfacet>
             </physdesc>
           </did>
           <c03 level="file">

--- a/Real_Masters_all/allenemo.xml
+++ b/Real_Masters_all/allenemo.xml
@@ -141,9 +141,7 @@ Emmet O. Allen Papers, Bentley Historical Library, University of Michigan</p>
             <unittitle>Letters from friend Judson Linden <unitdate type="inclusive" normal="1872/1888">1872-1888</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 folders</extent>
-            </physdesc>
-            <physdesc>
-              <physfacet>include some transcriptions of letters</physfacet>
+              <physfacet>includes some transcriptions of letters</physfacet>
             </physdesc>
           </did>
           <odd>

--- a/Real_Masters_all/aprillth.xml
+++ b/Real_Masters_all/aprillth.xml
@@ -322,8 +322,6 @@ Theophil Aprill papers, Bentley Historical Library, University of Michigan</p>
             <unittitle>WPAG Live Recording of Zion Church Service <unitdate type="inclusive" normal="1948-03-08">March 8, 1948</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">8 phonograph records</extent>
-            </physdesc>
-            <physdesc>
               <physfacet>33 1/3 rpm</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/batesmar.xml
+++ b/Real_Masters_all/batesmar.xml
@@ -5902,8 +5902,6 @@
                   <unittitle>Colombia</unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 folders</extent>
-                  </physdesc>
-                  <physdesc>
                     <physfacet>color transparencies</physfacet>
                   </physdesc>
                 </did>

--- a/Real_Masters_all/benzf.xml
+++ b/Real_Masters_all/benzf.xml
@@ -260,8 +260,6 @@ Fred E. Benz motion picture collection, Bentley Historical Library, University o
           <unittitle>Australia and New Zealand <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
           <physdesc altrender="whole">
             <extent altrender="materialtype spaceoccupied">12 reels</extent>
-          </physdesc>
-          <physdesc>
             <physfacet>black and white and color</physfacet>
           </physdesc>
         </did>
@@ -598,8 +596,6 @@ Fred E. Benz motion picture collection, Bentley Historical Library, University o
           <unittitle>Russia <unitdate type="inclusive" normal="1937">1937</unitdate></unittitle>
           <physdesc altrender="whole">
             <extent altrender="materialtype spaceoccupied">8 reels</extent>
-          </physdesc>
-          <physdesc>
             <physfacet>black and white and color</physfacet>
           </physdesc>
         </did>


### PR DESCRIPTION
I started looking for components that have multiple physdescs -- at least one with an extent and at least one without -- in search of things like...

<physdesc>
  <extent>22 videotapes</extent>
</physdesc>
<physdesc>
  <physfacet>Betacam SP</physfacet>
</physdesc>

...which should really just be one physdesc so that the extent and physfacet information will all end up together in the same extent record. However, it turns out that there are kind of a lot of these, and they shouldn't always be merged, and it probably isn't worth fixing it now. Might be better to fix it down the road if it actually causes problems.

The only issue I can think of right now is that the extent and the physfacet in this example would have gotten serialized separately by the exporter, so rather than displaying as:

(22 videotapes (Betacam SP))

It will display as...

(22 videotapes) (Betacam SP)

Not really a huge deal.
