### PR TITLE
Merging physdescs

### DIFF
--- a/Real_Masters_all/athdept.xml
+++ b/Real_Masters_all/athdept.xml
@@ -13633,8 +13633,7 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   <unittitle>Meet action</unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
-                    <physfacet>CD-Rs</physfacet>
-                  <physfacet>copy migrated from Kodak Photo CD, tiff format</physfacet>
+                    <physfacet>CD-Rs; copy migrated from Kodak Photo CD, tiff format</physfacet>
                   </physdesc>
                   </did>
               </c05>

--- a/Real_Masters_all/athdept.xml
+++ b/Real_Masters_all/athdept.xml
@@ -6236,11 +6236,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   <unittitle>Aerial photographs of Michigan Stadium, Golf Course, Athletic Campus, and central and north campus, slides of Athletic buildings</unittitle>
                   <physdesc>
                     <physfacet>4x6 color prints and 35mm slides</physfacet>
+                  <extent altrender="materialtype spaceoccupied">1 volumes</extent>
                   </physdesc>
-                  <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">1 volumes</extent>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -8460,11 +8458,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 folders</extent>
+                  <physfacet>cs, negatives, prints, game action, head shots</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>cs, negatives, prints, game action, head shots</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -8518,11 +8514,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 folders</extent>
+                  <physfacet>cs, game action</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>cs, game action</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -8936,11 +8930,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   <unittitle><unitdate type="inclusive" normal="2006">2006</unitdate> (headshots, game action)</unittitle>
                   <physdesc>
                     <physfacet>contact sheets &amp; digital files (CDs)</physfacet>
+                  <extent altrender="materialtype spaceoccupied">1 volumes</extent>
                   </physdesc>
-                  <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">1 volumes</extent>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -8948,11 +8940,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   <unittitle><unitdate type="inclusive" normal="2007">2007</unitdate> (headshots, coach's families, NCAA Super Regionals, golf outing, baseball tailgate)</unittitle>
                   <physdesc>
                     <physfacet>contact sheets &amp; digital files (CDs)</physfacet>
+                  <extent altrender="materialtype spaceoccupied">1 volumes</extent>
                   </physdesc>
-                  <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">1 volumes</extent>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -8970,11 +8960,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   <unittitle><unitdate type="inclusive" normal="2008">2008</unitdate> (headshots, game action, NCAA Regionals, stadium construction shots, Wilpon dedication ceremony)</unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">3 volumes</extent>
+                  <physfacet>contact sheets &amp; digital files (CDs)</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>contact sheets &amp; digital files (CDs)</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -10464,11 +10452,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 folders</extent>
+                  <physfacet>game action, cs sheets and cds</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>game action, cs sheets and cds</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -10478,11 +10464,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 folders</extent>
+                  <physfacet>game action, cs sheets and cds</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>game action, cs sheets and cds</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -10492,11 +10476,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 folders</extent>
+                  <physfacet>game action, cs sheets and cds</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>game action, cs sheets and cds</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -10506,11 +10488,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 folders</extent>
+                  <physfacet>game action, cs sheets and cds</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>game action, cs sheets and cds</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -10520,11 +10500,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">3 folders</extent>
+                  <physfacet>game action, cs sheets and cds</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>game action, cs sheets and cds</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -13656,11 +13634,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>CD-Rs</physfacet>
+                  <physfacet>copy migrated from Kodak Photo CD, tiff format</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>copy migrated from Kodak Photo CD, tiff format</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -19025,11 +19001,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   <unittitle><unitdate type="inclusive" normal="2005">2005</unitdate> (game action, team photos, post-season)</unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 volumes</extent>
+                  <physfacet>contact sheets &amp; digital files (CDs</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>contact sheets &amp; digital files (CDs</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -19037,11 +19011,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   <unittitle><unitdate type="inclusive" normal="2006">2006</unitdate> (game action, team photos, post-season)</unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 volumes</extent>
+                  <physfacet>contact sheets &amp; digital files (CDs</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>contact sheets &amp; digital files (CDs</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -19049,11 +19021,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   <unittitle><unitdate type="inclusive" normal="2007">2007</unitdate> (community service, kid clinic, team photos, head shots, game action, Special Olympics)</unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 volumes</extent>
+                  <physfacet>contact sheets &amp; digital files (CDs)</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>contact sheets &amp; digital files (CDs)</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -26816,11 +26786,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 volumes</extent>
+                  <physfacet>contact sheets &amp; digital files (CDs</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>contact sheets &amp; digital files (CDs</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
                 <odd>
                   <p>(game action, media day, athletes in action, banquet, team photos)</p>
                 </odd>
@@ -26839,11 +26807,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 volumes</extent>
+                  <physfacet>contact sheets &amp; digital files (CDs</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>contact sheets &amp; digital files (CDs</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
                 <odd>
                   <p>(basketball tailgate, team photos, media day, kid's clinic, game action, banquet)</p>
                 </odd>
@@ -26856,11 +26822,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 volumes</extent>
+                  <physfacet>contact sheets &amp; digital files (CDs</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>contact sheets &amp; digital files (CDs</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
                 <odd>
                   <p>(team photos, game action, welcome rally, tailgate, media day, game action, banquet)</p>
                 </odd>
@@ -26873,11 +26837,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 volumes</extent>
+                  <physfacet>contact sheets &amp; digital files (CDs</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>contact sheets &amp; digital files (CDs</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
                 <odd>
                   <p>(media guide shots, fan nite, team photos, locker rooms, media day, basketball camp, game action, Big 10 Floor Tour, banquet)</p>
                 </odd>
@@ -32036,11 +31998,9 @@ and files, including Media Guides, Photographs (usually subdivided into files of
                   <unittitle><unitdate type="inclusive" normal="2000">2000</unitdate> Big Ten Championship</unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 folders</extent>
+                  <physfacet>negatives, meet action</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>negatives, meet action</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>

--- a/Real_Masters_all/atwellhi.xml
+++ b/Real_Masters_all/atwellhi.xml
@@ -111,11 +111,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>[Plat maps of Washtenaw County, Mich.] <unitdate type="inclusive" normal="1838" certainty="approximate">circa 1838</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">20 maps</extent>
+            <physfacet>Scale [ca. 1:16,000] : 61 x 61 cm.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Scale [ca. 1:16,000] : 61 x 61 cm.</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>(Cadastral maps; show land ownership, annotated to show land transfers through 1850s(?))</p>
           </odd>
@@ -131,11 +129,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>Ann Arbor City, Block 2 S. R. 5 E <unitdate type="inclusive" normal="1900" certainty="approximate">circa 1900</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
+            <physfacet>Scale [1:360] col.; 49 x 41 cm.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Scale [1:360] col.; 49 x 41 cm.</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>(Cadastral map : Shows block bounded by Washington and Liberty Streets and Fourth and Fifth Avenues)</p>
           </odd>
@@ -146,11 +142,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>Ann Arbor, Michigan : lands of Anton Eisele et al. between Washington and Liberty Streets / J. B. Davis. <unitdate type="inclusive" normal="1887">1887</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
+            <physfacet>Scale 1:480: col.; 70 x 31 cm.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Scale 1:480: col.; 70 x 31 cm.</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>(Area shown later became Murray Street and vicinity. Cadastral map; shows land ownership, shows mill race and approximate channel of old creek)</p>
           </odd>
@@ -161,11 +155,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>Ann Arbor vill, [184-?]</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
+            <physfacet>Scale [ca. 1:5,500] 64 x 68 cm.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Scale [ca. 1:5,500] 64 x 68 cm.</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>(Cadastral maps of Lower Town area north of Huron River, Davidson &amp; Guiteau's Addition, and area along Miller Road on verso)</p>
           </odd>
@@ -176,11 +168,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>B. 7 S. R. 13 E. Ann Arbor Land Co. / J. B. Davis <unitdate type="inclusive" normal="1888">1888</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
+            <physfacet>Cadastral map Scale [1: 480] col.; 41 x 34 cm.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Cadastral map Scale [1: 480] col.; 41 x 34 cm.</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>(Shows block bounded by Monroe, Twelfth, and Hill Streets and East University Avenue)</p>
           </odd>
@@ -191,11 +181,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>Copy of plat, taken from Christian Hoffstetter's deed / J. B. Davis <unitdate type="inclusive" normal="1888">1888</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
+            <physfacet>Cadastral map. Scale 1:480. 58 x 30 cm.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Cadastral map. Scale 1:480. 58 x 30 cm.</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>(Area shown later became Murray Street and vicinity)</p>
           </odd>
@@ -206,11 +194,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>Data in red relates to Phoenix Block Subdivision of Block 1 South Range 4 East in the city of Ann Arbor, taken from a map of said city, dated 1853... / J. B. Davis <unitdate type="inclusive" normal="1900">1900</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
+            <physfacet>Cadastral map : scale [ca. 1:264] col.; 43 x 43 cm.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Cadastral map : scale [ca. 1:264] col.; 43 x 43 cm.</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>(Shows block bounded by Huron, Main, and Washington Streets and Fourth Avenue, shows land ownership.)</p>
           </odd>
@@ -221,11 +207,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>Eastern Add[it]ion to the village of Ann Arbor / surveyed in June 1839 by John Farnsworth <unitdate type="inclusive" normal="1899" certainty="approximate">circa 1899</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
+            <physfacet>Cadastral map Scale [1:2,376] col.; 40 x 26 cm.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Cadastral map Scale [1:2,376] col.; 40 x 26 cm.</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>(Shows area between Huron River, State Street, North University Avenue, and Fourteenth Street)</p>
           </odd>
@@ -248,11 +232,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>Map of J. D. Baldwin's Eastern Addition to the city of Ann Arbor / surveyed by De Volson Wood <unitdate type="inclusive" normal="1866">1866</unitdate>, <unitdate type="inclusive" normal="1888">1888</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
+            <physfacet>Cadastral map : Scale [1:960]. col.; 43 x 90 cm.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Cadastral map : Scale [1:960]. col.; 43 x 90 cm.</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>(Shows area south of Geddes Avenue and east of Oxford Street)</p>
           </odd>
@@ -269,11 +251,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>[untitled] <unitdate type="inclusive" normal="1840/1849" certainty="approximate">circa 1840s</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
+            <physfacet>Cadastral map; scale [1:6,000] col.; 55 x 55 cm.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Cadastral map; scale [1:6,000] col.; 55 x 55 cm.</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>(shows land ownership)</p>
           </odd>
@@ -284,11 +264,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>Map of Ormsby and Page's Addition to the village of Ann Arbor / by John Farnsworth <unitdate type="inclusive" normal="1838">1838</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
+            <physfacet>Cadastral map scale [ca. 1:1,200] 41 x 53 cm.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Cadastral map scale [ca. 1:1,200] 41 x 53 cm.</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>(Shows area between Huron River, Main Street, and Fuller Street)</p>
           </odd>
@@ -299,11 +277,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>Picnic Grove Addition and adjoining lands with Carpenter's Subdivision, Ann Arbor, Mich. / J. B. Davis; John Schmutz, draftsman <unitdate type="inclusive" normal="1902">1902</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
+            <physfacet>Cadastral map : Scale [1:1,200] col.; 46 x 52 cm.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Cadastral map : Scale [1:1,200] col.; 46 x 52 cm.</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>(Shows blocks between Wilmot, Forest, Hill, and Elm Streets and Washtenaw Avenue, shows some land ownership)</p>
           </odd>
@@ -322,11 +298,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>Agricultural Works, Ann Arbor, Michigan / J. B. Davis <unitdate type="inclusive" normal="1902">1902</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
+            <physfacet>Cadastral map : Scale [1:960] : 61 x 72 cm.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Cadastral map : Scale [1:960] : 61 x 72 cm.</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>("Third map." Shows land along Huron River from Broadway to foot of Maiden Lane, shows land ownership)</p>
           </odd>
@@ -337,11 +311,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>Agricultural Works, Ann Arbor, Michigan / J. B. Davis <unitdate type="inclusive" normal="1902">1902</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
+            <physfacet>Cadastral map : Scale [1:384] : 62 x 49 cm.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Cadastral map : Scale [1:384] : 62 x 49 cm.</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>("Fourth map.")</p>
           </odd>
@@ -352,11 +324,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>Agricultural Works, Ann Arbor, Michigan, general location of Anson Brown's 1st 2nd &amp; 3d purchases / J. B. Davis <unitdate type="inclusive" normal="1900">1900</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
+            <physfacet>Scale [1:3,600] : 24 x 33 cm., Ink on linen</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Scale [1:3,600] : 24 x 33 cm., Ink on linen</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>("Second map." Shows site of former dam and mill race and submerged island)</p>
           </odd>
@@ -367,11 +337,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>Ann Arbor, Michigan, Sinclair Mill site, present buildings / J. B. Davis <unitdate type="inclusive" normal="1895">1895</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
+            <physfacet>Cadastral map : Scale [1:384] : 41 x 41 cm., Ink on linen</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Cadastral map : Scale [1:384] : 41 x 41 cm., Ink on linen</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="item">
           <did>
@@ -380,11 +348,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
               <physfacet>profile : ms</physfacet>
+            <physfacet>Scale [1:1,200] Vertical scale [1:36] : 6 x 61 cm.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Scale [1:1,200] Vertical scale [1:36] : 6 x 61 cm.</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="item">
           <did>
@@ -392,11 +358,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>Lands of Michigan Milling Co., Ann Arbor, Mich., Fifth Ward, upstream from Broadway / J. B. Davis <unitdate type="inclusive" normal="1895">1895</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
+            <physfacet>Cadastral map : scale [1:384] : 46 x 36 cm., ink on linen</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Cadastral map : scale [1:384] : 46 x 36 cm., ink on linen</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="item">
           <did>
@@ -404,11 +368,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>[Map of Huron River in vicinity of Broadway and Argo Dam, Ann Arbor, Mich.] / John Schmutz <unitdate type="inclusive" normal="1900" certainty="approximate">circa 1900</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
+            <physfacet>Cadastral map : scale [ca. 1:3,600] : 33 x 22 cm., ink on linen</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Cadastral map : scale [ca. 1:3,600] : 33 x 22 cm., ink on linen</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>(Shows site of former dam and mill race and submerged island, shows land ownership)</p>
           </odd>
@@ -424,11 +386,9 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>Islands in Evans Lake, sections six and seven, T. 5 S. R. 3 E., Meridian of Michigan / surveyed ... by J. B. Davis <unitdate type="inclusive" normal="1896">1896</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
+            <physfacet>Scale [1:7.920] : 15 x 29 cm.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Scale [1:7.920] : 15 x 29 cm.</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>(Area shown is in Franklin Township, Lenawee County, Mich.)</p>
           </odd>

--- a/Real_Masters_all/atwellhi.xml
+++ b/Real_Masters_all/atwellhi.xml
@@ -347,8 +347,7 @@ Atwell-Hicks Map Collection, Bentley Historical Library, University of Michigan<
             <unittitle>Comparison of levels, Sinclair Mill power, Ann Arbor, Mich. / J. B. Davis <unitdate type="inclusive" normal="1888/1889">1888-1889</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 maps</extent>
-              <physfacet>profile : ms</physfacet>
-            <physfacet>Scale [1:1,200] Vertical scale [1:36] : 6 x 61 cm.</physfacet>
+              <physfacet>profile : ms; Scale [1:1,200] Vertical scale [1:36] : 6 x 61 cm.</physfacet>
             </physdesc>
             </did>
         </c02>

--- a/Real_Masters_all/bhl.xml
+++ b/Real_Masters_all/bhl.xml
@@ -14798,8 +14798,7 @@ Bentley Historical Library records, Bentley Historical Library, University of Mi
             <unittitle>Miscellaneous early design studies, plan studies, exterior elevation studies, and interior studies <unitdate type="inclusive" normal="1969/1972">1969-1972</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">75 sheets</extent>
-              <physfacet>approximate</physfacet>
-            <physfacet>Pencil sketches</physfacet>
+              <physfacet>approximate; Pencil sketches</physfacet>
             </physdesc>
             </did>
         </c02>

--- a/Real_Masters_all/bhl.xml
+++ b/Real_Masters_all/bhl.xml
@@ -14696,11 +14696,9 @@ Bentley Historical Library records, Bentley Historical Library, University of Mi
             <unittitle>Renderings, site plans, elevations, floor plans <unitdate type="inclusive">Undated</unitdate> and 1972.</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">40 sheets</extent>
+            <physfacet>Blue line prints</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Blue line prints</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -14768,11 +14766,9 @@ Bentley Historical Library records, Bentley Historical Library, University of Mi
             <unittitle>Library addition. Renderings, floor plans, site plans, elevations <unitdate type="inclusive" normal="1980">1980</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">27 sheets</extent>
+            <physfacet>Blue line prints</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Blue line prints</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -14791,11 +14787,9 @@ Bentley Historical Library records, Bentley Historical Library, University of Mi
             <unittitle>Bound set of drawings. Site plan and details; sculpture court plan and details; floor plans; roof plans; finish schedule; elevations; sections; millwork; foundation plans; roof framing plan; mechanical plans, diagram, schedule and details <unitdate type="inclusive" normal="1972">1972</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">47 sheets</extent>
+            <physfacet>Blue line prints</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Blue line prints</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -14805,11 +14799,9 @@ Bentley Historical Library records, Bentley Historical Library, University of Mi
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">75 sheets</extent>
               <physfacet>approximate</physfacet>
+            <physfacet>Pencil sketches</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Pencil sketches</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/bimedcom.xml
+++ b/Real_Masters_all/bimedcom.xml
@@ -10820,11 +10820,9 @@ Thiele, Maria, Technology Transfer Office <unitdate type="inclusive" normal="199
               </unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
+              <physfacet>negatives and contact sheets</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>negatives and contact sheets</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -13776,11 +13774,9 @@ Thiele, Maria, Technology Transfer Office <unitdate type="inclusive" normal="199
               <unittitle>Taubman Library <unitdate type="inclusive" normal="1979/1980">1979-1980</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">7 folders</extent>
+              <physfacet>prints and negatives</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>prints and negatives</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -13809,11 +13805,9 @@ Thiele, Maria, Technology Transfer Office <unitdate type="inclusive" normal="199
               <unittitle>University Hospital <unitdate type="inclusive" normal="1987">1987</unitdate>, <unitdate type="inclusive" normal="1991">1991</unitdate>, <unitdate type="inclusive" normal="1994">1994</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
+              <physfacet>prints, negatives, and transparencies</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>prints, negatives, and transparencies</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -15028,11 +15022,9 @@ Thiele, Maria, Technology Transfer Office <unitdate type="inclusive" normal="199
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 folders</extent>
+                <physfacet>prints and negatives</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>prints and negatives</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -21964,11 +21956,9 @@ Thiele, Maria, Technology Transfer Office <unitdate type="inclusive" normal="199
               <unittitle>Ward and Hospital Photographs <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
+              <physfacet>prints, slides and negatives</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>prints, slides and negatives</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/blairfam.xml
+++ b/Real_Masters_all/blairfam.xml
@@ -193,11 +193,9 @@
                 <unittitle>Letters to his granddaughter Effie North Blair <unitdate type="inclusive" normal="1893/1897">1893-1897</unitdate>, <unitdate>undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">4 folders</extent>
+                <physfacet>12 A.L.S. and typed transcripts</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>12 A.L.S. and typed transcripts</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
         </c02>
@@ -684,11 +682,9 @@
               <unittitle>"Old Homes" compiled by Helen Blair Lamar</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 folders</extent>
+              <physfacet>original and acid-free copy</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>original and acid-free copy</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/blanchjj.xml
+++ b/Real_Masters_all/blanchjj.xml
@@ -14988,11 +14988,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
+                  <dimensions>27:25</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>27:25</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -15001,11 +14999,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
+                  <dimensions>29:48</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>29:48</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -15014,11 +15010,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
+                  <dimensions>29:28</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>29:28</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -15027,11 +15021,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
+                  <dimensions>30:09</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>30:09</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -15040,11 +15032,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
+                  <dimensions>29:09</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>29:09</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -15053,11 +15043,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
+                  <dimensions>29:00</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>29:00</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -15066,11 +15054,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
+                  <dimensions>30:00</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>30:00</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -15079,11 +15065,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
+                  <dimensions>29:41</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>29:41</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -15092,11 +15076,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
+                  <dimensions>30:00</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>30:00</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
             </c04>
             <c04 level="file">
@@ -15110,11 +15092,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
+                  <dimensions>29:32</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>29:32</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -15123,11 +15103,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
+                  <dimensions>30:00</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>30:00</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -15136,11 +15114,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
+                  <dimensions>30:00</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>30:00</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -15149,11 +15125,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
+                  <dimensions>29:45</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>29:45</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -15162,11 +15136,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
+                  <dimensions>30:48</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>30:48</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -15175,11 +15147,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
+                  <dimensions>29:52</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>29:52</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -15188,11 +15158,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
+                  <dimensions>29:41</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>29:41</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -15375,11 +15343,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>27:55</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>27:55</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15388,11 +15354,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>12:00</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>12:00</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15407,11 +15371,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>29:20</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>29:20</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15454,11 +15416,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>75:00</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>75:00</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15467,11 +15427,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>95:00</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>95:00</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15486,11 +15444,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>7:30</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>7:30</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15517,11 +15473,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>60:00</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>60:00</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15530,11 +15484,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>54:00</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>54:00</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15543,11 +15495,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>20:00</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>20:00</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15556,11 +15506,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>90:00</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>90:00</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15615,11 +15563,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>29:10</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>29:10</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15628,11 +15574,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>4:00</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>4:00</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15641,11 +15585,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>1:30</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>1:30</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15654,11 +15596,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>12:11</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>12:11</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15667,11 +15607,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>12:00</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>12:00</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15726,11 +15664,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>22:00</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>22:00</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15745,11 +15681,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>15:00</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>15:00</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15758,11 +15692,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>10:00</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>10:00</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15771,11 +15703,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>10:00</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>10:00</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15784,11 +15714,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>19:00</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>19:00</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15821,11 +15749,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>9:15</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>9:15</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15840,11 +15766,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>3:51</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>3:51</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15853,11 +15777,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>8:30</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>8:30</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15866,11 +15788,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>1:20</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>1:20</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15879,11 +15799,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>21:00</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>21:00</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15910,11 +15828,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>16:00</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>16:00</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15935,11 +15851,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>55:00</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>55:00</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15948,11 +15862,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>17:05</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>17:05</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -15991,11 +15903,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>43:56</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>43:56</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -16010,11 +15920,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>63:00</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>63:00</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -16035,11 +15943,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>27:31</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>27:31</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -16060,11 +15966,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS [TM]</physfacet>
+                <dimensions>9:40</dimensions>
                 </physdesc>
-                <physdesc>
-                  <dimensions>9:40</dimensions>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -16089,11 +15993,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>VHS [TM]</physfacet>
+                  <dimensions>0:30</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>0:30</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -16102,11 +16004,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>VHS [TM]</physfacet>
+                  <dimensions>0:30</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>0:30</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -16115,11 +16015,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>VHS [TM]</physfacet>
+                  <dimensions>0:30</dimensions>
                   </physdesc>
-                  <physdesc>
-                    <dimensions>0:30</dimensions>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/blanfam.xml
+++ b/Real_Masters_all/blanfam.xml
@@ -10447,11 +10447,9 @@ Blanchard Family Papers, Bentley Historical Library, University of Michigan</p>
             <unittitle>Cobb, Victor</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 folders</extent>
+            <physfacet>includes photograph</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>includes photograph</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/blanjant.xml
+++ b/Real_Masters_all/blanjant.xml
@@ -115,11 +115,9 @@
             <unittitle>Clippings <unitdate type="inclusive" normal="1989">1989</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 folders</extent>
+            <physfacet>mainly photocopies</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>mainly photocopies</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/boyneusa.xml
+++ b/Real_Masters_all/boyneusa.xml
@@ -2580,11 +2580,9 @@ Boyne USA Resorts records, Bentley Historical Library, University of Michigan</p
               <unittitle>Skiers on slope, Hanson Challenge <unitdate type="inclusive" normal="1974-02">February 1974</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 photographs</extent>
+              <physfacet>color print</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>color print</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -4628,11 +4626,9 @@ Boyne USA Resorts records, Bentley Historical Library, University of Michigan</p
             <unittitle>Artists conception of various facilities</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">5 items</extent>
+            <physfacet>most 13x24" on masonite</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>most 13x24" on masonite</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -4640,11 +4636,9 @@ Boyne USA Resorts records, Bentley Historical Library, University of Michigan</p
             <unittitle>Promotional photos of Boyne USA facilities</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">5 items</extent>
+            <physfacet>most 16x24"</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>most 16x24"</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/bruffjn.xml
+++ b/Real_Masters_all/bruffjn.xml
@@ -200,8 +200,7 @@ John B. Bruff papers, Bentley Historical Library, University of Michigan</p>
             <unittitle><genreform normal="Sound recordings">Recordings</genreform> of ads for Bruff by Robert Kennedy and Philip Hart</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
-              <physfacet>reel-to-reel tapes</physfacet>
-            <physfacet>(15 sec. each) : analog, 7 1/2 ips; 5 in.</physfacet>
+              <physfacet>reel-to-reel tapes; (15 sec. each) : analog, 7 1/2 ips; 5 in.</physfacet>
             </physdesc>
             </did>
         </c02>

--- a/Real_Masters_all/bruffjn.xml
+++ b/Real_Masters_all/bruffjn.xml
@@ -201,11 +201,9 @@ John B. Bruff papers, Bentley Historical Library, University of Michigan</p>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
               <physfacet>reel-to-reel tapes</physfacet>
+            <physfacet>(15 sec. each) : analog, 7 1/2 ips; 5 in.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>(15 sec. each) : analog, 7 1/2 ips; 5 in.</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/cacioppo.xml
+++ b/Real_Masters_all/cacioppo.xml
@@ -4411,11 +4411,9 @@ George Cacioppo papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Plant sounds</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 reels</extent>
+              <physfacet>5 in. reels</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>5 in. reels</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -4558,11 +4556,9 @@ George Cacioppo papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>"Inori," Südwestfunk Symphony Orchestra, Karlheinz Stockhausen, conductor</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 reels</extent>
+                <physfacet>7 in. reels, mono, 7 1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7 in. reels, mono, 7 1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -4621,11 +4617,9 @@ George Cacioppo papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Transition, Bruxelles, Palais des beaux-arts <unitdate type="inclusive" normal="1972-09-30">September 30, 1972</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 reels</extent>
+              <physfacet>10 in. reel; 19 cm/sec.</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>10 in. reel; 19 cm/sec.</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -4633,11 +4627,9 @@ George Cacioppo papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>WDET</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 reels</extent>
+              <physfacet>10 in. reel</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>10 in. reel</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">

--- a/Real_Masters_all/cappaert.xml
+++ b/Real_Masters_all/cappaert.xml
@@ -714,11 +714,9 @@
             <unittitle>Interview with State Senator Sander Levin <unitdate type="inclusive" normal="1967">1967</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 reels</extent>
+            <physfacet>5 inch; 7.5 ips</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>5 inch; 7.5 ips</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/cislerw.xml
+++ b/Real_Masters_all/cislerw.xml
@@ -3451,11 +3451,9 @@
             <unittitle>Albion College series on energy</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">4 reels</extent>
+            <physfacet>7 in.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>7 in.</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <c03 level="file">
             <did>
               <container type="box" label="Box">33</container>

--- a/Real_Masters_all/conlinro.xml
+++ b/Real_Masters_all/conlinro.xml
@@ -616,11 +616,9 @@
             <unittitle>Testimony of Al Perline, tax counsel, J. L. Hudson Co. on SB1125 and SB1396 <unitdate type="inclusive">undated</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 reels</extent>
+            <physfacet>3 3/4 ips; 5 in.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>3 3/4 ips; 5 in.</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -628,11 +626,9 @@
             <unittitle>Discussion on taxes with state treasurer Sanford Brown, House speaker Don Pears, and Rollo G. Conlin <unitdate>undated</unitdate> WJR Detroit</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 reels</extent>
+            <physfacet>3 3/4 ips; 5 in.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>3 3/4 ips; 5 in.</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -640,11 +636,9 @@
             <unittitle>Hearings on House Resolution 128, held at Metropolitan Airport Detroit; and at Kent Co. Airport, Grand Rapids, Mich. <unitdate>undated</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 reels</extent>
+            <physfacet>7 1/2 ips and 3 3/4 ips; 7 in.; 2 sides</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>7 1/2 ips and 3 3/4 ips; 7 in.; 2 sides</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>changes from 7 1/2 ips to 3 3/3 ips early in the tape</p>
           </odd>
@@ -655,11 +649,9 @@
             <unittitle>Discussion re. Kalamazoo probate judges, and the Diagnosis Center <unitdate type="inclusive" normal="1956" certainty="approximate">circa 1956</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 reels</extent>
+            <physfacet>3 3/4 ips; 5 in.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>3 3/4 ips; 5 in.</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -667,11 +659,9 @@
             <unittitle>Tax study committee hearings, Kellogg Center Lansing <unitdate type="inclusive" normal="1958-12-02">December 2, 1958</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 reels</extent>
+            <physfacet>3 3/4 ips; 7 in.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>3 3/4 ips; 7 in.</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -679,11 +669,9 @@
             <unittitle>Discussion re. <unitdate type="inclusive" normal="1959-11">November 1959</unitdate> state tax problem. With Don Potter, WJIM, Lansing, <unitdate type="inclusive" normal="1959">1959</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 reels</extent>
+            <physfacet>3 3/4 ips; 5 in.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>3 3/4 ips; 5 in.</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -691,11 +679,9 @@
             <unittitle>WJR Sunday Supplement program (re. Michigan tax situation) <unitdate type="inclusive" normal="1959-06-14">June 14, 1959</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 reels</extent>
+            <physfacet>7 1/2 ips; 7 in.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>7 1/2 ips; 7 in.</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -703,11 +689,9 @@
             <unittitle>WJR Sunday Supplement program (re. Michigan tax situation) <unitdate type="inclusive" normal="1959-11-01">November 1, 1959</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 reels</extent>
+            <physfacet>7 1/2 ips; 7 in.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>7 1/2 ips; 7 in.</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -715,11 +699,9 @@
             <unittitle>Discussion in class of D. Cline and (?) Taylor at MSU <unitdate type="inclusive" normal="1960">1960</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 reels</extent>
+            <physfacet>3 3/4 ips; 7 in.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>3 3/4 ips; 7 in.</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -727,11 +709,9 @@
             <unittitle>Debate between John B. Swainson and Paul Bagwell, candidates for governor <unitdate type="inclusive" normal="1960-10">October 1960</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 reels</extent>
+            <physfacet>7 1/2 ips; 7 in.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>7 1/2 ips; 7 in.</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -739,11 +719,9 @@
             <unittitle>Public hearing on SB1396 and SB1145 <unitdate type="inclusive" normal="1961-04-25">April 25, 1961</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 reels</extent>
+            <physfacet>3 3/4 ips; 7 in.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>3 3/4 ips; 7 in.</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -766,11 +744,9 @@
             <unittitle>Government reorganization hearings <unitdate type="inclusive" normal="1963">1963</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 reels</extent>
+            <physfacet>3 3/4 ips; 7 in.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>3 3/4 ips; 7 in.</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -778,11 +754,9 @@
             <unittitle>Political advertisement WABJ <unitdate type="inclusive" normal="1964">1964</unitdate> primary (includes Romney ad. and Conlin ads.)</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 reels</extent>
+            <physfacet>7 1/2 ips; 5 in.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>7 1/2 ips; 5 in.</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -790,11 +764,9 @@
             <unittitle>"Meet the Press" interview with George Romney <unitdate type="inclusive" normal="1966-11-13">November 13, 1966</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 reels</extent>
+            <physfacet>3 3/4 ips; 7 in.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>3 3/4 ips; 7 in.</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/conlinro.xml
+++ b/Real_Masters_all/conlinro.xml
@@ -727,14 +727,10 @@
           <did>
             <container type="box" label="Box">5</container>
             <unittitle>WJIM television program, "Channel 6 Reports" <unitdate type="inclusive" normal="1961-09">September 1961</unitdate></unittitle>
-            <physdesc altrender="part">
+            <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 reels</extent>
-            </physdesc>
-            <physdesc altrender="part">
-              <extent altrender="materialtype spaceoccupied">30 minutes</extent>
-            </physdesc>
-            <physdesc>
               <physfacet>7 1/2 ips; 7 in.</physfacet>
+              <dimensions>30 minutes</dimensions>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/dancegal.xml
+++ b/Real_Masters_all/dancegal.xml
@@ -937,10 +937,9 @@ Dance Gallery Foundation records, Bentley Historical Library, University of Mich
               <container type="box" label="Box">4</container>
               <unittitle>Peninsula at Film Festival <unitdate type="inclusive" normal="2004-03">March 2004</unitdate></unittitle>
               <physdesc>
-                <physfacet>CD-R</physfacet>
+                <physfacet>CD-R; CD-Rs</physfacet>
               <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
-                <physfacet>CD-Rs</physfacet>
-              </physdesc>
+                </physdesc>
               </did>
           </c03>
           <c03 level="file">
@@ -948,10 +947,9 @@ Dance Gallery Foundation records, Bentley Historical Library, University of Mich
               <container type="box" label="Box">4</container>
               <unittitle>Peninsula Rehearsal <unitdate type="inclusive" normal="2004-06-23">June 23, 2004</unitdate></unittitle>
               <physdesc>
-                <physfacet>CD-R</physfacet>
+                <physfacet>CD-R; CD-Rs</physfacet>
               <extent altrender="materialtype spaceoccupied">3 optical disks</extent>
-                <physfacet>CD-Rs</physfacet>
-              </physdesc>
+                </physdesc>
               </did>
           </c03>
           <c03 level="file">
@@ -968,10 +966,9 @@ Dance Gallery Foundation records, Bentley Historical Library, University of Mich
               <container type="box" label="Box">4</container>
               <unittitle>Peninsula at Power Center <unitdate type="inclusive" normal="2004-06">June 2004</unitdate></unittitle>
               <physdesc>
-                <physfacet>CD-R</physfacet>
+                <physfacet>CD-R; CD-Rs</physfacet>
               <extent altrender="materialtype spaceoccupied">3 optical disks</extent>
-                <physfacet>CD-Rs</physfacet>
-              </physdesc>
+                </physdesc>
               </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/dancegal.xml
+++ b/Real_Masters_all/dancegal.xml
@@ -938,12 +938,10 @@ Dance Gallery Foundation records, Bentley Historical Library, University of Mich
               <unittitle>Peninsula at Film Festival <unitdate type="inclusive" normal="2004-03">March 2004</unitdate></unittitle>
               <physdesc>
                 <physfacet>CD-R</physfacet>
-              </physdesc>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
+              <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -951,12 +949,10 @@ Dance Gallery Foundation records, Bentley Historical Library, University of Mich
               <unittitle>Peninsula Rehearsal <unitdate type="inclusive" normal="2004-06-23">June 23, 2004</unitdate></unittitle>
               <physdesc>
                 <physfacet>CD-R</physfacet>
-              </physdesc>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">3 optical disks</extent>
+              <extent altrender="materialtype spaceoccupied">3 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -973,12 +969,10 @@ Dance Gallery Foundation records, Bentley Historical Library, University of Mich
               <unittitle>Peninsula at Power Center <unitdate type="inclusive" normal="2004-06">June 2004</unitdate></unittitle>
               <physdesc>
                 <physfacet>CD-R</physfacet>
-              </physdesc>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">3 optical disks</extent>
+              <extent altrender="materialtype spaceoccupied">3 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/davisde.xml
+++ b/Real_Masters_all/davisde.xml
@@ -5512,7 +5512,7 @@ David E. Davis papers, Bentley Historical Library, University of Michigan</p>
             <container type="box" label="Box">22</container>
             <unittitle><title render="italic">Deadline Now #193</title>, "The Big Three's topsy-turvy world," Guests: Sean McAlinden and David E. Davis, Jr., WGTE Public Media, <unitdate type="inclusive" normal="2009-06-12">June 12, 2009</unitdate> (DVD)</unittitle>
             <physdesc>
-              <physfacet></physfacet>
+              <physfacet/>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/davisde.xml
+++ b/Real_Masters_all/davisde.xml
@@ -5510,9 +5510,9 @@ David E. Davis papers, Bentley Historical Library, University of Michigan</p>
         <c02 level="file">
           <did>
             <container type="box" label="Box">22</container>
-            <unittitle><title render="italic">Deadline Now #193</title>, "The Big Three's topsy-turvy world," Guests: Sean McAlinden and David E. Davis, Jr., WGTE Public Media, <unitdate type="inclusive" normal="2009-06-12">June 12, 2009</unitdate> (DVD)</unittitle>
+            <unittitle><title render="italic">Deadline Now #193</title>, "The Big Three's topsy-turvy world," Guests: Sean McAlinden and David E. Davis, Jr., WGTE Public Media, <unitdate type="inclusive" normal="2009-06-12">June 12, 2009</unitdate></unittitle>
             <physdesc>
-              <physfacet/>
+              <physfacet>DVD</physfacet>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/deboerro.xml
+++ b/Real_Masters_all/deboerro.xml
@@ -1499,11 +1499,9 @@ Robby DeBoer Papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Tape 29-30: DeBoer Interviews <unitdate type="inclusive" normal="1994-10">October 1994</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>beta tapes</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>beta tapes</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1597,11 +1595,9 @@ Robby DeBoer Papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Tape 45-46: Baby Richard <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>beta tapes</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>beta tapes</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/demparty.xml
+++ b/Real_Masters_all/demparty.xml
@@ -23446,11 +23446,9 @@ Democratic Party of Michigan records, Bentley Historical Library, University of 
               <physdesc altrender="part">
                 <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>U-matic</physfacet>
+              <dimensions>4:11 min.</dimensions>
               </physdesc>
-              <physdesc altrender="part">
-                <dimensions>4:11 min.</dimensions>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/douglass.xml
+++ b/Real_Masters_all/douglass.xml
@@ -282,11 +282,9 @@ Douglass family (Detroit and Ann Arbor, Mich.) papers, Bentley Historical Librar
               <unittitle>Douglass Houghton field notes from Upper Peninsula geological survey <unitdate type="inclusive" normal="1839/1840">1839-1840</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
+              <physfacet>original and typescript copy</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>original and typescript copy</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Silas Douglas' copy made 1862 ?)</p>
             </odd>

--- a/Real_Masters_all/englerj.xml
+++ b/Real_Masters_all/englerj.xml
@@ -28916,14 +28916,9 @@ Topics extensively documented include state welfare and school funding reform, r
                 <container type="box" label="Box">142</container>
                 <unittitle>"Off the Record," WTVS-TV (PBS), 9:00 pm <unitdate type="inclusive" normal="1993-05-21">May 21, 1993</unitdate></unittitle>
                 <physdesc>
-                  <physfacet>U-matic format</physfacet>
-                </physdesc>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">30 minutes</extent>
-                </physdesc>
-                <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
-                  <physfacet>VHS (TM)</physfacet>
+                  <dimensions>30 minutes</dimensions>
+                  <physfacet>U-matic format</physfacet>
                 </physdesc>
               </did>
               <odd>
@@ -34076,14 +34071,9 @@ Topics extensively documented include state welfare and school funding reform, r
                 <container type="box" label="Box">156</container>
                 <unittitle>"Governor John Engler State of the State Address," <unitdate type="inclusive" normal="1993-01-26">January 26, 1993</unitdate></unittitle>
                 <physdesc>
-                  <physfacet>Reel 2A, Floor Cam, dubbed from Betacam SPcam</physfacet>
-                </physdesc>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">14 minutes</extent>
-                </physdesc>
-                <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
-                  <physfacet>VHS (TM)</physfacet>
+                  <physfacet>VHS (TM); Reel 2A, Floor Cam, dubbed from Betacam SPcam</physfacet>
+                  <dimensions>14 minutes</dimensions>
                 </physdesc>
               </did>
               <odd>
@@ -34233,14 +34223,9 @@ Topics extensively documented include state welfare and school funding reform, r
                 <container type="box" label="Box">156</container>
                 <unittitle><unitdate type="inclusive" normal="1991">1991</unitdate> Inauguration, United Cable Television of Mid-Michigan, Inc., <unitdate type="inclusive" normal="1991-01-01">January 1, 1991</unitdate></unittitle>
                 <physdesc>
-                  <physfacet>U-matic format</physfacet>
-                </physdesc>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">54 minutes</extent>
-                </physdesc>
-                <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
-                  <physfacet>VHS (TM)</physfacet>
+                  <dimensions>54 minutes</dimensions>
+                  <physfacet>U-matic format</physfacet>
                 </physdesc>
               </did>
               <odd>
@@ -34252,14 +34237,9 @@ Topics extensively documented include state welfare and school funding reform, r
                 <container type="box" label="Box">156</container>
                 <unittitle><unitdate type="inclusive" normal="1991">1991</unitdate> Inauguration, United Cable Television of Mid-Michigan, Inc., <unitdate type="inclusive" normal="1991-01-01">January 1, 1991</unitdate></unittitle>
                 <physdesc>
-                  <physfacet>U-matic format</physfacet>
-                </physdesc>
-                <physdesc altrender="whole">
-                  <dimensions>1:29</dimensions>
-                </physdesc>
-                <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
-                  <physfacet>VHS (TM)</physfacet>
+                  <physfacet>U-matic format</physfacet>
+                  <dimensions>1:29</dimensions>
                 </physdesc>
               </did>
               <odd>

--- a/Real_Masters_all/fajans.xml
+++ b/Real_Masters_all/fajans.xml
@@ -1134,11 +1134,9 @@
               <unittitle>Correspondence with Polish scholars</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 folders</extent>
+              <physfacet>photocopies</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>photocopies</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(in Polish)</p>
             </odd>

--- a/Real_Masters_all/feychas.xml
+++ b/Real_Masters_all/feychas.xml
@@ -1862,11 +1862,9 @@ Charles Fey papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Miscellaneous document re Masonic history</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
+              <physfacet>Photostats, positive</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>Photostats, positive</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(folders 230-231)</p>
             </odd>

--- a/Real_Masters_all/ghouse.xml
+++ b/Real_Masters_all/ghouse.xml
@@ -2256,11 +2256,9 @@
             <unittitle>Unlabeled</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">14 tapes</extent>
+            <physfacet>7 in. reel-to-reel audio tapes</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>7 in. reel-to-reel audio tapes</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -2268,11 +2266,9 @@
             <unittitle>Unlabeled</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+            <physfacet>5 in. reel-to-reel audio tapes</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>5 in. reel-to-reel audio tapes</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -2280,11 +2276,9 @@
             <unittitle>Unlabeled</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 tapes</extent>
+            <physfacet>4 in. reel-to-reel audio tapes</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>4 in. reel-to-reel audio tapes</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -2292,11 +2286,9 @@
             <unittitle>Conference on Vietnam</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">9 tapes</extent>
+            <physfacet>7 in. reel-to-reel audio tapes</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>7 in. reel-to-reel audio tapes</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -2304,11 +2296,9 @@
             <unittitle>Sermons</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">4 tapes</extent>
+            <physfacet>7 in. reel-to-reel audio tapes</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>7 in. reel-to-reel audio tapes</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/gmwill.xml
+++ b/Real_Masters_all/gmwill.xml
@@ -58287,8 +58287,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Excerpts from radio broadcasts of <unitdate type="inclusive" normal="1949-12-27">December 27, 1949</unitdate>, <unitdate type="inclusive" normal="1950-01-03">January 3, 1950</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>3.75 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 3.75 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58306,8 +58305,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Jefferson-Jackson Day Dinner</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>dual track; 1 7/8 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; dual track; 1 7/8 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58320,8 +58318,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Recording of radio broadcast on behalf of Harry Kelly, Republican candidate for governor</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>1 7/8 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 1 7/8 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58339,8 +58336,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Campaign radio address <unitdate type="inclusive" normal="1952-10-28">October 28, 1952</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>15 min., 7.5 ips; 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 15 min., 7.5 ips; 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58353,8 +58349,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Political address <unitdate type="inclusive" normal="1952-10-28" certainty="approximate">circa October 28, 1952</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58367,8 +58362,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Campaign radio address <unitdate type="inclusive" normal="1952-11-02">November 2, 1952</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>ca. 15 min., 7.5 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; ca. 15 min., 7.5 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58381,8 +58375,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Campaign speech of U.S. Senator Blair Moody <unitdate type="inclusive" normal="1952-11-03">November 3, 1952</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>15 min., 7.5 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 15 min., 7.5 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58395,8 +58388,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Campaign speech of Edward Carey <unitdate type="inclusive" normal="1952-11-03">November 3, 1952</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>15 mins., 7.5 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 15 mins., 7.5 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58412,8 +58404,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Campaign radio address <unitdate type="inclusive" normal="1952" certainty="approximate">1952 undated</unitdate> [duplicate available]</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>15 min.; 7.5 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 15 min.; 7.5 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58431,8 +58422,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Annual speech to Michigan Legislature <unitdate type="inclusive" normal="1953-01-15">January 15, 1953</unitdate> [duplicate available]</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58450,8 +58440,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Annual speech to Michigan Legislature <unitdate type="inclusive" normal="1954-01-25" certainty="approximate">circa January 25, 1954</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58467,8 +58456,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Addresses of David Steinman and G. Mennen Williams at Mackinac Bridge celebration <unitdate type="inclusive" normal="1954-05">May 1954</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58481,8 +58469,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Television program, "Nancy's Scrapbook," <unitdate type="inclusive" normal="1954-08-05" certainty="approximate">circa August 5, 1954</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58495,8 +58482,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Television Program, "Nancy's Scrapbook," <unitdate type="inclusive" normal="1954-08-12" certainty="approximate">circa August 12?, 1954</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58509,8 +58495,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Television program, "Nancy's Scrapbook," <unitdate type="inclusive" normal="1954-08-26" certainty="approximate">circa August 26?, 1954</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58523,8 +58508,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Television program, "Nancy's Scrapbook," <unitdate type="inclusive" normal="1954-09-02">September 2, 1954</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58537,8 +58521,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Television program, "Nancy's Scrapbook," <unitdate type="inclusive" normal="1954-09-09">September 9, 1954</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58551,8 +58534,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Television program, "Nancy's Scrapbook," <unitdate type="inclusive" normal="1954-09-16">September 16, 1954</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58565,8 +58547,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Political address of Edward A. Nowack discussing Williams-Donald Leonard gubernatorial campaign <unitdate type="inclusive" normal="1954-10-27">October 27, 1954</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58579,8 +58560,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Campaign address in Flint, undated 1954</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58598,8 +58578,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>G.M.W. speaking (via tape) at Teen-age Traffic Safety Conference at Michigan State <unitdate type="inclusive" normal="1955-02-18">February 18, 1955</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58612,8 +58591,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Crampton-Williams Testimonial Dinner, NAACP meeting <unitdate type="inclusive" normal="1955">1955</unitdate> undated</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>dual track, 2 hr 3.75 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; dual track, 2 hr 3.75 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58631,8 +58609,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW appearance on "Today" show, in connection with Michigan Week <unitdate type="inclusive" normal="1956-05-24">May 24, 1956</unitdate> (also discusses politics)</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58645,8 +58622,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Excerpts of debate between Republicans John Feikens and George Sallade, and Democrats Gus Scholle and Edward Carey <unitdate type="inclusive" normal="1956-08-06/1956-08-08">August 6-8, 1956</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58659,8 +58635,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Television address by gubernatorial candidate, Albert E. Cobo <unitdate type="inclusive" normal="1956-09-28">September 28, 1956</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58673,8 +58648,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Political messages (1 minute spots) for the election of 1956? <unitdate type="inclusive" normal="1956-10/1956-11">October-November 1956</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58687,8 +58661,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Radio talk by Rev. Charles D. Hamilton of Booneville, Mississippi discussing civil rights and the election of 1956 <unitdate type="inclusive" normal="1956-10">October 1956</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58701,8 +58674,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Campaign discussion with Albert Cobo on issues of mental health and education <unitdate type="inclusive" normal="1956-10-09">October 9, 1956</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -58725,8 +58697,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                   <unittitle>Discussion of state and national party meetings <unitdate type="inclusive" normal="1956-05-05">May 5, 1956</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                    <physfacet>reel-to-reel tapes</physfacet>
-                  <physfacet>7 in.</physfacet>
+                    <physfacet>reel-to-reel tapes; 7 in.</physfacet>
                   </physdesc>
                   </did>
                 <odd>
@@ -58739,8 +58710,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                   <unittitle>State legislation discussed by various legislators <unitdate type="inclusive" normal="1956-05-19">May 19, 1956</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                    <physfacet>reel-to-reel tapes</physfacet>
-                  <physfacet>7 in.</physfacet>
+                    <physfacet>reel-to-reel tapes; 7 in.</physfacet>
                   </physdesc>
                   </did>
                 <odd>
@@ -58753,8 +58723,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                   <unittitle>Election campaign issues (union-controlled Democratic Party) <unitdate type="inclusive" normal="1956-06-02">June 2, 1956</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                    <physfacet>reel-to-reel tapes</physfacet>
-                  <physfacet>7 in.</physfacet>
+                    <physfacet>reel-to-reel tapes; 7 in.</physfacet>
                   </physdesc>
                   </did>
                 <odd>
@@ -59011,8 +58980,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                   <unittitle>Mental illness <unitdate type="inclusive" normal="1956" certainty="approximate">1956 undated</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                    <physfacet>reel-to-reel tapes</physfacet>
-                  <physfacet>7 in.</physfacet>
+                    <physfacet>reel-to-reel tapes; 7 in.</physfacet>
                   </physdesc>
                   </did>
                 <odd>
@@ -59034,8 +59002,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW talks on WBBC (Flint) on UAW program about the budget, etc. <unitdate type="inclusive" normal="1957-03-06">March 6, 1957</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59066,8 +59033,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW speaking at UAW Special Collective Bargaining Convention, Detroit <unitdate type="inclusive" normal="1958-01-23">January 23, 1958</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59080,8 +59046,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Eric Johnston appearance on NBC program "Youth Wants to Know" discussing National Conference on Foreign Aspects of U.S. National Security <unitdate type="inclusive" normal="1958-02-23">February 23, 1958</unitdate> [30 min.],</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59094,8 +59059,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>WWJ-TV program relating to International Students Day <unitdate type="inclusive" normal="1958-02-26">February 26, 1958</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>30 min., 7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 30 min., 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59108,8 +59072,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW speaking at UAW Unemployment Conference, Lansing, Michigan <unitdate type="inclusive" normal="1958-03-12">March 12, 1958</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59122,8 +59085,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Foreign policy briefing <unitdate type="inclusive" normal="1958-04-12">April 12, 1958</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">6 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>3 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 3 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59136,8 +59098,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW appearance on "Viewpoint", Mutual Radio program. Interviewer: Rev. Dana F. Kennedy <unitdate type="inclusive" normal="1958-05-31">May 31, 1958</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>[14:15 min.], 7.5 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; [14:15 min.], 7.5 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59150,8 +59111,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Debate between GMW and Paul Bagwell at the Detroit Economic Club, broadcast over WJR-Radio <unitdate type="inclusive" normal="1958-10-06">October 6, 1958</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59164,8 +59124,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW appearance on Bob Siegrist Newscast (Wisc.) re: John Gunaca case <unitdate type="inclusive" normal="1958-12-04">December 4, 1958</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59178,8 +59137,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>UAW(?) convention. Guests: Edward Hutchinson, John Swainson, Edward Carey, and George Van Peursem <unitdate type="inclusive" normal="1958" certainty="approximate">1958 undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">7 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59195,8 +59153,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Paul D. Bagwell campaign speech <unitdate type="inclusive" normal="1958" certainty="approximate">1958 undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59214,8 +59171,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Inaugural address <unitdate type="inclusive" normal="1959-01">January 1959</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>3.75 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 3.75 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59228,8 +59184,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW speaks on state's financial condition <unitdate type="inclusive" normal="1959-04-29">April 29, 1959</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59242,8 +59197,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW statement for Mutual News on state's financial condition <unitdate type="inclusive" normal="1959-05-01">May 1, 1959</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 3 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 3 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59256,8 +59210,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Excerpt from GMW address on WJR "Your Government" series relating to state's taxing problems <unitdate type="inclusive" normal="1959-05-30">May 30, 1959</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59270,8 +59223,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Excerpts from GMW press conference in which he discusses political conditions in Eastern Europe <unitdate type="inclusive" normal="1959-07">July 1959</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59284,8 +59236,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Phone interview with Barry Gray about visit of GMW with Koslov(?), July 9, 1959</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59298,8 +59249,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Recording of GMW speaking on "The Hebrew Voice", WJLB-Radio program <unitdate type="inclusive" normal="1959-10-01">October 1, 1959</unitdate> [partially in Hebrew]</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>30 min., 7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 30 min., 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59315,8 +59265,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Howard Sugden speaking on book of Habakkuk at Child Evangelism Conference at South Church in Lansing <unitdate type="inclusive" normal="1959" certainty="approximate">1959 undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>3.75 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 3.75 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59329,8 +59278,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW speaking in Warsaw, Poland <unitdate type="inclusive" normal="1959" certainty="approximate">1959 undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59348,8 +59296,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Announcement of GMW of his decision not to run for reelection <unitdate type="inclusive" normal="1960-03-03">March 3, 1960</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59362,8 +59309,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>WMCA program "Pre Convention 1960" (Preview of possible Democratic candidates for U.S. presidency) <unitdate type="inclusive" normal="1960-03-30">March 30, 1960</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59376,8 +59322,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>WMBN (Petoskey) broadcast of arrival of John F. Kennedy at Pellston en route to Mackinac Island (featuring GMW and JFK) <unitdate type="inclusive" normal="1960-06-03">June 3, 1960</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59404,8 +59349,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Address by GMW supporting Constitutional Convention proposal <unitdate type="inclusive" normal="1960-10-05">October 5, 1960</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>13.5 min., 7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 13.5 min., 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59421,8 +59365,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Address by JFK at Michigan State University (introductory remarks by John Bl Swainson, Jerry Earhart?) <unitdate type="inclusive" normal="1960-10-14">October 14, 1960</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59435,8 +59378,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW appearance on Radio Station WHOM (New York) program, "The German Family Hour" (in German) <unitdate type="inclusive" normal="1960-10-30">October 30, 1960</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59456,8 +59398,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW speaking in Warsaw, Poland</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59470,8 +59411,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Campaign message on behalf of Fred Kappler for state representative</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59484,8 +59424,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW speaking (unidentified)</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>3.75 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 3.75 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59498,8 +59437,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Gerald R. Ford speaking on "Veterans News" concerning the Korean Truce</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 3 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 3 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59512,8 +59450,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Debate between Horace Gilmore and John Feikins at Local 600, UAW</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">4 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59526,8 +59463,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Philip Hart interview (also including recording of Hart ? children playing)</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59540,8 +59476,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Personal recording of Mary E. Payne (discharged Detroit school teacher)</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59554,8 +59489,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Stenorette (one unidentified)</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>stenorette</physfacet>
+                  <physfacet>reel-to-reel tapes; stenorette</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59573,8 +59507,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Recording of dinner in Leopoldville (Congo) for Premier Ileo <unitdate type="inclusive" normal="1961-03-25">March 25, 1961</unitdate> [in French and English]</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59592,8 +59525,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Address of GMW speaking on subject of Africa in St. Louis (Mo.) <unitdate type="inclusive" normal="1962-03-30">March 30, 1962</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>ca. 45 min., 7.5 ips, 10.5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; ca. 45 min., 7.5 ips, 10.5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59606,8 +59538,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Address of GMW at Forum Program of Boston College Law School <unitdate type="inclusive" normal="1962-04-03">April 3, 1962</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>ca. 60 min., 7.5 ips, 10.5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; ca. 60 min., 7.5 ips, 10.5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59620,8 +59551,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Interview in Ouagadougou, Upper Volta, [in French] <unitdate type="inclusive" normal="1962-05-11">May 11, 1962</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59639,8 +59569,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Recording of Groupe Vocal Congolais <unitdate type="inclusive" normal="1963-02">February 1963</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>3.75 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 3.75 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59658,8 +59587,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Sudanese music</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59677,8 +59605,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Farewell reception of African ambassadors in Washington, D.C. in honor of GMW <unitdate type="inclusive" normal="1966-03-29">March 29, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59694,8 +59621,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW appearance on "Sound Off," WBRB (Macomb County) radio program <unitdate type="inclusive" normal="1966-04-12">April 12, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59708,8 +59634,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW appearance on "In Our Opinion," WJRT (Flint) television program <unitdate type="inclusive" normal="1966-05" certainty="approximate">circa May, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59722,8 +59647,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW appearance at Democratic Party meeting in Escanaba <unitdate type="inclusive" normal="1966-06" certainty="approximate">circa June, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59739,8 +59663,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW answering questions on primary telethon program <unitdate type="inclusive" normal="1966-07" certainty="approximate">circa July, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59753,8 +59676,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW appearance on "Forum," WDTH radio program <unitdate type="inclusive" normal="1966-09-18">September 18, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59767,8 +59689,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW-Robert Griffin campaign debate before the Detroit Economic Club (excerpts and transcription) <unitdate type="inclusive" normal="1966-10-17">October 17, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>3.75 ips, 25 in. and (1) 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 3.75 ips, 25 in. and (1) 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59781,8 +59702,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW appearance on "Voters' Choice: The U.S. Senate Race," Michigan State University T.V. production <unitdate type="inclusive" normal="1966-10-21">October 21, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59795,8 +59715,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW-Robert Griffin debate on Lou Gordon program <unitdate type="inclusive" normal="1966-10-23">October 23, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>3.75 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 3.75 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59809,8 +59728,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW speaking at public meeting <unitdate type="inclusive" normal="1966-10-23">October 23, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>3.75 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 3.75 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59823,8 +59741,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Transcription of program at University of Detroit Field House upon occasion of campaign visit of Sen. Robert F. Kennedy, featuring Jerome P. Cavanagh, John Conyers, Zolton Ferency, and G. Mennen Williams <unitdate type="inclusive" normal="1966-10-29">October 29, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59837,8 +59754,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Sen. Robert F. Kennedy speaking in praise of GMW at political meeting at University of Detroit Field House <unitdate type="inclusive" normal="1966-10-29">October 29, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>3.75 ips, 4 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 3.75 ips, 4 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59851,8 +59767,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW speaking (side 1) to employees of the Wayne County Juvenile Court and at a Democratic Rally in Southfield, and GMW interview (side 2) on WJR, Detroit radio station <unitdate type="inclusive" normal="1966-10">October 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>3.75 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 3.75 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59865,8 +59780,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Robert Griffin appearance on Lou Gordon television program <unitdate type="inclusive" normal="1966-10">October 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>3.75 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 3.75 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59879,8 +59793,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>GMW-Robert Griffin debate <unitdate type="inclusive" normal="1966-10">October 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>3.75 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 3.75 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59893,8 +59806,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Endorsement by Robert Kennedy of GMW for U.S. Senate <unitdate type="inclusive" normal="1966-10">October 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>ca. 3 min., 7.5 ips, 4 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; ca. 3 min., 7.5 ips, 4 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59910,8 +59822,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Radio spots (Williams for U.S. Senate); 3 cuts: "Pursuit of Peace", "Education", and "Omnibus" <unitdate type="inclusive" normal="1966-10">October 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>ca. 3 min., 7.5 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; ca. 3 min., 7.5 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59927,8 +59838,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Radio spots (Williams for U.S. Senate); 4 cuts (including Edward Kennedy endorsement) <unitdate type="inclusive" normal="1966-10">October 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>ca. 4 min., 7.5 ips, 4 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; ca. 4 min., 7.5 ips, 4 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59944,8 +59854,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Radio spots (Williams for U.S. Senate) <unitdate type="inclusive" normal="1966-10">October 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 4 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 4 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59958,8 +59867,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Campaign song, "He's the Man for Us" sung by Johnny Desmond <unitdate type="inclusive" normal="1966-10">October 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 4 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 4 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59972,8 +59880,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Campaign statements and speeches <unitdate type="inclusive" normal="1966-09/1966-10">September-October 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>3.75 ips, 2 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 3.75 ips, 2 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -59986,8 +59893,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Interview with GMW for Voice of America broadcast <unitdate type="inclusive" normal="1966-12-09">December 9, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -60005,8 +59911,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Tribute to GMW on TULC program, Freedom Forum, upon occasion of his becoming Ambassador to the Philippine Islands <unitdate type="inclusive" normal="1968-06-16">June 16, 1968</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 7 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -60024,8 +59929,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Announcement of GMW decision to run for the Michigan Supreme Court <unitdate type="inclusive" normal="1970-05-19">May 19, 1970</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 6 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 6 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>
@@ -60041,8 +59945,7 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <unittitle>Campaign spots <unitdate type="inclusive" normal="1970-10">October 1970</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7.5 ips, 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7.5 ips, 5 in.</physfacet>
                 </physdesc>
                 </did>
               <odd>

--- a/Real_Masters_all/gmwill.xml
+++ b/Real_Masters_all/gmwill.xml
@@ -49023,11 +49023,9 @@
                 <unittitle>Formal Portraits</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 folders</extent>
+                <physfacet>includes tintype</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>includes tintype</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -58290,11 +58288,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>3.75 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3.75 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 1</p>
               </odd>
@@ -58311,11 +58307,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>dual track; 1 7/8 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>dual track; 1 7/8 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tapes 2-3</p>
               </odd>
@@ -58327,11 +58321,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>1 7/8 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>1 7/8 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 4</p>
               </odd>
@@ -58348,11 +58340,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>15 min., 7.5 ips; 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>15 min., 7.5 ips; 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 5</p>
               </odd>
@@ -58364,11 +58354,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 6</p>
               </odd>
@@ -58380,11 +58368,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>ca. 15 min., 7.5 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>ca. 15 min., 7.5 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 7</p>
               </odd>
@@ -58396,11 +58382,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>15 min., 7.5 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>15 min., 7.5 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 8</p>
               </odd>
@@ -58412,11 +58396,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>15 mins., 7.5 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>15 mins., 7.5 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>[transcript attached]</p>
               </odd>
@@ -58431,11 +58413,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>15 min.; 7.5 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>15 min.; 7.5 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 10</p>
               </odd>
@@ -58452,11 +58432,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 11</p>
               </odd>
@@ -58473,11 +58451,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>[duplicate available]</p>
               </odd>
@@ -58492,11 +58468,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tapes 13-14</p>
               </odd>
@@ -58508,11 +58482,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 15</p>
               </odd>
@@ -58524,11 +58496,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 16</p>
               </odd>
@@ -58540,11 +58510,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 17</p>
               </odd>
@@ -58556,11 +58524,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 18</p>
               </odd>
@@ -58572,11 +58538,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 19</p>
               </odd>
@@ -58588,11 +58552,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 20</p>
               </odd>
@@ -58604,11 +58566,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 21</p>
               </odd>
@@ -58620,11 +58580,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 22</p>
               </odd>
@@ -58641,11 +58599,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 23</p>
               </odd>
@@ -58657,11 +58613,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>dual track, 2 hr 3.75 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>dual track, 2 hr 3.75 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 24</p>
               </odd>
@@ -58678,11 +58632,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 25</p>
               </odd>
@@ -58694,11 +58646,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 26</p>
               </odd>
@@ -58710,11 +58660,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 27</p>
               </odd>
@@ -58726,11 +58674,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 28</p>
               </odd>
@@ -58742,11 +58688,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 29</p>
               </odd>
@@ -58758,11 +58702,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 30</p>
               </odd>
@@ -58784,11 +58726,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                     <physfacet>reel-to-reel tapes</physfacet>
+                  <physfacet>7 in.</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>7 in.</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
                 <odd>
                   <p>Tape 31</p>
                 </odd>
@@ -58800,11 +58740,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                     <physfacet>reel-to-reel tapes</physfacet>
+                  <physfacet>7 in.</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>7 in.</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
                 <odd>
                   <p>Tape 32</p>
                 </odd>
@@ -58816,11 +58754,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                     <physfacet>reel-to-reel tapes</physfacet>
+                  <physfacet>7 in.</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>7 in.</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
                 <odd>
                   <p>Tape 33</p>
                 </odd>
@@ -59076,11 +59012,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                     <physfacet>reel-to-reel tapes</physfacet>
+                  <physfacet>7 in.</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>7 in.</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
                 <odd>
                   <p>[choppy quality]</p>
                 </odd>
@@ -59101,11 +59035,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 54</p>
               </odd>
@@ -59135,11 +59067,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 57</p>
               </odd>
@@ -59151,11 +59081,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 58</p>
               </odd>
@@ -59167,11 +59095,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>30 min., 7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>30 min., 7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 59</p>
               </odd>
@@ -59183,11 +59109,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 60</p>
               </odd>
@@ -59199,11 +59123,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">6 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>3 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tapes 61-66</p>
               </odd>
@@ -59215,11 +59137,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>[14:15 min.], 7.5 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>[14:15 min.], 7.5 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 67</p>
               </odd>
@@ -59231,11 +59151,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 68</p>
               </odd>
@@ -59247,11 +59165,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 69</p>
               </odd>
@@ -59263,11 +59179,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">7 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>[Note: Edited tape is dated 1956]</p>
               </odd>
@@ -59282,11 +59196,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 77</p>
               </odd>
@@ -59303,11 +59215,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>3.75 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3.75 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 78</p>
               </odd>
@@ -59319,11 +59229,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 79</p>
               </odd>
@@ -59335,11 +59243,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 3 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 3 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 80</p>
               </odd>
@@ -59351,11 +59257,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>[transcript available], Tape 81</p>
               </odd>
@@ -59367,11 +59271,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 82</p>
               </odd>
@@ -59383,11 +59285,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 83</p>
               </odd>
@@ -59399,11 +59299,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>30 min., 7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>30 min., 7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>[duplicate tape available]</p>
               </odd>
@@ -59418,11 +59316,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>3.75 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3.75 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 85</p>
               </odd>
@@ -59434,11 +59330,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 86</p>
               </odd>
@@ -59455,11 +59349,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 87</p>
               </odd>
@@ -59471,11 +59363,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 88</p>
               </odd>
@@ -59487,11 +59377,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 89</p>
               </odd>
@@ -59517,11 +59405,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>13.5 min., 7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>13.5 min., 7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>[transcript available]</p>
               </odd>
@@ -59536,11 +59422,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 92</p>
               </odd>
@@ -59552,11 +59436,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 93</p>
               </odd>
@@ -59575,11 +59457,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>(see Tape 86)</p>
               </odd>
@@ -59591,11 +59471,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 95</p>
               </odd>
@@ -59607,11 +59485,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>3.75 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3.75 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 96</p>
               </odd>
@@ -59623,11 +59499,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 3 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 3 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 97</p>
               </odd>
@@ -59639,11 +59513,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">4 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tapes 98-101</p>
               </odd>
@@ -59655,11 +59527,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 102</p>
               </odd>
@@ -59671,11 +59541,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 103</p>
               </odd>
@@ -59687,11 +59555,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>stenorette</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>stenorette</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 104</p>
               </odd>
@@ -59708,11 +59574,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 105</p>
               </odd>
@@ -59729,11 +59593,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>ca. 45 min., 7.5 ips, 10.5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>ca. 45 min., 7.5 ips, 10.5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 106</p>
               </odd>
@@ -59745,11 +59607,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>ca. 60 min., 7.5 ips, 10.5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>ca. 60 min., 7.5 ips, 10.5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tapes 107-109</p>
               </odd>
@@ -59761,11 +59621,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 110</p>
               </odd>
@@ -59782,11 +59640,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>3.75 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3.75 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 111</p>
               </odd>
@@ -59803,11 +59659,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 112</p>
               </odd>
@@ -59824,11 +59678,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>[duplicate copy available]</p>
               </odd>
@@ -59843,11 +59695,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 114</p>
               </odd>
@@ -59859,11 +59709,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 115</p>
               </odd>
@@ -59875,11 +59723,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>[poor quality]</p>
               </odd>
@@ -59894,11 +59740,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tapes 117-118</p>
               </odd>
@@ -59910,11 +59754,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 119</p>
               </odd>
@@ -59926,11 +59768,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>3.75 ips, 25 in. and (1) 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3.75 ips, 25 in. and (1) 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tapes 120-122</p>
               </odd>
@@ -59942,11 +59782,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 123</p>
               </odd>
@@ -59958,11 +59796,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>3.75 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3.75 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 124</p>
               </odd>
@@ -59974,11 +59810,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>3.75 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3.75 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 125</p>
               </odd>
@@ -59990,11 +59824,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 126</p>
               </odd>
@@ -60006,11 +59838,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>3.75 ips, 4 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3.75 ips, 4 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 127</p>
               </odd>
@@ -60022,11 +59852,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>3.75 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3.75 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 128</p>
               </odd>
@@ -60038,11 +59866,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>3.75 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3.75 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 129</p>
               </odd>
@@ -60054,11 +59880,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>3.75 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3.75 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 130</p>
               </odd>
@@ -60070,11 +59894,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>ca. 3 min., 7.5 ips, 4 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>ca. 3 min., 7.5 ips, 4 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>[duplicate copy available]</p>
               </odd>
@@ -60089,11 +59911,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>ca. 3 min., 7.5 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>ca. 3 min., 7.5 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>[duplicate copy available]</p>
               </odd>
@@ -60108,11 +59928,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>ca. 4 min., 7.5 ips, 4 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>ca. 4 min., 7.5 ips, 4 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>[duplicate copy available]</p>
               </odd>
@@ -60127,11 +59945,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 4 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 4 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 134</p>
               </odd>
@@ -60143,11 +59959,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 4 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 4 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 135</p>
               </odd>
@@ -60159,11 +59973,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>3.75 ips, 2 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3.75 ips, 2 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 136</p>
               </odd>
@@ -60175,11 +59987,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 137</p>
               </odd>
@@ -60196,11 +60006,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>Tape 138</p>
               </odd>
@@ -60217,11 +60025,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 6 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 6 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>[duplicate copy available]</p>
               </odd>
@@ -60236,11 +60042,9 @@ CA-579 is Cuts 1-8.; Cut 1: "Looking for a Man" (20 sec.); Cut 2: "We Want Willi
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7.5 ips, 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7.5 ips, 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>2 cuts: 30 sec., 10 sec.</p>
               </odd>

--- a/Real_Masters_all/grandhot.xml
+++ b/Real_Masters_all/grandhot.xml
@@ -692,11 +692,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">28 prints</extent>
+                <physfacet>various prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>various prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -706,11 +704,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">29 prints</extent>
+                <physfacet>various b/w prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>various b/w prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -721,11 +717,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">43 prints</extent>
+                <physfacet>various prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>various prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
           <c03 level="file">
@@ -741,11 +735,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">62 prints</extent>
                   <extent altrender="carrier">in 2 envelopes</extent>
+                <physfacet>bulk b/w prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>bulk b/w prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -776,11 +768,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>Golf Course <unitdate type="inclusive" normal="1986-10-25">October 25, 1986</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">65 prints</extent>
+              <physfacet>5" x 7" color prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>5" x 7" color prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -788,11 +778,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>Rooms and Suites <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">19 prints</extent>
+              <physfacet>8" x 10" color prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>8" x 10" color prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -800,11 +788,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>Scenery <unitdate type="inclusive" normal="1987">1987</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">8 prints</extent>
+              <physfacet>8" x 10" color prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>8" x 10" color prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -818,11 +804,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">77 prints</extent>
                 <extent altrender="carrier">in 2 envelopes</extent>
+              <physfacet>8"x10" b/w prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>8"x10" b/w prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -830,11 +814,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>Michigan Savings and Loan Event <unitdate type="inclusive" normal="1975" certainty="approximate">circa 1975</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">21 prints</extent>
+              <physfacet>8" x 10" b/w prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>8" x 10" b/w prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -842,11 +824,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>NASA Reception set up with silver service and staff <unitdate type="inclusive" normal="1977">1977</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">38 prints</extent>
+              <physfacet>3 1/2" x 3 1/2" color snapshots</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>3 1/2" x 3 1/2" color snapshots</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -854,11 +834,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>Michigan Bankers' Association Hawaiian Luau <unitdate type="inclusive" normal="1978">1978</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">13 prints</extent>
+              <physfacet>5"x7" color prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>5"x7" color prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -866,11 +844,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>Knights of Columbus Event <unitdate type="inclusive" normal="1983">1983</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">22 prints</extent>
+              <physfacet>5"x7" color prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>5"x7" color prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -878,11 +854,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle><unitdate type="inclusive" normal="1983">1983</unitdate> Events</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 prints</extent>
+              <physfacet>5"x7" color prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>5"x7" color prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(includes images of Flip Wilson, Governor Blanchard and Governor DuPont)</p>
             </odd>
@@ -893,11 +867,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle><unitdate type="inclusive" normal="1987">1987</unitdate> Events</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">13 prints</extent>
+              <physfacet>Bulk 8"x10" color prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>Bulk 8"x10" color prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -905,11 +877,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>Democratic Governors' Association Event <unitdate type="inclusive" normal="1987-07">July 1987</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">17 prints</extent>
+              <physfacet>3"x5" color snapshots</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>3"x5" color snapshots</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(includes images of Musser with Bill and Hillary Clinton, and Jesse Jackson)</p>
             </odd>
@@ -920,11 +890,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>Democratic Governors' Association <unitdate type="inclusive" normal="1988" certainty="approximate">circa 1988</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">68 prints</extent>
+              <physfacet>5"x7" color prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>5"x7" color prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -932,11 +900,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>100th Anniversary Party <unitdate type="inclusive" normal="1987">1987</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">24 prints</extent>
+              <physfacet>color snapshots</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>color snapshots</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -945,11 +911,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">235 prints</extent>
                 <extent altrender="carrier">in 3 envelopes</extent>
+              <physfacet>5"x7" color prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>5"x7" color prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(includes images of Esther Williams)</p>
             </odd>
@@ -960,11 +924,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>Tea with John McCabe, author of <title render="italic">Grand Hotel</title>, <unitdate type="inclusive" normal="1987" certainty="approximate">circa 1987</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">23 prints</extent>
+              <physfacet>5"x7" color prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>5"x7" color prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -972,11 +934,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>MLSI Banquet <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">18 prints</extent>
+              <physfacet>5"x7" color prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>5"x7" color prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -984,11 +944,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>Victorian Weekend <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">32 prints</extent>
+              <physfacet>5"x7" color prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>5"x7" color prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -996,11 +954,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>Okemos Office Open House <unitdate type="inclusive" normal="1990-12">December 1990</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">25 prints</extent>
+              <physfacet>color snapshots</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>color snapshots</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -1008,11 +964,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>Republican Party Event <unitdate type="inclusive" normal="1990" certainty="approximate">circa 1990</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">20 prints</extent>
+              <physfacet>5"x7" color prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>5"x7" color prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(includes images of Robert Dole and other prominent Republican leaders)</p>
             </odd>
@@ -1023,11 +977,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>Newsletter Photographs of Events <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">11 prints</extent>
+              <physfacet>5"x7" color prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>5"x7" color prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(includes images of John Engler)</p>
             </odd>
@@ -1038,11 +990,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>"Somewhere In Time" Period Costume Event <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">65 prints</extent>
+              <physfacet>5"x7" color prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>5"x7" color prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -1079,11 +1029,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>Staff and Notable Personages</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">61 prints</extent>
+              <physfacet>various prints, bulk color</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>various prints, bulk color</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(includes images of Governor Blanchard, John Paul Stevens, Phyllis Diller, the Grand Hotel Orchestra, Ramsey Miller, etc.)</p>
             </odd>
@@ -1108,11 +1056,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>Water Tower Removal <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">18 prints</extent>
+              <physfacet>color snapshots</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>color snapshots</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -1120,11 +1066,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>Woodville Housing Project <unitdate type="inclusive" normal="1987-12">December 1987</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 prints</extent>
+              <physfacet>Polaroids</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>Polaroids</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -1136,11 +1080,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 <unittitle>Undated, possibly <unitdate type="inclusive" normal="1960" certainty="approximate">circa 1960</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">5 prints</extent>
+                <physfacet>8"x10" b/w prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>8"x10" b/w prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1150,11 +1092,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">7 prints</extent>
+                <physfacet>8"x10" b/w prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>8"x10" b/w prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1164,11 +1104,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">15 prints</extent>
+                <physfacet>color snapshots</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>color snapshots</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1178,11 +1116,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">73 prints</extent>
+                <physfacet>color snapshots</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>color snapshots</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>(includes golf course and pool remodeling)</p>
               </odd>
@@ -1195,11 +1131,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">38 prints</extent>
+                <physfacet>color snapshots</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>color snapshots</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>(includes golf course and pool remodeling)</p>
               </odd>
@@ -1212,11 +1146,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">45 prints</extent>
+                <physfacet>color snapshots</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>color snapshots</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1226,11 +1158,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">21 prints</extent>
+                <physfacet>color snapshots</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>color snapshots</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1240,11 +1170,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">53 prints</extent>
+                <physfacet>color snapshots</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>color snapshots</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1254,11 +1182,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">56 prints</extent>
+                <physfacet>color snapshots</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>color snapshots</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>(includes Corner Cottage)</p>
               </odd>
@@ -1269,11 +1195,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 <unittitle>Undated, possibly <unitdate type="inclusive" normal="1987">1987</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">15 prints</extent>
+                <physfacet>color snapshots</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>color snapshots</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1284,11 +1208,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">135 prints</extent>
                   <extent altrender="carrier">in 3 envelopes</extent>
+                <physfacet>color snapshots</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>color snapshots</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>(were originally organized in six mini-albums)</p>
               </odd>
@@ -1302,11 +1224,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">94 prints</extent>
                   <extent altrender="carrier">in 2 envelopes</extent>
+                <physfacet>color snapshots</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>color snapshots</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>(were originally in an album titled "Scenes and Construction")</p>
               </odd>
@@ -1319,11 +1239,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">41 prints</extent>
+                <physfacet>color snapshots</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>color snapshots</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1333,11 +1251,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">30 prints</extent>
+                <physfacet>18 Polaroids and 12 color snapshots</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>18 Polaroids and 12 color snapshots</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1347,11 +1263,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">48 prints</extent>
+                <physfacet>color snapshots</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>color snapshots</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1361,11 +1275,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">12 prints</extent>
+                <physfacet>color snapshots</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>color snapshots</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1375,11 +1287,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">37 prints</extent>
+                <physfacet>color snapshots</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>color snapshots</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1389,11 +1299,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">36 prints</extent>
+                <physfacet>color snapshots</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>color snapshots</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
         </c02>
@@ -1407,11 +1315,9 @@ Grand Hotel (Mackinac Island, Mich.) Records, Bentley Historical Library, Univer
               <unittitle>Images of fire recovery, Room 258 <unitdate type="inclusive" normal="1983-05-10">May 10, 1983</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">75 prints</extent>
+              <physfacet>5"x7" color prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>5"x7" color prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/griffmar.xml
+++ b/Real_Masters_all/griffmar.xml
@@ -5752,11 +5752,9 @@
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel tapes</physfacet>
+              <physfacet>7 1/2 ips; 7 in.</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>7 1/2 ips; 7 in.</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(This tape consists of a number of reports probably all recorded at one time.)</p>
             </odd>
@@ -5768,11 +5766,9 @@
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel tapes</physfacet>
+              <physfacet>7 1/2 ips; 7 in.</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>7 1/2 ips; 7 in.</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -5781,11 +5777,9 @@
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 audiotapes</extent>
                 <physfacet>reel-to-reel tapes</physfacet>
+              <physfacet>7 1/2 ips; 5 in.</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>7 1/2 ips; 5 in.</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -5794,11 +5788,9 @@
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel tapes</physfacet>
+              <physfacet>7 1/2 ips; 5 in.</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>7 1/2 ips; 5 in.</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -5808,11 +5800,9 @@
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel tapes</physfacet>
                 <dimensions>13:08</dimensions>
+              <physfacet>7 1/2 ips; 5 in.</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>7 1/2 ips; 5 in.</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -5821,11 +5811,9 @@
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>15 min.; reel-to-reel tapes</physfacet>
+              <physfacet>7 1/2 ips; 7 in.</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>7 1/2 ips; 7 in.</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -5834,11 +5822,9 @@
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel tapes</physfacet>
+              <physfacet>7 1/2 ips; 3 in.</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>7 1/2 ips; 3 in.</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -5847,11 +5833,9 @@
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>4 min.; reel-to-reel tapes</physfacet>
+              <physfacet>7 1/2 ips; 7 in.</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>7 1/2 ips; 7 in.</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -5860,11 +5844,9 @@
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>12 min.; reel-to-reel tapes</physfacet>
+              <physfacet>7 1/2 ips; 5 in.</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>7 1/2 ips; 5 in.</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -5873,11 +5855,9 @@
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel tapes</physfacet>
+              <physfacet>7 1/2 ips; 7 in.</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>7 1/2 ips; 7 in.</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -5887,11 +5867,9 @@
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel tapes</physfacet>
                 <dimensions>5:05</dimensions>
+              <physfacet>7 1/2 ips; 5 in.</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>7 1/2 ips; 5 in.</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -5900,11 +5878,9 @@
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 audiotapes</extent>
                 <physfacet>each statement runs about 30 seconds; reel-to-reel tapes</physfacet>
+              <physfacet>7 1/2 ips; 3 in.</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>7 1/2 ips; 3 in.</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -5913,11 +5889,9 @@
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>20:5; reel-to-reel tapes</physfacet>
+              <physfacet>7 1/2 ips; 7 in.</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>7 1/2 ips; 7 in.</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/griffmar.xml
+++ b/Real_Masters_all/griffmar.xml
@@ -5751,8 +5751,7 @@
               <unittitle>"Report on Congress" (weekly report of MWG) <unitdate type="inclusive" normal="1955/1956" certainty="approximate">circa 1955-1956</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                <physfacet>reel-to-reel tapes</physfacet>
-              <physfacet>7 1/2 ips; 7 in.</physfacet>
+                <physfacet>reel-to-reel tapes; 7 1/2 ips; 7 in.</physfacet>
               </physdesc>
               </did>
             <odd>
@@ -5765,8 +5764,7 @@
               <unittitle>Recording of MWG discussing the Federal National Mortgage Association, family food budgets, consent decrees in anti-trust suits, the <title render="italic">Statistical Abstract of the United States</title>, and population growth and new states., <unitdate type="inclusive" normal="1957" certainty="approximate">circa 1957</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                <physfacet>reel-to-reel tapes</physfacet>
-              <physfacet>7 1/2 ips; 7 in.</physfacet>
+                <physfacet>reel-to-reel tapes; 7 1/2 ips; 7 in.</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -5776,8 +5774,7 @@
               <unittitle>Radio report of MWG discussing the achievements of the 85th Congress. <unitdate type="inclusive" normal="1957-10/1957-11">October-November 1957</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 audiotapes</extent>
-                <physfacet>reel-to-reel tapes</physfacet>
-              <physfacet>7 1/2 ips; 5 in.</physfacet>
+                <physfacet>reel-to-reel tapes; 7 1/2 ips; 5 in.</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -5787,8 +5784,7 @@
               <unittitle>"Report from Washington" on the topic of civil defense system. <unitdate type="inclusive" normal="1957-10-20">October 20, 1957</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                <physfacet>reel-to-reel tapes</physfacet>
-              <physfacet>7 1/2 ips; 5 in.</physfacet>
+                <physfacet>reel-to-reel tapes; 7 1/2 ips; 5 in.</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -5798,9 +5794,8 @@
               <unittitle>Recording of "Congress in Action" featuring MWG discussing the extension of the Reciprocal Trade Agreements Act with guest Henry Kerns. <unitdate type="inclusive" normal="1958-02-20">February 20, 1958</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>reel-to-reel tapes; 7 1/2 ips; 5 in.</physfacet>
                 <dimensions>13:08</dimensions>
-              <physfacet>7 1/2 ips; 5 in.</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -5810,8 +5805,7 @@
               <unittitle>Recording of interview between MWG and Rajni Kaul of the Voice of America on Griffith's entry into politics, issues before the Congress, and life as member of Congress. <unitdate type="inclusive" normal="1958-05-15">May 15, 1958</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                <physfacet>15 min.; reel-to-reel tapes</physfacet>
-              <physfacet>7 1/2 ips; 7 in.</physfacet>
+                <physfacet>15 min.; reel-to-reel tapes; 7 1/2 ips; 7 in.</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -5821,8 +5815,7 @@
               <unittitle>Recording discussing function of the General Accounting Office. <unitdate type="inclusive" normal="1959" certainty="approximate">circa 1959</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                <physfacet>reel-to-reel tapes</physfacet>
-              <physfacet>7 1/2 ips; 3 in.</physfacet>
+                <physfacet>reel-to-reel tapes; 7 1/2 ips; 3 in.</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -5832,8 +5825,7 @@
               <unittitle>Interview with MWG on the trade expansion act recorded for the Voice of America. <unitdate type="inclusive" normal="1962-03-15">March 15, 1962</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                <physfacet>4 min.; reel-to-reel tapes</physfacet>
-              <physfacet>7 1/2 ips; 7 in.</physfacet>
+                <physfacet>4 min.; reel-to-reel tapes; 7 1/2 ips; 7 in.</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -5843,8 +5835,7 @@
               <unittitle>Recording of interview with MWG conducted by Ray Courage on tax cut bill in Congress. <unitdate type="inclusive" normal="1963" certainty="approximate">circa 1963</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                <physfacet>12 min.; reel-to-reel tapes</physfacet>
-              <physfacet>7 1/2 ips; 5 in.</physfacet>
+                <physfacet>12 min.; reel-to-reel tapes; 7 1/2 ips; 5 in.</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -5854,8 +5845,7 @@
               <unittitle>Recording of ceremonies in capitol rotunda for President John F. Kennedy. Participants include: Russell Black, Mike Mansfield, Earl Warren, and John McCormack. <unitdate type="inclusive" normal="1963-11-24">November 24, 1963</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                <physfacet>reel-to-reel tapes</physfacet>
-              <physfacet>7 1/2 ips; 7 in.</physfacet>
+                <physfacet>reel-to-reel tapes; 7 1/2 ips; 7 in.</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -5865,9 +5855,8 @@
               <unittitle>Recording of Congressman Peter Dupont of Delaware with guest MWG discussing economic discrimination of women. <unitdate type="inclusive" normal="1970" certainty="approximate">circa 1970</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>reel-to-reel tapes; 7 1/2 ips; 5 in.</physfacet>
                 <dimensions>5:05</dimensions>
-              <physfacet>7 1/2 ips; 5 in.</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -5877,8 +5866,7 @@
               <unittitle>Recordings of statement made for program "Capitol Hill Today;" include brief comments on sex discrimination <unitdate type="inclusive" normal="1969-10-21">October 21, 1969</unitdate>, <unitdate type="inclusive" normal="1970-08-10">August 10, 1970</unitdate> and health service, <unitdate type="inclusive" normal="1970-02-10">February 10, 1970</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 audiotapes</extent>
-                <physfacet>each statement runs about 30 seconds; reel-to-reel tapes</physfacet>
-              <physfacet>7 1/2 ips; 3 in.</physfacet>
+                <physfacet>each statement runs about 30 seconds; reel-to-reel tapes; 7 1/2 ips; 3 in.</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -5888,8 +5876,7 @@
               <unittitle>Radio recording of "What's the Issue?" on the subject of welfare with guest Representative Martha Griffiths. Host: Arch N. Booth; Report: Craig Palmer. <unitdate type="inclusive" normal="1973-04-12">April 12, 1973</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                <physfacet>20:5; reel-to-reel tapes</physfacet>
-              <physfacet>7 1/2 ips; 7 in.</physfacet>
+                <physfacet>20:5; reel-to-reel tapes; 7 1/2 ips; 7 in.</physfacet>
               </physdesc>
               </did>
           </c03>

--- a/Real_Masters_all/hartmemb.xml
+++ b/Real_Masters_all/hartmemb.xml
@@ -152,11 +152,9 @@
               <unittitle>Ledger <unitdate type="inclusive" normal="1922/1929">1922-1929</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
+              <physfacet>original and photocopy</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>original and photocopy</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/hartwick.xml
+++ b/Real_Masters_all/hartwick.xml
@@ -710,11 +710,9 @@ Edward N. Hartwick Papers, Bentley Historical Library, University of Michigan</p
               <unittitle>Richard Nixon train tour of Michigan <unitdate type="inclusive" normal="1956">1956</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 reels</extent>
+              <physfacet>color, silent</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>color, silent</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -955,11 +953,9 @@ Edward N. Hartwick Papers, Bentley Historical Library, University of Michigan</p
               <unittitle>Address of E. Frederic Morrow, administrative officer, special projects division at the White House; Detroit, Mich., Dwight Eisenhower Birthday celebration. Talk concerns civil rights struggle <unitdate type="inclusive" normal="1956-01-20">January 20, 1956</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">10 minutes</extent>
+              <physfacet>3 3/4 ips; 7 in.</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>3 3/4 ips; 7 in.</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="file">
@@ -972,11 +968,9 @@ Edward N. Hartwick Papers, Bentley Historical Library, University of Michigan</p
               <unittitle>14th Congressional District Republican Campaign Strategy Conference <unitdate type="inclusive" normal="1956-03-10">March 10, 1956</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+              <physfacet>double track; 3 3/4 ips; 7 in.</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>double track; 3 3/4 ips; 7 in.</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="file">
@@ -989,11 +983,9 @@ Edward N. Hartwick Papers, Bentley Historical Library, University of Michigan</p
               <unittitle>Address of Secretary of the Treasury, George M. Humphrey, Detroit Economic Club <unitdate type="inclusive" normal="1956-10-08">October 8, 1956</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+              <physfacet>3 3/4 ips; 7 in.</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>3 3/4 ips; 7 in.</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
       </c01>

--- a/Real_Masters_all/hofdavid.xml
+++ b/Real_Masters_all/hofdavid.xml
@@ -373,11 +373,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
               </unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 copies</extent>
+              <physfacet>Copies are, tan, blue, two shades of green</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>Copies are, tan, blue, two shades of green</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>[(Allen annotation: 3rd ed. The issue in tan, leather grained wraps May have priority. There is another issue of this second [sic] printing recognizable by its green wraps and a third issue in blue wraps.]</p>
             </odd>
@@ -587,11 +585,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 copies</extent>
+                  <physfacet>Cover title within thin, thick rule, wraps ivory colored. No publication list. Type 1 portrait of Benjamin. Lack of cover imprint corrected by rubber stamping 1st leaf. Text printed in blue ink. A few copies were issued in wraps intended for Book 1</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>Cover title within thin, thick rule, wraps ivory colored. No publication list. Type 1 portrait of Benjamin. Lack of cover imprint corrected by rubber stamping 1st leaf. Text printed in blue ink. A few copies were issued in wraps intended for Book 1</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -603,11 +599,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 copies</extent>
+                  <physfacet>Cover title within thin, thick rules. Type 1 frontis portrait of Benjamin. Some copies lack cover imprint which has been corrected by rubber stamping the first leaf. Text printed in blue ink.</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>Cover title within thin, thick rules. Type 1 frontis portrait of Benjamin. Some copies lack cover imprint which has been corrected by rubber stamping the first leaf. Text printed in blue ink.</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -638,11 +632,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 copies</extent>
+                  <physfacet>Cover title within thin, thick rules, type 1 frontis portrait of Benjamin. Blue wraps. Text printed in blue ink.</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>Cover title within thin, thick rules, type 1 frontis portrait of Benjamin. Blue wraps. Text printed in blue ink.</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -676,11 +668,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 copies</extent>
+                  <physfacet>The wraps are red, cover title within thin, thick rules. Type 1 frontis portrait. The text is printed in blue ink.</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>The wraps are red, cover title within thin, thick rules. Type 1 frontis portrait. The text is printed in blue ink.</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -730,11 +720,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 copies</extent>
+                  <physfacet>[Cover title within thin, thick, thin rules. Blue wraps. Type 3 frontis portrait of Benjamin. Ball of fire vol. 1 and 2 offered in publication list. Text printed in black ink. On later printings the Israelite House of David imprint has been altered to read House of David.]</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>[Cover title within thin, thick, thin rules. Blue wraps. Type 3 frontis portrait of Benjamin. Ball of fire vol. 1 and 2 offered in publication list. Text printed in black ink. On later printings the Israelite House of David imprint has been altered to read House of David.]</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -744,11 +732,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">4 copies</extent>
+                  <physfacet>[Cover title within thin, thick, thin rules. Blue gray wraps. Type 4 frontis portrait of Benjamin. Text printed in black ink. In later printings the Israelite House of David imprint has been altered to read House of David.]</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>[Cover title within thin, thick, thin rules. Blue gray wraps. Type 4 frontis portrait of Benjamin. Text printed in black ink. In later printings the Israelite House of David imprint has been altered to read House of David.]</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
             </c04>
             <c04 level="file">
@@ -774,11 +760,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                   <unittitle>Book 1</unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 copies</extent>
+                  <physfacet>[Pink wraps with two color cut of flag and eagle. Trumpet insignia printed in red. Wrapper title within equal size rules. Type 4 frontis portrait. Text printed in flack ink. A later is sue has the wrapper title within thick, thin rules and the wrapper with the flag and eagle cut is printed in one color. Text printed in black ink. Type 4 frontis portrait.]</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>[Pink wraps with two color cut of flag and eagle. Trumpet insignia printed in red. Wrapper title within equal size rules. Type 4 frontis portrait. Text printed in flack ink. A later is sue has the wrapper title within thick, thin rules and the wrapper with the flag and eagle cut is printed in one color. Text printed in black ink. Type 4 frontis portrait.]</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -790,11 +774,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 copies</extent>
+                  <physfacet>[Cover title within thin, thick, thin rules. Very pale blue color. Type 2 frontis portrait of Benjamin. Ball of fire, etc., offered in publication list. Text printed in black ink.]</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>[Cover title within thin, thick, thin rules. Very pale blue color. Type 2 frontis portrait of Benjamin. Ball of fire, etc., offered in publication list. Text printed in black ink.]</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
             </c04>
             <c04 level="file">
@@ -811,11 +793,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 copies</extent>
+                  <physfacet>[Pink wraps, cover printed in one color. Thick thin ruled border.]</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>[Pink wraps, cover printed in one color. Thick thin ruled border.]</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -827,11 +807,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 copies</extent>
+                  <physfacet>[Darker orange wraps, cover title within thin, thick, thin rules. Publication list offers Ball of fire, Books of poetry, Eden paradisiacal liberty. Type 4 portrait. Text printed in black ink.]</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>[Darker orange wraps, cover title within thin, thick, thin rules. Publication list offers Ball of fire, Books of poetry, Eden paradisiacal liberty. Type 4 portrait. Text printed in black ink.]</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
             </c04>
             <c04 level="file">
@@ -874,11 +852,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 copies</extent>
+                  <physfacet>[Photo offset reprint]</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>[Photo offset reprint]</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -890,11 +866,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                   </unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 copies</extent>
+                  <physfacet>[Photo offset reprint]</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>[Photo offset reprint]</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
             </c04>
             <c04 level="file">
@@ -1579,11 +1553,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                 <unittitle>Set 3. publisher "House of David, Drawer G, Benton Harbor" portrait of Benjamin with hat</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 copies</extent>
+                <physfacet>Green wraps, thick border, flag and eagle printed in one color</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>Green wraps, thick border, flag and eagle printed in one color</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1600,11 +1572,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                 <unittitle>Set 5. Allen 1930s ed., publisher "House of David, P.O. Box 477, Benton Harbor"</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">4 copies</extent>
+                <physfacet>Light green wraps, thick border, flag and eagle printed in one color</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>Light green wraps, thick border, flag and eagle printed in one color</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -2858,11 +2828,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 copies</extent>
+                <physfacet>[Smaller format and revised textually. Israelite House of David imprint. Flag and eagle cut at head of title on upper wrap. One with "House of David" imprint]</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>[Smaller format and revised textually. Israelite House of David imprint. Flag and eagle cut at head of title on upper wrap. One with "House of David" imprint]</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -2875,11 +2843,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">4 copies</extent>
+                <physfacet>[Flag and eagle cut on wraps. The imprint reads House of David. A later issue (3 copies) is in orange wraps.]</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>[Flag and eagle cut on wraps. The imprint reads House of David. A later issue (3 copies) is in orange wraps.]</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
           <c03 level="file">
@@ -2982,12 +2948,10 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 copies</extent>
-                </physdesc>
-                <physdesc>
-                  <dimensions>14.5 x 11 cm.</dimensions>
+                <dimensions>14.5 x 11 cm.</dimensions>
                   <physfacet>[Pink wraps. The wrap bears the imprint Israelite House of David however indications are that this was actually printed in the 1930s. The wrap has been completely reset but textually the same as the previous issue.</physfacet>
                 </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
           <c03 level="file">
@@ -6099,11 +6063,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                 <unittitle>Numbered</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">31 negatives</extent>
+                <physfacet>b/w, 4"x5"</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>b/w, 4"x5"</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>(Numbered 24,596 through 24,626 according to system at previous repository; numbers match with prints integrated into topical arrangement above.)</p>
               </odd>
@@ -6113,11 +6075,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
                 <unittitle>Topical</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 folders</extent>
+                <physfacet>mostly b/w, 5"x7"</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>mostly b/w, 5"x7"</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">21</container>
@@ -6257,11 +6217,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
               <unittitle><genreform normal="Glass negatives">Glass negatives</genreform>, <unitdate type="inclusive" normal="1918/1927" certainty="approximate">circa 1918-1927</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">39 negatives</extent>
+              <physfacet>5"x7"</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>5"x7"</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(prints available in the collection)</p>
             </odd>
@@ -6417,11 +6375,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
               <unittitle>Film</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 slides</extent>
+              <physfacet>color, 1"x1"</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>color, 1"x1"</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">22</container>
@@ -6446,11 +6402,9 @@ D.C. Allen House of David Collection, Bentley Historical Library, University of 
               <unittitle>Glass</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">95 slides</extent>
+              <physfacet>3.25"x4"; color, hand-tinted and b/w</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>3.25"x4"; color, hand-tinted and b/w</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(images are mostly duplicative of ones available in Photograph and/or Postcard subseries; only exceptions to this, i.e. images not available elsewhere in the collection, are listed below)</p>
             </odd>

--- a/Real_Masters_all/jensenka.xml
+++ b/Real_Masters_all/jensenka.xml
@@ -177,11 +177,9 @@ Kathryn Jensen photograph collection, Bentley Historical Library, University of 
               <physfacet>
                 <genreform normal="Glass phototransparencies.">glass negatives</genreform>
               </physfacet>
+            <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">2 folders</extent>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/kahnalb.xml
+++ b/Real_Masters_all/kahnalb.xml
@@ -2263,14 +2263,9 @@
       <c01 level="series">
         <did>
           <unittitle>Photographs of Completed Buildings in Leather Portfolios</unittitle>
-          <physdesc altrender="part">
+          <physdesc altrender="whole">
             <extent altrender="materialtype spaceoccupied">1326 prints</extent>
-            <extent altrender="carrier">in 85 volumes</extent>
-          </physdesc>
-          <physdesc altrender="part">
-            <extent altrender="materialtype spaceoccupied">1 boxes</extent>
-          </physdesc>
-          <physdesc>
+            <extent altrender="carrier">in 85 volumes and 1 box</extent>
             <physfacet>4-1/2x6-1/2-inch to 10x14-inch, black and-white prints</physfacet>
           </physdesc>
         </did>

--- a/Real_Masters_all/kelloggj.xml
+++ b/Real_Masters_all/kelloggj.xml
@@ -199,9 +199,7 @@
             <unittitle>Autobiographical and Biographical Notes</unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">2 folders</extent>
+            <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/102891" show="new" actuate="onrequest">
               <daodesc>
@@ -535,9 +533,7 @@
             </unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">3 folders</extent>
+            <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/102889" show="new" actuate="onrequest">
               <daodesc>
@@ -1112,17 +1108,15 @@
               <unittitle>Lecture series on topic of fevers <unitdate type="inclusive" normal="1898-10">October 1898</unitdate>, <unitdate type="inclusive" normal="1898">undated 1898</unitdate></unittitle>
               <physdesc>
                 <physfacet>.PDF and .ZIP files</physfacet>
+              <extent altrender="materialtype spaceoccupied">13 lectures</extent>
+                <extent altrender="carrier">in 2 folders</extent>
               </physdesc>
               <dao href="http://hdl.handle.net/2027.42/102755" show="new" actuate="onrequest">
                 <daodesc>
                   <p>[download item]</p>
                 </daodesc>
               </dao>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">13 lectures</extent>
-                <extent altrender="carrier">in 2 folders</extent>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -6324,9 +6318,7 @@
             <unittitle>Alcohol</unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">2 folders</extent>
+            <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/102893" show="new" actuate="onrequest">
               <daodesc>
@@ -6355,9 +6347,7 @@
             <unittitle>Battle Creek Sanitarium</unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">3 folders</extent>
+            <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/102895" show="new" actuate="onrequest">
               <daodesc>
@@ -6414,9 +6404,7 @@
             <unittitle>Colon and Gastro-Intestinal Tract</unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">2 folders</extent>
+            <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/102899" show="new" actuate="onrequest">
               <daodesc>
@@ -6445,9 +6433,7 @@
             <unittitle>Diet (general)</unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">3 folders</extent>
+            <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/102901" show="new" actuate="onrequest">
               <daodesc>
@@ -6476,9 +6462,7 @@
             <unittitle>Diseases, diagnosis, and treatment</unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">10 folders</extent>
+            <extent altrender="materialtype spaceoccupied">10 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/102903" show="new" actuate="onrequest">
               <daodesc>
@@ -6535,9 +6519,7 @@
             <unittitle>Exercise</unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">4 folders</extent>
+            <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/102907" show="new" actuate="onrequest">
               <daodesc>
@@ -6552,9 +6534,7 @@
             <unittitle>Food</unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">5 folders</extent>
+            <extent altrender="materialtype spaceoccupied">5 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/102908" show="new" actuate="onrequest">
               <daodesc>
@@ -6569,9 +6549,7 @@
             <unittitle>Health</unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">4 folders</extent>
+            <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/102909" show="new" actuate="onrequest">
               <daodesc>
@@ -6614,9 +6592,7 @@
             <unittitle>Hydrotherapy</unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">3 folders</extent>
+            <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/102911" show="new" actuate="onrequest">
               <daodesc>
@@ -6659,9 +6635,7 @@
             <unittitle>Meats, Tobacco, Tea, and Coffee</unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">2 folders</extent>
+            <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/102914" show="new" actuate="onrequest">
               <daodesc>
@@ -6690,9 +6664,7 @@
             <unittitle>Physiology</unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">5 folders</extent>
+            <extent altrender="materialtype spaceoccupied">5 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/102916" show="new" actuate="onrequest">
               <daodesc>
@@ -6721,9 +6693,7 @@
             <unittitle>Question Box Lectures</unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">2 folders</extent>
+            <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/102918" show="new" actuate="onrequest">
               <daodesc>
@@ -6738,9 +6708,7 @@
             <unittitle>Race Betterment and Eugenics</unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">2 folders</extent>
+            <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/102919" show="new" actuate="onrequest">
               <daodesc>
@@ -6783,9 +6751,7 @@
             <unittitle>Miscellaneous</unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">2 folders</extent>
+            <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/102922" show="new" actuate="onrequest">
               <daodesc>
@@ -6909,9 +6875,7 @@
             <unittitle>American Medical Missionary College <unitdate type="inclusive" normal="1901/1907" certainty="approximate">circa 1901-1907</unitdate></unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">3 folders</extent>
+            <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/102930" show="new" actuate="onrequest">
               <daodesc>
@@ -6926,9 +6890,7 @@
             <unittitle>Battle Creek Sanitarium <unitdate type="inclusive" normal="1881/1944">1881-1944</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">2 folders</extent>
+            <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/102931" show="new" actuate="onrequest">
               <daodesc>
@@ -7101,9 +7063,7 @@
               <unittitle>General (Correspondence, resolutions, meeting minutes, etc.) <unitdate type="inclusive" normal="1895/1908">1895-1908</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc>
                 <physfacet>.PDF and .ZIP files</physfacet>
-              </physdesc>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2 folders</extent>
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
               <dao href="http://hdl.handle.net/2027.42/105943" show="new" actuate="onrequest">
                 <daodesc>
@@ -7118,9 +7078,7 @@
               <unittitle>Lectures <unitdate type="inclusive" normal="1893/1906">1893-1906</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc>
                 <physfacet>.PDF and .ZIP files</physfacet>
-              </physdesc>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2 folders</extent>
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
               <dao href="http://hdl.handle.net/2027.42/105944" show="new" actuate="onrequest">
                 <daodesc>
@@ -7276,9 +7234,7 @@
               </unittitle>
               <physdesc>
                 <physfacet>.PDF and .ZIP files</physfacet>
-              </physdesc>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">9 folders</extent>
+              <extent altrender="materialtype spaceoccupied">9 folders</extent>
               </physdesc>
               <dao href="http://hdl.handle.net/2027.42/105954" show="new" actuate="onrequest">
                 <daodesc>
@@ -7327,9 +7283,7 @@
                 <unittitle>Battle Creek Sanitarium</unittitle>
                 <physdesc>
                   <physfacet>.PDF and .ZIP files</physfacet>
-                </physdesc>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">3 folders</extent>
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
                 </physdesc>
                 <dao href="http://hdl.handle.net/2027.42/105957" show="new" actuate="onrequest">
                   <daodesc>
@@ -7639,9 +7593,7 @@
             <unittitle>Various (primarily family materials): biographical materials, diaries, expense books, etc. <unitdate type="inclusive" normal="1885/1909" certainty="approximate">circa 1885-1909</unitdate></unittitle>
             <physdesc>
               <physfacet>Paper: 7 volumes; Digital: .PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">7 volumes</extent>
+            <extent altrender="materialtype spaceoccupied">7 volumes</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/105973" show="new" actuate="onrequest">
               <daodesc>
@@ -8255,9 +8207,7 @@
             <unittitle>Battle Creek Sanitarium (old) <unitdate type="inclusive" normal="1880/1902" certainty="approximate">circa 1880s-1902</unitdate></unittitle>
             <physdesc>
               <physfacet>.PDF and .ZIP files</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">2 folders</extent>
+            <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/106011" show="new" actuate="onrequest">
               <daodesc>
@@ -8318,9 +8268,7 @@
               <unittitle>Laboratory Scenes <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc>
                 <physfacet>.PDF and .ZIP files</physfacet>
-              </physdesc>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2 folders</extent>
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
               <dao href="http://hdl.handle.net/2027.42/106015" show="new" actuate="onrequest">
                 <daodesc>
@@ -8349,9 +8297,7 @@
               <unittitle>Physical fitness program <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc>
                 <physfacet>.PDF and .ZIP files</physfacet>
-              </physdesc>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2 folders</extent>
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
               <dao href="http://hdl.handle.net/2027.42/106017" show="new" actuate="onrequest">
                 <daodesc>

--- a/Real_Masters_all/koelzaw.xml
+++ b/Real_Masters_all/koelzaw.xml
@@ -812,11 +812,9 @@
               <unittitle>Unidentified Film Reel</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">6 reels</extent>
+              <physfacet>8mm; black and white motion pictures</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>8mm; black and white motion pictures</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
       </c01>

--- a/Real_Masters_all/kornegay.xml
+++ b/Real_Masters_all/kornegay.xml
@@ -428,11 +428,9 @@
               <unittitle>National Freedom Day Program <genreform source="aat" normal="Sound recordings">phonograph record</genreform>, <unitdate type="inclusive" normal="1951-02-01">February 1, 1951</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 16" phonorecord</extent>
+              <physfacet>33 1/3 rpm</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>33 1/3 rpm</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(stored separately)</p>
             </odd>

--- a/Real_Masters_all/kresgemf.xml
+++ b/Real_Masters_all/kresgemf.xml
@@ -2174,11 +2174,9 @@
               <unittitle><unitdate type="inclusive" normal="1940">1940</unitdate> Michigan-Pennsylvania football</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 reels</extent>
+              <physfacet>color</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>color</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -2186,22 +2184,18 @@
               <unittitle><unitdate type="inclusive" normal="1943">1943</unitdate> Michigan-Notre Dame football</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 reels</extent>
+              <physfacet>color and b&amp;w</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>color and b&amp;w</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
               <unittitle><unitdate type="inclusive" normal="1946">1946</unitdate> Michigan-Army football</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 reels</extent>
+              <physfacet>color</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>color</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
       </c01>

--- a/Real_Masters_all/lawtonjf.xml
+++ b/Real_Masters_all/lawtonjf.xml
@@ -855,8 +855,7 @@ James Frederick Lawton papers, Bentley Historical Library, University of Michiga
             <unittitle>Discussion with Lawton and others about Fielding H. Yost, the writing of the Victors, and other university-related topics</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
-              <physfacet>reel-to-reel tapes</physfacet>
-            <physfacet>7 in.; 3 3/4 ips</physfacet>
+              <physfacet>reel-to-reel tapes; 7 in.; 3 3/4 ips</physfacet>
             </physdesc>
             </did>
         </c02>

--- a/Real_Masters_all/lawtonjf.xml
+++ b/Real_Masters_all/lawtonjf.xml
@@ -856,11 +856,9 @@ James Frederick Lawton papers, Bentley Historical Library, University of Michiga
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
               <physfacet>reel-to-reel tapes</physfacet>
+            <physfacet>7 in.; 3 3/4 ips</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>7 in.; 3 3/4 ips</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/leejos.xml
+++ b/Real_Masters_all/leejos.xml
@@ -289,11 +289,9 @@ Joseph T. A. Lee papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Preliminary Site Plans Showing Phases of Project by Joseph T. A. Lee, Architect <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">5 items</extent>
+                <physfacet>blue-line prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>blue-line prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
           <c03 level="file">
@@ -311,11 +309,9 @@ Joseph T. A. Lee papers, Bentley Historical Library, University of Michigan</p>
                   <unittitle>Design Development and Construction Drawings by Joseph T. A. Lee, Architect <unitdate type="inclusive" normal="1969-06-18/1971-02-27">6/18/1969-2/27/1971</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">31 items</extent>
+                  <physfacet>twenty-three drawings on vellum and tracing paper and eight blue-line and sepia prints with pencil and ink notations</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>twenty-three drawings on vellum and tracing paper and eight blue-line and sepia prints with pencil and ink notations</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
             </c04>
             <c04 level="file">
@@ -329,11 +325,9 @@ Joseph T. A. Lee papers, Bentley Historical Library, University of Michigan</p>
                   <unittitle>Presentation Site Plans, Elevations and Renderings by Joseph T. A. Lee, Architect <unitdate type="inclusive" normal="1970-01-19/1971-05">1/19/1970-5/1971</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">16 items</extent>
+                  <physfacet>nine pencil drawings on-vellum and-tracing paper and seven blue-line prints with marker coloring</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>nine pencil drawings on-vellum and-tracing paper and seven blue-line prints with marker coloring</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -342,11 +336,9 @@ Joseph T. A. Lee papers, Bentley Historical Library, University of Michigan</p>
                   <unittitle>Preliminary Architectural Drawings by Joseph T. A. Lee, Architect, and Muschenheim, Hammarskjold &amp; Arms, Inc., Associated Architects <unitdate type="inclusive" normal="1970-05-11/1970-05-25">5/11/1970-5/25/1970</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">5 items</extent>
+                  <physfacet>blue-line prints with pencil notations</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>blue-line prints with pencil notations</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
             </c04>
             <c04 level="file">
@@ -360,11 +352,9 @@ Joseph T. A. Lee papers, Bentley Historical Library, University of Michigan</p>
                   <unittitle>Preliminary Architectural, Mechanical and Electrical Construction Drawings by Joseph T. A. Lee <unitdate type="inclusive" normal="1970-06-15">6/15/1970</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">15 items</extent>
+                  <physfacet>seven pencil-on-vellum drawings and eight blue-line prints ("Office Copy") with pencil notations</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>seven pencil-on-vellum drawings and eight blue-line prints ("Office Copy") with pencil notations</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
             </c04>
             <c04 level="file">
@@ -378,11 +368,9 @@ Joseph T. A. Lee papers, Bentley Historical Library, University of Michigan</p>
                   <unittitle>Preliminary Planning Studies by Joseph T. A. Lee, Architect <unitdate type="inclusive" normal="1970-08-01/1971-09-09">8/1/1970-9/9/1971</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">50 items</extent>
+                  <physfacet>twenty-one pencil drawings on vellum and tracing paper and twenty-nine blue-line and sepia prints with pencil and ink notations</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>twenty-one pencil drawings on vellum and tracing paper and twenty-nine blue-line and sepia prints with pencil and ink notations</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -391,11 +379,9 @@ Joseph T. A. Lee papers, Bentley Historical Library, University of Michigan</p>
                   <unittitle>Design Drawings Showing Sequence of Development by Joseph T. A. Lee, Architect <unitdate type="inclusive" normal="1970-06-20/1970-07-13">6/20/1970-7/13/1970</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">9 items</extent>
+                  <physfacet>two pencil-on-vellum drawings and seven blue-line, sepia and mylar prints with pencil notations</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>two pencil-on-vellum drawings and seven blue-line, sepia and mylar prints with pencil notations</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -404,11 +390,9 @@ Joseph T. A. Lee papers, Bentley Historical Library, University of Michigan</p>
                   <unittitle>Preliminary Planning Studies by Joseph T. A. Lee, Architect <unitdate type="inclusive" normal="1971-01-04/1971-06-30">1/4/1971-6/30/1971</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">9 items</extent>
+                  <physfacet>three pencil-on-vellum drawings and six blue-line prints with pencil notations</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>three pencil-on-vellum drawings and six blue-line prints with pencil notations</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
             </c04>
             <c04 level="file">
@@ -422,11 +406,9 @@ Joseph T. A. Lee papers, Bentley Historical Library, University of Michigan</p>
                   <unittitle>Architectural, Structural, Mechanical, Electrical and Landscape Construction Drawings by Joseph T. A. Lee, Architect, and Robert M. Darvas &amp; Associates, Consulting Structural Engineers <unitdate type="inclusive" normal="1970-08-26/1971-05-18">8/26/1970-5/18/1971</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">45 items</extent>
+                  <physfacet>twenty-one pencil drawings on vellum and tracing paper and twenty-four blue-line prints ("Office Set") with pencil notations</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>twenty-one pencil drawings on vellum and tracing paper and twenty-four blue-line prints ("Office Set") with pencil notations</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
             </c04>
             <c04 level="file">
@@ -440,11 +422,9 @@ Joseph T. A. Lee papers, Bentley Historical Library, University of Michigan</p>
                   <unittitle>Design Development and Construction Drawings by Joseph T. A Lee, Architect <unitdate type="inclusive" normal="1971-08-07/1971-11-03">8/7/1971-11/3/1971</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">40 items</extent>
+                  <physfacet>thirty pencil drawings on vellum and tracing paper and ten blue-line and sepia prints with pencil and ink notations</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>thirty pencil drawings on vellum and tracing paper and ten blue-line and sepia prints with pencil and ink notations</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
             </c04>
             <c04 level="file">
@@ -458,11 +438,9 @@ Joseph T. A. Lee papers, Bentley Historical Library, University of Michigan</p>
                   <unittitle>Design Development and Construction Drawings by Joseph T. A. Lee, Architect <unitdate type="inclusive" normal="1970-06-01/1976-08-01">6/1/1970-8/1/1976</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">35 items</extent>
+                  <physfacet>twenty-six pencil drawings on vellum and tracing paper and nine blue-line and sepia prints with pencil notations</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>twenty-six pencil drawings on vellum and tracing paper and nine blue-line and sepia prints with pencil notations</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
             </c04>
             <c04 level="file">
@@ -476,11 +454,9 @@ Joseph T. A. Lee papers, Bentley Historical Library, University of Michigan</p>
                   <unittitle>Construction Drawings by Joseph T. A. Lee, Architect <unitdate type="inclusive" normal="1971-06-28/1972-10-12">6/28/1971-10/12/1972</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">6 items</extent>
+                  <physfacet>five pencil-on-vellum drawings and one blue-line print with ink notations</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>five pencil-on-vellum drawings and one blue-line print with ink notations</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
             </c04>
           </c03>

--- a/Real_Masters_all/lesinski.xml
+++ b/Real_Masters_all/lesinski.xml
@@ -4862,11 +4862,9 @@ John Lesinski papers, Bentley Historical Library, University of Michigan</p>
             <unittitle><genreform normal="Motion pictures">Motion pictures</genreform>, probably from <unitdate type="inclusive" normal="1964">1964</unitdate> campaign</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 reels</extent>
+            <physfacet>Super 16 mm</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Super 16 mm</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/martinjn.xml
+++ b/Real_Masters_all/martinjn.xml
@@ -479,8 +479,7 @@ John Butlin Martin papers, Bentley Historical Library, University of Michigan</p
             <unittitle>Political messages used in campaign for the senate <unitdate type="inclusive" normal="1952">1952</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 audiotapes</extent>
-              <physfacet>reel-to-reel tapes</physfacet>
-            <physfacet>4-7 in.; 7 1/2 ips--15 ips</physfacet>
+              <physfacet>reel-to-reel tapes; 4-7 in.; 7 1/2 ips--15 ips</physfacet>
             </physdesc>
             </did>
         </c02>

--- a/Real_Masters_all/martinjn.xml
+++ b/Real_Masters_all/martinjn.xml
@@ -480,11 +480,9 @@ John Butlin Martin papers, Bentley Historical Library, University of Michigan</p
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 audiotapes</extent>
               <physfacet>reel-to-reel tapes</physfacet>
+            <physfacet>4-7 in.; 7 1/2 ips--15 ips</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>4-7 in.; 7 1/2 ips--15 ips</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/masonst.xml
+++ b/Real_Masters_all/masonst.xml
@@ -162,11 +162,9 @@ Stevens Thomson Mason Papers, Bentley Historical Library, University of Michigan
               <unittitle>Stevens T. Mason to "The Senators of the U. States" concerning his appointment as Secretary of the Michigan Territory <unitdate type="inclusive" normal="1831" certainty="approximate">1831 undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 pages</extent>
+              <physfacet>photostat</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>photostat</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="file">
@@ -406,11 +404,9 @@ Stevens Thomson Mason Papers, Bentley Historical Library, University of Michigan
               <unittitle>Richard Rush and Benjamin C. Howard to Mason, Monroe <unitdate type="inclusive" normal="1835-04-10">April 10, 1835</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 pages</extent>
+              <physfacet>photostat</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>photostat</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Letter urges moderation on the part of both Mason and the Ohio authorities with respect to border dispute)</p>
             </odd>
@@ -435,11 +431,9 @@ Stevens Thomson Mason Papers, Bentley Historical Library, University of Michigan
               <unittitle>Richard Rush and Benjamin C. Howard to Stevens T. Mason, Toledo <unitdate type="inclusive" normal="1835-04-14">April 14, 1835</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 pages</extent>
+              <physfacet>photostat</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>photostat</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Letter urging that force not be used by Mason against the Ohio authorities.)</p>
             </odd>
@@ -550,11 +544,9 @@ Stevens Thomson Mason Papers, Bentley Historical Library, University of Michigan
               <unittitle>Lewis Cass to Stevens T. Mason, Washington <unitdate type="inclusive" normal="1835-05-09">May 9, 1835</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">7 pages</extent>
+              <physfacet>original and typescript</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>original and typescript</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Cass admits his own belief that Michigan's claims are correct, but expresses concern lest possible "civil war" erupt between Michigan and Ohio. He says Jackson hopes conflict will be resolved without his interference beyond "advice and remonstrance." Cass advises Mason to "temper the firmness of the community with a due show of moderation.")</p>
             </odd>
@@ -664,11 +656,9 @@ Stevens Thomson Mason Papers, Bentley Historical Library, University of Michigan
               <unittitle>Unsigned note to Mason, dated New York City <unitdate type="inclusive" normal="1838-05-04">May 4, 1838</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 pages</extent>
+              <physfacet>photostat</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>photostat</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Refers to invitation of a "Judge McGruder" for Mason to visit him on his way through Baltimore.)</p>
             </odd>
@@ -680,11 +670,9 @@ Stevens Thomson Mason Papers, Bentley Historical Library, University of Michigan
               <unittitle>Stevens T. Mason to Professor Asa Gray, New York <unitdate type="inclusive" normal="1838-10-31">October 31, 1838</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 pages</extent>
+              <physfacet>photostat plus copy of original</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>photostat plus copy of original</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Mason encloses a copy of a letter giving instructions as to the expenditure of funds ($6500) appropriated by the Legislature to Professor Gray for his trip to Europe.)</p>
             </odd>
@@ -713,11 +701,9 @@ Stevens Thomson Mason Papers, Bentley Historical Library, University of Michigan
               <unittitle>[Firm of] Hale and Harding to Mason, Detroit <unitdate normal="1842-03-23">March 23, 1842</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 pages</extent>
+              <physfacet>photostat</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>photostat</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Letter refers to lands owned by Col. George W. Owens and V. Ellsworth.)</p>
             </odd>
@@ -729,11 +715,9 @@ Stevens Thomson Mason Papers, Bentley Historical Library, University of Michigan
               <unittitle>George W. Owens to Stevens T. Mason, Savannah <unitdate type="inclusive" normal="1842-05-04">May 4, 1842</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 pages</extent>
+              <physfacet>photostat</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>photostat</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Letter deals with personal financial matters.)</p>
             </odd>

--- a/Real_Masters_all/matthaei.xml
+++ b/Real_Masters_all/matthaei.xml
@@ -3278,11 +3278,9 @@ Matthaei Botanical Gardens (University of Michigan) records, Bentley Historical 
                 </unittitle>
                 <physdesc>
                   <physfacet>photocopied</physfacet>
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
-                <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/michbell.xml
+++ b/Real_Masters_all/michbell.xml
@@ -2671,11 +2671,9 @@
               <unittitle>Linemen</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
+              <physfacet>include color transparencies, 1957</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>include color transparencies, 1957</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/michecum.xml
+++ b/Real_Masters_all/michecum.xml
@@ -156,11 +156,9 @@ Michigan Ecumenical Forum records, Bentley Historical Library, University of Mic
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">5 folders</extent>
+                <physfacet>includes 7 <genreform>audio cassette</genreform> recordings of the April 1986 State Ecumenical Forum in Grand Rapids</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>includes 7 <genreform>audio cassette</genreform> recordings of the April 1986 State Ecumenical Forum in Grand Rapids</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -2299,11 +2297,9 @@ Michigan Ecumenical Forum records, Bentley Historical Library, University of Mic
                 <unittitle>"Dialogue on the Common Good: Seeking a Sustainable Society" <unitdate type="inclusive" normal="1991/1992">1991-1992</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">6 folders</extent>
+                <physfacet>contains two <genreform normal="Sound recordings">audio cassette</genreform> recording of the 1992 proceedings</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>contains two <genreform normal="Sound recordings">audio cassette</genreform> recording of the 1992 proceedings</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/micircut.xml
+++ b/Real_Masters_all/micircut.xml
@@ -97,11 +97,9 @@ Wayne County Circuit Court records, Bentley Historical Library, University of Mi
             <unittitle>Microfilm of circuit court records, including Journals A and B, Calendars A and B, and Case Files <unitdate type="inclusive" normal="1822/1851">1822-1851</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">34 microfilms</extent>
+            <physfacet>positive microfilm ?</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>positive microfilm ?</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/milanahs.xml
+++ b/Real_Masters_all/milanahs.xml
@@ -145,23 +145,18 @@ Milan Area Historical Society collection, Bentley Historical Library, University
             <container type="box" label="Box">1</container>
             <unittitle>Photographs (some with identifications) by Martha Churchill detailing the history and development of downtown Milan <unitdate type="inclusive" normal="2007">2007</unitdate></unittitle>
             <physdesc>
-              <physfacet>
-                <genreform normal="CD-ROMs">CD-ROMs;</genreform>
-              </physfacet>
-            </physdesc>
-            <unittitle>photo indexes</unittitle>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">12 optical disks</extent>
+              <extent>12 optical disks</extent>
               <physfacet>CD-ROMs</physfacet>
             </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">3 optical disks</extent>
-              <physfacet>CD-ROMs</physfacet>
-            </physdesc>
+          </did>
+        </c02>
+        <c02>
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Photo indexes</unittitle>
             <physdesc>
-              <physfacet>
-                <genreform normal="CD-ROMs">CD-ROMs</genreform>
-              </physfacet>
+              <extent>3 optical disks</extent>
+              <physfacet>CD-ROMs</physfacet>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/mimediaf.xml
+++ b/Real_Masters_all/mimediaf.xml
@@ -15807,11 +15807,9 @@ are organized by series established by the Media Resources Center. Within each s
               <unittitle>Original:</unittitle>
               <physdesc>
                 <physfacet>16m film, pos, color, optical, 800</physfacet>
+              <extent altrender="materialtype spaceoccupied">2 copies</extent>
               </physdesc>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">2 copies</extent>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
       </c01>

--- a/Real_Masters_all/moodyb.xml
+++ b/Real_Masters_all/moodyb.xml
@@ -2646,11 +2646,9 @@
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 phonograph records</extent>
+                <physfacet>12 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>12 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -2660,11 +2658,9 @@
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 phonograph records</extent>
+                <physfacet>12 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>12 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -2674,11 +2670,9 @@
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 phonograph records</extent>
+                <physfacet>12 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>12 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
           <c03 level="otherlevel" otherlevel="sub-subseries">
@@ -2691,11 +2685,9 @@
                 <unittitle>Spots <unitdate type="inclusive" normal="1952" certainty="approximate">circa 1952</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 phonograph records</extent>
+                <physfacet>10 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>10 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -2719,11 +2711,9 @@
                 </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">4 phonograph records</extent>
+                <physfacet>12 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>12 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -2731,11 +2721,9 @@
                 <unittitle>October 8, [195-]</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">4 phonograph records</extent>
+                <physfacet>12 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>12 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -2743,11 +2731,9 @@
                 <unittitle>October 15 [1950]</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">4 phonograph records</extent>
+                <physfacet>12 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>12 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
         </c02>

--- a/Real_Masters_all/msclub.xml
+++ b/Real_Masters_all/msclub.xml
@@ -307,11 +307,9 @@ Michigan Schoolmasters' Club Records, Bentley Historical Library, University of 
             <unittitle>Audiotapes <unitdate type="inclusive" normal="1969">1969</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 reels</extent>
+            <physfacet>7-inch reels, 3-3/4ips</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>7-inch reels, 3-3/4ips</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/muncyr.xml
+++ b/Real_Masters_all/muncyr.xml
@@ -2817,11 +2817,9 @@ Ralph W. Muncy papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Recordings of meetings <unitdate type="inclusive" normal="1949/1964">1949-1964</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">42 tapes</extent>
+              <physfacet>7 in. 3 3/4</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>7 in. 3 3/4</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/muschba.xml
+++ b/Real_Masters_all/muschba.xml
@@ -29808,11 +29808,9 @@ YDA.1986.004.01433</unitid>
                 <unittitle>Drawings, #.01513-.01598, .01486</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">87 sheets</extent>
+                <physfacet>various media; 76.5 x 96.6 cm. (30-1/8 x 38 in.) or smaller.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>various media; 76.5 x 96.6 cm. (30-1/8 x 38 in.) or smaller.</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>This set consists of 65 pencil on tracing paper, 1 pencil with pastel on tracing paper, 7 pencil on paper, 4 blueprints on paper, 4 ink on tracing paper, 1 ink on linen, 3 charcoal on tracing paper, and 2 blackline prints on paper.</p>
               </odd>
@@ -61500,11 +61498,9 @@ YDA.1986.004.02865</unitid>
                   <unittitle>Original Working Drawings 27-34, 36-38,41-50, 53, 55-64</unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">2 folders</extent>
+                  <physfacet>pencil and orange pencil on tracing paper and vellum; colored pencil on Xerox prints</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>pencil and orange pencil on tracing paper and vellum; colored pencil on Xerox prints</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>

--- a/Real_Masters_all/muschen.xml
+++ b/Real_Masters_all/muschen.xml
@@ -1493,11 +1493,9 @@
               <unittitle>Original Working Drawings 27-34, 36-38,41-50, 53, 55-64</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 folders</extent>
+              <physfacet>pencil and orange pencil on tracing paper and vellum; colored pencil on Xerox prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil and orange pencil on tracing paper and vellum; colored pencil on Xerox prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -3708,11 +3706,9 @@
               <unittitle>Washington State Veteran's Memorial Competition <unitdate>undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 folders</extent>
+              <physfacet>collage on blueline</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>collage on blueline</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/odellfc.xml
+++ b/Real_Masters_all/odellfc.xml
@@ -181,11 +181,9 @@
             <unittitle>Map of <geogname normal="Arkhangel'sk (Russia)">Archangel</geogname> district, Russia. 10 verst series. Allied Mapping Section, <unitdate type="inclusive" normal="1919">1919</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">6 sheets</extent>
+            <physfacet>Scale ca. 1:420,000</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Scale ca. 1:420,000</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>See description in folder 17</p>
           </odd>
@@ -195,11 +193,9 @@
             <unittitle><geogname normal="Arkhangel'sk (Russia)">Archangel</geogname> district, Russia. 1 verst series. Allied Mapping Section, <unitdate type="inclusive" normal="1919">1919</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">79 sheets</extent>
+            <physfacet>Scale 1:42,000</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Scale 1:42,000</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>Each sheet contains two squares, corresponding to the squares marked on the 10 verst sheets in folder 5. See description in folder 17</p>
           </odd>
@@ -248,11 +244,9 @@
             <unittitle>Spetsial'nyi plan" chasti Arkhangel'skoi gubernii. 5 verst series. <unitdate type="inclusive" normal="1919">1919</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">4 sheets</extent>
+            <physfacet>Scale 1:210,000</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Scale 1:210,000</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>(In Russian) See description in folder 17.</p>
           </odd>
@@ -263,11 +257,9 @@
             <unittitle>Map of <geogname normal="Arkhangel'sk (Russia)">Archangel</geogname> district. 10 verst series., <unitdate type="inclusive" normal="1918-10-12/1918-11-21">October 12, 1918-November 21, 1918</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">4 sheets</extent>
+            <physfacet>Scale 1:420,000</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Scale 1:420,000</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>See description in folder 17</p>
           </odd>
@@ -278,11 +270,9 @@
             <unittitle>Territory from <geogname normal="Lyavalya (Russia)">Lyavalya</geogname> to <geogname normal="Konetsbor (Russia)">Konetsbor</geogname>, south of Dvina River, <unitdate>undated</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">8 sheets</extent>
+            <physfacet>Scale 1:20,000</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Scale 1:20,000</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <odd>
             <p>(8 sheets of a 10 sheet map?)</p>
           </odd>
@@ -831,11 +821,9 @@
               <unittitle><geogname normal="Morjegorskaya (Russia)">Morjegorskaya</geogname> and defences, <unitdate type="inclusive" normal="1919-04-08">April 8, 1919</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 sheets</extent>
+              <physfacet>Scale ca. 1:7,200</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>Scale ca. 1:7,200</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/oslerdav.xml
+++ b/Real_Masters_all/oslerdav.xml
@@ -872,8 +872,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1961-10-15">10/15/1961</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">14 drawings</extent>
-                <physfacet>architectural, structural and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, structural and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -907,8 +906,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1969-03-12/1979-07-10">3/12/1969-7/10/1979</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">38 drawings</extent>
-                <physfacet>architectural, structural and landscape drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, structural and landscape drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -924,8 +922,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1964-01-30">1/30/1964</unitdate> revised <unitdate type="inclusive" normal="1964-04-16">4/16/1964</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">11 drawings</extent>
-                <physfacet>architectural and mechanical/electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural and mechanical/electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -957,8 +954,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1969-01-15">1/15/1969</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">14 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -969,8 +965,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Design Development Drawings of Conversation Area by David Osler, Architect <unitdate type="inclusive" normal="1970-03-27">3/27/1970</unitdate> (</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 drawings</extent>
-                <physfacet>architectural drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -981,8 +976,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Remodeling Construction Drawings by Osler Milling Architects, Inc. <unitdate type="inclusive" normal="1975">1975</unitdate> &amp; <unitdate type="inclusive" normal="1986-07-10">7/10/1986</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 drawings</extent>
-                <physfacet>architectural drawings</physfacet>
-              <physfacet>pencil-on-mylar and on-vellum originals</physfacet>
+                <physfacet>architectural drawings; pencil-on-mylar and on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1059,8 +1053,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1965-03-26">3/26/1965</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">12 drawings</extent>
-                <physfacet>architectural and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1076,8 +1069,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Schematic Design and Construction Drawings by David W. Osler Associates, Inc., Architects, Structural Design, Inc., and S. F. Sonk Associates <unitdate type="inclusive" normal="1996-12-02/1997-09-02">12/2/1996-9/2/1997</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">40 drawings</extent>
-                <physfacet>architectural, structural and mechanical, electrical;plumbing drawings</physfacet>
-              <physfacet>pencil-on-vellum originals, prints on mylar and vellum, and CAD drawings on vellum</physfacet>
+                <physfacet>architectural, structural and mechanical, electrical;plumbing drawings; pencil-on-vellum originals, prints on mylar and vellum, and CAD drawings on vellum</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1093,8 +1085,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Schematic Design Drawings by Osler/Milling Architects, Inc. <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 drawings</extent>
-                <physfacet>architectural drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1155,8 +1146,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by Osler Milling Architects, Inc. <unitdate type="inclusive" normal="1980-03-07/1981-02-16">3/7/1980-2/16/1981</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">26 drawings</extent>
-                <physfacet>architectural, structural and mechanical;electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, structural and mechanical;electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1172,8 +1162,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Schematic Design Drawings by David W. Osler Associates, Inc., Architects <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">35 drawings</extent>
-                <physfacet>architectural drawings</physfacet>
-              <physfacet>pencil and ink drawings on tracing paper and vellum and on blue-line and electrostatic prints</physfacet>
+                <physfacet>architectural drawings; pencil and ink drawings on tracing paper and vellum and on blue-line and electrostatic prints</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1189,8 +1178,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Preliminary Drawings by Osler Milling Architects, Inc. <unitdate type="inclusive" normal="1980-07-30">7/30/1980</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 drawings</extent>
-                <physfacet>architectural drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1201,8 +1189,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by Osler Milling Architects, Inc. <unitdate type="inclusive" normal="1980-09-30/1981-07-20">9/30/1980-7/20/1981</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">26 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil originals on vellum and mylar</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil originals on vellum and mylar</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1218,8 +1205,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Presentation Drawing <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 drawings</extent>
-                <physfacet>perspective</physfacet>
-              <physfacet>pencil-on-vellum original</physfacet>
+                <physfacet>perspective; pencil-on-vellum original</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1235,8 +1221,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1962-02-16/1962-03-31">2/16/1962-3/31/1962</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">9 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1252,8 +1237,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1967-11-15">11/15/1967</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1269,8 +1253,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler Associates, Inc., Architects, and North Star Land Surveying <unitdate type="inclusive" normal="1998-10-20">10/20/1998-8/22/1999</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">33 drawings</extent>
-                <physfacet>architectural surveys, mechanical drawings (building systems drawings), electrical drawings</physfacet>
-              <physfacet>pencil drawings on vellum and paper and CAD drawings on vellum and mylar</physfacet>
+                <physfacet>architectural surveys, mechanical drawings (building systems drawings), electrical drawings; pencil drawings on vellum and paper and CAD drawings on vellum and mylar</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1286,8 +1269,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Design Development and Construction Drawings, one dated <unitdate type="inclusive" normal="2008-06-26">6/26/2008</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 drawings</extent>
-                <physfacet>architectural sketches and drawings</physfacet>
-              <physfacet>ink and pencil drawings on tracing paper, blue-line print and vellum</physfacet>
+                <physfacet>architectural sketches and drawings; ink and pencil drawings on tracing paper, blue-line print and vellum</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1325,8 +1307,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Design Development Drawings by Osler Milling Architects, Inc. <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">7 drawings</extent>
-                <physfacet>architectural drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1342,8 +1323,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1956-03-26">3/26/1956</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">17 drawings</extent>
-                <physfacet>architectural and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1391,8 +1371,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1968-05-03">5/3/1968</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">14 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil drawings on vellum and on sepia prints</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil drawings on vellum and on sepia prints</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1408,8 +1387,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1963-03-01">3/1/1963</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1425,8 +1403,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by Osler Milling Architects, Inc. <unitdate type="inclusive" normal="1989-09-15">9/15/1989</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">11 drawings</extent>
-                <physfacet>architectural drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1442,8 +1419,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by Osler Milling Architects, Inc. <unitdate type="inclusive" normal="1984-01-03">1/3/1984</unitdate>, <unitdate type="inclusive" normal="1985-09-18">9/18/1985</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">21 drawings</extent>
-                <physfacet>architectural, mechanical and electrical;plumbing drawings</physfacet>
-              <physfacet>pencil-on-vellum originals and one sepia print</physfacet>
+                <physfacet>architectural, mechanical and electrical;plumbing drawings; pencil-on-vellum originals and one sepia print</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1459,8 +1435,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1964-01-03">1/3/1964</unitdate> revised <unitdate type="inclusive" normal="1964-03-27">3/27/1964</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">19 drawings</extent>
-                <physfacet>architectural, structural and mechanical;electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, structural and mechanical;electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1476,8 +1451,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Design Development and Construction Drawing by David W. Osler, Architect <unitdate type="inclusive" normal="1967-09-20/1969-02-21">9/20/1967-2/21/1969</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">23 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1516,8 +1490,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by Osler/Milling Architects, Inc. <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">14 drawings</extent>
-                <physfacet>architectural and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1542,8 +1515,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Design Development Drawings, five dated <unitdate type="inclusive" normal="1981-01/1988-11-20">1/1981-11/20/1988</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 drawings</extent>
-                <physfacet>architectural surveys and architectural drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural surveys and architectural drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1554,8 +1526,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by Osler/Milling Architects, Inc. <unitdate type="inclusive" normal="1981-05-25/1981-10-07">5/25/1981-10/7/1981</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">22 drawings</extent>
-                <physfacet>architectural, structural and mechanical;electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, structural and mechanical;electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1571,8 +1542,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1970-12-30/1971-01-15">12/30/1970-1/15/1971</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">9 drawings</extent>
-                <physfacet>architectural and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1610,8 +1580,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Landscape Drawings <unitdate type="inclusive" normal="1988-05-27/1989-10-19">5/27/1988-10/19/1989</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">9 drawings</extent>
-                  <physfacet>demolition surveys, grading plans, utility plans, irrigaiion drawings</physfacet>
-                <physfacet>pencil notations on mylar prints</physfacet>
+                  <physfacet>demolition surveys, grading plans, utility plans, irrigaiion drawings; pencil notations on mylar prints</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -1703,8 +1672,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Preliminary Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1978-11-06">11/6/1978</unitdate> revised <unitdate type="inclusive" normal="1979-06-11">6/11/1979</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 drawings</extent>
-                  <physfacet>architectural drawings</physfacet>
-                <physfacet>pencil-on-vellum originals</physfacet>
+                  <physfacet>architectural drawings; pencil-on-vellum originals</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -1720,8 +1688,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Construction Drawings by Osler Milling Architects, Inc. <unitdate type="inclusive" normal="1987-08-03">8/3/1987</unitdate> revised <unitdate type="inclusive" normal="1987-08-31">8/31/1987</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">6 drawings</extent>
-                  <physfacet>architectural drawings</physfacet>
-                <physfacet>pencil-on-vellum originals</physfacet>
+                  <physfacet>architectural drawings; pencil-on-vellum originals</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -1738,8 +1705,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1973-04-27">4/27/1973</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">9 drawings</extent>
-                <physfacet>architectural and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1755,8 +1721,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1967-05-01">5/1/1967</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">14 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1772,8 +1737,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect, and Charles W. Cares, Landscape Architect <unitdate type="inclusive" normal="1965-12-20/1966-01-03">12/20/1965-1/3/1966</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">19 drawings</extent>
-                <physfacet>architectural, mechanical and electrical;landscape drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical;landscape drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1793,8 +1757,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Presentation Board I <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 drawings</extent>
-                  <physfacet>site plan</physfacet>
-                <physfacet>ink and colored pencil drawing on poster board</physfacet>
+                  <physfacet>site plan; ink and colored pencil drawing on poster board</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -1805,8 +1768,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Presentation Board II <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 drawings</extent>
-                  <physfacet>site plan</physfacet>
-                <physfacet>ink and colored pencil drawing on poster board</physfacet>
+                  <physfacet>site plan; ink and colored pencil drawing on poster board</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -1817,8 +1779,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Presentation Board III <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">6 drawings</extent>
-                  <physfacet>perspectives</physfacet>
-                <physfacet>water-color paintings on poster board</physfacet>
+                  <physfacet>perspectives; water-color paintings on poster board</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -1829,8 +1790,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Presentation Board IV <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">6 drawings</extent>
-                  <physfacet>perspectives</physfacet>
-                <physfacet>water-color paintings on poster board</physfacet>
+                  <physfacet>perspectives; water-color paintings on poster board</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -1847,8 +1807,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler Associates, Inc., Architects <unitdate type="inclusive" normal="1993-04-14/1993-10-13">4/14/1993-10/13/1993</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">16 drawings</extent>
-                <physfacet>architectural, structural and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals and mylar prints</physfacet>
+                <physfacet>architectural, structural and electrical drawings; pencil-on-vellum originals and mylar prints</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1864,8 +1823,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler Associates, Inc., Architects <unitdate type="inclusive" normal="1995-06-20">6/20/1995</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">10 drawings</extent>
-                <physfacet>architectural drawings</physfacet>
-              <physfacet>pencil drawings on mylar prints</physfacet>
+                <physfacet>architectural drawings; pencil drawings on mylar prints</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1881,8 +1839,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1969-10-16">10/16/1969</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1898,8 +1855,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1970-07-21/1971-05-24">7/21/1970-5/24/1971</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">22 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1910,8 +1866,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings of Master Bedroom Addition by Osler Milling Architects, Inc. <unitdate type="inclusive" normal="1986-07-02">7/2/1986</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 drawings</extent>
-                <physfacet>architectural drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1946,8 +1901,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1963-04-23">4/23/1963</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 drawings</extent>
-                <physfacet>architectural drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1963,8 +1917,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Design Development and Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1977-01-21">1/21/1977</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">14 drawings</extent>
-                <physfacet>perspectives and architectural;electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>perspectives and architectural;electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -1991,8 +1944,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect, and Migdal, Layne &amp; Sachs, Inc., Consulting Engineers <unitdate type="inclusive" normal="1968-03-22">3/22/1968</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">12 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2008,8 +1960,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Design Development Drawings, two dated <unitdate type="inclusive" normal="2006-03-08">3/8/2006</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">11 drawings</extent>
-                <physfacet>perspectives, sketches and architectural drawings</physfacet>
-              <physfacet>pencil and ink drawings on tracing paper, vellum and blue-line prints and one electrostatic print</physfacet>
+                <physfacet>perspectives, sketches and architectural drawings; pencil and ink drawings on tracing paper, vellum and blue-line prints and one electrostatic print</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2025,8 +1976,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1967-02-03">2/3/1967</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">17 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2042,8 +1992,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by Osler Milling Architects, Inc. <unitdate type="inclusive" normal="1985-03-22/1985-03-22">3/22/1985-6/25/1985</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">11 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2059,8 +2008,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Design Development and Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1977-09-12/1977-11-15">9/12/1977-11/15/1977</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">13 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2108,8 +2056,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1963-09-01">9/1/1963</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2136,8 +2083,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1977-08-26">8/26/1977</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">14 drawings</extent>
-                <physfacet>architectural and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2171,8 +2117,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Design Development and Construction Drawings of Interior by David W. Osler, Architect <unitdate type="inclusive" normal="1974-06-07/1978-01-10">6/7/1974-1/10/1978</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">25 drawings</extent>
-                <physfacet>perspectives and architectural;electrical drawings</physfacet>
-              <physfacet>pencil drawings on vellum and tracing paper</physfacet>
+                <physfacet>perspectives and architectural;electrical drawings; pencil drawings on vellum and tracing paper</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2183,8 +2128,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by Osler Milling Architects, Inc. <unitdate type="inclusive" normal="1979-10-08/1980-04-18">10/8/1979-4/18/1980</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 drawings</extent>
-                <physfacet>architectural and furniture layout drawings</physfacet>
-              <physfacet>pencil drawings on vellum and tracing paper</physfacet>
+                <physfacet>architectural and furniture layout drawings; pencil drawings on vellum and tracing paper</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2218,8 +2162,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings of Addition by David W. Osler &amp; Partners, Inc., Architects <unitdate type="inclusive" normal="1978-10-31">10/31/1978</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">11 drawings</extent>
-                <physfacet>architectural, structural and mechanical;electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, structural and mechanical;electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2253,8 +2196,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings of Model Phase by David W. Osler, Architect <unitdate type="inclusive" normal="1971-10-04/1971-11-17">10/4/1971-11/17/1971</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">35 drawings</extent>
-                <physfacet>architectural, mechanical and electrical;plumbing drawings</physfacet>
-              <physfacet>pencil drawings on vellum and on mylar and sepia prints</physfacet>
+                <physfacet>architectural, mechanical and electrical;plumbing drawings; pencil drawings on vellum and on mylar and sepia prints</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2265,8 +2207,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David Osler, Architect, and David W. Osler &amp; Partners, Inc. <unitdate type="inclusive" normal="1971-11-17">11/17/1971</unitdate> revised <unitdate type="inclusive" normal="1972-01-03">1/3/1972</unitdate> some revised <unitdate type="inclusive" normal="1978-08-25">8/25/1978</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">37 drawings</extent>
-                <physfacet>architectural and mechanical drawings</physfacet>
-              <physfacet>pencil drawings on vellum and on sepia prints</physfacet>
+                <physfacet>architectural and mechanical drawings; pencil drawings on vellum and on sepia prints</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2277,8 +2218,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings, Phase I, Reissued for Bid, by David W. Osler &amp; Partners, Inc., and Osler/Milling Architects <unitdate type="inclusive" normal="1971-11-17">11/17/1971</unitdate> re-issued <unitdate type="inclusive" normal="1978-08-25">8/25/1978</unitdate> revised <unitdate type="inclusive" normal="1979-01-17">1/17/1979</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">39 drawings</extent>
-                <physfacet>architectural and mechanical drawings</physfacet>
-              <physfacet>pencil drawings on vellum and on sepia prints</physfacet>
+                <physfacet>architectural and mechanical drawings; pencil drawings on vellum and on sepia prints</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2294,8 +2234,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by Osler/Milling Architects, Inc., Furstenburg, Crompton &amp; Associates, Inc., Mechanical Engineer, and Neil Adams, Inc., Electrical Engineer <unitdate type="inclusive" normal="1983-10-31/1984-02-14">10/31/1983-2/14/1984</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals and mylar prints</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals and mylar prints</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2327,8 +2266,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawing by David W. Osler, Architect <unitdate type="inclusive" normal="1960-02-15">2/15/1960</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">17 drawings</extent>
-                <physfacet>architectural drawings</physfacet>
-              <physfacet>pencil drawings on vellum and mylar</physfacet>
+                <physfacet>architectural drawings; pencil drawings on vellum and mylar</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2350,8 +2288,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>First Oslund Scheme Drawings after Oxford Original by David W. Osler, Architect <unitdate type="inclusive" normal="1968-03-20">3/20/1968</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">37 drawings</extent>
-                  <physfacet>architectural, mechanical and landscape drawings</physfacet>
-                <physfacet>pencil drawings on vellum and on sepia prints</physfacet>
+                  <physfacet>architectural, mechanical and landscape drawings; pencil drawings on vellum and on sepia prints</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -2362,8 +2299,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Miscellaneous Drawings <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">6 drawings</extent>
-                  <physfacet>perspectives and architectural drawings</physfacet>
-                <physfacet>ink drawings on mylar and on vellum</physfacet>
+                  <physfacet>perspectives and architectural drawings; ink drawings on mylar and on vellum</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -2374,8 +2310,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Preliminary Schemes Drawings, Oslund I &amp; II, two drawings dated <unitdate type="inclusive" normal="1973">1973</unitdate>, <unitdate type="inclusive" normal="1977">1977</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">38 drawings</extent>
-                  <physfacet>perspectives, architectural drawings and sketches</physfacet>
-                <physfacet>pencil and ink drawings on vellum, tracing paper, sepia prints and blue-line prints</physfacet>
+                  <physfacet>perspectives, architectural drawings and sketches; pencil and ink drawings on vellum, tracing paper, sepia prints and blue-line prints</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -2386,8 +2321,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Oslund I Drawings Leading to Final Scheme # 4 by David W. Osler, Architect, one drawing dated <unitdate type="inclusive" normal="1976-03-30">3/30/1976</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">13 drawings</extent>
-                  <physfacet>architectural drawings</physfacet>
-                <physfacet>pencil-on-vellum originals</physfacet>
+                  <physfacet>architectural drawings; pencil-on-vellum originals</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -2398,8 +2332,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Preliminary Scheme Drawings, Oslund III by David W. Osler, Architect, two drawings dated <unitdate type="inclusive" normal="1974">1974</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">31 drawings</extent>
-                  <physfacet>architectural and perspective drawings;sketches</physfacet>
-                <physfacet>pencil-on-vellum originals</physfacet>
+                  <physfacet>architectural and perspective drawings;sketches; pencil-on-vellum originals</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -2417,8 +2350,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Master Plan Documents by Atwell-Hicks, Civil Engineers, Surveyors, Planners <unitdate type="inclusive" normal="1987-07-20">7/20/1987</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">10 drawings</extent>
-                  <physfacet>architectural surveys, landscape surveys, utility plans</physfacet>
-                <physfacet>mylar prints</physfacet>
+                  <physfacet>architectural surveys, landscape surveys, utility plans; mylar prints</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -2429,8 +2361,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Schematic Design Drawings <unitdate type="inclusive" normal="1985-06-03/1987-07-20">6/3/1985-7/20/1987</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">32 drawings</extent>
-                  <physfacet>architectural surveys, site plans, utility plans; plumbing drawings, landscape drawings</physfacet>
-                <physfacet>ink and pencil-on-vellum originals and sepia and blue-line prints</physfacet>
+                  <physfacet>architectural surveys, site plans, utility plans; plumbing drawings, landscape drawings; ink and pencil-on-vellum originals and sepia and blue-line prints</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -2441,8 +2372,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Construction Drawings by Osler/Milling Architects, Inc. <unitdate type="inclusive" normal="1985-10-14/1987-04-16">10/14/1985-4/16/1987</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">31 drawings</extent>
-                  <physfacet>engineering, architectural and mechanical, electrical;plumbing drawings</physfacet>
-                <physfacet>mylar prints and pencil and ink originals on vellum and on sepia and blue-line prints</physfacet>
+                  <physfacet>engineering, architectural and mechanical, electrical;plumbing drawings; mylar prints and pencil and ink originals on vellum and on sepia and blue-line prints</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -2460,8 +2390,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Site Plan Approval Documents by David W. Osler Associates, Inc., Architects, and Midwestern Consulting, LLC <unitdate type="inclusive" normal="2000-11-01">11/1/2000</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">13 drawings</extent>
-                  <physfacet>site plans, utility plans, and architectural drawings</physfacet>
-                <physfacet>vellum and mylar prints</physfacet>
+                  <physfacet>site plans, utility plans, and architectural drawings; vellum and mylar prints</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -2472,8 +2401,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Third Amendment to Master Deed Documents by Midwestern Consulting, LLC <unitdate type="inclusive" normal="2001-06-21">6/21/2001</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">8 drawings</extent>
-                  <physfacet>site plans, utility plans; architectural drawings</physfacet>
-                <physfacet>mylar prints</physfacet>
+                  <physfacet>site plans, utility plans; architectural drawings; mylar prints</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -2484,8 +2412,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Oslund II, Inc., Construction Drawings by David W. Osler Associates, Inc., Architects, and Midwestern Consulting, LLC <unitdate type="inclusive" normal="2001-07-30">7/30/2001</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">32 drawings</extent>
-                  <physfacet>architectural surveys, utility plans, stractural drawings, mechanical drawings (building systems drawings), electrical drawings</physfacet>
-                <physfacet>vellum and mylar prints</physfacet>
+                  <physfacet>architectural surveys, utility plans, stractural drawings, mechanical drawings (building systems drawings), electrical drawings; vellum and mylar prints</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -2503,8 +2430,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Fourth Amendment to Master Deed Documents by Midwestern Consulting, LLC, and Atwell-Hicks, Inc. <unitdate type="inclusive" normal="2003-09-30">9/30/2003</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">26 drawings</extent>
-                  <physfacet>site plans, utility plans, architectural drawings</physfacet>
-                <physfacet>vellum prints</physfacet>
+                  <physfacet>site plans, utility plans, architectural drawings; vellum prints</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -2515,8 +2441,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Oslund III, Inc., Construction Drawings by David W. Osler Associates, Inc., Architects, and Midwestern Consulting, LLC <unitdate type="inclusive" normal="2001-07-30/2003-12-18">7/30/2001-12/18/2003</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">25 drawings</extent>
-                  <physfacet>architectural drawings and utility plans</physfacet>
-                <physfacet>CAD prints</physfacet>
+                  <physfacet>architectural drawings and utility plans; CAD prints</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -2527,8 +2452,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Oslund III, Inc., Construction Drawings (cont.) by David W. Osler Associates, Inc., Architects, and Midwestern Consulting, LLC <unitdate type="inclusive" normal="2001-07-30/2003-12-18">7/30/2001-12/18/2003</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">25 drawings</extent>
-                  <physfacet>architectural, mechanical and electrical;plumbing drawings</physfacet>
-                <physfacet>CAD prints</physfacet>
+                  <physfacet>architectural, mechanical and electrical;plumbing drawings; CAD prints</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -2545,8 +2469,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1975-08-01">8/1/1975</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">14 drawings</extent>
-                <physfacet>architectural and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2562,8 +2485,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Schematic Design, Design Development and Construction Drawings by David W. Osler Associates, Inc., Mulder &amp; Associates and HH Engineering, Limited <unitdate type="inclusive" normal="2000-12-28/2004-03-12">12/28/2000-3/12/2004</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">50 drawings</extent>
-                <physfacet>perspective views (images) and architectural drawings</physfacet>
-              <physfacet>pencil drawings on tracing paper, vellum and blue-line prints and CAD drawings on paper</physfacet>
+                <physfacet>perspective views (images) and architectural drawings; pencil drawings on tracing paper, vellum and blue-line prints and CAD drawings on paper</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2597,8 +2519,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1973-06-04/1975-08-27">6/4/1973-8/27/1975</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">8 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2614,8 +2535,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler &amp; Partners, Inc. <unitdate type="inclusive" normal="1979-02-05/1979-03-05">2/5/1979-3/5/1979</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">7 drawings</extent>
-                <physfacet>architectural, structural and mechanical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, structural and mechanical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2631,8 +2551,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Design Development and Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1966-07-05/1975-08-14">7/5/1966</unitdate> &amp; <unitdate type="inclusive" normal="1975-08-14">8/14/1975</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">21 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2648,8 +2567,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Design Development and Construction Drawings by David W. Osler Associates, Inc. <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">19 drawings</extent>
-                <physfacet>architectural and electrical drawings</physfacet>
-              <physfacet>original pencil and ink drawings on vellum and on one blue-line print</physfacet>
+                <physfacet>architectural and electrical drawings; original pencil and ink drawings on vellum and on one blue-line print</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2665,8 +2583,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1965-09-30/1966-07-18">9/30/1965-7/18/1966</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2677,8 +2594,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Glazing Replacement Details by David W. Osler Associates, Architects, Inc. <unitdate type="inclusive" normal="1990-03-14">3/14/1990</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 drawings</extent>
-                <physfacet>architectural drawing</physfacet>
-              <physfacet>pencil-on-vellum original</physfacet>
+                <physfacet>architectural drawing; pencil-on-vellum original</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2728,8 +2644,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect, and Migdal, Layne &amp; Sachs, Inc. Engineers <unitdate type="inclusive" normal="1967-04-10/1969-01-19">4/10/1967-3/19/1969</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">17 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2745,8 +2660,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Schematic Design and Design Development Drawings by David W. Osler Associates, Inc., Architects <unitdate type="inclusive" normal="1994-02-28/1994-04-25">2/28/1994-4/25/1994</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">38 drawings</extent>
-                <physfacet>perspectives, sketches and architectural drawings</physfacet>
-              <physfacet>pencil and ink originals on tracing paper, vellum and mylar and CAD drawings on mylar</physfacet>
+                <physfacet>perspectives, sketches and architectural drawings; pencil and ink originals on tracing paper, vellum and mylar and CAD drawings on mylar</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2762,8 +2676,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Design Development Drawings by David W. Osler, Architect, and Washtenaw Engineering Co., Inc. <unitdate normal="1973-01-24/1973-01-30" type="inclusive">1/24/1973-01/30/1973</unitdate> (</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">18 drawings</extent>
-                <physfacet>perspectives, surveys and architectural drawings</physfacet>
-              <physfacet>pencil and ink originals on vellum and on blue-line and sepia prints</physfacet>
+                <physfacet>perspectives, surveys and architectural drawings; pencil and ink originals on vellum and on blue-line and sepia prints</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2779,8 +2692,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by Osler Milling Architects, Inc. <unitdate type="inclusive" normal="1980-04-11/1980-08-04">4/11/1980-8/4/1980</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">12 drawings</extent>
-                <physfacet>architectural and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2812,8 +2724,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect, and Cummins and Barnard, Engineers <unitdate type="inclusive" normal="1963-10-15">10/15/1963</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">22 drawings</extent>
-                <physfacet>architectural, structural and mechanical, electrical;plumbing drawings</physfacet>
-              <physfacet>pencil drawings on vellum and sepia prints</physfacet>
+                <physfacet>architectural, structural and mechanical, electrical;plumbing drawings; pencil drawings on vellum and sepia prints</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2829,8 +2740,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1966-08-22">8/22/1966</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">16 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2846,8 +2756,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1965-09-17/1966-05-08">9/17/1965-5/8/1966</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">16 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2923,8 +2832,7 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 drawings</extent>
                 <physfacet>site plans, elevations (orthographic projections) and
-sections (orthographic projections)</physfacet>
-              <physfacet>electrostatic copies on tempered masonite</physfacet>
+sections (orthographic projections); electrostatic copies on tempered masonite</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2935,8 +2843,7 @@ sections (orthographic projections)</physfacet>
               <unittitle>Presentation Board II <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 drawings</extent>
-                <physfacet>perspective, elevation and section drawings</physfacet>
-              <physfacet>electrostatic copies on tempered masonite</physfacet>
+                <physfacet>perspective, elevation and section drawings; electrostatic copies on tempered masonite</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -2978,8 +2885,7 @@ sections (orthographic projections)</physfacet>
                 <unittitle>Site Plans and Perspective Drawings, including Landscape Sketches and Notes by Charles W. Cares, Landscape Architect <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">7 drawings</extent>
-                  <physfacet>pencil drawings</physfacet>
-                <physfacet>on tracing paper and vellum</physfacet>
+                  <physfacet>pencil drawings; on tracing paper and vellum</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -3013,8 +2919,7 @@ sections (orthographic projections)</physfacet>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1963-07-18">7/18/1963</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 drawings</extent>
-                <physfacet>architectural, mechanical and electrical drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, mechanical and electrical drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>
@@ -3085,8 +2990,7 @@ sections (orthographic projections)</physfacet>
               <unittitle>Construction Drawings by David W. Osler, Architect <unitdate type="inclusive" normal="1966-04-22">4/22/1966</unitdate> revised <unitdate type="inclusive" normal="1966-11-12">11/12/1966</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">24 drawings</extent>
-                <physfacet>architectural, structural and mechanical, electrical;plumbing drawings</physfacet>
-              <physfacet>pencil-on-vellum originals</physfacet>
+                <physfacet>architectural, structural and mechanical, electrical;plumbing drawings; pencil-on-vellum originals</physfacet>
               </physdesc>
               </did>
           </c03>

--- a/Real_Masters_all/oslerdav.xml
+++ b/Real_Masters_all/oslerdav.xml
@@ -873,11 +873,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">14 drawings</extent>
                 <physfacet>architectural, structural and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -910,11 +908,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">38 drawings</extent>
                 <physfacet>architectural, structural and landscape drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -929,11 +925,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">11 drawings</extent>
                 <physfacet>architectural and mechanical/electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -947,11 +941,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Preliminary Drawings <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 blueprints</extent>
+              <physfacet>colored pencil drawings on blue-line prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>colored pencil drawings on blue-line prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -966,11 +958,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">14 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -980,11 +970,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 drawings</extent>
                 <physfacet>architectural drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -994,11 +982,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 drawings</extent>
                 <physfacet>architectural drawings</physfacet>
+              <physfacet>pencil-on-mylar and on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-mylar and on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1018,11 +1004,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Architectural and Landscape Drawings (T-1 to A-12) by David W. Osler Associates, Inc., Architects <unitdate type="inclusive" normal="1944-08-25/1995-03-28">8/25/1994-3/28/1995</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">16 drawings</extent>
+                <physfacet>red pencil drawings on mylar prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>red pencil drawings on mylar prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1031,11 +1015,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Architectural Drawings (A-13 to A-29) <unitdate type="inclusive" normal="1995-03-28/1995-05-31">3/28/1995-5/31/1995</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">17 drawings</extent>
+                <physfacet>mylar prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>mylar prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1044,11 +1026,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Mechanical and Electrical Drawings by David W. Osler Associates, Inc., Architects, and S. F. Sonk Associates, Inc. <unitdate type="inclusive" normal="1995-03-28">3/28/1995</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">19 drawings</extent>
+                <physfacet>electrostatic prints on vellum and mylar</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>electrostatic prints on vellum and mylar</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
         </c02>
@@ -1063,11 +1043,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Construction Drawing (A-2) by Osler Milling Architects, Inc. <unitdate type="inclusive" normal="1983-11-29">11/29/1983</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 drawings</extent>
+              <physfacet>pencil-on-vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1082,11 +1060,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">12 drawings</extent>
                 <physfacet>architectural and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1101,11 +1077,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">40 drawings</extent>
                 <physfacet>architectural, structural and mechanical, electrical;plumbing drawings</physfacet>
+              <physfacet>pencil-on-vellum originals, prints on mylar and vellum, and CAD drawings on vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals, prints on mylar and vellum, and CAD drawings on vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1120,11 +1094,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 drawings</extent>
                 <physfacet>architectural drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1144,11 +1116,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Site Preparation and Landscape Drawings by URS Greiner Woodward Clyde, Civil Engineers, and David W. Osler Associates, Inc., Architects <unitdate type="inclusive" normal="1999-08-02">8/2/1999</unitdate>, <unitdate type="inclusive" normal="1999-05-19">5/19/1999</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">10 drawings</extent>
+                <physfacet>CAD drawings on vellum</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>CAD drawings on vellum</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1157,11 +1127,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Architectural Drawings by David W. Osler Associates, Inc., Architects <unitdate type="inclusive" normal="1999-02-08/2001-02-13">2/8/1999-2/13/2001</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">206 drawings</extent>
+                <physfacet>pencil originals on tracing paper and vellum and CAD drawings on vellum</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>pencil originals on tracing paper and vellum and CAD drawings on vellum</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1170,11 +1138,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Mechanical and Electrical Drawings by James Partridge Associates, Inc. <unitdate type="inclusive" normal="1999-05-10/1999-08-30">5/10/1999-8/30/1999</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">10 drawings</extent>
+                <physfacet>CAD drawings on vellum</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>CAD drawings on vellum</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
         </c02>
@@ -1190,11 +1156,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">26 drawings</extent>
                 <physfacet>architectural, structural and mechanical;electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1209,11 +1173,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">35 drawings</extent>
                 <physfacet>architectural drawings</physfacet>
+              <physfacet>pencil and ink drawings on tracing paper and vellum and on blue-line and electrostatic prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil and ink drawings on tracing paper and vellum and on blue-line and electrostatic prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1228,11 +1190,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 drawings</extent>
                 <physfacet>architectural drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -1242,11 +1202,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">26 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil originals on vellum and mylar</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil originals on vellum and mylar</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1261,11 +1219,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 drawings</extent>
                 <physfacet>perspective</physfacet>
+              <physfacet>pencil-on-vellum original</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum original</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1280,11 +1236,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">9 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1299,11 +1253,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1318,11 +1270,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">33 drawings</extent>
                 <physfacet>architectural surveys, mechanical drawings (building systems drawings), electrical drawings</physfacet>
+              <physfacet>pencil drawings on vellum and paper and CAD drawings on vellum and mylar</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil drawings on vellum and paper and CAD drawings on vellum and mylar</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1337,11 +1287,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 drawings</extent>
                 <physfacet>architectural sketches and drawings</physfacet>
+              <physfacet>ink and pencil drawings on tracing paper, blue-line print and vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>ink and pencil drawings on tracing paper, blue-line print and vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1355,11 +1303,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Perspective Drawings by David W. Osler, Osler/Milling Architects, Inc. <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 drawings</extent>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -1368,11 +1314,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Site Survey by Washtenaw Engineering Co., Inc. <unitdate type="inclusive" normal="1986-10-31">10/31/1986</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 drawings</extent>
+              <physfacet>blue-line print</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>blue-line print</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -1382,11 +1326,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">7 drawings</extent>
                 <physfacet>architectural drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1401,11 +1343,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">17 drawings</extent>
                 <physfacet>architectural and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1419,11 +1359,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Perspective Drawing by David W. Osler Associates, Inc., Architects <unitdate type="inclusive" normal="1991-09-24">9/24/1991</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 drawings</extent>
+              <physfacet>pencil-on-vellum original</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum original</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1437,11 +1375,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Perspective Drawing by David W. Osler <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 drawings</extent>
+              <physfacet>pencil-on-vellum original</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum original</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1456,11 +1392,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">14 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil drawings on vellum and on sepia prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil drawings on vellum and on sepia prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1475,11 +1409,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1494,11 +1426,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">11 drawings</extent>
                 <physfacet>architectural drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1513,11 +1443,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">21 drawings</extent>
                 <physfacet>architectural, mechanical and electrical;plumbing drawings</physfacet>
+              <physfacet>pencil-on-vellum originals and one sepia print</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals and one sepia print</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1532,11 +1460,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">19 drawings</extent>
                 <physfacet>architectural, structural and mechanical;electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1551,11 +1477,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">23 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1593,11 +1517,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">14 drawings</extent>
                 <physfacet>architectural and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1621,11 +1543,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 drawings</extent>
                 <physfacet>architectural surveys and architectural drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -1635,11 +1555,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">22 drawings</extent>
                 <physfacet>architectural, structural and mechanical;electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1654,11 +1572,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">9 drawings</extent>
                 <physfacet>architectural and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1672,11 +1588,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Perspective Drawing by David W. Osler</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 drawings</extent>
+              <physfacet>pencil-on-vellum original</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum original</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1697,11 +1611,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">9 drawings</extent>
                   <physfacet>demolition surveys, grading plans, utility plans, irrigaiion drawings</physfacet>
+                <physfacet>pencil notations on mylar prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>pencil notations on mylar prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1710,11 +1622,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Architectural Drawings (A-1 to A-24) <unitdate type="inclusive" normal="1989-06-12">6/12/1989</unitdate> revised <unitdate type="inclusive" normal="1989-09-22">9/22/1989</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">25 drawings</extent>
+                <physfacet>pencil drawings on blue-line prints and vellum</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>pencil drawings on blue-line prints and vellum</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
           <c03 level="file">
@@ -1730,11 +1640,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Architectural Drawings (A-30 to A-45) <unitdate type="inclusive" normal="1989-06-12">6/12/1989</unitdate> revised <unitdate type="inclusive" normal="1989-09-22">9/22/1989</unitdate> one dated <unitdate type="inclusive" normal="1990-03-02">3/2/1990</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">18 drawings</extent>
+                <physfacet>pencil notations on mylar prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>pencil notations on mylar prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1743,11 +1651,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Architectural Drawings (A-46 to A-64) <unitdate type="inclusive" normal="1989-06-12">6/12/1989</unitdate> revised <unitdate type="inclusive" normal="1989-09-22">9/22/1989</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">16 drawings</extent>
+                <physfacet>pencil notations on mylar prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>pencil notations on mylar prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1756,11 +1662,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <unittitle>Structural and Electrical Drawings of Existing and Expansion Buildings by Osler Milling Architects, Inc., Robert Darvas Associates, P.C., Structural Engineers, BADA Engineering and Quinn Evans, Architects <unitdate type="inclusive" normal="1989-06-12">6/12/1989</unitdate> revised <unitdate type="inclusive" normal="1990-06-18">6/18/1990</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">14 drawings</extent>
+                <physfacet>pencil notations on mylar prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>pencil notations on mylar prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
         </c02>
@@ -1800,11 +1704,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 drawings</extent>
                   <physfacet>architectural drawings</physfacet>
+                <physfacet>pencil-on-vellum originals</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>pencil-on-vellum originals</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
           <c03 level="file">
@@ -1819,11 +1721,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">6 drawings</extent>
                   <physfacet>architectural drawings</physfacet>
+                <physfacet>pencil-on-vellum originals</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>pencil-on-vellum originals</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
         </c02>
@@ -1839,11 +1739,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">9 drawings</extent>
                 <physfacet>architectural and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1858,11 +1756,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">14 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1877,11 +1773,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">19 drawings</extent>
                 <physfacet>architectural, mechanical and electrical;landscape drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1900,11 +1794,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 drawings</extent>
                   <physfacet>site plan</physfacet>
+                <physfacet>ink and colored pencil drawing on poster board</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>ink and colored pencil drawing on poster board</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1914,11 +1806,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 drawings</extent>
                   <physfacet>site plan</physfacet>
+                <physfacet>ink and colored pencil drawing on poster board</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>ink and colored pencil drawing on poster board</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1928,11 +1818,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">6 drawings</extent>
                   <physfacet>perspectives</physfacet>
+                <physfacet>water-color paintings on poster board</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>water-color paintings on poster board</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -1942,11 +1830,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">6 drawings</extent>
                   <physfacet>perspectives</physfacet>
+                <physfacet>water-color paintings on poster board</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>water-color paintings on poster board</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
         </c02>
@@ -1962,11 +1848,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">16 drawings</extent>
                 <physfacet>architectural, structural and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals and mylar prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals and mylar prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -1981,11 +1865,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">10 drawings</extent>
                 <physfacet>architectural drawings</physfacet>
+              <physfacet>pencil drawings on mylar prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil drawings on mylar prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2000,11 +1882,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2019,11 +1899,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">22 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -2033,11 +1911,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 drawings</extent>
                 <physfacet>architectural drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2051,11 +1927,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Perspective Drawing by David W. Osler <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 drawings</extent>
+              <physfacet>pencil-on-vellum original</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum original</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(1 drawing of 2 elevations)</p>
             </odd>
@@ -2073,11 +1947,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 drawings</extent>
                 <physfacet>architectural drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2092,11 +1964,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">14 drawings</extent>
                 <physfacet>perspectives and architectural;electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2110,11 +1980,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Perspective Drawing by David W. Osler <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 drawings</extent>
+              <physfacet>pencil-on-vellum original</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum original</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -2124,11 +1992,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">12 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2143,11 +2009,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">11 drawings</extent>
                 <physfacet>perspectives, sketches and architectural drawings</physfacet>
+              <physfacet>pencil and ink drawings on tracing paper, vellum and blue-line prints and one electrostatic print</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil and ink drawings on tracing paper, vellum and blue-line prints and one electrostatic print</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2162,11 +2026,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">17 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2181,11 +2043,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">11 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2200,11 +2060,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">13 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2218,11 +2076,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Perspective Drawing by David W. Osler <unitdate type="inclusive" normal="1978">1978</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 drawings</extent>
+              <physfacet>pencil-on-vellum original</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum original</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2236,11 +2092,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Perspective Drawings by David W. Osler <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 drawings</extent>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2255,11 +2109,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2273,11 +2125,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Perspective Drawings by David W. Osler <unitdate type="inclusive" normal="1977">1977</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 drawings</extent>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -2287,11 +2137,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">14 drawings</extent>
                 <physfacet>architectural and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2324,11 +2172,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">25 drawings</extent>
                 <physfacet>perspectives and architectural;electrical drawings</physfacet>
+              <physfacet>pencil drawings on vellum and tracing paper</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil drawings on vellum and tracing paper</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -2338,11 +2184,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 drawings</extent>
                 <physfacet>architectural and furniture layout drawings</physfacet>
+              <physfacet>pencil drawings on vellum and tracing paper</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil drawings on vellum and tracing paper</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2375,11 +2219,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">11 drawings</extent>
                 <physfacet>architectural, structural and mechanical;electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2412,11 +2254,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">35 drawings</extent>
                 <physfacet>architectural, mechanical and electrical;plumbing drawings</physfacet>
+              <physfacet>pencil drawings on vellum and on mylar and sepia prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil drawings on vellum and on mylar and sepia prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -2426,11 +2266,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">37 drawings</extent>
                 <physfacet>architectural and mechanical drawings</physfacet>
+              <physfacet>pencil drawings on vellum and on sepia prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil drawings on vellum and on sepia prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -2440,11 +2278,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">39 drawings</extent>
                 <physfacet>architectural and mechanical drawings</physfacet>
+              <physfacet>pencil drawings on vellum and on sepia prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil drawings on vellum and on sepia prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2459,11 +2295,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals and mylar prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals and mylar prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2477,11 +2311,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Perspective Drawing by David W. Osler <unitdate type="inclusive" normal="1978">1978</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 drawings</extent>
+              <physfacet>pencil-on-vellum original</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum original</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2496,11 +2328,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">17 drawings</extent>
                 <physfacet>architectural drawings</physfacet>
+              <physfacet>pencil drawings on vellum and mylar</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil drawings on vellum and mylar</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2521,11 +2351,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">37 drawings</extent>
                   <physfacet>architectural, mechanical and landscape drawings</physfacet>
+                <physfacet>pencil drawings on vellum and on sepia prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>pencil drawings on vellum and on sepia prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -2535,11 +2363,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">6 drawings</extent>
                   <physfacet>perspectives and architectural drawings</physfacet>
+                <physfacet>ink drawings on mylar and on vellum</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>ink drawings on mylar and on vellum</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -2549,11 +2375,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">38 drawings</extent>
                   <physfacet>perspectives, architectural drawings and sketches</physfacet>
+                <physfacet>pencil and ink drawings on vellum, tracing paper, sepia prints and blue-line prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>pencil and ink drawings on vellum, tracing paper, sepia prints and blue-line prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -2563,11 +2387,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">13 drawings</extent>
                   <physfacet>architectural drawings</physfacet>
+                <physfacet>pencil-on-vellum originals</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>pencil-on-vellum originals</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -2577,11 +2399,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">31 drawings</extent>
                   <physfacet>architectural and perspective drawings;sketches</physfacet>
+                <physfacet>pencil-on-vellum originals</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>pencil-on-vellum originals</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
           <c03 level="file">
@@ -2598,11 +2418,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">10 drawings</extent>
                   <physfacet>architectural surveys, landscape surveys, utility plans</physfacet>
+                <physfacet>mylar prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>mylar prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -2612,11 +2430,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">32 drawings</extent>
                   <physfacet>architectural surveys, site plans, utility plans; plumbing drawings, landscape drawings</physfacet>
+                <physfacet>ink and pencil-on-vellum originals and sepia and blue-line prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>ink and pencil-on-vellum originals and sepia and blue-line prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -2626,11 +2442,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">31 drawings</extent>
                   <physfacet>engineering, architectural and mechanical, electrical;plumbing drawings</physfacet>
+                <physfacet>mylar prints and pencil and ink originals on vellum and on sepia and blue-line prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>mylar prints and pencil and ink originals on vellum and on sepia and blue-line prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
           <c03 level="file">
@@ -2647,11 +2461,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">13 drawings</extent>
                   <physfacet>site plans, utility plans, and architectural drawings</physfacet>
+                <physfacet>vellum and mylar prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>vellum and mylar prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -2661,11 +2473,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">8 drawings</extent>
                   <physfacet>site plans, utility plans; architectural drawings</physfacet>
+                <physfacet>mylar prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>mylar prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -2675,11 +2485,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">32 drawings</extent>
                   <physfacet>architectural surveys, utility plans, stractural drawings, mechanical drawings (building systems drawings), electrical drawings</physfacet>
+                <physfacet>vellum and mylar prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>vellum and mylar prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
           <c03 level="file">
@@ -2696,11 +2504,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">26 drawings</extent>
                   <physfacet>site plans, utility plans, architectural drawings</physfacet>
+                <physfacet>vellum prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>vellum prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -2710,11 +2516,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">25 drawings</extent>
                   <physfacet>architectural drawings and utility plans</physfacet>
+                <physfacet>CAD prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>CAD prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -2724,11 +2528,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">25 drawings</extent>
                   <physfacet>architectural, mechanical and electrical;plumbing drawings</physfacet>
+                <physfacet>CAD prints</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>CAD prints</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
         </c02>
@@ -2744,11 +2546,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">14 drawings</extent>
                 <physfacet>architectural and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2763,11 +2563,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">50 drawings</extent>
                 <physfacet>perspective views (images) and architectural drawings</physfacet>
+              <physfacet>pencil drawings on tracing paper, vellum and blue-line prints and CAD drawings on paper</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil drawings on tracing paper, vellum and blue-line prints and CAD drawings on paper</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2800,11 +2598,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">8 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2819,11 +2615,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">7 drawings</extent>
                 <physfacet>architectural, structural and mechanical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2838,11 +2632,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">21 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2857,11 +2649,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">19 drawings</extent>
                 <physfacet>architectural and electrical drawings</physfacet>
+              <physfacet>original pencil and ink drawings on vellum and on one blue-line print</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>original pencil and ink drawings on vellum and on one blue-line print</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2876,11 +2666,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -2890,11 +2678,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 drawings</extent>
                 <physfacet>architectural drawing</physfacet>
+              <physfacet>pencil-on-vellum original</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum original</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2908,11 +2694,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Perspective Drawings by David W. Osler <unitdate type="inclusive" normal="1978-07">7/1978</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 drawings</extent>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2945,11 +2729,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">17 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2964,11 +2746,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">38 drawings</extent>
                 <physfacet>perspectives, sketches and architectural drawings</physfacet>
+              <physfacet>pencil and ink originals on tracing paper, vellum and mylar and CAD drawings on mylar</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil and ink originals on tracing paper, vellum and mylar and CAD drawings on mylar</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -2983,11 +2763,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">18 drawings</extent>
                 <physfacet>perspectives, surveys and architectural drawings</physfacet>
+              <physfacet>pencil and ink originals on vellum and on blue-line and sepia prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil and ink originals on vellum and on blue-line and sepia prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -3002,11 +2780,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">12 drawings</extent>
                 <physfacet>architectural and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -3020,11 +2796,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Perspective Drawing by David W. Osler <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 drawings</extent>
+              <physfacet>pencil-on-vellum original</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum original</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -3039,11 +2813,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">22 drawings</extent>
                 <physfacet>architectural, structural and mechanical, electrical;plumbing drawings</physfacet>
+              <physfacet>pencil drawings on vellum and sepia prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil drawings on vellum and sepia prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -3058,11 +2830,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">16 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -3077,11 +2847,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">16 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -3138,11 +2906,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Preliminary Drawing by David W. Osler Associates, Architects, Inc. <unitdate type="inclusive" normal="1995-10-19">10/19/1995</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 drawings</extent>
+              <physfacet>colored pencil drawing on electrostatic print</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>colored pencil drawing on electrostatic print</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -3158,11 +2924,9 @@ David W. Osler papers, Bentley Historical Library, University of Michigan</p>
                 <extent altrender="materialtype spaceoccupied">3 drawings</extent>
                 <physfacet>site plans, elevations (orthographic projections) and
 sections (orthographic projections)</physfacet>
+              <physfacet>electrostatic copies on tempered masonite</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>electrostatic copies on tempered masonite</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -3172,11 +2936,9 @@ sections (orthographic projections)</physfacet>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 drawings</extent>
                 <physfacet>perspective, elevation and section drawings</physfacet>
+              <physfacet>electrostatic copies on tempered masonite</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>electrostatic copies on tempered masonite</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -3217,11 +2979,9 @@ sections (orthographic projections)</physfacet>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">7 drawings</extent>
                   <physfacet>pencil drawings</physfacet>
+                <physfacet>on tracing paper and vellum</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>on tracing paper and vellum</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -3254,11 +3014,9 @@ sections (orthographic projections)</physfacet>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">15 drawings</extent>
                 <physfacet>architectural, mechanical and electrical drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -3272,11 +3030,9 @@ sections (orthographic projections)</physfacet>
               <unittitle>Perspective Drawing by David W. Osler <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 drawings</extent>
+              <physfacet>pencil-on-vellum original</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum original</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -3313,11 +3069,9 @@ sections (orthographic projections)</physfacet>
               <unittitle>Perspective Drawing by David W. Osler <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 drawings</extent>
+              <physfacet>pencil-on-vellum original</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum original</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -3332,11 +3086,9 @@ sections (orthographic projections)</physfacet>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">24 drawings</extent>
                 <physfacet>architectural, structural and mechanical, electrical;plumbing drawings</physfacet>
+              <physfacet>pencil-on-vellum originals</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum originals</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -3350,11 +3102,9 @@ sections (orthographic projections)</physfacet>
               <unittitle>Perspective Drawing by Osler Milling Architects, Inc. <unitdate type="inclusive">undated</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 drawings</extent>
+              <physfacet>pencil-on-vellum original</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil-on-vellum original</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">

--- a/Real_Masters_all/ovshinskyharv.xml
+++ b/Real_Masters_all/ovshinskyharv.xml
@@ -1728,13 +1728,12 @@
             <container type="box" label="Box">11</container>
             <unittitle><title render="italic">Barrington Bunny</title>, <unitdate type="inclusive" normal="1974">1974</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">1 video recordings</extent>
+              <extent altrender="materialtype spaceoccupied">1 reels</extent>
+              <physfacet>16mm film reel</physfacet>
             </physdesc>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
-            </physdesc>
-            <physdesc>
-              <physfacet>16mm film reel and Beta SP tape</physfacet>
+              <physfacet>Beta SP tape</physfacet>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/ovshinskyharv.xml
+++ b/Real_Masters_all/ovshinskyharv.xml
@@ -1690,11 +1690,9 @@
             <unittitle>WRIF <title render="italic">Spare Change</title> Morning Talk Show, <unitdate type="inclusive" normal="1969/1970">1969-1970</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">8 audiotapes</extent>
+            <physfacet>7 in. reel-to-reel</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>7 in. reel-to-reel</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -1702,11 +1700,9 @@
             <unittitle>Miscellaneous radio programs, <unitdate type="inclusive">undated</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">21 audiotapes</extent>
+            <physfacet>7-in. reel-to-reels</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>7-in. reel-to-reels</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -1714,11 +1710,9 @@
             <unittitle>HKO/ABX News, <unitdate type="inclusive">undated</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
+            <physfacet>10.5-in. reel-to-reel</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>10.5-in. reel-to-reel</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -1754,11 +1748,9 @@
               <unittitle><unitdate type="inclusive" normal="1974/2005">1974-2005</unitdate> with gaps </unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">29 videotapes</extent>
+              <physfacet>Sony DVCAM videocassettes</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>Sony DVCAM videocassettes</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -1782,11 +1774,9 @@
               </unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">36 videotapes</extent>
+              <physfacet>23 Sony DVCAM videocassettes and 13 Beta SP videocassettes</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>23 Sony DVCAM videocassettes and 13 Beta SP videocassettes</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="file">
@@ -1795,11 +1785,9 @@
             <unittitle><title render="italic">Pendragon's Park</title>, <unitdate type="inclusive" normal="2002">2002</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">11 videotapes</extent>
+            <physfacet>Beta SP videocassettes</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Beta SP videocassettes</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -1813,11 +1801,9 @@
               </unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">10 videotapes</extent>
+              <physfacet>Sony DVCAM videocassettes</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>Sony DVCAM videocassettes</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/peterell.xml
+++ b/Real_Masters_all/peterell.xml
@@ -2315,11 +2315,9 @@
               <unittitle>Interview with EP by William S. Ballenger <unitdate type="inclusive" normal="1995-05-01">May 1, 1995</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">55 minutes</extent>
+              <physfacet>VHS videotape</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>VHS videotape</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/physiol.xml
+++ b/Real_Masters_all/physiol.xml
@@ -843,11 +843,9 @@
               <unittitle>Home Movies of Dr. J. W. Bean <unitdate type="inclusive" normal="1950/1959" certainty="approximate">circa 1950s</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 reels</extent>
+              <physfacet>16 mm, color]</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>16 mm, color]</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Niagara Falls-Vacation scenes of Niagara falls and family; 11-Dorothy, Tommy, and Baby-More scenes of family and Niagara Falls. Also shots of chickens in the front yard of a home suffering the paralysis of high 02; Ill Dr. Bean's Family--Shots of Dr. Bean's family, (Mother, Father, etc.). Film is upside down.</p>
             </odd>
@@ -859,11 +857,9 @@
               <unittitle>Experiments of Dr. J. W. Bean on adult rats <unitdate type="inclusive" normal="1950/1951">1950-1951</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 reels</extent>
+              <physfacet>16 mm, black and white]</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>16 mm, black and white]</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(research films taken by Dr. Bean, 1950-51)</p>
             </odd>

--- a/Real_Masters_all/pondfam.xml
+++ b/Real_Masters_all/pondfam.xml
@@ -2140,11 +2140,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">38 volumes</extent>
                     <physfacet>bound sheets</physfacet>
+                  <physfacet>Ink on linen</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>Ink on linen</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
                 <odd>
                   <p>elevations, sections, details, footing plan, floor plans, roof plan, mechanical plans, tree plan, site plans.</p>
                 </odd>
@@ -2200,11 +2198,9 @@
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">14 volumes</extent>
                     <physfacet>bound sheets</physfacet>
+                  <physfacet>Ink on linen</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>Ink on linen</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
                 <odd>
                   <p>floor plans, roof plan, elevations, sections, details</p>
                 </odd>

--- a/Real_Masters_all/pondfam.xml
+++ b/Real_Masters_all/pondfam.xml
@@ -2139,8 +2139,7 @@
                   <unittitle>Michigan League <unitdate type="inclusive" normal="1927">1927</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">38 volumes</extent>
-                    <physfacet>bound sheets</physfacet>
-                  <physfacet>Ink on linen</physfacet>
+                    <physfacet>bound sheets; Ink on linen</physfacet>
                   </physdesc>
                   </did>
                 <odd>
@@ -2197,8 +2196,7 @@
                   <unittitle>Press Building [Student Publications Building] <unitdate type="inclusive" normal="1930">1930</unitdate></unittitle>
                   <physdesc altrender="whole">
                     <extent altrender="materialtype spaceoccupied">14 volumes</extent>
-                    <physfacet>bound sheets</physfacet>
-                  <physfacet>Ink on linen</physfacet>
+                    <physfacet>bound sheets; Ink on linen</physfacet>
                   </physdesc>
                   </did>
                 <odd>

--- a/Real_Masters_all/rfwms.xml
+++ b/Real_Masters_all/rfwms.xml
@@ -2023,11 +2023,9 @@
                 <unittitle><unitdate type="inclusive" normal="1964-12-11">December 11, 1964</unitdate> Sidney Brecht (Blues); Max Roach -- Ray Charles -- Gravy Train Waltz</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 parts</extent>
+                <physfacet>also includes cassette copy</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>also includes cassette copy</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/romneyg.xml
+++ b/Real_Masters_all/romneyg.xml
@@ -43145,14 +43145,9 @@
               <did>
                 <container type="box" label="Box">368</container>
                 <unittitle>GR press conference Brussels <unitdate type="inclusive" normal="1965-04-29">April 29, 1965</unitdate></unittitle>
-                <physdesc>
-                  <physfacet>3-3/4 ips (1);</physfacet>
-                </physdesc>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
-                </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips (2, 3)</physfacet>
+                  <physfacet>3-3/4 ips (1); 7-1/2 ips (2, 3)</physfacet>
                 </physdesc>
               </did>
             </c04>
@@ -44234,17 +44229,9 @@
               <did>
                 <container type="box" label="Box">373</container>
                 <unittitle>Lou Gordon and Guy Nunn Radio interviews, undated</unittitle>
-                <physdesc>
-                  <physfacet>3-3/4 ips (tapes 1-4);</physfacet>
-                </physdesc>
-                <physdesc>
-                  <physfacet>1-7/8 ips (tapes 5-6);</physfacet>
-                </physdesc>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">10 tapes</extent>
-                </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips (tapes 7-10</physfacet>
+                  <physfacet>3-3/4 ips (tapes 1-4); 1-7/8 ips (tapes 5-6); 7-1/2 ips (tapes 7-10)</physfacet>
                 </physdesc>
               </did>
             </c04>
@@ -44507,14 +44494,9 @@
               <did>
                 <container type="box" label="Box">376</container>
                 <unittitle>GR theme song of 1964 Campaign <unitdate type="inclusive" normal="1964">1964</unitdate></unittitle>
-                <physdesc>
-                  <physfacet>7-1/2 ips (nos. 1-4);</physfacet>
-                </physdesc>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">5 tapes</extent>
-                </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips (no.5)</physfacet>
+                  <physfacet>7-1/2 ips (nos. 1-4); 3-3/4 ips (no.5)</physfacet>
                 </physdesc>
               </did>
             </c04>

--- a/Real_Masters_all/romneyg.xml
+++ b/Real_Masters_all/romneyg.xml
@@ -40685,11 +40685,9 @@
                 <unittitle>GR speech, S-A-E meeting <unitdate type="inclusive" normal="1953-12-08">December 8, 1953</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
           <c03 level="file">
@@ -40713,11 +40711,9 @@
                 <unittitle>GR press conference, Detroit <unitdate type="inclusive" normal="1954-10-14">October 14, 1954</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -40752,11 +40748,9 @@
                 <unittitle>GR speech, Chicago All American Motors Show <unitdate type="inclusive" normal="1954-12-02">December 2, 1954</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -40798,11 +40792,9 @@
                 <unittitle>GR speech, Browns Lake Resort, Burlinton, Wisconsin <unitdate type="inclusive" normal="1955-10-11">October 11, 1955</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -40896,11 +40888,9 @@
                 <unittitle>GR speech, Milwaukee Preview <unitdate type="inclusive" normal="1957-09-14">September 14, 1957</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -40935,11 +40925,9 @@
                 <unittitle>GR speech, Detroit Employee Meeting <unitdate type="inclusive" normal="1957-11-15">November 15, 1957</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -40963,11 +40951,9 @@
                 <unittitle>GR speech, Auto Buy Rally - Cleveland Auto Dealers <unitdate type="inclusive" normal="1958-03-14">March 14, 1958</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -41002,11 +40988,9 @@
                 <unittitle>GR speech, Brown's Lake, Wisconsin <unitdate type="inclusive" normal="1958-09-10">September 10, 1958</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -41014,11 +40998,9 @@
                 <unittitle>GR speech, Employee Preview, Milwaukee <unitdate type="inclusive" normal="1958-09-13">September 13, 1958</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -41044,11 +41026,9 @@
                 <unittitle>GR speech, Kelvinator Convention Luncheon, Grand Rapids, Michigan <unitdate type="inclusive" normal="1958-10-06">October 6, 1958</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -41090,11 +41070,9 @@
                 <unittitle>GR speech, Adcraft Club of Detroit <unitdate type="inclusive" normal="1959-01-30">January 30, 1959</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -41111,11 +41089,9 @@
                 <unittitle>GR interview, Marshall Berges, Detroit bureau manager for Time Magazine <unitdate type="inclusive" normal="1959-03-11">March 11, 1959</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -41409,11 +41385,9 @@
                 <unittitle>GR speech, Los Angeles Dealer Meeting <unitdate type="inclusive" normal="1960-09-09">September 9, 1960</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -41553,11 +41527,9 @@
                 <unittitle>GR press conference <unitdate type="inclusive" normal="1960-12-15">December 15, 1960</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
           <c03 level="file">
@@ -41599,11 +41571,9 @@
                 <unittitle>GR speech, Stockholder Meeting <unitdate type="inclusive" normal="1961-02-01">February 1, 1961</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -41611,11 +41581,9 @@
                 <unittitle>GR speech, Farm Management Banquet, Lansing, Michigan <unitdate type="inclusive" normal="1961-02-02">February 2, 1961</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -41740,11 +41708,9 @@
                 <unittitle>GR press conference, C.F.M., Traverse City <unitdate type="inclusive" normal="1961-05-04">May 4, 1961</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -41770,11 +41736,9 @@
                 <unittitle>GR interview, Henry Moscow <unitdate type="inclusive" normal="1961-05-12">May 12, 1961</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -41800,11 +41764,9 @@
                 <unittitle>GR speech, Birmingham, Michigan <unitdate type="inclusive" normal="1961-06">June 1961</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -41821,11 +41783,9 @@
                 <unittitle>GR speech, Utah PIA address <unitdate type="inclusive" normal="1961-06-20">June 20, 1961</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -41842,11 +41802,9 @@
                 <unittitle>GR speech, Lakefront Employees <unitdate type="inclusive" normal="1961-07-25">July 25, 1961</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -41872,11 +41830,9 @@
                 <unittitle>GR press conference, W. Reuther, Contract Agreement <unitdate type="inclusive" normal="1961-08-30">August 30, 1961</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -41884,11 +41840,9 @@
                 <unittitle>GR speech, Dealers Speech, Chicago <unitdate type="inclusive" normal="1961-08-31">August 31, 1961</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -41914,11 +41868,9 @@
                 <unittitle>GR speech, Dealers speech, New Orleans <unitdate type="inclusive" normal="1961-09-07">September 7, 1961</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -41980,11 +41932,9 @@
                 <unittitle>GR speech, C.F.M. Annual Meeting <unitdate type="inclusive" normal="1961-10-28">October 28, 1961</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -42037,11 +41987,9 @@
                 <unittitle>GR speech, American Farm Bureau, Chicago, Illinois <unitdate type="inclusive" normal="1961-12-12">December 12, 1961</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -42049,11 +41997,9 @@
                 <unittitle>GR speech, C.F.M., University of Michigan, Dearborn Center <unitdate type="inclusive" normal="1961-12-16">December 16, 1961</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
           <c03 level="file">
@@ -42068,11 +42014,9 @@
                 <unittitle>GR debate, Romney vs. Scholle, Lansing, WKAR Radio <unitdate type="inclusive" normal="1962-01-09">January 9, 1962</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -42080,11 +42024,9 @@
                 <unittitle>GR lecture, Calvin College, Grand Rapids, Michigan <unitdate type="inclusive" normal="1962-02-01">February 1, 1962</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -42092,11 +42034,9 @@
                 <unittitle>GR interview, Meeting the Press, NBC-TV <unitdate type="inclusive" normal="1962-02-03">February 3, 1962</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -42104,11 +42044,9 @@
                 <unittitle>GR speech, American Motors Corporation, Stockholders' Meeting <unitdate type="inclusive" normal="1962-02-07">February 7, 1962</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">4 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -42116,11 +42054,9 @@
                 <unittitle>GR press conference <unitdate type="inclusive" normal="1962-02-12">February 12, 1962</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -42155,11 +42091,9 @@
                 <unittitle>GR speech, Michigan Livestock Association, East Lansing <unitdate type="inclusive" normal="1962-03-02">March 2, 1962</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -42329,11 +42263,9 @@
                 <unittitle>GR speech, Edward Lamb Award presentation, New York City <unitdate type="inclusive" normal="1962-05-29">May 29, 1962</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -42494,11 +42426,9 @@
                 <unittitle>GR speech, State Convention <unitdate type="inclusive" normal="1962-09-19">September 19, 1962</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -42756,11 +42686,9 @@
                 <unittitle>GR press conference: Rule 9, Ford-Canton talk <unitdate type="inclusive" normal="1963-02-06/1963-02-08">February 6-8, 1963</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -42786,11 +42714,9 @@
                 <unittitle>Press conferences <unitdate type="inclusive" normal="1963-03-19/1963-03-29">March 19-29, 1963</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -42929,11 +42855,9 @@
                 <unittitle>GR speech, Tribute Dinner, Salt Lake City <unitdate type="inclusive" normal="1964-01-17">January 17, 1964</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -42977,11 +42901,9 @@
                 <unittitle>GR conference on tourist industry expansion <unitdate type="inclusive" normal="1964-06-02">June 2, 1964</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -42989,11 +42911,9 @@
                 <unittitle>Meeting of Governors, Federal-State Relations, Cleveland, Ohio <unitdate type="inclusive" normal="1964-06-06/1964-06-10">June 6-10, 1964</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43001,11 +42921,9 @@
                 <unittitle>GR conference, Juvenile Delinquency <unitdate type="inclusive" normal="1964-06-11">June 11, 1964</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43013,11 +42931,9 @@
                 <unittitle>GR speech, at T.U.L.C. <unitdate type="inclusive" normal="1964-06-13">June 13, 1964</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43185,11 +43101,9 @@
                 <unittitle>GR speech, MASA meeting, Grand Rapids, Michigan <unitdate type="inclusive" normal="1965-01-13/1965-01-14">January 13-14, 1965</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43345,11 +43259,9 @@
                 <unittitle>GR speech, Traffic Safety Legislation <unitdate type="inclusive" normal="1966-01-27">January 27, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43375,11 +43287,9 @@
                 <unittitle>GR speech, 46th Annual Meeting of Ypsilanti Area Chamber of Commerce <unitdate type="inclusive" normal="1966-03-02">March 2, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43387,11 +43297,9 @@
                 <unittitle>GR local government conference, Flint, Michigan <unitdate type="inclusive" normal="1966-04-01">April 1, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43399,11 +43307,9 @@
                 <unittitle>GR local government conference, Kalamazoo, Michigan <unitdate type="inclusive" normal="1966-04-04">April 4, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">7 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43411,11 +43317,9 @@
                 <unittitle>GR local government conference, Benton Harbor, Michigan <unitdate type="inclusive" normal="1966-04-05">April 5, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">9 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43423,11 +43327,9 @@
                 <unittitle>GR local government conference, Saginaw, Michigan <unitdate type="inclusive" normal="1966-04-06">April 6, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">4 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43435,11 +43337,9 @@
                 <unittitle>GR local government conference, Grand Rapids, Michigan <unitdate type="inclusive" normal="1966-04-11">April 11, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43447,11 +43347,9 @@
                 <unittitle>GR local government conference, Lansing, Michigan <unitdate type="inclusive" normal="1966-04-12">April 12, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">4 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43459,11 +43357,9 @@
                 <unittitle>GR local government conference, Mt. Pleasant, Michigan <unitdate type="inclusive" normal="1966-04-14">April 14, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43498,11 +43394,9 @@
                 <unittitle>GR local government conference, Detroit, Michigan <unitdate type="inclusive" normal="1966-05-02">May 2, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43510,11 +43404,9 @@
                 <unittitle>GR local government conference, Ann Arbor, Michigan <unitdate type="inclusive" normal="1966-05-03">May 3, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">4 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43522,11 +43414,9 @@
                 <unittitle>GR local government conference, Marquette, Michigan <unitdate type="inclusive" normal="1966-05-04">May 4, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43534,11 +43424,9 @@
                 <unittitle>GR local government conference, Mt. Clemens, Michigan <unitdate type="inclusive" normal="1966-05-06">May 6, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43546,11 +43434,9 @@
                 <unittitle>GR local government conference, Cheboygan, Michigan <unitdate type="inclusive" normal="1966-05-09">May 9, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43567,11 +43453,9 @@
                 <unittitle>GR speech, Lincoln, Nebraska <unitdate type="inclusive" normal="1966-05-19">May 19, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43651,11 +43535,9 @@
                 <unittitle>GR speech, Detroit school money crisis <unitdate type="inclusive" normal="1966-08-09">August 9, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43699,11 +43581,9 @@
                 <unittitle>GR speech, Halleck Day Ceremonies, Logansport, Indiana <unitdate type="inclusive" normal="1966-10-13">October 13, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43747,11 +43627,9 @@
                 <unittitle>GR speech, "Ask the Action team," Grand Rapids, Michigan <unitdate type="inclusive" normal="1966-11-03">November 3, 1966</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
           <c03 level="file">
@@ -43793,11 +43671,9 @@
                 <unittitle>GR speech to precinct workers, Anchorage, Alaska <unitdate type="inclusive" normal="1967-02-18">February 18, 1967</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43823,11 +43699,9 @@
                 <unittitle>GR speeches 7:00 p.m. and 9:00 p.m., Salt Lake City, Utah <unitdate type="inclusive" normal="1967-02-20">February 20, 1967</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43835,11 +43709,9 @@
                 <unittitle>GR speech and related, Ricks College, Rexburg, Idaho <unitdate type="inclusive" normal="1967-02-21">February 21, 1967</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43901,11 +43773,9 @@
                 <unittitle>GR speech, Amway Convention <unitdate type="inclusive" normal="1967-05-27">May 27, 1967</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43940,11 +43810,9 @@
                 <unittitle>GR speeches, Monmouth Hotel, Spring Lake, New Jersey <unitdate type="inclusive" normal="1967-06-22">June 22, 1967</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43952,11 +43820,9 @@
                 <unittitle>GR conference, Tax Reform, Governor's office, State Capitol, Lansing, Michigan <unitdate type="inclusive" normal="1967-06-22/1967-06-28">June 22-28, 1967</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">5 tapes</extent>
+                <physfacet>1-7/8 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>1-7/8 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -43997,11 +43863,9 @@
                 <unittitle>GR press conference, Midwest Governors, Lake of the Ozarks, Missouri <unitdate type="inclusive" normal="1967-08-30">August 30, 1967</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -44042,11 +43906,9 @@
                 <unittitle>GR speech, Bismark, South Dakota <unitdate type="inclusive" normal="1967-10-25">October 25, 1967</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>3-3/4 ips and 7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips and 7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -44114,11 +43976,9 @@
                 <unittitle>GR speech, Senior Symposia, Dartmouth College, Hanover, New Hampshire <unitdate type="inclusive" normal="1967-10-30">October 30, 1967</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -44135,11 +43995,9 @@
                 <unittitle>GR speech on crime, Providence, Rhode Island <unitdate type="inclusive" normal="1967-10-31">October 31, 1967</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -44232,11 +44090,9 @@
                 <unittitle>GR speech, Nationalities Reception, GOP National Convention <unitdate type="inclusive" normal="1968-08">August 1968</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -44267,11 +44123,9 @@
                 <unittitle>GR speech on Vietnam, University of Detroit, undated</unittitle>
                 <physdesc>
                   <physfacet>7-1/2 ips</physfacet>
+                <extent altrender="materialtype spaceoccupied">3 tapes</extent>
                 </physdesc>
-                <physdesc altrender="part">
-                  <extent altrender="materialtype spaceoccupied">3 tapes</extent>
-                </physdesc>
-              </did>
+                </did>
               <odd>
                 <p>(tape 1 is missing)</p>
               </odd>
@@ -44282,11 +44136,9 @@
                 <unittitle>GR debate, with Ferency, undated</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -44542,11 +44394,9 @@
                 <unittitle>GR interview, Radio WCCO, Minneapolis, Minnesota <unitdate type="inclusive" normal="1962-05-02">May 2, 1962</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>7-1/2 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -44590,11 +44440,9 @@
                 <unittitle>GR speech re: education <unitdate type="inclusive" normal="1962-10-12">October 12, 1962</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+                <physfacet>3-3/4 ips</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3-3/4 ips</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/sandersw.xml
+++ b/Real_Masters_all/sandersw.xml
@@ -333,11 +333,9 @@ Walter Sanders papers, Bentley Historical Library, University of Michigan</p>
             <unittitle><genreform normal="Architectural drawings">Architectural drawings</genreform>, <unitdate type="inclusive" normal="1952">1952</unitdate> of Sanders residence at 99 Barton Drive North, Ann Arbor, Michigan</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 folders</extent>
+            <physfacet>pencil on tracing paper; blueprints</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>pencil on tracing paper; blueprints</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>
@@ -360,11 +358,9 @@ Walter Sanders papers, Bentley Historical Library, University of Michigan</p>
             <unittitle><genreform normal="Architectural darawings">Drawings</genreform> of the Oscar Eberbach residence in Ann Arbor, Michigan</unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 items</extent>
+            <physfacet>pencil on cardboard</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>pencil on cardboard</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
       </c01>
     </dsc>

--- a/Real_Masters_all/sinclaim.xml
+++ b/Real_Masters_all/sinclaim.xml
@@ -6928,11 +6928,9 @@ Mary P. Sinclair papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Don't Waste Michigan Meeting, Ann Arbor <unitdate type="inclusive" normal="1995-02-05">February 5, 1995</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+              <physfacet>VHS</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>VHS</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -6958,11 +6956,9 @@ Mary P. Sinclair papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Fermi 2 Greenpeace Rally-Monroe, Michigan. Harvey Wasserman-Cyrus, etc. <unitdate type="inclusive" normal="1994-06-22">June 22, 1994</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 tapes</extent>
+              <physfacet>VHS</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>VHS</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/sincljl.xml
+++ b/Real_Masters_all/sincljl.xml
@@ -12327,11 +12327,9 @@
                 <unittitle>Ann Arbor Community Park Program on WNRZ-FM <unitdate type="inclusive" normal="1972-07/1972-08">July-August 1972</unitdate> (Unit III, nos. 47-49)</unittitle>
                 <physdesc>
                   <extent>3 reels</extent>
+                <physfacet>7-1/2 and 3 and 3 3/4 ips. 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 and 3 and 3 3/4 ips. 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -12452,11 +12450,9 @@
                 <unittitle>"Ann Arbor Boogie" recordings of various performances <unitdate type="inclusive" normal="1973-09">September 1973</unitdate> (Unit IV, nos. 74-77)</unittitle>
                 <physdesc>
                   <extent>4 reels</extent>
+                <physfacet>7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -12464,11 +12460,9 @@
                 <unittitle>"Detroit Blues" various artists' performances <unitdate type="inclusive" normal="1973-09">September 1973</unitdate> (Unit IV, nos. 78-79)</unittitle>
                 <physdesc>
                   <extent>2 reels</extent>
+                <physfacet>7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -12476,11 +12470,9 @@
                 <unittitle>"Chicago Blues" various artist performances, undated (Unit IV, nos. 80-81)</unittitle>
                 <physdesc>
                   <extent>2 reels</extent>
+                <physfacet>7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips., 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -12488,11 +12480,9 @@
                 <unittitle><unitdate type="inclusive" normal="1972">1972</unitdate> Recordings, various performances Unit IV, nos. 82-85)</unittitle>
                 <physdesc>
                   <extent>4 reels</extent>
+                <physfacet>7-1/2 ips. 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips. 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -12500,11 +12490,9 @@
                 <unittitle><unitdate type="inclusive" normal="1973">1973</unitdate> Recordings, various performances (Unit IV, nos. 86-90)</unittitle>
                 <physdesc>
                   <extent>5 reels</extent>
+                <physfacet>7-1/2 ips. 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips. 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -12512,11 +12500,9 @@
                 <unittitle>Hound Dog Taylor <unitdate type="inclusive" normal="1973-09">September 1973</unitdate> (Unit IV, nos. 91-92)</unittitle>
                 <physdesc>
                   <extent>2 reels</extent>
+                <physfacet>7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -12524,11 +12510,9 @@
                 <unittitle>Mighty Joe Young, <unitdate type="inclusive" normal="1973">September 1973</unitdate> (Unit IV, no. 93, 94, 94a)</unittitle>
                 <physdesc>
                   <extent>3 reels</extent>
+                <physfacet>7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -12577,11 +12561,9 @@
                 <unittitle>10 for 2 soundtrack (from John Sinclair Freedom Rally, Ann Arbor) <unitdate type="inclusive" normal="1971-12-10">December 10, 1971 (Unit V, nos. 100-101)</unitdate></unittitle>
                 <physdesc>
                   <extent>2 reels</extent>
+                <physfacet>7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips., 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -12936,11 +12918,9 @@
                 <unittitle>Detroit, live and studio recordings (Unit VII, no. 120-124)</unittitle>
                 <physdesc>
                   <extent>5 reels</extent>
+                <physfacet>7-1/2 and 3 3/4 ips., 7 in</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 and 3 3/4 ips., 7 in</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -12966,11 +12946,9 @@
                 <unittitle>Guardian Angel live and studio recordings, <unitdate type="bulk" normal="1972">1972</unitdate> (Unit VII, no. 127)</unittitle>
                 <physdesc>
                   <extent>5 reels</extent>
+                <physfacet>7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips., 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -12987,11 +12965,9 @@
                 <unittitle>Lightnin, various live demo recordings and live performances <unitdate type="inclusive" normal="1972/1974">1972-1974</unitdate> (Unit VII, nos. 129-133)</unittitle>
                 <physdesc>
                   <extent>4 reels</extent>
+                <physfacet>7-1/2 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -12999,11 +12975,9 @@
                 <unittitle>Lightnin, various live demo recordings and live performances <unitdate type="inclusive" normal="1972/1974">1972-1974</unitdate></unittitle>
                 <physdesc>
                   <extent>4 reels</extent>
+                <physfacet>7-1/2 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -13069,11 +13043,9 @@
                   <unittitle>MC 5 Back in the USA sessions <unitdate type="inclusive" normal="1969-07/1969-08">July-August, 1969</unitdate> (Unit VII, no. 140-142)</unittitle>
                   <physdesc>
                     <extent>3 reels</extent>
+                  <physfacet>7-1/2 ips. 7 in.</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>7-1/2 ips. 7 in.</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
               <c05 level="file">
                 <did>
@@ -13090,11 +13062,9 @@
                   <unittitle>MC 5 jam at Headsound Studios, Ypsilanti <unitdate type="inclusive" normal="1970-11-08">November 8, 1970</unitdate> Unit VII, nos. 144-145</unittitle>
                   <physdesc>
                     <extent>2 reels</extent>
+                  <physfacet>7 1/2 ips, 7 in.</physfacet>
                   </physdesc>
-                  <physdesc>
-                    <physfacet>7 1/2 ips, 7 in.</physfacet>
-                  </physdesc>
-                </did>
+                  </did>
               </c05>
             </c04>
             <c04 level="file">
@@ -13130,11 +13100,9 @@
                 <unittitle>Radio King and His Court of Rhythm, various live, demo, and studio recordings <unitdate type="bulk" normal="1972/1975">1972-1975</unitdate> (Unit VII, no. 148-155)</unittitle>
                 <physdesc>
                   <extent>8 reels</extent>
+                <physfacet>7-1/2 ips, 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips, 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -13196,11 +13164,9 @@
                 <unittitle>The Up, various live, demo and studio recordings, <unitdate type="bulk" normal="1969/1972">1969-1972</unitdate> (Unit VII, nos. 162-180)</unittitle>
                 <physdesc>
                   <extent>19 reels</extent>
+                <physfacet>7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips., 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -13208,11 +13174,9 @@
                 <unittitle>The Urbations, various live, demo and studio recordings, <unitdate type="bulk" normal="1982/1984">1982-1984</unitdate> (Unit VII, no. 181-188)</unittitle>
                 <physdesc>
                   <extent>8 reels</extent>
+                <physfacet>primarily 7 /12 ips., 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>primarily 7 /12 ips., 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
           </c03>
           <c03 level="subseries">
@@ -13252,11 +13216,9 @@
                 <unittitle>WEMU, Ypsilanti, John Sinclair and Michael G. Nastos <unitdate type="inclusive" normal="1981">1981</unitdate> (Unit VIII, no. 192)</unittitle>
                 <physdesc>
                   <extent>3 reels</extent>
+                <physfacet>7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7-1/2 ips., 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -16208,11 +16170,9 @@
                     <unittitle>Auto plant, unidentified</unittitle>
                     <physdesc>
                       <extent>4 sheets</extent>
+                    <physfacet>prints only</physfacet>
                     </physdesc>
-                    <physdesc>
-                      <physfacet>prints only</physfacet>
-                    </physdesc>
-                  </did>
+                    </did>
                 </c06>
                 <c06 level="file">
                   <did>
@@ -16541,11 +16501,9 @@
                     <unittitle>Rock concerts, including Edgar Winter and Average White Band <unitdate type="inclusive">undated</unitdate></unittitle>
                     <physdesc>
                       <extent>7 sheets</extent>
+                    <physfacet>prints only</physfacet>
                     </physdesc>
-                    <physdesc>
-                      <physfacet>prints only</physfacet>
-                    </physdesc>
-                  </did>
+                    </did>
                 </c06>
               </c05>
               <c05 level="file">
@@ -16933,11 +16891,9 @@
                     <unittitle>Unidentified</unittitle>
                     <physdesc>
                       <extent>2 sheets</extent>
+                    <physfacet>print only</physfacet>
                     </physdesc>
-                    <physdesc>
-                      <physfacet>print only</physfacet>
-                    </physdesc>
-                  </did>
+                    </did>
                 </c06>
               </c05>
               <c05 level="file">

--- a/Real_Masters_all/sinoamer.xml
+++ b/Real_Masters_all/sinoamer.xml
@@ -4233,11 +4233,9 @@ National Archive on Sino-American Relations records, Bentley Historical Library,
               <unittitle>Burnham, Donald C. <unitdate type="inclusive" normal="1973">1973</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 reels</extent>
+              <physfacet>Super-8 sound film</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>Super-8 sound film</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/smithtal.xml
+++ b/Real_Masters_all/smithtal.xml
@@ -1723,11 +1723,9 @@ Talbot Smith papers, Bentley Historical Library, University of Michigan</p>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
               <physfacet>reel-to-reel tapes</physfacet>
+            <physfacet>analog; 7 in.</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>analog; 7 in.</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <c03 level="file">
             <did>
               <container type="box" label="Box">46</container>

--- a/Real_Masters_all/smithtal.xml
+++ b/Real_Masters_all/smithtal.xml
@@ -1722,8 +1722,7 @@ Talbot Smith papers, Bentley Historical Library, University of Michigan</p>
             </unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
-              <physfacet>reel-to-reel tapes</physfacet>
-            <physfacet>analog; 7 in.</physfacet>
+              <physfacet>reel-to-reel tapes; analog; 7 in.</physfacet>
             </physdesc>
             </did>
           <c03 level="file">

--- a/Real_Masters_all/sounding.xml
+++ b/Real_Masters_all/sounding.xml
@@ -1810,11 +1810,9 @@
               <unittitle><title render="italic">Soundings: A Center for Women</title>: promotional video, <unitdate type="inclusive" normal="1992-09-03">September 3, 1992</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 videotapes</extent>
+              <physfacet>one VHS format copy and two professional broadcast formats, including the original edit master</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>one VHS format copy and two professional broadcast formats, including the original edit master</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="item">
             <did>

--- a/Real_Masters_all/stowele.xml
+++ b/Real_Masters_all/stowele.xml
@@ -233,11 +233,9 @@ Leland Stowe papers, Bentley Historical Library, University of Michigan</p>
             <unittitle><genreform normal="Photographs">Photographs</genreform> of Stowe and wife, <unitdate type="inclusive" normal="1939/1989" certainty="approximate">circa 1939-1989</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 folders</extent>
+            <physfacet>black and white prints</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>black and white prints</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/swainson.xml
+++ b/Real_Masters_all/swainson.xml
@@ -5939,11 +5939,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -5952,11 +5950,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>? ips; 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>? ips; 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -5965,11 +5961,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>3 3/4 ips; 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3 3/4 ips; 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -5978,11 +5972,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7 1/2 ips; 5 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7 1/2 ips; 5 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -5991,11 +5983,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>3 3/4 ips; 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3 3/4 ips; 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -6015,11 +6005,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>7 1/2 ips; 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>7 1/2 ips; 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -6028,11 +6016,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>3 3/4 ips; 7 in</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3 3/4 ips; 7 in</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>
@@ -6041,11 +6027,9 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes</physfacet>
+                <physfacet>3 3/4 ips; 7 in.</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>3 3/4 ips; 7 in.</physfacet>
-                </physdesc>
-              </did>
+                </did>
             </c04>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/swainson.xml
+++ b/Real_Masters_all/swainson.xml
@@ -5938,8 +5938,7 @@
                 <unittitle><unitdate type="inclusive" normal="1961-01-01">January 1, 1961</unitdate> Inauguration ceremonies of JBS</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7 in.</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -5949,8 +5948,7 @@
                 <unittitle><unitdate type="inclusive" normal="1961-05">May 1961</unitdate> JBS appearing on American Bandstand program upon occasion of Michigan Week, <unitdate type="inclusive" normal="1961-05-21/1961-05-27">May 21-27, 1961</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>? ips; 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; ? ips; 7 in.</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -5960,8 +5958,7 @@
                 <unittitle><unitdate type="inclusive" normal="1961-11-02">November 2, 1961</unitdate> Mental Health Conference, Kalamazoo, Michigan</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>3 3/4 ips; 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 3 3/4 ips; 7 in.</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -5971,8 +5968,7 @@
                 <unittitle><unitdate type="inclusive" normal="1962-01-15">January 15, 1962</unitdate> JBS interview with Lou Gordon</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7 1/2 ips; 5 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7 1/2 ips; 5 in.</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -5982,8 +5978,7 @@
                 <unittitle><unitdate type="inclusive" normal="1962-04-07">April 7, 1962</unitdate> Speeches of Lynn Bartlett and Philip A. Hart</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>3 3/4 ips; 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 3 3/4 ips; 7 in.</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -6004,8 +5999,7 @@
                 <unittitle><unitdate type="inclusive" normal="1962-06-13">June 13, 1962</unitdate> WBRB (Macomb County) phone-in radio program, "Sound Off" with JBS discussing politics and public issues</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>7 1/2 ips; 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 7 1/2 ips; 7 in.</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -6015,8 +6009,7 @@
                 <unittitle><unitdate type="inclusive" normal="1962-09-15">September 15, 1962</unitdate> JBS speaking at Mount Pleasant High School</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>3 3/4 ips; 7 in</physfacet>
+                  <physfacet>reel-to-reel tapes; 3 3/4 ips; 7 in</physfacet>
                 </physdesc>
                 </did>
             </c04>
@@ -6026,8 +6019,7 @@
                 <unittitle><unitdate type="inclusive" normal="1962-09-24">September 24, 1962</unitdate> JBS at NAACP dinner, Detroit, Michigan</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
-                  <physfacet>reel-to-reel tapes</physfacet>
-                <physfacet>3 3/4 ips; 7 in.</physfacet>
+                  <physfacet>reel-to-reel tapes; 3 3/4 ips; 7 in.</physfacet>
                 </physdesc>
                 </did>
             </c04>

--- a/Real_Masters_all/tsaoonce.xml
+++ b/Real_Masters_all/tsaoonce.xml
@@ -146,11 +146,9 @@ Makepeace Uho Tsao ONCE Festival collection, Bentley Historical Library, Univers
             </unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 items</extent>
+            <physfacet>Poster and program, mauve on white, 16.1 x 10.1</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>Poster and program, mauve on white, 16.1 x 10.1</physfacet>
-            </physdesc>
-          </did>
+            </did>
         </c02>
         <c02 level="file">
           <did>

--- a/Real_Masters_all/umussoc.xml
+++ b/Real_Masters_all/umussoc.xml
@@ -5089,11 +5089,9 @@ University Musical Society (University of Michigan) Records, Bentley Historical 
               <unittitle>May Festival <unitdate type="inclusive" normal="1918-05-18/1918-05-21">May 18-21, 1918</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">21 photographs</extent>
+              <physfacet>mounted on 22" x35" board</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>mounted on 22" x35" board</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -5129,11 +5127,9 @@ University Musical Society (University of Michigan) Records, Bentley Historical 
               <physdesc altrender="part">
                 <extent altrender="materialtype spaceoccupied">4 prints</extent>
                 <dimensions>11" x 14"</dimensions>
+              <physfacet>35mm negatives</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>35mm negatives</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -6912,11 +6908,9 @@ University Musical Society (University of Michigan) Records, Bentley Historical 
               <unittitle>Youth Performance Series <unitdate type="inclusive" normal="2001/2003">2001-2003</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 tapes</extent>
+              <physfacet>VHS</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>VHS</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="subseries">
@@ -7048,11 +7042,9 @@ University Musical Society (University of Michigan) Records, Bentley Historical 
               <unittitle>Chicago Classical Oriental Ensemble <unitdate type="inclusive" normal="2008-02-08">February 8, 2008</unitdate></unittitle>
               <physdesc>
                 <physfacet>DVCAM</physfacet>
+              <extent altrender="materialtype spaceoccupied">3 tapes</extent>
               </physdesc>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">3 tapes</extent>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -7060,11 +7052,9 @@ University Musical Society (University of Michigan) Records, Bentley Historical 
               <unittitle>Midnight's Children Events with Salman Rushdie <unitdate type="inclusive" normal="2003">2003</unitdate></unittitle>
               <physdesc>
                 <physfacet>DAT</physfacet>
+              <extent altrender="materialtype spaceoccupied">5 tapes</extent>
               </physdesc>
-              <physdesc altrender="whole">
-                <extent altrender="materialtype spaceoccupied">5 tapes</extent>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
       </c01>
@@ -7292,11 +7282,9 @@ University Musical Society (University of Michigan) Records, Bentley Historical 
               <unittitle>May Festival <unitdate type="inclusive" normal="1918-05-18/1918-05-21">May 18-21, 1918</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">21 photographs</extent>
+              <physfacet>mounted on 22" x35" board</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>mounted on 22" x35" board</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/vandenba.xml
+++ b/Real_Masters_all/vandenba.xml
@@ -4403,11 +4403,9 @@
               <unittitle>Speech in Chicago with Crosswell excerpts <unitdate type="inclusive" normal="1936-10-17">October 17, 1936</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 phonograph records</extent>
+              <physfacet>78 rpm; 7 sides</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>78 rpm; 7 sides</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(transcribed December 8, 1949)</p>
             </odd>
@@ -4418,11 +4416,9 @@
               <unittitle>WXYZ Michigan Radio Network <unitdate type="inclusive" normal="1945-01-05">January 5, 1945</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 phonograph records</extent>
+              <physfacet>78 rpm</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>78 rpm</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -4430,11 +4426,9 @@
               <unittitle>"Future Republican Party Objectives" (Lincoln's Day Dinner <unitdate type="inclusive" normal="1949-02-10">February 10, 1949</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 phonograph records</extent>
+              <physfacet>78 rpm</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>78 rpm</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -4442,11 +4436,9 @@
               <unittitle>War aims speech <unitdate type="inclusive" normal="1943" certainty="approximate">circa 1943</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
+              <physfacet>78 rpm</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>78 rpm</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
           <c03 level="file">
             <did>
@@ -4463,11 +4455,9 @@
               <unittitle>"Fight for Peace" (re-election campaign speech; parts I and II)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 phonograph records</extent>
+              <physfacet>33 1/3 rpm</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>33 1/3 rpm</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(cassette copy in Box 8)</p>
             </odd>
@@ -4478,11 +4468,9 @@
               <unittitle>"Stop the Drums" (WJR radio speech) <unitdate type="inclusive" normal="1946-12-07">December 7, 1946</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 phonograph records</extent>
+              <physfacet>33 1/3 rpm</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>33 1/3 rpm</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(cassette copy in Box 8)</p>
             </odd>
@@ -4493,11 +4481,9 @@
               <unittitle>Report to the People <unitdate type="inclusive" normal="1949-07-26">July 26, 1949</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
+              <physfacet>33 1/3 rpm</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>33 1/3 rpm</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(cassette copy in Box 8)</p>
             </odd>

--- a/Real_Masters_all/vpcfo.xml
+++ b/Real_Masters_all/vpcfo.xml
@@ -19446,11 +19446,9 @@ Vice President and Chief Financial Officer (University of Michigan) Records, Ben
                 <unittitle>Finance &amp; Capital Projects <unitdate type="inclusive" normal="2004">2004</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 folders</extent>
+                <physfacet>1 .ppt file</physfacet>
                 </physdesc>
-                <physdesc>
-                  <physfacet>1 .ppt file</physfacet>
-                </physdesc>
-              </did>
+                </did>
               <accessrestrict>
                 <p>[ER RESTRICTED until <date type="restriction" normal="2028-07-01">July 1, 2028</date>]</p>
               </accessrestrict>

--- a/Real_Masters_all/watsonas.xml
+++ b/Real_Masters_all/watsonas.xml
@@ -487,11 +487,9 @@ Andrew S. Watson Papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Dr. Ackerman Interview/Program <unitdate type="inclusive" normal="1970" certainty="approximate">circa 1970</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 reels</extent>
+              <physfacet>35 mm</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>35 mm</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="file">
@@ -557,11 +555,9 @@ Andrew S. Watson Papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>Mother-Father-Homosexual Son (also called "St. Louis Interview) <unitdate type="inclusive" normal="1974">1974</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 reels</extent>
+              <physfacet>1-inch reels</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>1-inch reels</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
         <c02 level="file">
@@ -644,11 +640,9 @@ Andrew S. Watson Papers, Bentley Historical Library, University of Michigan</p>
               <unittitle>L&amp;P Classes <unitdate type="inclusive" normal="1970" certainty="approximate">circa 1970</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 reels</extent>
+              <physfacet>Reel-to-Reel</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>Reel-to-Reel</physfacet>
-              </physdesc>
-            </did>
+              </did>
           </c03>
         </c02>
       </c01>

--- a/Real_Masters_all/weillou.xml
+++ b/Real_Masters_all/weillou.xml
@@ -369,11 +369,9 @@ Louis A. Weil papers, Bentley Historical Library, University of Michigan</p>
             <unittitle><genreform normal="Phonograph records">Phonograph records</genreform> of broadcast featuring Supreme Court Justice Eugene Black in which he exposes "Michigan Gang" <unitdate type="inclusive" normal="1948-05-27">May 27, 1948</unitdate></unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">3 phonograph records</extent>
+            <physfacet>78 rpm</physfacet>
             </physdesc>
-            <physdesc>
-              <physfacet>78 rpm</physfacet>
-            </physdesc>
-          </did>
+            </did>
           <c03 level="file">
             <did>
               <unittitle><genreform normal="Phonograph records">Phonograph records</genreform> of broadcast featuring Supreme Court Justice Eugene Black in which he exposes "Michigan Gang" <unitdate type="inclusive" normal="1948-05-27">May 27, 1948</unitdate></unittitle>

--- a/Real_Masters_all/weinsteina.xml
+++ b/Real_Masters_all/weinsteina.xml
@@ -903,9 +903,7 @@
             <unittitle><title render="italic">Lady Liberty (Living Theatre)</title>, <unitdate type="inclusive">undated</unitdate></unittitle>
             <physdesc>
               <physfacet>.ZIP file</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">2 folders</extent>
+            <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/109209" show="new" actuate="onrequest">
               <daodesc>
@@ -1999,9 +1997,7 @@
             <unittitle><title render="italic">Ward Six</title>, <unitdate type="inclusive">undated</unitdate></unittitle>
             <physdesc>
               <physfacet>.ZIP file</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">2 folders</extent>
+            <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/109236" show="new" actuate="onrequest">
               <daodesc>

--- a/Real_Masters_all/whittfam.xml
+++ b/Real_Masters_all/whittfam.xml
@@ -861,12 +861,10 @@ Whittemore Family Papers
             <unittitle>Letters of Temperance Mack, Almira Covey and Hyrum Smith <unitdate type="inclusive" normal="1835/1849">1835-1849</unitdate></unittitle>
             <physdesc>
               <physfacet>photostatic copies</physfacet>
-            </physdesc>
-            <physdesc altrender="whole">
-              <extent altrender="materialtype spaceoccupied">23 items</extent>
+            <extent altrender="materialtype spaceoccupied">23 items</extent>
               <extent altrender="carrier">in 2 folders</extent>
             </physdesc>
-          </did>
+            </did>
           <odd>
             <p>[Note: originals have been placed in library vault; a negative microfilm of these letters is also available]</p>
           </odd>

--- a/Real_Masters_all/wuom.xml
+++ b/Real_Masters_all/wuom.xml
@@ -8944,9 +8944,7 @@ Samuel T. Dana, Dean Emeritius of the School of Natural Resources.)</abstract>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 sound discs</extent>
                   <physfacet>4 sides</physfacet>
-                </physdesc>
-                <physdesc>
-                  <physfacet>12 in., 33 1/3 rpm</physfacet>
+                <physfacet>12 in., 33 1/3 rpm</physfacet>
                 </physdesc>
                 <unitid>[D1]</unitid>
               </did>
@@ -8961,9 +8959,7 @@ Samuel T. Dana, Dean Emeritius of the School of Natural Resources.)</abstract>
                 <unittitle>"Festival of Song" <unitdate type="inclusive" normal="1959/1971">1959/60-1970/71</unitdate></unittitle>
                 <physdesc>
                   <extent>7 sound discs</extent>
-                </physdesc>
-                <physdesc>
-                  <physfacet>12 in., 33 1/3 rpm</physfacet>
+                <physfacet>12 in., 33 1/3 rpm</physfacet>
                 </physdesc>
                 <unitid>[D2-D8]</unitid>
               </did>
@@ -8973,9 +8969,7 @@ Samuel T. Dana, Dean Emeritius of the School of Natural Resources.)</abstract>
                   <unittitle>Theme Music for Down Story Book Lane</unittitle>
                   <physdesc>
                     <extent>1 sound discs</extent>
-                  </physdesc>
-                  <physdesc>
-                    <physfacet>12 in., 33 1/3 rpm</physfacet>
+                  <physfacet>12 in., 33 1/3 rpm</physfacet>
                   </physdesc>
                   <unitid>[D9]</unitid>
                 </did>
@@ -8995,9 +8989,7 @@ Samuel T. Dana, Dean Emeritius of the School of Natural Resources.)</abstract>
                 <unittitle>[Acceptance Speech, Baird Carillon Dedication] / Charles Baird; [Nationally broadcast greetings to University of Michigan Alumni Clubs / T. Hawley Tapping, recorded <unitdate type="inclusive" normal="1937">1937</unitdate></unittitle>
                 <physdesc>
                   <extent>1 sound discs</extent>
-                </physdesc>
-                <physdesc>
-                  <physfacet>aluminum acetate; 10 in., 78 rpm</physfacet>
+                <physfacet>aluminum acetate; 10 in., 78 rpm</physfacet>
                 </physdesc>
                 <unitid>[D10]</unitid>
               </did>
@@ -9009,9 +9001,7 @@ Samuel T. Dana, Dean Emeritius of the School of Natural Resources.)</abstract>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 sound discs</extent>
                   <physfacet>2 sides</physfacet>
-                </physdesc>
-                <physdesc>
-                  <physfacet>aluminum acetate; 10 in., 78 rpm)</physfacet>
+                <physfacet>aluminum acetate; 10 in., 78 rpm)</physfacet>
                 </physdesc>
                 <unitid>[D11]</unitid>
               </did>
@@ -9022,9 +9012,7 @@ Samuel T. Dana, Dean Emeritius of the School of Natural Resources.)</abstract>
                 <unittitle>[Addresses for] 110th Birthday Party of University of Michigan / Alexander G. Ruthven, Clair Hughes, recorded <unitdate type="inclusive" normal="1947-01-16">January 16, 1947</unitdate></unittitle>
                 <physdesc>
                   <extent>1 sound discs</extent>
-                </physdesc>
-                <physdesc>
-                  <physfacet>aluminum acetate, inside start; 12 in., 33 1/3 rpm</physfacet>
+                <physfacet>aluminum acetate, inside start; 12 in., 33 1/3 rpm</physfacet>
                 </physdesc>
                 <unitid>[D12]</unitid>
               </did>
@@ -9038,9 +9026,7 @@ Samuel T. Dana, Dean Emeritius of the School of Natural Resources.)</abstract>
                 <unittitle>[Comments on University of Michigan 100th Anniversary] / Arthur L. Cross; To the Dallas Alumni <unitdate type="inclusive" normal="1938-01-20">January 20, 1938</unitdate> / T. Hawley Tapping, recorded <unitdate type="inclusive" normal="1938">1938</unitdate></unittitle>
                 <physdesc>
                   <extent>1 sound discs</extent>
-                </physdesc>
-                <physdesc>
-                  <physfacet>aluminum acetate; 8 in., 33 1/3 rpm</physfacet>
+                <physfacet>aluminum acetate; 8 in., 33 1/3 rpm</physfacet>
                 </physdesc>
                 <unitid>[D13]</unitid>
               </did>
@@ -9055,9 +9041,7 @@ Samuel T. Dana, Dean Emeritius of the School of Natural Resources.)</abstract>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 sound discs</extent>
                   <physfacet>sides 1 and 3</physfacet>
-                </physdesc>
-                <physdesc>
-                  <physfacet>aluminum acetate; 12 in., 78 rpm</physfacet>
+                <physfacet>aluminum acetate; 12 in., 78 rpm</physfacet>
                 </physdesc>
                 <unitid>[D14]</unitid>
               </did>
@@ -9069,9 +9053,7 @@ Samuel T. Dana, Dean Emeritius of the School of Natural Resources.)</abstract>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 sound discs</extent>
                   <physfacet>2 sides</physfacet>
-                </physdesc>
-                <physdesc>
-                  <physfacet>12 in., 33 1/3 rpm</physfacet>
+                <physfacet>12 in., 33 1/3 rpm</physfacet>
                 </physdesc>
                 <unitid>[D15]</unitid>
               </did>
@@ -9082,9 +9064,7 @@ Samuel T. Dana, Dean Emeritius of the School of Natural Resources.)</abstract>
                 <unittitle>Rose Bowl Greetings / Fritz Crisler; 111th Anniversary greetings / Alexander G. Ruthven, [T. Hawley] Tapping, recorded <unitdate type="inclusive" normal="1948">1948</unitdate></unittitle>
                 <physdesc>
                   <extent>1 sound discs</extent>
-                </physdesc>
-                <physdesc>
-                  <physfacet>aluminum acetate; 10 in. 33 1/3 rpm</physfacet>
+                <physfacet>aluminum acetate; 10 in. 33 1/3 rpm</physfacet>
                 </physdesc>
                 <unitid>[D16]</unitid>
               </did>

--- a/Real_Masters_all/wuom.xml
+++ b/Real_Masters_all/wuom.xml
@@ -8943,8 +8943,7 @@ Samuel T. Dana, Dean Emeritius of the School of Natural Resources.)</abstract>
                 <unittitle>Euripides' <title render="italic">Orestes</title>: A new dramatic version by the University of Michigan translator; Don Gillis, composer; Orien Dalley, conductor; Jerry Sandler, director, First radio performance, <unitdate type="inclusive" normal="1960">1960</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 sound discs</extent>
-                  <physfacet>4 sides</physfacet>
-                <physfacet>12 in., 33 1/3 rpm</physfacet>
+                  <physfacet>4 sides; 12 in., 33 1/3 rpm</physfacet>
                 </physdesc>
                 <unitid>[D1]</unitid>
               </did>
@@ -9000,8 +8999,7 @@ Samuel T. Dana, Dean Emeritius of the School of Natural Resources.)</abstract>
                 <unittitle>[Address] to Rochester [Alumni Club] / T. Hawley Tapping; [Comments on University of Michigan 100th Anniversary / Arthur L. Cross, recorded <unitdate type="inclusive" normal="1937">1937</unitdate></unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 sound discs</extent>
-                  <physfacet>2 sides</physfacet>
-                <physfacet>aluminum acetate; 10 in., 78 rpm)</physfacet>
+                  <physfacet>2 sides; aluminum acetate; 10 in., 78 rpm)</physfacet>
                 </physdesc>
                 <unitid>[D11]</unitid>
               </did>
@@ -9040,8 +9038,7 @@ Samuel T. Dana, Dean Emeritius of the School of Natural Resources.)</abstract>
                 <unittitle>[Comments re: "Varsity" and the <unitdate type="inclusive" normal="1937">1937</unitdate> Michigan football team] / Fielding H. Yost; Harry Kipke; Michigan Band</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 sound discs</extent>
-                  <physfacet>sides 1 and 3</physfacet>
-                <physfacet>aluminum acetate; 12 in., 78 rpm</physfacet>
+                  <physfacet>sides 1 and 3; aluminum acetate; 12 in., 78 rpm</physfacet>
                 </physdesc>
                 <unitid>[D14]</unitid>
               </did>
@@ -9052,8 +9049,7 @@ Samuel T. Dana, Dean Emeritius of the School of Natural Resources.)</abstract>
                 <unittitle>Football Preview <unitdate type="inclusive" normal="1953">1953</unitdate> / Bill Fleming, Fritz Crisler, et al.</unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 sound discs</extent>
-                  <physfacet>2 sides</physfacet>
-                <physfacet>12 in., 33 1/3 rpm</physfacet>
+                  <physfacet>2 sides; 12 in., 33 1/3 rpm</physfacet>
                 </physdesc>
                 <unitid>[D15]</unitid>
               </did>

--- a/Real_Masters_all/ztgergan.xml
+++ b/Real_Masters_all/ztgergan.xml
@@ -904,8 +904,7 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Miscellaneous (single family residences) (No Job No.)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">50 drawings</extent>
-                <physfacet>approximate number</physfacet>
-              <physfacet>pencil and ink on paper and cardboard, water color on cardboard, photostats</physfacet>
+                <physfacet>approximate number; pencil and ink on paper and cardboard, water color on cardboard, photostats</physfacet>
               </physdesc>
               </did>
             <odd>

--- a/Real_Masters_all/ztgergan.xml
+++ b/Real_Masters_all/ztgergan.xml
@@ -148,11 +148,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Adrian. Bethany Assembly of God Church (Job no. 75-529) <unitdate type="inclusive" normal="1975">1975</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">25 drawings</extent>
+              <physfacet>pencil on paper vellum, blue line prints, thermofax prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum, blue line prints, thermofax prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Site plans, floor plans, elevations, sections, details, structural and electrical plans, renderings)</p>
             </odd>
@@ -163,11 +161,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ann Arbor. Pentecostal Church of God, Jackson Road (Job No. 717 <unitdate type="inclusive" normal="1950">1950</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">6 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plans, elevations, sections, details, electrical and heating plan)</p>
             </odd>
@@ -178,11 +174,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ann Arbor. Jehovah's Witnesses Church, Stadium Blvd. (Job No. 893) <unitdate type="inclusive" normal="1959">1959</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">7 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plans, elevations, sections, details, and structural plans)</p>
             </odd>
@@ -193,11 +187,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Belleville. Trinity Church, Belleville Road <unitdate type="inclusive" normal="1950">1950</unitdate> (Job No. 711), <unitdate type="inclusive" normal="1950">1950</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">7 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plans, floor plans, elevations, sections, electrical and heating plans)</p>
             </odd>
@@ -208,11 +200,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Chelsea. Zion Lutheran Church (Job No. 679, church house and pastor's residence) <unitdate type="inclusive" normal="1947/1949">1947-1949</unitdate></unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">17 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plans, floor plans, elevations, sections, details)</p>
             </odd>
@@ -222,11 +212,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Dearborn. St. Clement Orthodox Church <unitdate type="inclusive" normal="1964">1964</unitdate> (Job No. 921)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">50 drawings</extent>
+              <physfacet>pencil on paper vellum, blue line prints, photographs</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum, blue line prints, photographs</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plans, renderings, floor plans, elevations, sections, details, structural, mechanical, and electrical plans)</p>
             </odd>
@@ -255,11 +243,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Detroit. St. Clement Ohridski (church house) 2930 25th Street, <unitdate type="inclusive" normal="1947/1948">1947-1948</unitdate> (Job No. 653)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">8 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plans, elevations, sections, details)</p>
             </odd>
@@ -270,11 +256,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Fenton. Presbyterian Church <unitdate type="inclusive" normal="1961">1961</unitdate> (Job No. 902)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">10 drawings</extent>
+              <physfacet>blue line prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>blue line prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plans, elevations, sections, details, structural, mechanical, and electrical plans)</p>
             </odd>
@@ -285,11 +269,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Manchester. Methodist Church (addition) <unitdate type="inclusive" normal="1958">1958</unitdate> (No Job No.)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">10 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plans, elevations, sections, details, and heating plans)</p>
             </odd>
@@ -300,11 +282,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Spring Arbor. Spring Arbor Free Methodist Church (addition) <unitdate type="inclusive" normal="1958">1958</unitdate> (Job No. 77-546)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">50 sheets</extent>
+              <physfacet>pencil on paper and paper vellum, blue line prints, thermofax prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper and paper vellum, blue line prints, thermofax prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Site plan, floor plans, elevations, sections, details, structural, electrical, and mechanical plans)</p>
             </odd>
@@ -315,11 +295,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Waltz. St. John's Evangelical Lutheran Church <unitdate type="inclusive" normal="1957/1958">1957-1958</unitdate> (Job No. 862)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">22 drawings</extent>
+              <physfacet>blue line prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>blue line prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plans, elevations, sections, details, structural and mechanical plans)</p>
             </odd>
@@ -330,11 +308,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ypsilanti. Church Building for American Baptist Home Mission Society, E. Forest Avenue and Allen Street <unitdate type="inclusive" normal="1943">1943</unitdate> (Job No. 571)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Floor plans, elevations, sections, details)</p>
             </odd>
@@ -357,11 +333,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ypsilanti. Emmanuel Lutheran Church (proposed parish hall) <unitdate type="inclusive" normal="1955">1955</unitdate> (Job No. 638)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 drawings</extent>
+              <physfacet>blue line prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>blue line prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Floor plans)</p>
             </odd>
@@ -372,11 +346,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ypsilanti. First Presbyterian Church (new organ and choir gallery) <unitdate type="inclusive" normal="1946">1946</unitdate> (Job No. 643)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">20 drawings</extent>
+              <physfacet>pencil on paper and paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper and paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Floor plans, sketches, elevations, sections, perspectives)</p>
             </odd>
@@ -387,11 +359,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ypsilanti. First Presbyterian Church <unitdate type="inclusive" normal="1950">1950</unitdate> (Job No. 737)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">13 drawings</extent>
+              <physfacet>pencil on paper and paper vellum, blue prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper and paper vellum, blue prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Floor plans, heating plans)</p>
             </odd>
@@ -402,11 +372,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ypsilanti. St. Luke's Church (remodeling) <unitdate type="inclusive" normal="1951">1951</unitdate> (Job No. 750)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 drawings</extent>
+              <physfacet>pencil on paper vellum, and specifications</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum, and specifications</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Floor plans, sections, details)</p>
             </odd>
@@ -417,11 +385,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ypsilanti. Calvary Baptist Church (addition), Oakland Boulevard and Davis Street <unitdate type="inclusive" normal="1952/1955">1952-1955</unitdate> (Job No. 765)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">9 drawings</extent>
+              <physfacet>pencil on paper vellum, blue line prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum, blue line prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plans, elevations, sections, structural plans)</p>
             </odd>
@@ -432,11 +398,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ypsilanti. Willow Run Baptist Church (addition) <unitdate type="inclusive" normal="1952">1952</unitdate> (Job No. 772)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 drawings</extent>
+              <physfacet>pencil on paper vellum, blue line print</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum, blue line print</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Floor plans, elevations, sections, details)</p>
             </odd>
@@ -447,11 +411,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ypsilanti. Emmanuel Lutheran Church (addition) <unitdate type="inclusive" normal="1952">1952</unitdate> (Job No. 847)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">19 drawings</extent>
+              <physfacet>blue line prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>blue line prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plans, floor plans, elevations, sections, details, structural, and mechanical plans)</p>
             </odd>
@@ -462,11 +424,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Orthodox churches (No Job No.)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">36 drawings</extent>
+              <physfacet>pencil on paper, paperboard, and paper vellum, blueprints, photograph</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper, paperboard, and paper vellum, blueprints, photograph</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(studies, etc.)</p>
             </odd>
@@ -482,11 +442,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ann Arbor. D.M. Silkworth Oil Co. (gasoline station), S. University at Church Street <unitdate type="inclusive" normal="1939">1939</unitdate> (No Job No.)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 drawings</extent>
+              <physfacet>blueprint</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>blueprint</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plans, elevations, sections, details)</p>
             </odd>
@@ -500,11 +458,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ann Arbor. D.M. Silkworth Oil Co. (service station), SW corner of Packard and Stadium Road <unitdate type="inclusive" normal="1940">1940</unitdate> (Job No. 515)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 drawings</extent>
+              <physfacet>blueprint, and specifications</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>blueprint, and specifications</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plans, floor plans, elevations, section, details)</p>
             </odd>
@@ -515,11 +471,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ann Arbor. Link George and Sales Building, Huron and Division Streets <unitdate type="inclusive" normal="1947">1947</unitdate> (Job No. 655)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 drawings</extent>
+              <physfacet>blueprints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>blueprints</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plans, elevations, sections, details)</p>
             </odd>
@@ -530,11 +484,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ann Arbor. D.M. Silkworth Oil Co. (service station), E. Ann and Glen Streets <unitdate type="inclusive" normal="1950">1950</unitdate> (Job No. 720)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">6 drawings</extent>
+              <physfacet>pencil on paper vellum, blue print</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum, blue print</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plans, floor plans, elevations, sections, details, structural plan)</p>
             </odd>
@@ -545,11 +497,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Belleville. D.M. Silkworth Oil Co. and Mr. J.L. Patterson (service station), Huron River Drive and Riggs Street <unitdate type="inclusive" normal="1937">1937</unitdate>, <unitdate type="inclusive" normal="1942">1942</unitdate> (Job No. 474)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">6 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plans, elevations, sections, details)</p>
             </odd>
@@ -560,11 +510,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Dearborn Township. W.J. Cunningham (service station), Van Born and Jim Daly Roads <unitdate type="inclusive" normal="1945">1945</unitdate> (No Job No.)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plan, elevations, sections, details)</p>
             </odd>
@@ -575,11 +523,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Garden City. D.M. Silkworth Oil Co. (store building and addition), NW corner Ford and Middle Belt Roads <unitdate type="inclusive" normal="1940">1940</unitdate> (Job Nos. 514, 517)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">6 drawings</extent>
+              <physfacet>pencil on paper vellum and blueprint and specification</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum and blueprint and specification</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plans, floor plans, elevations, sections)</p>
             </odd>
@@ -590,11 +536,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Milan. D.M. Silkworth Oil Co. (Ford-Gulf Service Station) <unitdate type="inclusive" normal="1938">1938</unitdate> (Job No. 480)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">8 drawings</extent>
+              <physfacet>pencil on paper and paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper and paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plans, rendering, elevations, sections, framing plan)</p>
             </odd>
@@ -605,11 +549,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Northville. D.M. Silkworth Oil Co. (service station), Main and Wing Streets <unitdate type="inclusive" normal="1941">1941</unitdate> (Job No. 531)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plan, elevations, sections, details)</p>
             </odd>
@@ -620,11 +562,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Wayne. D.M. Silkworth Oil Co. (Gulf service station) <unitdate type="inclusive" normal="1938">1938</unitdate> (Job No. 481)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">8 drawings</extent>
+              <physfacet>pencil on paper and paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper and paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plans, rendering, elevations, sections, details, framing plan)</p>
             </odd>
@@ -635,11 +575,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Wayne. D.M. Silkworth Oil Co. (service station), Wayne and Van Born Roads <unitdate type="inclusive" normal="1942">1942</unitdate> (Job No. 558)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 drawings</extent>
+              <physfacet>blueprint, and specification</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>blueprint, and specification</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plans, floor plans, elevations, sections, details)</p>
             </odd>
@@ -650,11 +588,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Wayne County. Vannoy Brothers (garage and service station), Joy Road and Middle Belt Road <unitdate type="inclusive" normal="1946">1946</unitdate> (Job No. 626)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">10 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plans, elevations, sections, structural plan)</p>
             </odd>
@@ -665,11 +601,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Wayne Cty. Texaco Station for Peter Theodore, Inc. (Detroit) Metropolitan Wayne County Airport) <unitdate type="inclusive" normal="1959">1959</unitdate> (Job No. 895)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">14 drawings</extent>
+              <physfacet>blue line print</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>blue line print</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(site plans, floor plan, elevations, sections, details, structural, mechanical, and electrical plans)</p>
             </odd>
@@ -680,11 +614,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ypsilanti. George W. Hayes Realty Co. (garage building), Michigan Avenue at Water Street <unitdate type="inclusive" normal="1928/1929">1928-1929</unitdate> (Job No. 368)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plans, elevations, sections, details)</p>
             </odd>
@@ -695,11 +627,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ypsilanti. D.M. Silkworth Oil Co. (oil station and store), Michigan Avenue <unitdate type="inclusive" normal="1929">1929</unitdate> (Job No. 374)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">10 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Floor plans, elevations, sections, details)</p>
             </odd>
@@ -710,11 +640,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ypsilanti. D.M. Silkworth Oil Co. (service and oil station), 15 E. Michigan Avenue <unitdate type="inclusive" normal="1935">1935</unitdate> (Job No. 432)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">7 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plans, elevations, sections)</p>
             </odd>
@@ -725,11 +653,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ypsilanti. D.M. Silkworth Oil Co. (store building), 102 E. Michigan Avenue at River Street <unitdate type="inclusive" normal="1945">1945</unitdate> (Job No. 591)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">5 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plans, elevations, sections)</p>
             </odd>
@@ -780,11 +706,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ann Arbor. Washtenaw County Building, Huron and Main Street <unitdate type="inclusive" normal="1946">1946</unitdate> (Job No. 592)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">58 drawings</extent>
+              <physfacet>pencil on paper and paper vellum, water color on cardboard</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper and paper vellum, water color on cardboard</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plans, floor plans, renderings, elevations, sections, details, structural, mechanical, electrical plans)</p>
             </odd>
@@ -813,11 +737,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ann Arbor. Washtenaw County Building, Huron and Main Street <unitdate type="inclusive" normal="1953">1953</unitdate> (Job No. 775)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">58 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plans, rendering, floor plans, elevations, sections, details, structural, mechanical, electrical, furniture plans)</p>
             </odd>
@@ -831,11 +753,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ann Arbor. Washtenaw County Building (concessions area) <unitdate type="inclusive" normal="1955">1955</unitdate> (Job No. 775B)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 drawings</extent>
+              <physfacet>blue line prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>blue line prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Floor plan, elevations, roughing in, equipment)</p>
             </odd>
@@ -849,11 +769,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ann Arbor. Washtenaw County Building (parking structure) <unitdate type="inclusive" normal="1955">1955</unitdate> (Job No. 810)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">12 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plans, sections, details, mechanical plans)</p>
             </odd>
@@ -864,11 +782,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Washtenaw County Building (remodeling) <unitdate type="inclusive" normal="1966/1967">1966-1967</unitdate> (Job No. 951)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">7 drawings</extent>
+              <physfacet>pencil on paper vellum, blue line prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum, blue line prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Floor plans, details, mechanical plans)</p>
             </odd>
@@ -882,11 +798,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Washtenaw County Building (annex) <unitdate type="inclusive" normal="1967">1967</unitdate> (Job No. 6706)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">41 drawings</extent>
+              <physfacet>pencil on paper and paper vellum, sepia print, blue line prints, pencil on mylar</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper and paper vellum, sepia print, blue line prints, pencil on mylar</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plans, floor plans, elevations, sections, details, structural mechanical, electrical plans)</p>
             </odd>
@@ -900,11 +814,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ann Arbor. Ypsi-Ann Building, 4th Avenue and Washington Street (No Job No.)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">6 drawings</extent>
+              <physfacet>ink on cardboard, photostats, printed flyer</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>ink on cardboard, photostats, printed flyer</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Renderings, floor plans)</p>
             </odd>
@@ -915,11 +827,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ypsilanti. Washtenaw Country Club (clubhouse, garage, and tool house), Packard Road <unitdate type="inclusive" normal="1929">1929</unitdate> (Job No. 367)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">32 drawings</extent>
+              <physfacet>pencil on paper, ink on linen, blue-prints</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper, ink on linen, blue-prints</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Studies, site plans, floor plans, renderings, elevations, sections, details, structural, and heating plans)</p>
             </odd>
@@ -930,11 +840,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ypsilanti. D.M. Silkworth (residence), Huron and Race Street <unitdate type="inclusive" normal="1935">1935</unitdate> (Job No. 426)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">4 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Floor plans, elevations, sections, details)</p>
             </odd>
@@ -945,11 +853,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Jeff Silkworth (house) <unitdate type="inclusive" normal="1942">1942</unitdate> (Job No. 546)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Floor plans, elevations)</p>
             </odd>
@@ -960,11 +866,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Ypsilanti. Banks and Stowe (sandwich shop), Michigan Avenue and River Street <unitdate type="inclusive" normal="1944">1944</unitdate> (No Job No.)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">2 drawings</extent>
+              <physfacet>pencil on paper vellum</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil on paper vellum</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Plot plan, floor plan, elevations, section)</p>
             </odd>
@@ -975,11 +879,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Miscellaneous (apartment buildings) (No Job No.)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">7 drawings</extent>
+              <physfacet>ink on paper and cardboard, photostats</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>ink on paper and cardboard, photostats</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Renderings)</p>
             </odd>
@@ -990,11 +892,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <unittitle>Miscellaneous (businesses) (No Job No.)</unittitle>
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">8 drawings</extent>
+              <physfacet>photostats, pencil and ink on paper and cardboard</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>photostats, pencil and ink on paper and cardboard</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Renderings)</p>
             </odd>
@@ -1005,11 +905,9 @@ Z. T. Gerganoff architectural firm records, Bentley Historical Library, Universi
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">50 drawings</extent>
                 <physfacet>approximate number</physfacet>
+              <physfacet>pencil and ink on paper and cardboard, water color on cardboard, photostats</physfacet>
               </physdesc>
-              <physdesc>
-                <physfacet>pencil and ink on paper and cardboard, water color on cardboard, photostats</physfacet>
-              </physdesc>
-            </did>
+              </did>
             <odd>
               <p>(Renderings)</p>
             </odd>


### PR DESCRIPTION
If a component had 2 physdescs, one with an extent and one without (physfacet or dimensions), the elements from the second were merged into the first.  So something like 

physdesc
  extent>2 tapes</extent
physdesc
physdesc
  physfacet>VHS<physfacet
physdesc

Becomes

physdesc
 extent  2 tapes  extent
 physfacet  VHS  physfacet
physdesc

I don't see any examples where that was obviously the wrong thing to do, so hopefully this will help ensure that we're making a single extent record instead of an extent and a separate physical description note when appropriate.
