### PR TITLE
prettyprint and run revamped "aspacify extents" script

### DIFF
--- a/Real_Masters_all/access.xml
+++ b/Real_Masters_all/access.xml
@@ -1,54 +1,56 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE ead PUBLIC "+//ISBN 1-931666-00-8//DTD ead.dtd (Encoded Archival Description (EAD) Version 2002)//EN" "ead.dtd">
 <ead>
-
-<eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
-
-<eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::access.xml//EN" encodinganalog="Identifier">
+  <eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
+    <eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::access.xml//EN" encodinganalog="Identifier">
 umich-bhl-98121</eadid>
-
-<filedesc><titlestmt><titleproper encodinganalog="Title">Finding Aid for 
+    <filedesc>
+      <titlestmt>
+        <titleproper encodinganalog="Title">Finding Aid for 
 Arab Community Center for Economic and Social Services records.
 </titleproper>
-<author encodinganalog="Creator">Collection processed and finding aid created by 
-Ben Bond </author></titlestmt>
-
-<publicationstmt><publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
-<date encodinganalog="Date" normal="2016">
-2016</date></publicationstmt></filedesc>
-
-<profiledesc>
-<creation>Encoded finding aid created by 
+        <author encodinganalog="Creator">Collection processed and finding aid created by 
+Ben Bond </author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
+        <date encodinganalog="Date" normal="2016">
+2016</date>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>Encoded finding aid created by 
 Olga Virakhovskaya 
 <date>2015</date></creation>
-
-<langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage><descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules></profiledesc>
-
-<revisiondesc><change><date>2016-02-05</date><item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item></change></revisiondesc></eadheader>
-
-<frontmatter><titlepage>
-
-<publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
-
-<titleproper>Finding aid for<lb/>
+      <langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage>
+      <descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules>
+    </profiledesc>
+    <revisiondesc>
+      <change>
+        <date>2016-02-05</date>
+        <item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item>
+      </change>
+    </revisiondesc>
+  </eadheader>
+  <frontmatter>
+    <titlepage>
+      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <titleproper>Finding aid for<lb/>
 Arab Community Center for Economic and Social Services records.
 </titleproper>
-
-<author>Finding aid created by<lb/> 
+      <author>Finding aid created by<lb/> 
 Ben Bond, in January, 2016
 </author>
-
-</titlepage>
-</frontmatter>
-
-<archdesc level="recordgrp" audience="external" type="inventory" relatedencoding="MARC21"><did>
-
-<origination>
-<corpname source="lcnaf" encodinganalog="110">
+    </titlepage>
+  </frontmatter>
+  <archdesc level="recordgrp" audience="external" type="inventory" relatedencoding="MARC21">
+    <did>
+      <origination>
+        <corpname source="lcnaf" encodinganalog="110">
 Arab Community Center for Economic and Social Services 
-</corpname></origination>
-
-<unittitle encodinganalog="245">
+</corpname>
+      </origination>
+      <unittitle encodinganalog="245">
 Arab Community Center for Economic and Social Services records
 <unitdate type="inclusive" encodinganalog="245$f">
 1976-2009
@@ -58,125 +60,171 @@ Arab Community Center for Economic and Social Services records
 1992-2005
 </unitdate>
 </unittitle>
-
-<physdesc><extent encodinganalog="300">
+      <physdesc>
+        <extent encodinganalog="300">
 0.75 linear feet and 1 archived website (online)
-</extent></physdesc>
-
-<unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
+</extent>
+      </physdesc>
+      <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 98121 Bd 2
 </unitid>
-
-<langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
-
-<abstract>
+      <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
+      <abstract>
 Based in Dearborn, MI, the Arab Community Center for Economic and Social Services (ACCESS) works to provide services and assistance to new immigrants. They seek to establish a sense of community among Arab Americans and to provide a place to express traditions and pursue cultural activities. The collection includes a history of the organization and of the Arab-American community in Detroit, newsletters, annual reports, and information about many of the organization's activities.</abstract>
-
-
-<repository><corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
-<extptr href="bhladd" show="embed" actuate="onload"/></repository></did>
-
-<descgrp type="admin">
-<acqinfo encodinganalog="541"><p>
+      <repository>
+        <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
+        <extptr href="bhladd" show="embed" actuate="onload"/>
+      </repository>
+    </did>
+    <descgrp type="admin">
+      <acqinfo encodinganalog="541">
+        <p>
 Donated by Arab Community Center for Economic and Social Services (donor no. <num type="donor" encodinganalog="541$e">7938</num>) in several accessions beginning in 1991. Select publications have been donated at different times by Orchard Lake School (donor no. <num type="donor" encodinganalog="541$e">7402</num>), Karen Majewski (donor no. <num type="donor" encodinganalog="541$e">10014</num>),  Mary Anne Stella (donor no. <num type="donor" encodinganalog="541$e">10769</num>, and Sally Howell (donor no. <num type="donor" encodinganalog="541$e">10840</num>).
  
-</p></acqinfo>
-
-<accruals encodinganalog="584"><p>Periodic additions to the records expected.</p></accruals>
-
-
-
-<accessrestrict encodinganalog="506">
-<p>The collection is open without restriction</p>
- </accessrestrict>
-
-
-<userestrict encodinganalog="540"><p>
+</p>
+      </acqinfo>
+      <accruals encodinganalog="584">
+        <p>Periodic additions to the records expected.</p>
+      </accruals>
+      <accessrestrict encodinganalog="506">
+        <p>The collection is open without restriction</p>
+      </accessrestrict>
+      <userestrict encodinganalog="540">
+        <p>
 Copyright is held by the Regents of the University of Michigan.
-</p></userestrict>
-
-
-<prefercite encodinganalog="524"><p>[item], folder, box,
-Arab Community Center for Economic and Social Services records, Bentley Historical Library, University of Michigan</p>  <p>For archived online materials: [item], http:webarchives.cdlib.org/site/sw1ft8f57f
-Arab Community Center for Economic and Social Services records, Bentley Historical Library, University of Michigan</p></prefercite>
-
-<processinfo><p>[Delete this set of tags if not needed for digital material processing]</p>
-<p><extptr href="digitalproc" show="embed" actuate="onload"/></p>
-</processinfo>
-
-</descgrp>
-
-<bioghist encodinganalog="545">
-<p>Founded by a group of volunteers in 1971 out of a storefront in Dearborn's impoverished south end, the Arab Community Center for Economic and Social Services (ACCESS) was created to assist the Arab immigrant population adapt to life in the United States. ACCESS offers English instruction and interpreters and seek to establish a sense of community among Arab Americans. In addition ACCESS provides a place to express traditions and pursue cultural activities.</p>
-
-<p>As of 2016, ACCESS is the largest Arab American human services nonprofit in the United States. With eight locations and more than 100 programs serving metro Detroit, ACCESS offers a wide range of social, economic, health and educational services to a diverse population. Through initiatives like the Arab American National Museum (AANM), the National Network for Arab American Communities (NNAAC), ACCESS Growth Center, and the Center for Arab American Philanthropy (CAAP), ACCESS serves all Americans.</p>
-
-
-</bioghist>
-
- 
-
-<scopecontent encodinganalog="520">
-<p>The ACCESS records encompass an array of items donated at different times and include historical information about ACCESS, announcements, programs, newsletters, reports, miscellaneous publications, and archived website.   </p></scopecontent>
-
-<controlaccess><p><extptr href="accnote" show="embed" actuate="onload"/></p><controlaccess><head>Subjects:</head>
-
-<corpname source="lcnaf" encodinganalog="610">Arab Community Center for Economic and Social Services.</corpname>
-<subject source="lcsh" encodinganalog="650">Arab Americans--Michigan.</subject>
-<subject source="lcsh" encodinganalog="650">Communities--Services for--Michigan.</subject> 
-<subject source="lcsh" encodinganalog="650">Immigrants--Services for--Michigan.</subject>
-<subject source="lcsh" encodinganalog="650">Muslims--Michigan.</subject>
-</controlaccess>
-<controlaccess>
-
-<head>Genre Terms:</head>
-        
+</p>
+      </userestrict>
+      <prefercite encodinganalog="524">
+        <p>[item], folder, box,
+Arab Community Center for Economic and Social Services records, Bentley Historical Library, University of Michigan</p>
+        <p>For archived online materials: [item], http:webarchives.cdlib.org/site/sw1ft8f57f
+Arab Community Center for Economic and Social Services records, Bentley Historical Library, University of Michigan</p>
+      </prefercite>
+      <processinfo>
+        <p>[Delete this set of tags if not needed for digital material processing]</p>
+        <p>
+          <extptr href="digitalproc" show="embed" actuate="onload"/>
+        </p>
+      </processinfo>
+    </descgrp>
+    <bioghist encodinganalog="545">
+      <p>Founded by a group of volunteers in 1971 out of a storefront in Dearborn's impoverished south end, the Arab Community Center for Economic and Social Services (ACCESS) was created to assist the Arab immigrant population adapt to life in the United States. ACCESS offers English instruction and interpreters and seek to establish a sense of community among Arab Americans. In addition ACCESS provides a place to express traditions and pursue cultural activities.</p>
+      <p>As of 2016, ACCESS is the largest Arab American human services nonprofit in the United States. With eight locations and more than 100 programs serving metro Detroit, ACCESS offers a wide range of social, economic, health and educational services to a diverse population. Through initiatives like the Arab American National Museum (AANM), the National Network for Arab American Communities (NNAAC), ACCESS Growth Center, and the Center for Arab American Philanthropy (CAAP), ACCESS serves all Americans.</p>
+    </bioghist>
+    <scopecontent encodinganalog="520">
+      <p>The ACCESS records encompass an array of items donated at different times and include historical information about ACCESS, announcements, programs, newsletters, reports, miscellaneous publications, and archived website.   </p>
+    </scopecontent>
+    <controlaccess>
+      <p>
+        <extptr href="accnote" show="embed" actuate="onload"/>
+      </p>
+      <controlaccess>
+        <head>Subjects:</head>
+        <corpname source="lcnaf" encodinganalog="610">Arab Community Center for Economic and Social Services.</corpname>
+        <subject source="lcsh" encodinganalog="650">Arab Americans--Michigan.</subject>
+        <subject source="lcsh" encodinganalog="650">Communities--Services for--Michigan.</subject>
+        <subject source="lcsh" encodinganalog="650">Immigrants--Services for--Michigan.</subject>
+        <subject source="lcsh" encodinganalog="650">Muslims--Michigan.</subject>
+      </controlaccess>
+      <controlaccess>
+        <head>Genre Terms:</head>
         <genreform source="aat" encodinganalog="655">Websites.</genreform>
-      </controlaccess> 
-
-</controlaccess>
-
-
-<dsc type="combined">
-<c01 level="series"><did><unittitle>ACCESS records</unittitle></did><scopecontent><p>The ACCESS records encompass an array of items donated at different times. The records include historical information about ACCESS, announcements and other materials that inform about activities and programs, anniversary banquet newsletters, annual reports, and miscellaneous publications. Also, contents    of the archived website starting from 2010.</p></scopecontent>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>History, <unitdate type="inclusive">1996</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Activities and programs, <unitdate type="inclusive">1976</unitdate>, <unitdate type="inclusive">1991-2005</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Anniversary banquet, <unitdate type="inclusive">2001-2003</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Anniversary dinner, <unitdate type="inclusive">1992-1997</unitdate>, <unitdate type="inclusive">2008</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Annual reports, <unitdate type="inclusive">1987-2009</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Arab Center, <unitdate type="inclusive">1976</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Newsletters, <unitdate type="inclusive">1982-2004</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Miscellaneous publications, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-
-
-<c02 level="file"><did><physloc>Online</physloc><unittitle>Archived snapshots of the website</unittitle><dao href="98121-w-1https://wayback.archive-it.org/5486/*/https://www.accesscommunity.org" show="new" actuate="onrequest">
+      </controlaccess>
+    </controlaccess>
+    <dsc type="combined">
+      <c01 level="series">
+        <did>
+          <unittitle>ACCESS records</unittitle>
+        </did>
+        <scopecontent>
+          <p>The ACCESS records encompass an array of items donated at different times. The records include historical information about ACCESS, announcements and other materials that inform about activities and programs, anniversary banquet newsletters, annual reports, and miscellaneous publications. Also, contents    of the archived website starting from 2010.</p>
+        </scopecontent>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>History, <unitdate type="inclusive">1996</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Activities and programs, <unitdate type="inclusive">1976</unitdate>, <unitdate type="inclusive">1991-2005</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Anniversary banquet, <unitdate type="inclusive">2001-2003</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Anniversary dinner, <unitdate type="inclusive">1992-1997</unitdate>, <unitdate type="inclusive">2008</unitdate> </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Annual reports, <unitdate type="inclusive">1987-2009</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Arab Center, <unitdate type="inclusive">1976</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Newsletters, <unitdate type="inclusive">1982-2004</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Miscellaneous publications, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <physloc>Online</physloc>
+            <unittitle>Archived snapshots of the website</unittitle>
+            <dao href="98121-w-1https://wayback.archive-it.org/5486/*/https://www.accesscommunity.org" show="new" actuate="onrequest">
               <daodesc>
                 <p>[view item]</p>
               </daodesc>
-            </dao></did></c02>
-				
-<c02 level="file"><did><physloc>Online</physloc><unittitle>Archives snapshots of the website</unittitle><dao href="https://wayback.archive-it.org/org-934/*/http://www.accesscommunity.org/site/PageServer?pagename=homepage" show="new" actuate="onrequest">
+            </dao>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <physloc>Online</physloc>
+            <unittitle>Archives snapshots of the website</unittitle>
+            <dao href="https://wayback.archive-it.org/org-934/*/http://www.accesscommunity.org/site/PageServer?pagename=homepage" show="new" actuate="onrequest">
               <daodesc>
                 <p>[view item]</p>
               </daodesc>
-            </dao></did></c02>				
-				
-				</c01>
-
-</dsc>
-<descgrp type="add"><relatedmaterial><head>Related Materials</head>
-
-<p>Researchers should note that the Bentley Historical Library holds the following collections:</p>
-
-<p><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-2016013" show="new" actuate="onrequest">Sally Howell papers</title> </p>
-
-<p><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-0227" show="new" actuate="onrequest">Barbara C. Aswad Papers</title></p>
-
-
-
-</relatedmaterial></descgrp>
-</archdesc>
-
-
-
+            </dao>
+          </did>
+        </c02>
+      </c01>
+    </dsc>
+    <descgrp type="add">
+      <relatedmaterial>
+        <head>Related Materials</head>
+        <p>Researchers should note that the Bentley Historical Library holds the following collections:</p>
+        <p>
+          <title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-2016013" show="new" actuate="onrequest">Sally Howell papers</title>
+        </p>
+        <p>
+          <title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-0227" show="new" actuate="onrequest">Barbara C. Aswad Papers</title>
+        </p>
+      </relatedmaterial>
+    </descgrp>
+  </archdesc>
 </ead>

--- a/Real_Masters_all/admissls.xml
+++ b/Real_Masters_all/admissls.xml
@@ -2636,8 +2636,8 @@
         <c02 level="subseries">
           <did>
             <unittitle><unitdate type="inclusive" normal="2002-02-25">February 25, 2002</unitdate> capture</unittitle>
-            <physdesc>
-              <extent>2 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
               <physfacet>CD-ROMs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/alawraad.xml
+++ b/Real_Masters_all/alawraad.xml
@@ -102,8 +102,8 @@
       <c01 level="series">
         <did>
           <unittitle>New Beginnings Documentary: Interviews and film footage</unittitle>
-          <physdesc>
-            <extent>18 optical disks</extent>
+          <physdesc altrender="whole">
+            <extent altrender="materialtype spaceoccupied">18 optical disks</extent>
             <physfacet>DVDs</physfacet>
           </physdesc>
         </did>

--- a/Real_Masters_all/alumasso.xml
+++ b/Real_Masters_all/alumasso.xml
@@ -3696,7 +3696,7 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">133</container>
-              <unittitle>Governing Board Meetings <unitdate type="inclusive" normal="1958/1962">1958-1962</unitdate><unitdate type="bulk" normal="1960">1960</unitdate></unittitle>
+              <unittitle>Governing Board Meetings <unitdate type="inclusive" normal="1958/1962">1958-1962</unitdate> <unitdate type="bulk" normal="1960">1960</unitdate></unittitle>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/amculfkl.xml
+++ b/Real_Masters_all/amculfkl.xml
@@ -50,59 +50,59 @@
         <extent altrender="carrier">in 31 boxes</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent>220 optical discs</extent>
-        <physfacet>CD-Rs</physfacet>
+        <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
+        <physfacet>8mm videocassettes</physfacet>
       </physdesc>
       <physdesc altrender="part">
-        <extent>27 optical discs</extent>
-        <physfacet>CD-RWs</physfacet>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent>1 optical discs</extent>
-        <physfacet>mini CDs</physfacet>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent>2 optical discs</extent>
-        <physfacet>MiniDiscs</physfacet>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent>1 optical discs</extent>
-        <physfacet>Hi-MD (MiniDisc)</physfacet>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent>10 optical discs</extent>
-        <physfacet>DVD-Rs</physfacet>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent>1 optical discs</extent>
-        <physfacet>mini DVDs</physfacet>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent>10 floppy disks</extent>
-        <physfacet>3.5"</physfacet>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent>9 USB thumb drives</extent>
-        <physfacet>3 4GB, 3 2GB, 2 512MB, and 2 128MB</physfacet>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent>97 audiocassettes</extent>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent>132 audiocassettes</extent>
-        <physfacet>microcassettes</physfacet>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent>4 videotapes</extent>
-        <physfacet>VHS (TM)</physfacet>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent>1 videotapes</extent>
+        <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
         <physfacet>mini-DVs</physfacet>
       </physdesc>
       <physdesc altrender="part">
-        <extent>1 videotapes</extent>
-        <physfacet>8mm videocassettes</physfacet>
+        <extent altrender="materialtype spaceoccupied">4 videotapes</extent>
+        <physfacet>VHS (TM)</physfacet>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">132 audiocassettes</extent>
+        <physfacet>microcassettes</physfacet>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">97 audiocassettes</extent>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">9 USB thumb drives</extent>
+        <physfacet>3 4GB, 3 2GB, 2 512MB, and 2 128MB</physfacet>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">10 floppy disks</extent>
+        <physfacet>3.5"</physfacet>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">1 optical discs</extent>
+        <physfacet>mini DVDs</physfacet>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">10 optical discs</extent>
+        <physfacet>DVD-Rs</physfacet>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">1 optical discs</extent>
+        <physfacet>Hi-MD (MiniDisc)</physfacet>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">2 optical discs</extent>
+        <physfacet>MiniDiscs</physfacet>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">1 optical discs</extent>
+        <physfacet>mini CDs</physfacet>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">27 optical discs</extent>
+        <physfacet>CD-RWs</physfacet>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">220 optical discs</extent>
+        <physfacet>CD-Rs</physfacet>
       </physdesc>
       <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>

--- a/Real_Masters_all/archcoll.xml
+++ b/Real_Masters_all/archcoll.xml
@@ -4050,7 +4050,10 @@
           </scopecontent>
           <c03 level="otherlevel" otherlevel="sub-subseries">
             <did>
-              <unittitle><unitdate type="inclusive" normal="1993/2008">1993-2008</unitdate> <unitdate normal="1998/2008" type="bulk">bulk 1998-2008</unitdate></unittitle>
+              <unittitle>
+                <unitdate type="inclusive" normal="1993/2008">1993-2008</unitdate>
+                <unitdate normal="1998/2008" type="bulk">bulk 1998-2008</unitdate>
+              </unittitle>
             </did>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/archcoll.xml
+++ b/Real_Masters_all/archcoll.xml
@@ -4373,8 +4373,8 @@
                 <did>
                   <container type="box" label="Box">56</container>
                   <unittitle>Troy/Birmingham Transit Center <unitdate type="inclusive" normal="2008">2008</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>CD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -8876,8 +8876,8 @@
               <did>
                 <container type="box" label="Box">37</container>
                 <unittitle>Promotional CD-Rom <unitdate type="inclusive" normal="1996">1996</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-ROMs</physfacet>
                 </physdesc>
               </did>
@@ -12993,8 +12993,8 @@
               <unittitle>
                 <title render="italic">More Than a Handsome Box</title>
               </unittitle>
-              <physdesc>
-                <extent>3 zip disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 zip disks</extent>
               </physdesc>
             </did>
             <odd>
@@ -13216,8 +13216,8 @@
                 <did>
                   <container type="box" label="Box">73</container>
                   <unittitle>Taubman College Photos <unitdate type="inclusive" normal="2000-11">November 2000</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>CD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -14357,12 +14357,12 @@
                 <did>
                   <container type="box" label="Box">77</container>
                   <unittitle>North Campus Redux Lecture, Doug Kelbaugh <unitdate type="inclusive" normal="2002-10-07">October 7, 2002</unitdate> (includes zip disk and CD)</unittitle>
-                  <physdesc>
-                    <extent>1 zip disks</extent>
-                  </physdesc>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>CDs</physfacet>
+                  </physdesc>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 zip disks</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -14460,8 +14460,8 @@
                 <did>
                   <container type="box" label="Box">77</container>
                   <unittitle>TCAUP Picnic, <unitdate type="inclusive" normal="2002">Fall 2002</unitdate> (includes a zip disk)</unittitle>
-                  <physdesc>
-                    <extent>1 zip disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 zip disks</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -14741,8 +14741,8 @@
                   <did>
                     <container type="box" label="Box">78</container>
                     <unittitle>Kelbaugh, Doug <unitdate type="inclusive" normal="1999/2000" certainty="approximate">circa 1999-2000</unitdate></unittitle>
-                    <physdesc>
-                      <extent>1 zip disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 zip disks</extent>
                     </physdesc>
                   </did>
                   <odd>
@@ -16601,8 +16601,8 @@
             <did>
               <container type="box" label="Box">80</container>
               <unittitle>Architecture and Urban Planning (UM): Reinventing Practice <unitdate type="inclusive" normal="1996-03-16">March 16, 1996</unitdate></unittitle>
-              <physdesc>
-                <extent>4 tapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 tapes</extent>
               </physdesc>
             </did>
             <accessrestrict>

--- a/Real_Masters_all/armenian.xml
+++ b/Real_Masters_all/armenian.xml
@@ -131,8 +131,8 @@
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>"Armenian Rugs: The Gregorian Collection,"1983</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-ROMs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/artscitz.xml
+++ b/Real_Masters_all/artscitz.xml
@@ -227,8 +227,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>Presentations</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/assasist.xml
+++ b/Real_Masters_all/assasist.xml
@@ -2120,7 +2120,10 @@
         </c02>
         <c02 level="subseries">
           <did>
-            <unittitle><unitdate type="inclusive" normal="1949/1985">1949-1985</unitdate> <unitdate normal="1970/1979" type="bulk">primarily 1970-1979</unitdate></unittitle>
+            <unittitle>
+              <unitdate type="inclusive" normal="1949/1985">1949-1985</unitdate>
+              <unitdate normal="1970/1979" type="bulk">primarily 1970-1979</unitdate>
+            </unittitle>
           </did>
           <c03 level="file">
             <did>
@@ -3082,7 +3085,10 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">29</container>
-                <unittitle><unitdate type="inclusive" normal="1953/1982">1953-1982</unitdate> <unitdate normal="1971/1982" type="bulk">primarily 1971-1982</unitdate></unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1953/1982">1953-1982</unitdate>
+                  <unitdate normal="1971/1982" type="bulk">primarily 1971-1982</unitdate>
+                </unittitle>
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">5 folders</extent>
                 </physdesc>

--- a/Real_Masters_all/asstpres.xml
+++ b/Real_Masters_all/asstpres.xml
@@ -335,7 +335,9 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">54</container>
-            <unittitle><unitdate type="inclusive" normal="1978/1985">1978 Spring-1985 Winter</unitdate></unittitle>
+            <unittitle>
+              <unitdate type="inclusive" normal="1978/1985">1978 Spring-1985 Winter</unitdate>
+            </unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">22 folders</extent>
             </physdesc>
@@ -363,7 +365,9 @@
         <c02 level="file">
           <did>
             <container type="box" label="Box">52</container>
-            <unittitle><unitdate type="inclusive" normal="1960/1973">1960-1973</unitdate></unittitle>
+            <unittitle>
+              <unitdate type="inclusive" normal="1960/1973">1960-1973</unitdate>
+            </unittitle>
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">14 folders</extent>
             </physdesc>

--- a/Real_Masters_all/athdept.xml
+++ b/Real_Masters_all/athdept.xml
@@ -5885,8 +5885,8 @@
                   <did>
                     <container type="box" label="Box">12 A</container>
                     <unittitle>Removal of PAT Turf and Installation of FieldTurf <unitdate type="inclusive" normal="2003">2003</unitdate></unittitle>
-                    <physdesc>
-                      <extent>2 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                       <physfacet>CDs and thumbnails</physfacet>
                     </physdesc>
                   </did>
@@ -14220,8 +14220,8 @@
                   <did>
                     <container type="box" label="Box">108</container>
                     <unittitle>Team photo and headshots</unittitle>
-                    <physdesc>
-                      <extent>1 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                       <physfacet>CD, contact sheets</physfacet>
                     </physdesc>
                   </did>
@@ -14230,8 +14230,8 @@
                   <did>
                     <container type="box" label="Box">108</container>
                     <unittitle>Minnesota, 1/219/2002</unittitle>
-                    <physdesc>
-                      <extent>2 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                       <physfacet>CDs</physfacet>
                     </physdesc>
                   </did>
@@ -14309,8 +14309,8 @@
                   <did>
                     <container type="box" label="Box">108</container>
                     <unittitle>Iowa <unitdate type="inclusive" normal="2003-02-21">2/21/2003</unitdate></unittitle>
-                    <physdesc>
-                      <extent>2 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                       <physfacet>cd, contact sheets</physfacet>
                     </physdesc>
                   </did>
@@ -16141,11 +16141,11 @@
                       <container type="box" label="Box">161</container>
                       <unittitle><unitdate type="inclusive" normal="1998/1999">1998/99</unitdate> Old Hockey Files</unittitle>
                       <physdesc>
-                        <extent>1 optical disks</extent>
-                        <physfacet>CD-Rs</physfacet>
-                      </physdesc>
-                      <physdesc>
                         <physfacet>CD produced 8/1/2001</physfacet>
+                      </physdesc>
+                      <physdesc altrender="whole">
+                        <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+                        <physfacet>CD-Rs</physfacet>
                       </physdesc>
                     </did>
                     <odd>
@@ -18448,8 +18448,8 @@
                   <did>
                     <container type="box" label="Box">213</container>
                     <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> Season Files and Media guide</unittitle>
-                    <physdesc>
-                      <extent>2 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                       <physfacet>cds</physfacet>
                     </physdesc>
                   </did>
@@ -18458,8 +18458,8 @@
                   <did>
                     <container type="box" label="Box">213</container>
                     <unittitle>Team Photo and Player headshots</unittitle>
-                    <physdesc>
-                      <extent>2 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                       <physfacet>cds</physfacet>
                     </physdesc>
                   </did>
@@ -18468,8 +18468,8 @@
                   <did>
                     <container type="box" label="Box">213</container>
                     <unittitle>Compiled player action</unittitle>
-                    <physdesc>
-                      <extent>2 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                       <physfacet>cds</physfacet>
                     </physdesc>
                   </did>
@@ -18640,8 +18640,8 @@
                   <did>
                     <container type="box" label="Box">213</container>
                     <unittitle>St Peters, NCAA <unitdate type="inclusive" normal="2003-11-26">11/26/2003</unitdate></unittitle>
-                    <physdesc>
-                      <extent>2 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                       <physfacet>contact sheet, cds</physfacet>
                     </physdesc>
                   </did>
@@ -18650,8 +18650,8 @@
                   <did>
                     <container type="box" label="Box">213</container>
                     <unittitle>St. Peters, NCAA <unitdate type="inclusive" normal="2003-11-26">11/26/2003</unitdate></unittitle>
-                    <physdesc>
-                      <extent>2 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                       <physfacet>contact sheet, cds</physfacet>
                     </physdesc>
                   </did>
@@ -23894,8 +23894,8 @@
                   <did>
                     <container type="box" label="Box">76</container>
                     <unittitle>Iowa, 1/232004</unittitle>
-                    <physdesc>
-                      <extent>2 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                       <physfacet>contact sheet, cds</physfacet>
                     </physdesc>
                   </did>
@@ -23904,8 +23904,8 @@
                   <did>
                     <container type="box" label="Box">76</container>
                     <unittitle>Minnesota <unitdate type="inclusive" normal="2004-01-24">1/24/2004</unitdate></unittitle>
-                    <physdesc>
-                      <extent>2 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                       <physfacet>contact sheet, cds</physfacet>
                     </physdesc>
                   </did>
@@ -23939,8 +23939,8 @@
                   <did>
                     <container type="box" label="Box">76</container>
                     <unittitle>Headshots and Posed Action</unittitle>
-                    <physdesc>
-                      <extent>2 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                       <physfacet>contact sheet, cds</physfacet>
                     </physdesc>
                   </did>
@@ -23985,8 +23985,8 @@
                   <did>
                     <container type="box" label="Box">76</container>
                     <unittitle>Ohio State <unitdate type="inclusive" normal="2005-02-06">2/6/2005</unitdate></unittitle>
-                    <physdesc>
-                      <extent>2 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                       <physfacet>cds, contact sheets, Photo services</physfacet>
                     </physdesc>
                   </did>
@@ -24025,8 +24025,8 @@
                   <did>
                     <container type="box" label="Box">76</container>
                     <unittitle>Compilation Discs</unittitle>
-                    <physdesc>
-                      <extent>2 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                       <physfacet>cds</physfacet>
                     </physdesc>
                   </did>
@@ -24079,8 +24079,8 @@
                   <did>
                     <container type="box" label="Box">76</container>
                     <unittitle>Northwestern <unitdate type="inclusive" normal="2006-01-28">1/28/2006</unitdate></unittitle>
-                    <physdesc>
-                      <extent>2 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                       <physfacet>contact sheet, cds</physfacet>
                     </physdesc>
                   </did>
@@ -24089,8 +24089,8 @@
                   <did>
                     <container type="box" label="Box">76</container>
                     <unittitle>Michigan State <unitdate type="inclusive" normal="2006-01-29">1/29/2006</unitdate></unittitle>
-                    <physdesc>
-                      <extent>2 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                       <physfacet>contact sheet, cds</physfacet>
                     </physdesc>
                   </did>
@@ -41397,8 +41397,8 @@
                   <did>
                     <container type="box" label="Box">221</container>
                     <unittitle>NCAA Sanctions, (hearings, ruling, appeal, reversal) <unitdate type="inclusive" normal="2003-02/2003-09">February-September, 2003</unitdate></unittitle>
-                    <physdesc>
-                      <extent>1 volumes</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 volumes</extent>
                     </physdesc>
                   </did>
                 </c06>

--- a/Real_Masters_all/axelrods.xml
+++ b/Real_Masters_all/axelrods.xml
@@ -2315,7 +2315,10 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">12</container>
-              <unittitle><unitdate type="inclusive" normal="1960/1969" certainty="approximate">1960s</unitdate> <unitdate type="inclusive" normal="1970/1979" certainty="approximate">1970s</unitdate></unittitle>
+              <unittitle>
+                <unitdate type="inclusive" normal="1960/1969" certainty="approximate">1960s</unitdate>
+                <unitdate type="inclusive" normal="1970/1979" certainty="approximate">1970s</unitdate>
+              </unittitle>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/bandum.xml
+++ b/Real_Masters_all/bandum.xml
@@ -1287,8 +1287,8 @@
           <c03 level="file">
             <did>
               <unittitle>Audio Cassette</unittitle>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
               </physdesc>
             </did>
             <c04 level="file">
@@ -1306,8 +1306,8 @@
               <did>
                 <container type="box" label="Box">9</container>
                 <unittitle>"Halftime Classics: The University of Michigan Marching Band <unitdate type="inclusive" normal="1977/1978">1977-1978</unitdate> George R. Cavender, Conductor," <unitdate type="inclusive" normal="1978">1978</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -1316,8 +1316,8 @@
               <did>
                 <container type="box" label="Box">9</container>
                 <unittitle>"Fire Up . . . It's Saturday: Highlights of The Michigan Marching Band, Eric A, Becher, Conductor," <unitdate type="inclusive" normal="1980/1989" certainty="approximate">circa 1980s</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -1326,8 +1326,8 @@
               <did>
                 <container type="box" label="Box">9</container>
                 <unittitle>"A Saturday Tradition," <unitdate type="inclusive" normal="1993">1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -1336,8 +1336,8 @@
               <did>
                 <container type="box" label="Box">9</container>
                 <unittitle>"Hurrah for the Yellow and Blue: Michigan Marching Band, Kevin L. Seatole, Director," <unitdate type="inclusive" normal="1998">1998</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -1346,8 +1346,8 @@
               <did>
                 <container type="box" label="Box">9</container>
                 <unittitle>"Michigan Championship Celebration</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -1356,8 +1356,8 @@
               <did>
                 <container type="box" label="Box">9</container>
                 <unittitle>"The Spirit of Michigan: Michigan Marching Band, Men's Glee Club, Women's Glee Club," <unitdate type="inclusive" normal="1998">1998</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -1366,8 +1366,8 @@
               <did>
                 <container type="box" label="Box">9</container>
                 <unittitle>"It's All About Blue: Marching Band 1999-2000,"</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -1382,8 +1382,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>George Cavender Interview with Jeff Wohl <unitdate type="inclusive" normal="1998-03">March 1998</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1391,8 +1391,8 @@
           <c03 level="file">
             <did>
               <unittitle>Michigan Marching Band Video Yearbook</unittitle>
-              <physdesc>
-                <extent>5 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">5 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1450,8 +1450,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"A Michigan Tribute" (Victims of September 11, 2001) <unitdate type="inclusive" normal="2001">2001</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1460,8 +1460,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"Take the Field" Volume I <unitdate type="inclusive" normal="1985">1985</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1470,8 +1470,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"Take the Field" Volume II <unitdate type="inclusive" normal="1989">1989</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1480,8 +1480,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"Take the Field Volume III Saturday Fantastique," <unitdate type="inclusive" normal="2001">2001</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/barretta.xml
+++ b/Real_Masters_all/barretta.xml
@@ -586,8 +586,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Lecture Notes <unitdate type="inclusive" normal="1934" certainty="approximate">circa 1934</unitdate></unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
           <odd>

--- a/Real_Masters_all/bashlisa.xml
+++ b/Real_Masters_all/bashlisa.xml
@@ -187,8 +187,8 @@
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>CD-ROM copy of Bashert journals <unitdate type="inclusive" normal="1998/2004">1998-2004</unitdate></unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-ROMs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/beggvic.xml
+++ b/Real_Masters_all/beggvic.xml
@@ -148,8 +148,8 @@
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Cassette tape</unittitle>
-            <physdesc>
-              <extent>1 audiocassettes</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
             </physdesc>
           </did>
           <odd>

--- a/Real_Masters_all/behnerf.xml
+++ b/Real_Masters_all/behnerf.xml
@@ -184,19 +184,25 @@
             <c04 level="file">
               <did>
                 <container type="box" label="Box">1</container>
-                <unittitle><unitdate type="inclusive" normal="1901-07-01/1901-12-31">1901 July 1-December 31</unitdate></unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1901-07-01/1901-12-31">1901 July 1-December 31</unitdate>
+                </unittitle>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">1</container>
-                <unittitle><unitdate type="inclusive" normal="1902-01-01/1902-12-31">1902 January 1-December 31</unitdate></unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1902-01-01/1902-12-31">1902 January 1-December 31</unitdate>
+                </unittitle>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <container type="box" label="Box">1</container>
-                <unittitle><unitdate type="inclusive" normal="1903-01-01/1904-01-02">1903 January 1-1904 January 2</unitdate></unittitle>
+                <unittitle>
+                  <unitdate type="inclusive" normal="1903-01-01/1904-01-02">1903 January 1-1904 January 2</unitdate>
+                </unittitle>
               </did>
             </c04>
             <c04 level="file">

--- a/Real_Masters_all/bellmarg.xml
+++ b/Real_Masters_all/bellmarg.xml
@@ -1029,7 +1029,9 @@
           <c03 level="file">
             <did>
               <container type="box" label="Box">6</container>
-              <unittitle><unitdate type="inclusive" normal="1928-01/1928-02">January-February 1928</unitdate></unittitle>
+              <unittitle>
+                <unitdate type="inclusive" normal="1928-01/1928-02">January-February 1928</unitdate>
+              </unittitle>
             </did>
           </c03>
           <c03 level="file">

--- a/Real_Masters_all/benfordh.xml
+++ b/Real_Masters_all/benfordh.xml
@@ -800,8 +800,8 @@
             <unittitle>
               <unitdate type="inclusive" normal="2003">2003</unitdate>
             </unittitle>
-            <physdesc>
-              <extent>4 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -811,8 +811,8 @@
             <unittitle>
               <unitdate type="inclusive" normal="2003">2003</unitdate>
             </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/bennettj.xml
+++ b/Real_Masters_all/bennettj.xml
@@ -22,7 +22,8 @@
       <change>
         <date>2016-01-08</date>
         <item>Digital audio added</item>
-      </change><change>
+      </change>
+      <change>
         <date>2007-10-30</date>
         <item>Original encoding from Word 2000 file using Word macros and Xmetal.</item>
       </change>
@@ -49,7 +50,8 @@
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">0.98 GB</extent>
-      </physdesc><repository>
+      </physdesc>
+      <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
         <extptr href="bhladd" show="embed" actuate="onload"/>
       </repository>
@@ -71,9 +73,12 @@
         <p>[item], folder, box,
 John B. Bennett papers, Bentley Historical Library, University of Michigan</p>
       </prefercite>
-    <processinfo>
-<p><extptr href="digitalproc" show="embed" actuate="onload"/></p>
-</processinfo></descgrp>
+      <processinfo>
+        <p>
+          <extptr href="digitalproc" show="embed" actuate="onload"/>
+        </p>
+      </processinfo>
+    </descgrp>
     <bioghist encodinganalog="545">
       <p>John Bonifas Bennett was a Representative from Michigan. He was born in Garden, Delta County, Mich. on January 10, 1904. He attended the public schools, and graduated from Watersmeet High School in Michigan, and from Marquette University Law School in Milwaukee, Wisconsin, in 1925. Bennett took a postgraduate course at Chicago, IL University Law School in 1926, and was admitted to the Wisconsin bar in 1925 and the Michigan bar in 1926. He practiced law in Ontonagon, Michigan from 1926-1942. Bennett was a prosecuting attorney of Ontonagon County from 1929-1934, deputy commissioner of the Michigan Department of Labor and Industry from 1935-1937, and was elected as a republican to the Seventy-eighty Congress from January 3, 1943-January 3, 1945. He was an unsuccessful candidate for reelection in 1944 to the Seventy-ninth Congress, and resumed the practice of law. In 1946, Bennett was elected to the Eightieth and to the eight succeeding Congresses and served from January 3, 1947, until his death, August 9, 1964.</p>
     </bioghist>
@@ -650,11 +655,55 @@ John B. Bennett papers, Bentley Historical Library, University of Michigan</p>
             <physfacet>reel-to-reel tapes</physfacet>
           </physdesc>
         </did>
-        
-        
-      <c02 level="otherlevel" otherlevel="item-main"><did><unittitle>Radio program with Bennett and congressman Victor A. Knox on the subject of social security, <unitdate type="inclusive">1954 May</unitdate></unittitle><physdesc><physfacet>Audio Reel-to-Reel, 5 inch, 7 ½ ips</physfacet></physdesc></did><c03 level="otherlevel" otherlevel="item-part"><did><physloc>Online</physloc><unittitle>[Part 1]</unittitle><unitid>[85529-SR-1-1]</unitid><physdesc><physfacet>mp3 file</physfacet></physdesc><dao href="85529-SR-1-1" show="new" actuate="onrequest"><daodesc><p>[access item]</p></daodesc></dao> <abstract>(Bennett and Knox discuss changes and amendments to the Social Security act.)</abstract></did></c03></c02>
-<c02 level="otherlevel" otherlevel="item-main"><did><unittitle>Campaign message discussing the issues of special relevance to the voters of the Upper Peninsula, <unitdate type="inclusive">1954</unitdate></unittitle><physdesc><physfacet>Audio Reel-to-Reel, 7 inch, 7 ½ ips</physfacet></physdesc></did><c03 level="otherlevel" otherlevel="item-part"><did><physloc>Online</physloc><unittitle>[Part 1]</unittitle><unitid>[85529-SR-2-1]</unitid><physdesc><physfacet>mp3 file</physfacet></physdesc><dao href="85529-SR-2-1" show="new" actuate="onrequest"><daodesc><p>[access item]</p></daodesc></dao> <abstract>(Campaign message also discusses the Korean War, taxes, government spending, and mining.)</abstract></did></c03></c02>
-</c01>
+        <c02 level="otherlevel" otherlevel="item-main">
+          <did>
+            <unittitle>Radio program with Bennett and congressman Victor A. Knox on the subject of social security, <unitdate type="inclusive">1954 May</unitdate></unittitle>
+            <physdesc>
+              <physfacet>Audio Reel-to-Reel, 5 inch, 7 ½ ips</physfacet>
+            </physdesc>
+          </did>
+          <c03 level="otherlevel" otherlevel="item-part">
+            <did>
+              <physloc>Online</physloc>
+              <unittitle>[Part 1]</unittitle>
+              <unitid>[85529-SR-1-1]</unitid>
+              <physdesc>
+                <physfacet>mp3 file</physfacet>
+              </physdesc>
+              <dao href="85529-SR-1-1" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[access item]</p>
+                </daodesc>
+              </dao>
+              <abstract>(Bennett and Knox discuss changes and amendments to the Social Security act.)</abstract>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="otherlevel" otherlevel="item-main">
+          <did>
+            <unittitle>Campaign message discussing the issues of special relevance to the voters of the Upper Peninsula, <unitdate type="inclusive">1954</unitdate></unittitle>
+            <physdesc>
+              <physfacet>Audio Reel-to-Reel, 7 inch, 7 ½ ips</physfacet>
+            </physdesc>
+          </did>
+          <c03 level="otherlevel" otherlevel="item-part">
+            <did>
+              <physloc>Online</physloc>
+              <unittitle>[Part 1]</unittitle>
+              <unitid>[85529-SR-2-1]</unitid>
+              <physdesc>
+                <physfacet>mp3 file</physfacet>
+              </physdesc>
+              <dao href="85529-SR-2-1" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[access item]</p>
+                </daodesc>
+              </dao>
+              <abstract>(Campaign message also discusses the Korean War, taxes, government spending, and mining.)</abstract>
+            </did>
+          </c03>
+        </c02>
+      </c01>
     </dsc>
     <descgrp type="add">
       <index>

--- a/Real_Masters_all/bhl.xml
+++ b/Real_Masters_all/bhl.xml
@@ -5307,8 +5307,8 @@
                 <did>
                   <container type="box" label="Box">20</container>
                   <unittitle>General <unitdate type="inclusive" normal="1968/1971">1968-1971</unitdate></unittitle>
-                  <physdesc>
-                    <extent>3 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">3 folders</extent>
                   </physdesc>
                 </did>
                 <odd>
@@ -5576,8 +5576,8 @@
                     <unittitle>
                       <unitdate type="inclusive" normal="2004">2004</unitdate>
                     </unittitle>
-                    <physdesc>
-                      <extent>1 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                       <physfacet>CD-ROMs</physfacet>
                     </physdesc>
                   </did>
@@ -14305,8 +14305,8 @@
             <did>
               <container type="box" label="Box">54</container>
               <unittitle>Bentley Historical Library Dedication/groundbreaking ceremony <unitdate type="inclusive" normal="1973">1973</unitdate></unittitle>
-              <physdesc>
-                <extent>1 audiotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel, 7 in., 3 3/4 ips</physfacet>
               </physdesc>
             </did>
@@ -14315,8 +14315,8 @@
             <did>
               <container type="box" label="Box">54</container>
               <unittitle>G. M. Williams Room Dedication <unitdate type="inclusive" normal="1975">1975</unitdate></unittitle>
-              <physdesc>
-                <extent>1 audiotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel, 7 in., 3 3/4 ips</physfacet>
               </physdesc>
             </did>
@@ -14343,8 +14343,8 @@
             <did>
               <container type="box" label="Box">54</container>
               <unittitle>Robben Fleming and Robert Warner, WUOM re: Ford Library</unittitle>
-              <physdesc>
-                <extent>1 audiotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel, 5 in., 3 3/4 ips</physfacet>
                 <dimensions>4 minutes</dimensions>
               </physdesc>
@@ -14355,11 +14355,11 @@
               <container type="box" label="Box">54</container>
               <unittitle>Floyd Starr Room Dedication, September 18, 1977</unittitle>
               <physdesc altrender="part">
-                <extent>1 audiotapes</extent>
-                <physfacet>reel-to-reel, 7 in., 3 3/4 ips</physfacet>
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
               </physdesc>
               <physdesc altrender="part">
-                <extent>1 audiocassettes</extent>
+                <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
+                <physfacet>reel-to-reel, 7 in., 3 3/4 ips</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -14376,8 +14376,8 @@
             <did>
               <container type="box" label="Box">54</container>
               <unittitle>Fritz Crisler, Friends of the Michigan Historical Collections <unitdate type="inclusive" normal="1979-11-13">November 13, 1979</unitdate></unittitle>
-              <physdesc>
-                <extent>1 audiotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel, 7 in., 7 1/2 ips</physfacet>
               </physdesc>
             </did>
@@ -14553,8 +14553,8 @@
             <did>
               <container type="box" label="Box">55</container>
               <unittitle>Bentley Historical Library</unittitle>
-              <physdesc>
-                <extent>6 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">6 film reels</extent>
               </physdesc>
             </did>
             <c04 level="file">

--- a/Real_Masters_all/bhl.xml
+++ b/Real_Masters_all/bhl.xml
@@ -5481,7 +5481,10 @@
           </c03>
           <c03 level="subseries">
             <did>
-              <unittitle><unitdate type="inclusive" normal="1982/2005">1982-2005</unitdate> <unitdate normal="1988/2000" type="bulk">Bulk 1988-2000</unitdate></unittitle>
+              <unittitle>
+                <unitdate type="inclusive" normal="1982/2005">1982-2005</unitdate>
+                <unitdate normal="1988/2000" type="bulk">Bulk 1988-2000</unitdate>
+              </unittitle>
             </did>
             <c04 level="file">
               <did>

--- a/Real_Masters_all/binghamk.xml
+++ b/Real_Masters_all/binghamk.xml
@@ -184,7 +184,9 @@
         </c02>
         <c02 level="file">
           <did>
-            <unittitle><unitdate type="inclusive" normal="1848-01/1848-02">January-Feb. 1848</unitdate></unittitle>
+            <unittitle>
+              <unitdate type="inclusive" normal="1848-01/1848-02">January-Feb. 1848</unitdate>
+            </unittitle>
           </did>
           <c03 level="file">
             <did>

--- a/Real_Masters_all/brecks.xml
+++ b/Real_Masters_all/brecks.xml
@@ -641,8 +641,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Ann Arbor Train and Trolley Watchers <unitdate type="inclusive" normal="1981/1991">1981-1991</unitdate></unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-Rs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/brewerdwight.xml
+++ b/Real_Masters_all/brewerdwight.xml
@@ -117,7 +117,7 @@
             <container type="box" label="Box">1</container>
             <unittitle>Correspondence, <unitdate type="inclusive" normal="1862/1865">1862-1865</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent>18 folders</extent>
+              <extent altrender="materialtype spaceoccupied">18 folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/burnettp.xml
+++ b/Real_Masters_all/burnettp.xml
@@ -18,7 +18,8 @@
       <langusage encodinganalog="Language">The finding aid is written in <language langcode="eng" scriptcode="Latn">English</language></langusage>
       <descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules>
     </profiledesc>
-    <revisiondesc> <change>
+    <revisiondesc>
+      <change>
         <date>2016-02-10</date>
         <item>Added 2015 accession.</item>
       </change>
@@ -48,9 +49,9 @@
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">12 linear feet</extent>
       </physdesc>
-<physdesc altrender="part">
+      <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize box</extent>
-      </physdesc>		
+      </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>
       </physdesc>
@@ -83,17 +84,18 @@ Patricia Hill Burnett papers, Bentley Historical Library, University of Michigan
       <p>Her involvement with Michigan NOW led to a position on the NOW National Board, 1971-1975, and to the chair of NOW's International Committee. An inveterate traveler with a world view, Burnett was instrumental in expanding NOW into an international organization. She played a great part in organizing the International Feminist Planning Conference held at Harvard (May 1973) and convened the NOW International Feminist Conference in 1973. She also took an around-the-world trip the same year to survey the status of women in several countries. Through her organizational efforts, twenty-five NOW international affiliations were organized in twenty-one countries. Burnett was a NOW delegate to the United Nations' International Women's Year (IWY) conference in Mexico City in 1975, and to the IWY Houston Conference in 1977. As chair of the World Feminist Commission she hoped to organize the International Feminist Convention in Brussels in 1977. Burnett later attended the UN Decade for Women Copenhagen Conference in 1980. In 1987 Burnett traveled as a delegate of the International Women's Forum to honor President Corazon Aquino as Woman of the Year.</p>
       <p>Burnett was instrumental in organizing the Michigan Women's Republican Caucus, which she has called the "first feminist Republican Women's Organization." Her other Republican Party activities have included the Michigan Issues Committee and the State Central Committee. Governor Milliken appointed her to the Michigan Women's Commission in 1973; she served first as vice-chair (1975) and then as chair (1976). After serving for four years on the executive board of directors of the National Association of Commissions for Women (NACW), Burnett was elected president of NACW in 1979.</p>
       <p>Burnett was active in civic affairs, serving on the New Detroit Employment and Art Committees and the Detroit Human Rights Commission. She has also served as president of the Detroit House of Corrections, 1973-1976.</p>
-      <p>Patricia Hill Burnett has lectured on women in art, women in business, and, most widely, on feminism. As a portrait painter she inaugurated and executed a series of portraits of leading feminists. These were later placed in the "Women's Hall of Fame." </p><p>Due to her long career as a portrait painter, Burnett was called on to be one of twelve founding members of the Council of Leading American Painters which was responsible for the organization and promotion of the Nattional Portrait Seminar.
-	</p><p>She received many honors for her artistic, business, and feminist activities. In 1987 Burnett was inducted into the Michigan Women's Hall of Fame, and in 1995 she published a memoir entitled <title render="italic">True Colors: An Artist's Journey from Beauty Queen to Feminist</title>.  
-    </p><p>Patricia Hill Burnett died in December 2014, at the age of 94.</p>
+      <p>Patricia Hill Burnett has lectured on women in art, women in business, and, most widely, on feminism. As a portrait painter she inaugurated and executed a series of portraits of leading feminists. These were later placed in the "Women's Hall of Fame." </p>
+      <p>Due to her long career as a portrait painter, Burnett was called on to be one of twelve founding members of the Council of Leading American Painters which was responsible for the organization and promotion of the Nattional Portrait Seminar.
+	</p>
+      <p>She received many honors for her artistic, business, and feminist activities. In 1987 Burnett was inducted into the Michigan Women's Hall of Fame, and in 1995 she published a memoir entitled <title render="italic">True Colors: An Artist's Journey from Beauty Queen to Feminist</title>.  
+    </p>
+      <p>Patricia Hill Burnett died in December 2014, at the age of 94.</p>
     </bioghist>
-	 
-	 
-<arrangement encodinganalog="351">
-<p>The papers of Patricia Hill Burnett are organized into nine series: Biographical; Correspondence; Speeches, Publications, and Interviews; Topical Files; Talks; Trips; Hearings and Reports, Domestic Assault; Notebooks; and Art.</p>
- 
-</arrangement>	 <scopecontent encodinganalog="520">
-       <p>While most of the material relates directly to Patricia Hill Burnett, the papers also relate to the more general women's movement during the 1970s and early 1980s.</p>
+    <arrangement encodinganalog="351">
+      <p>The papers of Patricia Hill Burnett are organized into nine series: Biographical; Correspondence; Speeches, Publications, and Interviews; Topical Files; Talks; Trips; Hearings and Reports, Domestic Assault; Notebooks; and Art.</p>
+    </arrangement>
+    <scopecontent encodinganalog="520">
+      <p>While most of the material relates directly to Patricia Hill Burnett, the papers also relate to the more general women's movement during the 1970s and early 1980s.</p>
     </scopecontent>
     <controlaccess>
       <p>
@@ -122,22 +124,22 @@ Patricia Hill Burnett papers, Bentley Historical Library, University of Michigan
       </controlaccess>
       <controlaccess>
         <head>Subjects - Visual Materials:</head>
-<subject source="lctgm" encodinganalog="650">Activists.</subject>
-<subject source="lctgm" encodinganalog="650">Celebrities.</subject>        
-		  <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n95075830">Burnett, Patricia Hill, 1920-</persname>
+        <subject source="lctgm" encodinganalog="650">Activists.</subject>
+        <subject source="lctgm" encodinganalog="650">Celebrities.</subject>
+        <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n95075830">Burnett, Patricia Hill, 1920-</persname>
         <subject source="lctgm" encodinganalog="650">Feminists.</subject>
         <persname source="lcnaf" encodinganalog="600" authfilenumber="http://id.loc.gov/authorities/names/n79022087">Ford, Gerald R., 1913-2006.</persname>
         <subject source="lcsh" encodinganalog="650">International Women's Year, 1975.</subject>
         <corpname source="lcnaf" encodinganalog="610">National Women's Conference (1st : 1977 : Houston, Tex.)</corpname>
-<subject source="lctgm" encodinganalog="650">People associated with politics &amp; government.</subject>		  
+        <subject source="lctgm" encodinganalog="650">People associated with politics &amp; government.</subject>
         <subject source="lcsh" encodinganalog="650">Women.</subject>
         <corpname source="lcnaf" encodinganalog="610" authfilenumber="http://id.loc.gov/authorities/names/n81029030">World Conference of the International Women's Year (1975 : Conference Centre of the Mexican Ministry of Foreign Affairs)</corpname>
       </controlaccess>
       <controlaccess>
         <head>Genre Terms:</head>
- <genreform source="aat" encodinganalog="655">Copy prints.</genreform>		  
+        <genreform source="aat" encodinganalog="655">Copy prints.</genreform>
         <genreform source="aat" encodinganalog="655">Photographs.</genreform>
- <genreform source="aat" encodinganalog="655">Portraits.</genreform>		  
+        <genreform source="aat" encodinganalog="655">Portraits.</genreform>
       </controlaccess>
     </controlaccess>
     <dsc type="combined">
@@ -163,43 +165,42 @@ Patricia Hill Burnett papers, Bentley Historical Library, University of Michigan
             </physdesc>
           </did>
         </c02>
-<c02 level="file">
+        <c02 level="file">
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>Clippings, articles, resumes</unittitle>
-             
           </did>
-        </c02>	<c02 level="file">
+        </c02>
+        <c02 level="file">
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>Articles on art talks</unittitle>
-             
           </did>
-        </c02>		  <c02 level="file">
+        </c02>
+        <c02 level="file">
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>Articles, original</unittitle>
-             
           </did>
-        </c02>	<c02 level="file">
+        </c02>
+        <c02 level="file">
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>Brochure</unittitle>
-             
           </did>
-        </c02><c02 level="file">
+        </c02>
+        <c02 level="file">
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>Awards, programs</unittitle>
-             
           </did>
-        </c02>	<c02 level="file">
+        </c02>
+        <c02 level="file">
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>Articles</unittitle>
-             
           </did>
-        </c02>		  	  		  	  
+        </c02>
       </c01>
       <c01 level="series">
         <did>
@@ -423,18 +424,15 @@ Patricia Hill Burnett papers, Bentley Historical Library, University of Michigan
             </unittitle>
           </did>
         </c02>
-      
-		
-<c02 level="file">
+        <c02 level="file">
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>
               <unitdate type="inclusive" normal="1976/1978">1976-1978</unitdate>
-               
             </unittitle>
           </did>
-        </c02>		
-<c02 level="file">
+        </c02>
+        <c02 level="file">
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>
@@ -442,34 +440,35 @@ Patricia Hill Burnett papers, Bentley Historical Library, University of Michigan
               <unitdate type="inclusive">undated</unitdate>
             </unittitle>
           </did>
-    
-
-	     </c02>		
-<c02 level="file">
+        </c02>
+        <c02 level="file">
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>
 Art correspondence              
-            </unittitle><physdesc altrender="whole">
+            </unittitle>
+            <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
-        </c02>		<c02 level="file">
+        </c02>
+        <c02 level="file">
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>
 FBI             
-            </unittitle> 
+            </unittitle>
           </did>
-        </c02>	<c02 level="file">
+        </c02>
+        <c02 level="file">
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>
-<unitdate type="inclusive" normal="1974/1992">1974-1992</unitdate>              
-            </unittitle> 
+              <unitdate type="inclusive" normal="1974/1992">1974-1992</unitdate>
+            </unittitle>
           </did>
-        </c02>			
-		</c01>
+        </c02>
+      </c01>
       <c01 level="series">
         <did>
           <unittitle>Speeches, Publications, and Interviews  </unittitle>
@@ -501,93 +500,338 @@ FBI
             <unittitle>Book on Status of Women--Research Materials</unittitle>
           </did>
         </c02>
-
-
-<c02 level="file">
+        <c02 level="file">
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>General</unittitle>
           </did>
         </c02>
-
-<c02 level="file">
+        <c02 level="file">
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>Books</unittitle>
           </did>
         </c02>
-<c02 level="file">
+        <c02 level="file">
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Speakers Bureau Information</unittitle>
           </did>
         </c02>
-<c02 level="file"><did><unittitle>Talks </unittitle> <physdesc><extent>8 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">8</container><unittitle>General</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">8</container><unittitle>Materials for Talks</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">8</container><unittitle>Miscellaneous/Miscellaneous Non-art talks </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">8</container><unittitle>Talks '84</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">8</container><unittitle>Women</unittitle></did></c02>
-
-
-<c02 level="file"><did><container type="box" label="Box">9 </container><unittitle>"Art of the Portrait" Conference Talk</unittitle></did></c02>
-
-
-<c02 level="file"><did><container type="box" label="Box">9</container><unittitle>Art Talks</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">9 </container><unittitle>Dialogue on the Delights of Painting for the Amateur</unittitle></did></c02>
-
-
-<c02 level="file"><did><container type="box" label="Box">9 </container><unittitle>Do Men and Women Speak the Same Language </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-
-
-<c02 level="file"><did><container type="box" label="Box">9 </container><unittitle>Glamor of an Art Career</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">9 </container><unittitle>Have Women Painters/Artists Been Brushed Aside </unittitle> <physdesc><extent>3 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">9 </container><unittitle>Having It All and Loving It </unittitle> <physdesc><extent>3 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">9 </container><unittitle>Introductions</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">9 </container><unittitle>Life in an Artists Studio</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">9 </container><unittitle>Life Lines</unittitle></did></c02>
-
-
-<c02 level="file"><did><container type="box" label="Box">9 </container><unittitle>Michigan Women's Foundation</unittitle></did></c02>
-
-<c02 level="file"><did><container type="box" label="Box">9 </container><unittitle>Painting the Famous and the Infamous </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">9 </container><unittitle>Posing Your Sitter</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">9 </container><unittitle>Profiles of the Famous</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">9 </container><unittitle>Story of My Life </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">9 </container><unittitle>Talk on "True Colors"</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">9 </container><unittitle>Talks</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">9 </container><unittitle>"Women Artists" Winning in the Portrait World" </unittitle></did></c02>
-
-
- 
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Battered women</unittitle></did></c02>
-
-
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Cutups of Various Articles That  May be Useful in the Future</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Domestic Assault</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Encounters with U.S. Presidents</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Feminist Speeches</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Health</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>How to Become a Woman Executive Up the Corporate Ladder </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>International</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Ms Missing from "Old Masters"</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>My Working Palette</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Now Was My Time</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Oral History</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Organizing an International Feminist Network</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Reference for Future Talks</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Research on Talks </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Sexual Harassment</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Talk to Republican Convention, <unitdate type="inclusive">September 1988</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Testimony for the Hearing on the Republican Platform</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>The Progress of Women</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Using the Right Side of the Brain in Portrait Painting</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Will Women's Rights Go Wrong?</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>The Winds of Change are Blowing</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Women on the Rise</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10 </container><unittitle>Women Today in Russia, Israel, India &amp; Thailand</unittitle></did></c02>
-
-		  
+        <c02 level="file">
+          <did>
+            <unittitle>Talks </unittitle>
+            <physdesc>
+              <extent>8 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">8</container>
+            <unittitle>General</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">8</container>
+            <unittitle>Materials for Talks</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">8</container>
+            <unittitle>Miscellaneous/Miscellaneous Non-art talks </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">8</container>
+            <unittitle>Talks '84</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">8</container>
+            <unittitle>Women</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9 </container>
+            <unittitle>"Art of the Portrait" Conference Talk</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9</container>
+            <unittitle>Art Talks</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9 </container>
+            <unittitle>Dialogue on the Delights of Painting for the Amateur</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9 </container>
+            <unittitle>Do Men and Women Speak the Same Language </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9 </container>
+            <unittitle>Glamor of an Art Career</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9 </container>
+            <unittitle>Have Women Painters/Artists Been Brushed Aside </unittitle>
+            <physdesc>
+              <extent>3 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9 </container>
+            <unittitle>Having It All and Loving It </unittitle>
+            <physdesc>
+              <extent>3 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9 </container>
+            <unittitle>Introductions</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9 </container>
+            <unittitle>Life in an Artists Studio</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9 </container>
+            <unittitle>Life Lines</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9 </container>
+            <unittitle>Michigan Women's Foundation</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9 </container>
+            <unittitle>Painting the Famous and the Infamous </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9 </container>
+            <unittitle>Posing Your Sitter</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9 </container>
+            <unittitle>Profiles of the Famous</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9 </container>
+            <unittitle>Story of My Life </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9 </container>
+            <unittitle>Talk on "True Colors"</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9 </container>
+            <unittitle>Talks</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9 </container>
+            <unittitle>"Women Artists" Winning in the Portrait World" </unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Battered women</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Cutups of Various Articles That  May be Useful in the Future</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Domestic Assault</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Encounters with U.S. Presidents</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Feminist Speeches</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Health</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>How to Become a Woman Executive Up the Corporate Ladder </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>International</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Ms Missing from "Old Masters"</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>My Working Palette</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Now Was My Time</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Oral History</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Organizing an International Feminist Network</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Reference for Future Talks</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Research on Talks </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Sexual Harassment</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Talk to Republican Convention, <unitdate type="inclusive">September 1988</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Testimony for the Hearing on the Republican Platform</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>The Progress of Women</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Using the Right Side of the Brain in Portrait Painting</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Will Women's Rights Go Wrong?</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>The Winds of Change are Blowing</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Women on the Rise</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10 </container>
+            <unittitle>Women Today in Russia, Israel, India &amp; Thailand</unittitle>
+          </did>
+        </c02>
       </c01>
       <c01 level="series">
         <did>
@@ -1289,16 +1533,48 @@ FBI
             <unittitle>Zonta Club <unitdate type="inclusive" normal="1975/1984">1975-1984</unitdate></unittitle>
           </did>
         </c02>
-<c02 level="file"><did><container type="box" label="Box">8</container><unittitle>Printed Materials -- NOW, other U.S. women's Organizations, and ERA</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">8</container><unittitle>Victim Assault Pamphlets</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">9</container><unittitle>Veteran Feminists of America, <unitdate type="inclusive">1992-2002</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">9</container><unittitle>World Feminist Commission, <unitdate type="inclusive">1982-2000</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10</container><unittitle>Detroit NOW</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10</container><unittitle>NOW</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10</container><unittitle>Recollections of NOWZonta Club, <unitdate type="inclusive">1994-1998</unitdate></unittitle></did></c02>
-
-
-		  
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">8</container>
+            <unittitle>Printed Materials -- NOW, other U.S. women's Organizations, and ERA</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">8</container>
+            <unittitle>Victim Assault Pamphlets</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9</container>
+            <unittitle>Veteran Feminists of America, <unitdate type="inclusive">1992-2002</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">9</container>
+            <unittitle>World Feminist Commission, <unitdate type="inclusive">1982-2000</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10</container>
+            <unittitle>Detroit NOW</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10</container>
+            <unittitle>NOW</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10</container>
+            <unittitle>Recollections of NOWZonta Club, <unitdate type="inclusive">1994-1998</unitdate></unittitle>
+          </did>
+        </c02>
       </c01>
       <c01 level="series">
         <did>
@@ -1328,12 +1604,12 @@ FBI
             <unittitle>Non-Nuclear Family</unittitle>
           </did>
         </c02>
-<c02 level="file">
+        <c02 level="file">
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>Non-Nuclear Family</unittitle>
           </did>
-        </c02>		  
+        </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">5</container>
@@ -1469,11 +1745,9 @@ FBI
             <unittitle><unitdate type="inclusive" normal="1974/1975">1974-1975</unitdate>, <unitdate type="inclusive" normal="1976">1976</unitdate>, <unitdate type="inclusive" normal="1988" certainty="approximate">1988</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
           </did>
         </c02>
-       
-        
-<c02 level="file">
+        <c02 level="file">
           <did>
-            <container type="box" label="Box">6</container>       
+            <container type="box" label="Box">6</container>
             <unittitle>Notes for book?</unittitle>
           </did>
         </c02>
@@ -1485,64 +1759,349 @@ FBI
         <scopecontent>
           <p>The final series, Art, further documents Butnett's artistic endeavors. The series consists of information about her involvement with the Portrait Club of New York, a collection of reference photographs of her portrait clients, a varied selection of photo duplications depicting Burnett's original pieces, and an original drawing and poster of a drawing made by Burnett. There is also a collection of more personal photos that include snapshots of Burnett with Gerald Ford, Betty Friedan, Gloria Steinem, and Indira Ghandi.</p>
         </scopecontent>
- 
-<c02 level="file"><did><container type="box" label="Box">6</container><unittitle>Personal Photos</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">8</container><unittitle>The Portrait Club of New York, <unitdate type="inclusive">1979-1998</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">8</container><unittitle>American Artist</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">8</container><unittitle>Council of Leading Portrait Painters (Sanden)</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">8</container><unittitle>Art Commissions -- Margaret Thatcher</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">8</container><unittitle>Maura Corrigan</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">8</container><unittitle>Flowers</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">8</container><unittitle>N.O.W.</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">8</container><unittitle>Scarab Club</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">8</container><unittitle>Sketch Copies, photographs</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">8</container><unittitle>Wilson, Ellen</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">10</container><unittitle>Art -- General</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">11</container><unittitle>Reference photos</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Aquino -- Corozon</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Barbara Walters</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Betty Friedman</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Cisler, Walker</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Farenthold, Sissy</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Fran Street</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Fisher, Max</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Ford, Benson</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Ford, Betty </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Ford, Mrs. Edsel</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Gribbs, Roman + Katherine</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Governor John &amp; Michele Engler</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Governor Milliken</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Honorable Helen Wilson Nies</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Indira Ghandi</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Kevorkian, Jack &amp; Fieger, Geoffrey</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Jackie Goiner Kersey</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Judge Robert Young</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Judge Ruth Bader Ginsberg</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Mankiller, Wilma</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Margaret Chase Smith </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Mayor Dennis Archer</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Mayor Young</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Oates, Joyce Carol</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Ogden</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Papandreou, Margaret</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Parks, Rosa</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Patricia Ireland</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>President Violeta de Chamorro</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Shaw, Alden</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Steinem, Gloria</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Taylor, Clifford </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Tereshkova, Valentina </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Thatcher, Margaret</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Thomas, Marlo</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Vivica Lindfors</unittitle></did></c03></c02>
-<c02 level="file"><did><container type="box" label="Box">12</container><unittitle>Lithographs and Watercolors</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">12</container><unittitle>Collection of Portrait Copy Prints</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">12</container><unittitle>Transparencies</unittitle></did></c02>
-<c02 level="file"><did><container type="folder" label="Oversize folder">1 </container><unittitle>Original drawing of Patricia Burnett</unittitle></did></c02>
-<c02 level="file"><did><container type="folder" label="Oversize folder">1 </container><unittitle>Poster (drawing by Patricia Burnett)</unittitle></did></c02>
-<c02 level="file"><did><container type="folder" label="Oversize folder">1 </container><unittitle>Original signed print by cartoonist Cathy Gwisewitz, also signed by Virginia Allen and Lynda Robb</unittitle></did></c02></c01>
-        
-       
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">6</container>
+            <unittitle>Personal Photos</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">8</container>
+            <unittitle>The Portrait Club of New York, <unitdate type="inclusive">1979-1998</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">8</container>
+            <unittitle>American Artist</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">8</container>
+            <unittitle>Council of Leading Portrait Painters (Sanden)</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">8</container>
+            <unittitle>Art Commissions -- Margaret Thatcher</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">8</container>
+            <unittitle>Maura Corrigan</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">8</container>
+            <unittitle>Flowers</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">8</container>
+            <unittitle>N.O.W.</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">8</container>
+            <unittitle>Scarab Club</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">8</container>
+            <unittitle>Sketch Copies, photographs</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">8</container>
+            <unittitle>Wilson, Ellen</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">10</container>
+            <unittitle>Art -- General</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">11</container>
+            <unittitle>Reference photos</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Aquino -- Corozon</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Barbara Walters</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Betty Friedman</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Cisler, Walker</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Farenthold, Sissy</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Fran Street</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Fisher, Max</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Ford, Benson</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Ford, Betty </unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Ford, Mrs. Edsel</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Gribbs, Roman + Katherine</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Governor John &amp; Michele Engler</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Governor Milliken</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Honorable Helen Wilson Nies</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Indira Ghandi</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Kevorkian, Jack &amp; Fieger, Geoffrey</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Jackie Goiner Kersey</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Judge Robert Young</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Judge Ruth Bader Ginsberg</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Mankiller, Wilma</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Margaret Chase Smith </unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Mayor Dennis Archer</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Mayor Young</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Oates, Joyce Carol</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Ogden</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Papandreou, Margaret</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Parks, Rosa</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Patricia Ireland</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>President Violeta de Chamorro</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Shaw, Alden</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Steinem, Gloria</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Taylor, Clifford </unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Tereshkova, Valentina </unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Thatcher, Margaret</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Thomas, Marlo</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Vivica Lindfors</unittitle>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">12</container>
+            <unittitle>Lithographs and Watercolors</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">12</container>
+            <unittitle>Collection of Portrait Copy Prints</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">12</container>
+            <unittitle>Transparencies</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="folder" label="Oversize folder">1 </container>
+            <unittitle>Original drawing of Patricia Burnett</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="folder" label="Oversize folder">1 </container>
+            <unittitle>Poster (drawing by Patricia Burnett)</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="folder" label="Oversize folder">1 </container>
+            <unittitle>Original signed print by cartoonist Cathy Gwisewitz, also signed by Virginia Allen and Lynda Robb</unittitle>
+          </did>
+        </c02>
+      </c01>
     </dsc>
   </archdesc>
 </ead>

--- a/Real_Masters_all/burnettp.xml
+++ b/Real_Masters_all/burnettp.xml
@@ -521,8 +521,8 @@ FBI
         <c02 level="file">
           <did>
             <unittitle>Talks </unittitle>
-            <physdesc>
-              <extent>8 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">8 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -542,8 +542,8 @@ FBI
           <did>
             <container type="box" label="Box">8</container>
             <unittitle>Miscellaneous/Miscellaneous Non-art talks </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -581,8 +581,8 @@ FBI
           <did>
             <container type="box" label="Box">9 </container>
             <unittitle>Do Men and Women Speak the Same Language </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -596,8 +596,8 @@ FBI
           <did>
             <container type="box" label="Box">9 </container>
             <unittitle>Have Women Painters/Artists Been Brushed Aside </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -605,8 +605,8 @@ FBI
           <did>
             <container type="box" label="Box">9 </container>
             <unittitle>Having It All and Loving It </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -638,8 +638,8 @@ FBI
           <did>
             <container type="box" label="Box">9 </container>
             <unittitle>Painting the Famous and the Infamous </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -659,8 +659,8 @@ FBI
           <did>
             <container type="box" label="Box">9 </container>
             <unittitle>Story of My Life </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -722,8 +722,8 @@ FBI
           <did>
             <container type="box" label="Box">10 </container>
             <unittitle>How to Become a Woman Executive Up the Corporate Ladder </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -773,8 +773,8 @@ FBI
           <did>
             <container type="box" label="Box">10 </container>
             <unittitle>Research on Talks </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1888,8 +1888,8 @@ FBI
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>Ford, Betty </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1963,8 +1963,8 @@ FBI
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>Margaret Chase Smith </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2032,8 +2032,8 @@ FBI
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>Taylor, Clifford </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2041,8 +2041,8 @@ FBI
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>Tereshkova, Valentina </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/caasum.xml
+++ b/Real_Masters_all/caasum.xml
@@ -2496,8 +2496,8 @@
               <did>
                 <container type="box" label="Box">9</container>
                 <unittitle>General <unitdate type="inclusive" normal="1988/1993">1988-1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>3 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 folders</extent>
                 </physdesc>
               </did>
               <odd>
@@ -2508,8 +2508,8 @@
               <did>
                 <container type="box" label="Box">10</container>
                 <unittitle>General <unitdate type="inclusive" normal="1988/1993">1988-1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
               <odd>
@@ -3095,8 +3095,8 @@
             <did>
               <container type="box" label="Box">14</container>
               <unittitle>Chronological files <unitdate type="inclusive" normal="1970/1994">1970-1994</unitdate></unittitle>
-              <physdesc>
-                <extent>28 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">28 folders</extent>
               </physdesc>
             </did>
             <odd>
@@ -3107,8 +3107,8 @@
             <did>
               <container type="box" label="Box">15</container>
               <unittitle>Chronological files <unitdate type="inclusive" normal="1994/2009">1994-2009</unitdate></unittitle>
-              <physdesc>
-                <extent>27 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">27 folders</extent>
               </physdesc>
             </did>
             <odd>
@@ -4248,8 +4248,8 @@
             <did>
               <container type="box" label="Box">20</container>
               <unittitle>Stone, Pauline, Publications <unitdate type="inclusive" normal="1975/1980">1975-1980</unitdate></unittitle>
-              <physdesc>
-                <extent>1 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 folders</extent>
               </physdesc>
             </did>
             <odd>
@@ -4260,8 +4260,8 @@
             <did>
               <container type="box" label="Box">21</container>
               <unittitle>Stone, Pauline, Publications <unitdate type="inclusive" normal="1975/1980">1975-1980</unitdate></unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
             <odd>

--- a/Real_Masters_all/cauppub.xml
+++ b/Real_Masters_all/cauppub.xml
@@ -63,13 +63,13 @@
       </origination>
       <unittitle encodinganalog="245">A. Alfred Taubman College of Architecture and Urban Planning (University of Michigan) publications <unitdate type="inclusive" encodinganalog="245$f" normal="1876/2013">1876-2013</unitdate>, <unitdate type="bulk" encodinganalog="245$g" normal="1950/2012">1950-2012</unitdate></unittitle>
       <physdesc altrender="part">
-        <extent encodinganalog="300">13 linear feet</extent>
+        <extent altrender="materialtype spaceoccupied">523 MB</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent>11 oversize folders</extent>
+        <extent altrender="materialtype spaceoccupied">11 oversize folders</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent>523 MB</extent>
+        <extent altrender="materialtype spaceoccupied">13 linear feet</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">976 Bimu C181 2</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
@@ -602,8 +602,8 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle><title render="italic">College of Architecture and Design Announcement</title>, <unitdate type="inclusive" normal="1947/1973">1947-1973</unitdate></unittitle>
-              <physdesc>
-                <extent>2 volumes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 volumes</extent>
               </physdesc>
             </did>
           </c03>
@@ -1021,8 +1021,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Lecture Posters, <unitdate type="inclusive" normal="1975/1978">1975-1978</unitdate></unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -3408,8 +3408,8 @@
           <did>
             <container type="box" label="CD Box">2</container>
             <unittitle>Website capture <unitdate type="inclusive" normal="2002-05-15">May 15, 2002</unitdate></unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CDs</physfacet>
             </physdesc>
           </did>
@@ -3418,8 +3418,8 @@
           <did>
             <container type="box" label="CD Box">2</container>
             <unittitle>Website capture <unitdate type="inclusive" normal="2003-05-22">May 22, 2003</unitdate></unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CDs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/ceplum.xml
+++ b/Real_Masters_all/ceplum.xml
@@ -243,7 +243,7 @@
               <container type="box" label="Box">1</container>
               <unittitle>CEPL Sponsored Forums and Events, <unitdate normal="2008/2011" type="inclusive">2008-2011</unitdate></unittitle>
               <physdesc altrender="part">
-                <extent>1 optical disks</extent>
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD</physfacet>
               </physdesc>
             </did>
@@ -349,7 +349,7 @@
               <container type="box" label="Box">1</container>
               <unittitle>Michigan Ethics Bowl Team (MEBT) <unitdate type="inclusive" normal="2009/2010">2009-2010</unitdate></unittitle>
               <physdesc altrender="part">
-                <extent>1 optical disks</extent>
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD</physfacet>
               </physdesc>
             </did>
@@ -433,7 +433,7 @@
               <container type="box" label="Box">1</container>
               <unittitle>Peace Corps <unitdate type="inclusive" normal="2010">2010</unitdate></unittitle>
               <physdesc altrender="part">
-                <extent>1 optical disks</extent>
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/chonmyron.xml
+++ b/Real_Masters_all/chonmyron.xml
@@ -58,10 +58,8 @@ Myron E. Chon scrapbook
 
 
 </unittitle>
-      <physdesc>
-        <extent encodinganalog="300">
-1 volume
-</extent>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">1 volumes</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2016010 AC

--- a/Real_Masters_all/chonmyron.xml
+++ b/Real_Masters_all/chonmyron.xml
@@ -1,54 +1,56 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE ead PUBLIC "+//ISBN 1-931666-00-8//DTD ead.dtd (Encoded Archival Description (EAD) Version 2002)//EN" "ead.dtd">
 <ead>
-
-<eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
-
-<eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::chonmyron.xml//EN" encodinganalog="Identifier">
+  <eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
+    <eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::chonmyron.xml//EN" encodinganalog="Identifier">
 umich-bhl-2016010</eadid>
-
-<filedesc><titlestmt><titleproper encodinganalog="Title">Finding Aid for 
+    <filedesc>
+      <titlestmt>
+        <titleproper encodinganalog="Title">Finding Aid for 
 Myron E. Chon scrapbook
 
 </titleproper>
-<author encodinganalog="Creator">Collection processed and finding aid created by 
-Elizabeth Carron </author></titlestmt>
-
-<publicationstmt><publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
-<date encodinganalog="Date" normal="2016">
-2016</date></publicationstmt></filedesc>
-
-<profiledesc>
-<creation>Encoded finding aid created by 
+        <author encodinganalog="Creator">Collection processed and finding aid created by 
+Elizabeth Carron </author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
+        <date encodinganalog="Date" normal="2016">
+2016</date>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>Encoded finding aid created by 
 Olga Virakhovskaya 
 <date>2016</date></creation>
-
-<langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage><descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules></profiledesc>
-
-<revisiondesc><change><date>2016-01-26</date><item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item></change></revisiondesc></eadheader>
-
-<frontmatter><titlepage>
-
-<publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
-
-<titleproper>Finding aid for<lb/>
+      <langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage>
+      <descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules>
+    </profiledesc>
+    <revisiondesc>
+      <change>
+        <date>2016-01-26</date>
+        <item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item>
+      </change>
+    </revisiondesc>
+  </eadheader>
+  <frontmatter>
+    <titlepage>
+      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <titleproper>Finding aid for<lb/>
 Myron E. Chon scrapbook</titleproper>
-
-<author>Finding aid created by<lb/> 
+      <author>Finding aid created by<lb/> 
 Elizabeth Carron, January 2016
 </author>
-
-</titlepage>
-</frontmatter>
-
-<archdesc level="recordgrp" audience="external" type="inventory" relatedencoding="MARC21"><did>
-
-<origination>
-<corpname source="lcnaf" encodinganalog="110">
+    </titlepage>
+  </frontmatter>
+  <archdesc level="recordgrp" audience="external" type="inventory" relatedencoding="MARC21">
+    <did>
+      <origination>
+        <corpname source="lcnaf" encodinganalog="110">
 Chon, Myron Edward
-</corpname></origination>
-
-<unittitle encodinganalog="245">
+</corpname>
+      </origination>
+      <unittitle encodinganalog="245">
 Myron E. Chon scrapbook
 <unitdate type="inclusive" encodinganalog="245$f">
 1919-1923
@@ -56,88 +58,90 @@ Myron E. Chon scrapbook
 
 
 </unittitle>
-
-<physdesc><extent encodinganalog="300">
+      <physdesc>
+        <extent encodinganalog="300">
 1 volume
-</extent></physdesc>
-
-<unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
+</extent>
+      </physdesc>
+      <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2016010 AC
 </unitid>
-
-<langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
-
-<abstract>
+      <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
+      <abstract>
 University of Michigan Class of 1923 graduate. Scrapbook contains photographs and memorabilia depicting student life and activities.
 </abstract>
-
-
-<repository><corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
-<extptr href="bhladd" show="embed" actuate="onload"/></repository></did>
-
-<descgrp type="admin">
-<acqinfo encodinganalog="541"><p>
+      <repository>
+        <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
+        <extptr href="bhladd" show="embed" actuate="onload"/>
+      </repository>
+    </did>
+    <descgrp type="admin">
+      <acqinfo encodinganalog="541">
+        <p>
 Donated by Timothy Brzozka (donor no.<num type="donor" encodinganalog="541$e">11410</num>), in January, 2016. 
  
-</p></acqinfo>
-
- 
-
-<accruals encodinganalog="584"><p>
+</p>
+      </acqinfo>
+      <accruals encodinganalog="584">
+        <p>
 No further additions to the records are expected.
-</p></accruals><accessrestrict encodinganalog="506">
-<p>The collection is open without restriction.</p>
- </accessrestrict>
-
-
-<userestrict encodinganalog="540"><p>
-Copyright is held by the Regents of the University of Michigan.</p></userestrict>
-
-
-<prefercite encodinganalog="524"><p>[item], folder, box,
-Myron E. Chon scrapbook, Bentley Historical Library, University of Michigan</p></prefercite>
- 
- </descgrp>
-
-<bioghist encodinganalog="545">
- <p>Myron "Mike" Edward Chon was born in Chicago on December 12, 1902 to Anne Bransky and Benjamin W. Chon, Jewish immigrants from Eastern Europe. One of five children and elder brother to the famed New Yorker editor William Shawn (University of Michigan ex-Class of 1929), Chon entered the University of Michigan in 1919 where he quickly joined the Zeta Beta Tau fraternity. A noted composer and saxophonist, he played in a variety of events across Michigan. </p>
- 
- <p>Chon returned to Chicago after graduating in 1923 to work in advertising. In 1934, Arthur Meyerhoff offered him the position of executive creative director for the newly formed Arthur Meyerhoff Associates. During his career he led a variety of advertising campaigns including the All-American Girls Professional Baseball League and the Doublemint Twins. Myron Chon  died April 29, 1987.</p>
-
-
-</bioghist>
-
- 
-
-<scopecontent encodinganalog="520">
-<p>The scrapbook features photographs and memorabilia depicting student life and activity at the University of Michigan. Highlights include collegiate football, school traditions like Cap Night and tug-of-war, and programs hosted by the Zeta Beta Tau fraternity and the Michigan Union including "Midnight Frolics" and "Mimes of Michigan Union".</p>
-</scopecontent>
-
-<controlaccess><p><extptr href="accnote" show="embed" actuate="onload"/></p><controlaccess><head>Subjects:</head>
-
-<persname source="lcnaf" encodinganalog="600">Chon, Myron Edward.</persname>
-<subject source="lcsh" encodinganalog="650">Greek letter societies--Michigan--Ann Arbor.</subject>
-<subject source="lcsh" encodinganalog="650">Jewish college students--Michigan--Ann Arbor.</subject>
-<corpname source="lcnaf" encodinganalog="610">University of Michigan--Students--Social life and customs--1911-1920.</corpname>
-<corpname source="lcnaf" encodinganalog="610">University of Michigan--Students--Societies, etc.</corpname>
-<corpname source="lcnaf" encodinganalog="610">Zeta Beta Tau (Fraternity). Phi Chapter (University of Michigan)</corpname>
-
-</controlaccess>
-
-<controlaccess><head>Genre Terms:</head>
-<genreform source="aat" encodinganalog="655">Scrapbooks.</genreform></controlaccess>
-
-</controlaccess>
-
-
-<dsc type="combined">
-<c01 level="series"><did><unittitle>Myron Edward Chon</unittitle></did>
-<c02 level="file"><did><container type="volume" label="Volume">1	</container><unittitle>Scrapbook, <unitdate type="inclusive">1919-1923</unitdate></unittitle></did></c02></c01>
-
-</dsc><descgrp type="add"><relatedmaterial><head>Related material</head><p>The Bentley Historical Library holds the Zeta Beta Tau, Phi Chapter (University of Michigan) records, 1916-1962.</p></relatedmaterial></descgrp>
-
-</archdesc>
-
-
-
+</p>
+      </accruals>
+      <accessrestrict encodinganalog="506">
+        <p>The collection is open without restriction.</p>
+      </accessrestrict>
+      <userestrict encodinganalog="540">
+        <p>
+Copyright is held by the Regents of the University of Michigan.</p>
+      </userestrict>
+      <prefercite encodinganalog="524">
+        <p>[item], folder, box,
+Myron E. Chon scrapbook, Bentley Historical Library, University of Michigan</p>
+      </prefercite>
+    </descgrp>
+    <bioghist encodinganalog="545">
+      <p>Myron "Mike" Edward Chon was born in Chicago on December 12, 1902 to Anne Bransky and Benjamin W. Chon, Jewish immigrants from Eastern Europe. One of five children and elder brother to the famed New Yorker editor William Shawn (University of Michigan ex-Class of 1929), Chon entered the University of Michigan in 1919 where he quickly joined the Zeta Beta Tau fraternity. A noted composer and saxophonist, he played in a variety of events across Michigan. </p>
+      <p>Chon returned to Chicago after graduating in 1923 to work in advertising. In 1934, Arthur Meyerhoff offered him the position of executive creative director for the newly formed Arthur Meyerhoff Associates. During his career he led a variety of advertising campaigns including the All-American Girls Professional Baseball League and the Doublemint Twins. Myron Chon  died April 29, 1987.</p>
+    </bioghist>
+    <scopecontent encodinganalog="520">
+      <p>The scrapbook features photographs and memorabilia depicting student life and activity at the University of Michigan. Highlights include collegiate football, school traditions like Cap Night and tug-of-war, and programs hosted by the Zeta Beta Tau fraternity and the Michigan Union including "Midnight Frolics" and "Mimes of Michigan Union".</p>
+    </scopecontent>
+    <controlaccess>
+      <p>
+        <extptr href="accnote" show="embed" actuate="onload"/>
+      </p>
+      <controlaccess>
+        <head>Subjects:</head>
+        <persname source="lcnaf" encodinganalog="600">Chon, Myron Edward.</persname>
+        <subject source="lcsh" encodinganalog="650">Greek letter societies--Michigan--Ann Arbor.</subject>
+        <subject source="lcsh" encodinganalog="650">Jewish college students--Michigan--Ann Arbor.</subject>
+        <corpname source="lcnaf" encodinganalog="610">University of Michigan--Students--Social life and customs--1911-1920.</corpname>
+        <corpname source="lcnaf" encodinganalog="610">University of Michigan--Students--Societies, etc.</corpname>
+        <corpname source="lcnaf" encodinganalog="610">Zeta Beta Tau (Fraternity). Phi Chapter (University of Michigan)</corpname>
+      </controlaccess>
+      <controlaccess>
+        <head>Genre Terms:</head>
+        <genreform source="aat" encodinganalog="655">Scrapbooks.</genreform>
+      </controlaccess>
+    </controlaccess>
+    <dsc type="combined">
+      <c01 level="series">
+        <did>
+          <unittitle>Myron Edward Chon</unittitle>
+        </did>
+        <c02 level="file">
+          <did>
+            <container type="volume" label="Volume">1	</container>
+            <unittitle>Scrapbook, <unitdate type="inclusive">1919-1923</unitdate></unittitle>
+          </did>
+        </c02>
+      </c01>
+    </dsc>
+    <descgrp type="add">
+      <relatedmaterial>
+        <head>Related material</head>
+        <p>The Bentley Historical Library holds the Zeta Beta Tau, Phi Chapter (University of Michigan) records, 1916-1962.</p>
+      </relatedmaterial>
+    </descgrp>
+  </archdesc>
 </ead>

--- a/Real_Masters_all/christga.xml
+++ b/Real_Masters_all/christga.xml
@@ -1304,8 +1304,8 @@
           <did>
             <container type="box" label="Box">13</container>
             <unittitle>Radio address of Sam Morris</unittitle>
-            <physdesc>
-              <extent>1 sound discs</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
             </physdesc>
           </did>
           <odd>

--- a/Real_Masters_all/ciforum.xml
+++ b/Real_Masters_all/ciforum.xml
@@ -1095,8 +1095,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle><unitdate type="inclusive" normal="1997">1997</unitdate> NOVA PowerPoint and <unitdate type="inclusive" normal="1997-03">March 1997</unitdate> CIF Web Site</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1105,8 +1105,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Nominations <unitdate type="inclusive" normal="1990/2006">1990-2006</unitdate> and Reports, <unitdate type="inclusive" normal="1993/1997">1993-1997</unitdate>, <unitdate type="inclusive" normal="2004/2006">2004-2006</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1170,8 +1170,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle><unitdate type="inclusive" normal="1990">1990</unitdate> Construction Innovation Forum and NOVA Awards</unittitle>
-              <physdesc>
-                <extent>1 videocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1180,8 +1180,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle><unitdate type="inclusive" normal="1993">1993</unitdate> NOVA Awards</unittitle>
-              <physdesc>
-                <extent>1 videocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1190,8 +1190,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle><unitdate type="inclusive" normal="1995">1995</unitdate> Innovation Celebration program</unittitle>
-              <physdesc>
-                <extent>1 videocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/civileng.xml
+++ b/Real_Masters_all/civileng.xml
@@ -286,7 +286,7 @@
             <container type="box" label="Box">6</container>
             <unittitle>Reports of Department Chairs, <unitdate type="inclusive" normal="1999/2000">1999-2000</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent>2 folders</extent>
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -518,7 +518,7 @@
               <container type="box" label="Box">7</container>
               <unittitle>Department Correspondence, <unitdate type="inclusive" normal="1987/1992">1987-1992</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent>2 folders</extent>
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -549,7 +549,7 @@
             <container type="box" label="Box">7</container>
             <unittitle>Executive Committee </unittitle>
             <physdesc altrender="whole">
-              <extent>2 folders</extent>
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
           <accessrestrict>
@@ -561,7 +561,7 @@
             <container type="box" label="Box">3</container>
             <unittitle>Faculty Meeting Minutes, <unitdate type="inclusive" normal="1985">1985</unitdate>, <unitdate type="inclusive" normal="1989/1996">1989-1996</unitdate>, <unitdate type="inclusive" normal="1998">1998</unitdate>, <unitdate type="inclusive" normal="2000/2001">2000-2001</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent>9 folders</extent>
+              <extent altrender="materialtype spaceoccupied">9 folders</extent>
             </physdesc>
           </did>
           <accessrestrict>
@@ -600,7 +600,7 @@
             <container type="box" label="Box">3</container>
             <unittitle>Rules of the Faculty Minutes, <unitdate type="inclusive" normal="1963/1984">1963-1984</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent>3 folders</extent>
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
           <accessrestrict>
@@ -630,7 +630,7 @@
             <container type="box" label="Box">3</container>
             <unittitle>Search for Department Chair, <unitdate type="inclusive" normal="1984">1984</unitdate>, <unitdate type="inclusive" normal="1999">1999</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent>2 folders</extent>
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
           <accessrestrict>
@@ -650,7 +650,7 @@
             <container type="box" label="Box">3</container>
             <unittitle>Academic Budget, <unitdate type="inclusive" normal="1941/1947">1941-1947</unitdate>, <unitdate type="inclusive" normal="1949/1951">1949-1951</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent>2 folders</extent>
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
           <accessrestrict>
@@ -700,7 +700,7 @@
             <container type="box" label="Box">5</container>
             <unittitle>Correspondence, <unitdate type="inclusive" normal="1993/1994">1993-1994</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent>2 folders</extent>
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -836,8 +836,8 @@
           <did>
             <container type="box" label="Box">5</container>
             <unittitle>Photographic Roster of the Engineering Faculty, <unitdate type="inclusive" normal="1960">1960</unitdate>, <unitdate type="inclusive" normal="1966/1967">1966-1967</unitdate></unittitle>
-            <physdesc>
-              <extent>3 volumes</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 volumes</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/cleageab.xml
+++ b/Real_Masters_all/cleageab.xml
@@ -3588,8 +3588,8 @@
         <c02 level="file">
           <did>
             <unittitle>Messages by Jaramogi Abebe Agyeman</unittitle>
-            <physdesc>
-              <extent>10 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">10 optical disks</extent>
               <physfacet>CDs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/cmenasp.xml
+++ b/Real_Masters_all/cmenasp.xml
@@ -231,8 +231,8 @@
                 <title render="italic">The Development Choices Model</title>
                 <unitdate type="inclusive" normal="1992">1992</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>1 floppy disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
                 <physfacet>3.5"</physfacet>
               </physdesc>
             </did>
@@ -268,8 +268,8 @@
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle><title render="italic">Armed Rivalry in the Middle East</title>, <unitdate type="inclusive" normal="1992" certainty="approximate">circa 1992</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 floppy disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
                   <physfacet>3.5"</physfacet>
                 </physdesc>
               </did>

--- a/Real_Masters_all/coveycra.xml
+++ b/Real_Masters_all/coveycra.xml
@@ -270,8 +270,8 @@
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Pride Fest <unitdate type="inclusive" normal="2007">2007</unitdate> Ferndale Mi.</unittitle>
-            <physdesc>
-              <extent>5 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">5 optical disks</extent>
               <physfacet>DVDs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/cumbey.xml
+++ b/Real_Masters_all/cumbey.xml
@@ -17127,8 +17127,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Law Talk audio <unitdate type="inclusive" normal="2004-02-27">February 27, 2004</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -17137,8 +17137,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Javier Solana <unitdate type="inclusive" normal="2004">2004</unitdate></unittitle>
-              <physdesc>
-                <extent>2 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -17154,8 +17154,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Channel 7 Local News <unitdate type="inclusive" normal="1993-03-10">3/10/1993</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17183,8 +17183,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Jay Cole (Mission Ministries, Arkansas), "Speaking Out" radio and TV spots regarding AIDS, homosexuals, abortion, New Age, etc.</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17196,8 +17196,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Combined tape that includes Kent Schroder's presentation on the Summer Institute of Linguistics and Technology, and Jay Gary's presentation on AD <unitdate type="inclusive" normal="2000">2000</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17209,8 +17209,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Combined tape that includes Pecos River Learning Center Tape, Geraldo Rivera "John Rogers-MISA" and the Governor's Conference on Education <unitdate type="inclusive" normal="1989">1989</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17222,8 +17222,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Combined tape that includes The 700 Club TV Program with Pat Robertson and Jay Gary's presentation on the Power of AD <unitdate type="inclusive" normal="2000">2000</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17235,8 +17235,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Combined tape: television programs "Straight Talk" with Jeffrey Miller and Copeland Ministries <unitdate type="inclusive" normal="1997">1997</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17248,8 +17248,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Conference on New Age Movement</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17264,8 +17264,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Cumbey-Presentation "Apostasy in the Church: Pat Robertson Expose"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17277,8 +17277,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Cumbey and Ed Taub Debate <unitdate type="inclusive" normal="1990-07-07">7/7/1990</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM), copied</physfacet>
               </physdesc>
             </did>
@@ -17290,8 +17290,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Cumbey debates with Elizabeth Burrows <unitdate type="inclusive" normal="1987-01">January 1987</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17303,8 +17303,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Cumbey-Presentation "Melanin and the Mark of the Beast"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17316,8 +17316,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Cumbey-Presentation on the New Age Movement in North Dakota <unitdate type="inclusive" normal="1987-03-01/1987-03-08">3/1/1987-3/8/1987</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17329,8 +17329,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Cumbey-Presentation on the New Age Movement at the Human-Life International Conference</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17342,8 +17342,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Cumbey-Presentation on the New Age Movement in St. Mary's, Kansas <unitdate type="inclusive" normal="1988-03-12">3/12/1988</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM), master</physfacet>
               </physdesc>
             </did>
@@ -17355,8 +17355,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Cumbey-Presentation on AD <unitdate type="inclusive" normal="2000">2000</unitdate> and the New Age Movement, <unitdate type="inclusive" normal="1990-03-03">3/3/1990</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17368,8 +17368,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Cumbey-Presentation on Pat Robertson: "Who is this Man? Let's Piece the Clues Together," <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM), master</physfacet>
               </physdesc>
             </did>
@@ -17381,8 +17381,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>"Fetal Tissue Research:The Untold Story"; a Life Issues Television Production</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
                 <dimensions>30 minutes</dimensions>
               </physdesc>
@@ -17395,8 +17395,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Interview with Cumbey on Mother Angelica Live TV Program <unitdate type="inclusive" normal="1988-05-17">05/17/1988</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17408,8 +17408,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Michigan Alliance of Families-New Age Conference II, Cumbey discussion of the New Age</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17421,8 +17421,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>PBS Special, "Voices of a New Age," <unitdate type="inclusive" normal="1994">1994</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17434,8 +17434,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>The 700 Club television program <unitdate type="inclusive" normal="1989-02-28/1989-03-02">February 28, 1989-March 2, 1989</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17450,8 +17450,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>"Viewpoint on the News: The New Age Debate"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17463,8 +17463,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Kathy Walsh television interview of Cumbey on TV2 <unitdate type="inclusive" normal="1994-01-24">1/24/1994</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17476,8 +17476,8 @@
             <did>
               <container type="box" label="Box">85</container>
               <unittitle>Armageddon Script, Cumbey</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -17564,8 +17564,8 @@
                 <did>
                   <container type="box" label="Box">86</container>
                   <unittitle>Introduction</unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
                 <odd>
@@ -17576,8 +17576,8 @@
                 <did>
                   <container type="box" label="Box">86</container>
                   <unittitle>"Inspiration" vs. Channeling</unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
                 <odd>
@@ -17588,8 +17588,8 @@
                 <did>
                   <container type="box" label="Box">86</container>
                   <unittitle>Doctrine of "Chrystology"</unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
                 <odd>
@@ -17600,8 +17600,8 @@
                 <did>
                   <container type="box" label="Box">86</container>
                   <unittitle>Doctrine of the "Godhead"</unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
                 <odd>
@@ -17612,8 +17612,8 @@
                 <did>
                   <container type="box" label="Box">86</container>
                   <unittitle>Doctrine of "Atonement" vs. "Reincarnation"</unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
                 <odd>
@@ -17624,8 +17624,8 @@
                 <did>
                   <container type="box" label="Box">86</container>
                   <unittitle>The "Apostasy"</unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
                 <odd>
@@ -17642,8 +17642,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle>A Planned Deception #1, Constance Cumbey</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17690,8 +17690,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1993">1993</unitdate> David Whitaker</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17702,8 +17702,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1993">1993</unitdate> Outcome Based Education</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17714,8 +17714,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1993">1993</unitdate> America <unitdate type="inclusive" normal="2000">2000</unitdate> Cathy and Greg Finnegan</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17726,8 +17726,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1993">1993</unitdate> Constitutional Convention, Chip Bishop, Rick Butkowski</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17738,8 +17738,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1993">1993</unitdate> Curtis Rundell</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17750,8 +17750,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1993">1993</unitdate> Criminal Justice System, Stephen Markman</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17762,8 +17762,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1993">1993</unitdate> Tort Litigations, Harry Philo</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17774,8 +17774,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1993">1993</unitdate> Health Care Law, Dr. James Bridges</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17786,8 +17786,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1993">1993</unitdate> District Courts, William Bledsoe</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17798,8 +17798,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1993">1993</unitdate> Father Paul Marx</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17810,8 +17810,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1993">1993</unitdate> Home Schooling, Alan Cropsey</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17822,8 +17822,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1993">1993</unitdate> David Katz</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17834,8 +17834,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1993">1993</unitdate> Norm Hughes</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17846,8 +17846,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1994">1994</unitdate> James Miller</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17858,8 +17858,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1994">1994</unitdate> Jim Parks</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17870,8 +17870,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1994">1994</unitdate> Michelle Miller</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17882,8 +17882,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1994">1994</unitdate> Eileen Brown</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17894,8 +17894,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1994">1994</unitdate> New Year's Eve</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17906,8 +17906,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1994">1994</unitdate> Jim Miller, Last Show Before Election Primary</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17920,8 +17920,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1994">1994</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17946,8 +17946,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1996">1996</unitdate> Malachi Martin</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17958,8 +17958,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1996">1996</unitdate> Barry Waldner</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17984,8 +17984,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1997">1997</unitdate> Christian Coalition</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -17996,8 +17996,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1997">1997</unitdate> Mike Betzold</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18008,8 +18008,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1997">1997</unitdate> David Newman</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18020,8 +18020,8 @@
               <did>
                 <container type="box" label="Box">86</container>
                 <unittitle><unitdate type="inclusive" normal="1997">1997</unitdate> New Age Dorothy</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18034,8 +18034,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1997">1997</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18074,8 +18074,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="1999">1999</unitdate> Javier Solana</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18100,8 +18100,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="2000">2000</unitdate> Joan Ueon</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18126,8 +18126,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="2001">2001</unitdate> Larry Wasser</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18138,8 +18138,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="2001">2001</unitdate> Cliff Kincaid</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18150,8 +18150,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="2001">2001</unitdate> Soap Box</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18176,8 +18176,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> David Lee</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18188,8 +18188,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> Herb Peters</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18200,8 +18200,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> "Open Lines"</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18212,8 +18212,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> Judge Callahan, Eric White</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18224,8 +18224,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> Dan Manville, Prisons</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18236,8 +18236,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> Mary Jo Anderson</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18266,8 +18266,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> Suzanne George, Dr. Migliozano</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18278,8 +18278,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> Microchip</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18290,8 +18290,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> Herb Peters, Javier Solana</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18302,8 +18302,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> Schools</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18314,8 +18314,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="2003">2003</unitdate> Rev. Moon</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18354,8 +18354,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive">Undated</unitdate>, Judge Kelly, Mark Buche</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18366,8 +18366,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive">Undated</unitdate>, Home Invasion Killing, Javier Solana</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18378,8 +18378,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive">Undated</unitdate>, Dr. Byrne</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18390,8 +18390,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive">Undated</unitdate>, Father Paul Marx, Gino Vitale</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18402,8 +18402,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive">Undated</unitdate>, Peter Dugan</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18414,8 +18414,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive">Undated</unitdate>, Gary Allward</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18426,8 +18426,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive">Undated</unitdate>, Jim Hirsu</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18438,8 +18438,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive">Undated</unitdate>, Demond Wilson</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18455,8 +18455,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle>The Big Lie Technique of Constance Cumbey <unitdate type="inclusive" normal="1986">1986</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18484,8 +18484,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="1987">1987</unitdate> Constance Cumbey on Trinity Broadcasting (TBN), <unitdate type="inclusive" normal="1988">1988</unitdate> Constance Cumbey -- The New World Order and the Russian Connection</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18496,8 +18496,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="1990">1990</unitdate> Interview: Constance Cumbey -- Earth Day <unitdate type="inclusive" normal="1990">1990</unitdate> WJR <unitdate type="inclusive" normal="1991">1991</unitdate> Constance Cumbey's New Age Monitor</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18544,8 +18544,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive">Undated</unitdate>, Melanin and the Mark of the Beast, Constance Cumbey</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18565,8 +18565,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive">Undated</unitdate>, Prophecy Seminar, Tulsa, OK. Host, John Barela</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18582,8 +18582,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle><unitdate type="inclusive" normal="1986">1986</unitdate> Broadcaster's Luncheon, Constance Cumbey</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18628,8 +18628,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle>The New Age Movement, The New Age Movement in Prophecy Part I</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18640,8 +18640,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle>The New Age Movement in Prophecy Part II, Nazism and The New Age Movement</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18652,8 +18652,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle>The New Age Clean Up</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18681,8 +18681,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle>Atty. Constance Cumbey, Address #2</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18693,8 +18693,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle>Atty. Constance Cumbey, Address #4</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18705,8 +18705,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle>Atty. Constance Cumbey, Address #6</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -18717,8 +18717,8 @@
               <did>
                 <container type="box" label="Box">87</container>
                 <unittitle>Constance Cumbey Workshop</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>

--- a/Real_Masters_all/dancegal.xml
+++ b/Real_Masters_all/dancegal.xml
@@ -881,8 +881,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Dance Gallery <unitdate type="inclusive" normal="2001">2001</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -891,8 +891,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>PSDC <unitdate type="inclusive" normal="2002-04">April 2002</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -901,8 +901,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>PSDC Photos <unitdate type="inclusive" normal="2002-12">December 2002</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -911,8 +911,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Raw Capture Degas/Peninsula Performance Network <unitdate type="inclusive" normal="2003">2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -921,8 +921,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Raw Capture Peninsula at Performance Network <unitdate type="inclusive" normal="2003">2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -931,8 +931,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>DGS/PSDC Peninsula, <unitdate type="inclusive" normal="2003">Spring 2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -961,8 +961,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>PSDC Pictures <unitdate type="inclusive" normal="2004-04-26">April 26, 2004</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -981,8 +981,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Adult Modern Photos, <unitdate type="inclusive" normal="2006">Summer 2006</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -991,8 +991,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Dance Gallery Photos <unitdate type="inclusive" normal="2006-06-21">June 21, 2006</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1001,8 +1001,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Newsletter Photos <unitdate type="inclusive" normal="2006-07">July 2006</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1011,8 +1011,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle><unitdate type="inclusive" normal="2006">Fall 2006</unitdate> Photos</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1021,8 +1021,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Dance Gallery <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1031,8 +1031,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Earle Photos <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1041,8 +1041,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>PSDC <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1051,8 +1051,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Martin &amp; Peter 4 Mac</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1061,8 +1061,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Dance Gallery Foundation Website Capture</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1076,8 +1076,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>UMS Dance Program, Did You Know, Vol. 1 <unitdate type="inclusive" normal="2003-02">February, 2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1086,8 +1086,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Peter Sparling, Border Crossings <unitdate type="inclusive" normal="2000-04-06">April 6, 2000</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1096,8 +1096,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Peter Sparling Dance Company in Peninsula, Power Center <unitdate type="inclusive" normal="2004-06-23">June 23, 2004</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1106,8 +1106,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Peter Sparling Dance Company Repertory, Performance Network <unitdate type="inclusive" normal="2004-08-22">August 22, 2004</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1116,8 +1116,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Peter Sparling Dance Company, Gluck's Orfeo ed Euridice, Educational Presentation <unitdate type="inclusive" normal="2001-04-11">April 11, 2001</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1126,8 +1126,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>MCACA Dance/New Works--Dance Gallery/Peter Sparling &amp; Co., Sample of Work of Interpretive Artist <unitdate type="inclusive" normal="1997-04-24">April 24, 1997</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1136,8 +1136,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Repertory Sampler--Dance Gallery/Peter Sparling &amp; Co.</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1146,8 +1146,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Wildt St. Tom</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1156,8 +1156,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Peter Sparling Dance Company, www.Comnet.Org/DanceGallery</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1166,8 +1166,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Comcast Newsmakers Peter Sparling TRT: 5 Minutes</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1176,8 +1176,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>1. DGS Youth Repertory Group, Performance Network <unitdate type="inclusive" normal="2003-06-01">June 1, 2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1186,8 +1186,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>2. PSDC, Katz Elementary <unitdate type="inclusive" normal="1997-03-18">March 18, 1997</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1196,8 +1196,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>3. PSDC, Estabrook New Horizon <unitdate type="inclusive" normal="1997-02-04">February 4, 1997</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1206,8 +1206,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>4. PSDC, Excerpts from Repertory</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1216,8 +1216,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>5. PSDC, Hearts Plunder</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1226,8 +1226,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>6. PSDC, Orfeo and Euridice</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1236,8 +1236,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>7. PSDC, Orfeo ed Euridice, Michigan Theater</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1246,8 +1246,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>8. UMS Presents PSDC, Orfeo ed Eurdice <unitdate type="inclusive" normal="2001-05-19">May 19, 2001</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1256,8 +1256,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>9. PSDC, Berliner Mass/Seven Enigmas <unitdate type="inclusive" normal="1997-07-12">July 12, 1997</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1266,8 +1266,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>10. PSDC, General Promo Video</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1276,8 +1276,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>11. PSDC, Peninsula <unitdate type="inclusive" normal="2003-05-13">May 13, 2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1286,8 +1286,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>12. BRAVO, Celebrating the Arts in Southeast Michigan</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1296,8 +1296,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>13. Peter Sparling: Heidi Stoeckley</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1306,8 +1306,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>14. PSDC, Excerpts from Repertory (Orfeo, Chronicles)</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1316,8 +1316,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>15. PSDC, Adventures in New Media <unitdate type="inclusive" normal="2000-07-10">July 10, 2000</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1326,8 +1326,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>16. PSDC, Excerpts from Repertory</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1336,8 +1336,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>17. PSDC, "Winter" from Vivaldi Four Seasons</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1346,8 +1346,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>18. PSDC, Diversion of Angels/Chronicles</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1356,8 +1356,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>19. DGS, The Wildt Street Space</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1366,8 +1366,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>20. UMS Presents PSDC, The Orfeo ed Euridice Residency</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1376,8 +1376,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>21. DGS, Bernie $ Dottie <unitdate type="inclusive" normal="2000-07-15">July 15, 2000</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1386,8 +1386,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>22. PSDC, Traffic !/Possible Dances/Orfeo Suite <unitdate type="inclusive" normal="2001-01-11">January 11, 2001</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1396,8 +1396,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>23. PSDC, NEA Proposal FY <unitdate type="inclusive" normal="2001">2001</unitdate> Access/Dance</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1406,8 +1406,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>24. DGS, Christina Sears, Girlstown Summer Camp <unitdate type="inclusive" normal="2002">2002</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1416,8 +1416,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>25. Peter Sparling, The Institute for Humanities</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1426,8 +1426,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>26. PSDC &amp; DGS, Promotional Video</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1436,8 +1436,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>28. PSDC &amp; DGS, Master GLPAA Promo Video</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1446,8 +1446,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>29. PSDC &amp; DGS, Repertory Sampler</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1456,8 +1456,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>30. PSDC, "Move It" Dress Rehearsal <unitdate type="inclusive" normal="1992-06-24">June 24, 1992</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1466,8 +1466,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>31. PSDC, Travelogue (excerpts)</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1476,8 +1476,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>32. PSDC, Promotional Video <unitdate type="inclusive" normal="1998-09-10">September 10, 1998</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1486,8 +1486,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>33. PSDC, "Possible Dances"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1496,8 +1496,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>34. DGS, Moscow Ballet Nutcracker/Kid's <unitdate type="inclusive" normal="2002">2002</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1506,8 +1506,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>35. DGS, Moscow Ballet/Kid's <unitdate type="inclusive" normal="2001">2001</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1516,8 +1516,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>36. DGS, Nutcracker/Academy of Dance Arts <unitdate type="inclusive" normal="2001/2002">2001-2002</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1526,8 +1526,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>37. Peter Sparling, MCACA Samples of Work <unitdate type="inclusive" normal="1995">1995</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1536,8 +1536,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>38. DGS &amp; Janet Lilly, Storybook, Michigan Theater, April 23</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1560,8 +1560,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>DGS/PSDC, Winter Wonderland, December 5 &amp; 6 <unitdate type="inclusive" normal="2003">2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD</physfacet>
               </physdesc>
             </did>
@@ -1570,8 +1570,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Dance Gallery Studio, Spring Showcase, <unitdate type="inclusive" normal="2002">May 12 2002</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD</physfacet>
               </physdesc>
             </did>
@@ -1580,8 +1580,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Peter Sparling Dance Company, Promotional Video, Peninsula Part II, Les Parisiennes <unitdate type="inclusive" normal="2004">2004</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1590,8 +1590,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Peter Sparling, The End of Shame <unitdate type="inclusive" normal="2005-08-08">August 8, 2005</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1600,8 +1600,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Peter Sparling, Odes (Studio Version) <unitdate type="inclusive" normal="2005">2005</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1619,8 +1619,8 @@
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Peter Sparling Dance Gallery Foundation Website Snapshots <unitdate type="inclusive" normal="2008-07-09">July 9, 2008</unitdate></unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-Rs</physfacet>
             </physdesc>
           </did>
@@ -1629,8 +1629,8 @@
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Dance Gallery Foundation Website capture <unitdate type="inclusive" normal="2008-12-16">December 16, 2008</unitdate></unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-Rs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/davisannb.xml
+++ b/Real_Masters_all/davisannb.xml
@@ -39,14 +39,14 @@
       </origination>
       <unittitle encodinganalog="245">Ann B. Davis papers <unitdate type="inclusive" encodinganalog="245$f"> 1944-2014 </unitdate> <unitdate type="bulk" encodinganalog="245$g"> 1956-2010 </unitdate></unittitle>
       <physdesc altrender="part">
-        <extent encodinganalog="300">3.5 linear feet</extent>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent encodinganalog="300">1 oversize volumes</extent>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent encodinganalog="300">15 GB</extent>
+        <extent altrender="materialtype spaceoccupied">15 GB</extent>
         <physfacet>online</physfacet>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">1 oversize volumes</extent>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">3.5 linear feet</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number"> 2015044 Aa Ac </unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
@@ -459,8 +459,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Alice's Brady Bunch Cookbook, <unitdate type="inclusive" normal="1994">1994</unitdate></unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -468,8 +468,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Brady CD-ROM, <unitdate type="inclusive" normal="1995">1995</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-ROMs</physfacet>
               </physdesc>
             </did>
@@ -514,8 +514,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Photographs </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -548,8 +548,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Myrnalene, <unitdate type="inclusive" normal="1961">1961</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -649,8 +649,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1993/1996">1993-1996</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -677,8 +677,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="2006/2007">2006-2007</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
             <odd>
@@ -737,8 +737,8 @@
             <did>
               <physloc>Online </physloc>
               <unittitle>Granny's Dinner Playhouse, Dallas, Texas, <unitdate type="inclusive" normal="1975">1975</unitdate></unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -859,8 +859,8 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Friend's Pictures </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -868,8 +868,8 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Italy, <unitdate type="inclusive">October-November, 1971</unitdate></unittitle>
-            <physdesc>
-              <extent>6 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">6 folders</extent>
             </physdesc>
           </did>
           <odd>
@@ -886,8 +886,8 @@
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Miscellaneous Photographs </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -901,8 +901,8 @@
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Photo Albums, <unitdate type="inclusive" normal="1960/1979" certainty="approximate">1960s-1970s</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -922,8 +922,8 @@
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Thailand, <unitdate type="inclusive">September, 1967</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -931,8 +931,8 @@
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Vietnam, <unitdate type="inclusive">September, 1967</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -941,10 +941,10 @@
             <container type="box" label="Box">4</container>
             <unittitle>Color Slides, circa <unitdate type="inclusive" normal="1971/1976">1971-1976</unitdate></unittitle>
             <physdesc altrender="part">
-              <extent>2 folders</extent>
+              <extent altrender="materialtype spaceoccupied">10 slides boxes</extent>
             </physdesc>
             <physdesc altrender="part">
-              <extent>10 slides boxes</extent>
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
           <odd>

--- a/Real_Masters_all/davisde.xml
+++ b/Real_Masters_all/davisde.xml
@@ -5325,8 +5325,8 @@
           <did>
             <container type="box" label="Box">18</container>
             <unittitle>DED Speeches (floppy disk) <unitdate type="inclusive" normal="1996/1999">1996-1999</unitdate></unittitle>
-            <physdesc>
-              <extent>1 floppy disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
               <physfacet>3.5"</physfacet>
             </physdesc>
           </did>
@@ -5338,8 +5338,8 @@
           <did>
             <container type="box" label="Box">18</container>
             <unittitle>Jackie Stewart interview (floppy disk) <unitdate type="inclusive" normal="1999-05-27">May 27, 1999</unitdate></unittitle>
-            <physdesc>
-              <extent>1 floppy disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
               <physfacet>3.5"</physfacet>
             </physdesc>
           </did>
@@ -5348,8 +5348,8 @@
           <did>
             <container type="box" label="Box">18</container>
             <unittitle>Toyota/Land Rover Speech (floppy disk) <unitdate type="inclusive" normal="2000-01-14">January 14, 2000</unitdate></unittitle>
-            <physdesc>
-              <extent>1 floppy disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
               <physfacet>3.5"</physfacet>
             </physdesc>
           </did>
@@ -5358,8 +5358,8 @@
           <did>
             <container type="box" label="Box">18</container>
             <unittitle>Swedish C of C speech (floppy disk)</unittitle>
-            <physdesc>
-              <extent>1 floppy disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
               <physfacet>3.5"</physfacet>
             </physdesc>
           </did>
@@ -5368,8 +5368,8 @@
           <did>
             <container type="box" label="Box">18</container>
             <unittitle>NADA Speech draft (floppy disk)</unittitle>
-            <physdesc>
-              <extent>1 floppy disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
               <physfacet>3.5"</physfacet>
             </physdesc>
           </did>
@@ -5378,8 +5378,8 @@
           <did>
             <container type="box" label="Box">18</container>
             <unittitle>Automobile Magazine -- Fangio with Chevy (zip disk)</unittitle>
-            <physdesc>
-              <extent>1 zip disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 zip disks</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/deboerro.xml
+++ b/Real_Masters_all/deboerro.xml
@@ -1228,8 +1228,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>"Do You Feel It: Special Edition Release for The DeBoer Committee for Children's Rights <unitdate type="inclusive" normal="1993">1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1237,8 +1237,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>"Hear My Voice: Justice for Jessi DeBoer and Children in Crisis Everywhere," <unitdate type="inclusive" normal="1993">1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1247,8 +1247,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>Hear My Voice, Illinois Chapter, WJJG-AM 1530 Live Radio Broadcast <unitdate type="inclusive" normal="1997">1997</unitdate></unittitle>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
               </physdesc>
             </did>
           </c03>
@@ -1274,8 +1274,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"Champions for Children" fundraising event</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVDs</physfacet>
               </physdesc>
             </did>
@@ -1284,8 +1284,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>Hear My Voice Conference <unitdate type="inclusive" normal="1999">1999</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1297,8 +1297,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>Hear My Voice Kids, slide show <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVDs</physfacet>
               </physdesc>
             </did>
@@ -1394,8 +1394,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Tape 1: WJBK Detroit <unitdate type="inclusive" normal="1992-01">January 1992</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1404,8 +1404,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Tape 2: TV2 News <unitdate type="inclusive" normal="1992-10">October 1992</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1414,8 +1414,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Tape 3: <title render="italic">20/20</title>; Local News Segments, <unitdate type="inclusive" normal="1992/1993">1992-1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1424,8 +1424,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Tape 4: TV2 News; <title render="italic">Good Morning America</title>, <unitdate type="inclusive" normal="1993-01">January 1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1434,8 +1434,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle>Tape 5: <title render="italic">Good Morning America</title>, <unitdate type="inclusive" normal="1993-01/1993-02">January-February 1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1444,8 +1444,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle>Tape 6: <title render="italic">Good Morning America</title>, <unitdate type="inclusive" normal="1993-01/1993-08">January, April, August 1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1454,8 +1454,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle>Tape 7-14: "Schmidt vs. DeBoer," Court TV <unitdate type="inclusive" normal="1993-02">February 1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>8 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">8 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1464,8 +1464,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle>Tape 15: <title render="italic">20/20</title>, <unitdate type="inclusive" normal="1993-03">March 1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1474,8 +1474,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle>Tape 16: Justice for Jessi Rally <unitdate type="inclusive" normal="1993-04">April 1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1484,8 +1484,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle>Tape 17-18: Justice for Jessi Rights Rally in D.C. <unitdate type="inclusive" normal="1993-07">July 1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1494,8 +1494,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle>Tape 19: <title render="italic">Good Morning America</title>, <unitdate type="inclusive" normal="1993-07">July 1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1504,8 +1504,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle>Tape 20: WDIV-TV Detroit <unitdate type="inclusive" normal="1993-08">August 1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1514,8 +1514,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle>Tape 21: <title render="italic">NBC News Now</title>, <unitdate type="inclusive" normal="1993-08">August 1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1524,8 +1524,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle>Tape 22: "Jessica: The Final Hours," KGAN-TV <unitdate type="inclusive" normal="1993-08">August 1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1534,8 +1534,8 @@
               <did>
                 <container type="box" label="Box">14</container>
                 <unittitle>Tape 23: George Rogers Clark High School Support Video <unitdate type="inclusive" normal="1993-10">October 1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1544,8 +1544,8 @@
               <did>
                 <container type="box" label="Box">14</container>
                 <unittitle>Tape 24-25: <title render="italic">American Journal</title>, <unitdate type="inclusive" normal="1993" certainty="approximate">circa 1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1554,8 +1554,8 @@
               <did>
                 <container type="box" label="Box">14</container>
                 <unittitle>Tape 26: Rally in Washington <unitdate type="inclusive" normal="1993">1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1564,8 +1564,8 @@
               <did>
                 <container type="box" label="Box">14</container>
                 <unittitle>Tape 27: <title render="italic">Whose Child is This? The War for Baby Jessica</title>, <unitdate type="inclusive" normal="1993">1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1574,8 +1574,8 @@
               <did>
                 <container type="box" label="Box">14</container>
                 <unittitle>Tape 28: <title render="italic">NBC News Now</title>, <unitdate type="inclusive" normal="1994-07">July 1994</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1584,8 +1584,8 @@
               <did>
                 <container type="box" label="Box">14</container>
                 <unittitle>Tape 29-30: DeBoer Interviews <unitdate type="inclusive" normal="1994-10">October 1994</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 videotapes</extent>
                   <physfacet>beta tapes</physfacet>
                 </physdesc>
               </did>
@@ -1594,8 +1594,8 @@
               <did>
                 <container type="box" label="Box">14</container>
                 <unittitle>Tape 31: <title render="italic">48 Hours</title>, <unitdate type="inclusive" normal="1994">1994</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1604,8 +1604,8 @@
               <did>
                 <container type="box" label="Box">14</container>
                 <unittitle>Tape 32: <title render="italic">The Crusaders</title>, <unitdate type="inclusive" normal="1994">1994</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1614,8 +1614,8 @@
               <did>
                 <container type="box" label="Box">14</container>
                 <unittitle>Tape 33: <title render="italic">PrimeTime Live</title>, <unitdate type="inclusive" normal="1994">1994</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1624,8 +1624,8 @@
               <did>
                 <container type="box" label="Box">14</container>
                 <unittitle>Tape 34: NBC News NOW <unitdate type="inclusive" normal="1994">1994</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1634,8 +1634,8 @@
               <did>
                 <container type="box" label="Box">14</container>
                 <unittitle>Tape 35: WDIV-TV Detroit <unitdate type="inclusive" normal="1999">1999</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1644,8 +1644,8 @@
               <did>
                 <container type="box" label="Box">14</container>
                 <unittitle>Tape 36: Comparisons to Elian Gonzalez <title render="italic">Good Morning America</title>, <title render="italic">NBC Today Show</title>, <title render="italic">Fox TV News</title>, <unitdate type="inclusive" normal="2000">2000</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1654,8 +1654,8 @@
               <did>
                 <container type="box" label="Box">14</container>
                 <unittitle>Tape 37: "What ever happened to Baby Jessica," WDIV <unitdate type="inclusive" normal="2003">2003</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1664,8 +1664,8 @@
               <did>
                 <container type="box" label="Box">14</container>
                 <unittitle>Tape 38: <title render="italic">Can You Hear?</title>, <unitdate type="inclusive">undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1674,8 +1674,8 @@
               <did>
                 <container type="box" label="Box">14</container>
                 <unittitle>Tape 39: CBS This Morning <unitdate type="inclusive">undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1684,8 +1684,8 @@
               <did>
                 <container type="box" label="Box">14</container>
                 <unittitle>Tape 40-41: DeBoer Committee for Children's Rights <unitdate type="inclusive">undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1694,8 +1694,8 @@
               <did>
                 <container type="box" label="Box">15</container>
                 <unittitle>Tape 42: Jan DeBoer Interview, MSNBC <unitdate type="inclusive">undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1704,8 +1704,8 @@
               <did>
                 <container type="box" label="Box">15</container>
                 <unittitle>Tape 43: Robby and Jan DeBoer, Interview Training <unitdate type="inclusive">undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1719,8 +1719,8 @@
               <did>
                 <container type="box" label="Box">15</container>
                 <unittitle>Tape 44: Atkins, Josh (Ohio) <unitdate type="inclusive">undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1729,8 +1729,8 @@
               <did>
                 <container type="box" label="Box">15</container>
                 <unittitle>Tape 45-46: Baby Richard <unitdate type="inclusive">undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 videotapes</extent>
                   <physfacet>beta tapes</physfacet>
                 </physdesc>
               </did>
@@ -1739,8 +1739,8 @@
               <did>
                 <container type="box" label="Box">15</container>
                 <unittitle>Tape 47: Mankin, Allyson <unitdate type="inclusive" normal="1996">1996</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1749,8 +1749,8 @@
               <did>
                 <container type="box" label="Box">15</container>
                 <unittitle>Tape 48-49: Meldrum, Timothy Jr. (South Dakota) <unitdate type="inclusive" normal="2001/2002">2001-2002</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1759,8 +1759,8 @@
               <did>
                 <container type="box" label="Box">15</container>
                 <unittitle>Tape 50-51: Moore, Justin (Ohio) <unitdate type="inclusive" normal="1999/2002">1999-2002</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1769,8 +1769,8 @@
               <did>
                 <container type="box" label="Box">15</container>
                 <unittitle>Tape 52: Raub, Paula and Hawk (Washington) <unitdate type="inclusive" normal="2000" certainty="approximate">circa 2000</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1779,8 +1779,8 @@
               <did>
                 <container type="box" label="Box">15</container>
                 <unittitle>Tape 53: Simonitch, Ashlee and Nicholas (Kansas) <unitdate type="inclusive">undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1789,8 +1789,8 @@
               <did>
                 <container type="box" label="Box">15</container>
                 <unittitle>Tape 54: Smith, Lily and Pearl (Michigan) <unitdate type="inclusive" normal="2000" certainty="approximate">circa 2000</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1799,8 +1799,8 @@
               <did>
                 <container type="box" label="Box">15</container>
                 <unittitle>Tape 55: Birth Parent Rights Discussion <unitdate type="inclusive" normal="1993-03">March 1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1809,8 +1809,8 @@
               <did>
                 <container type="box" label="Box">15</container>
                 <unittitle>Tape 56: "Listen to the Children," Family Law Section of the State of Michigan Bar <unitdate type="inclusive" normal="1993-03">March 1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1819,8 +1819,8 @@
               <did>
                 <container type="box" label="Box">15</container>
                 <unittitle>Tape 57: "The Long Journey Home," <title render="italic">20/20</title>, <unitdate type="inclusive" normal="1992-12">December 1992</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1829,8 +1829,8 @@
               <did>
                 <container type="box" label="Box">15</container>
                 <unittitle>Tape 58: "Why Don't Kids Have a Voice?" ABC News Special <unitdate type="inclusive" normal="2001">2001</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1844,8 +1844,8 @@
               <did>
                 <container type="box" label="Box">15</container>
                 <unittitle>Tape 59-61: Drake Hotel/Ali Event <unitdate type="inclusive" normal="2002-10">October 2002</unitdate></unittitle>
-                <physdesc>
-                  <extent>3 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -1854,8 +1854,8 @@
               <did>
                 <container type="box" label="Box">15</container>
                 <unittitle>Tape 62: First Annual Children's Rights Benefit Dinner <unitdate type="inclusive" normal="1993-11">November 1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>

--- a/Real_Masters_all/delanghe.xml
+++ b/Real_Masters_all/delanghe.xml
@@ -1191,8 +1191,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>"Photos: Gay's Piece," <unitdate type="inclusive" normal="2004-06-09">June 9, 2004</unitdate> [Statuary: Classics in Motion, Ann Arbor Dance Works]</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1201,8 +1201,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>"Gay Delanghe Photos Fr: UM Dance Dept." [Miscellaneous Studio Shots]</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1221,8 +1221,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>"Ann Arbor Dance Works," Tom Bower <unitdate type="inclusive" normal="2005-06-08">June 8, 2005</unitdate> [Freeze Frame, Ann Arbor Dance Works]</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1231,8 +1231,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>"Ann Arbor Dance Works: Gently Quirked: Choreography: Robin Wilson," <unitdate type="inclusive" normal="2003-06-11">June 11, 2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1251,8 +1251,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>"Ann Arbor Dance Works: Portraits," Tom Bower <unitdate type="inclusive" normal="2003-06-11">June 11, 2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1261,8 +1261,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>"Ann Arbor Dance Works: Venice, Milan, Florence: Choreography: Gay Delanghe," Tom Bower <unitdate type="inclusive" normal="2003-06-11">June 11, 2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1271,8 +1271,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>"A2 Dance Works Selected Photos for Dance Magazine," Tom Bower <unitdate type="inclusive" normal="2003-06-12">June 12, 2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1281,8 +1281,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>"Statues Project" [Images to be projected during performance]</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1291,8 +1291,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>"Ann Arbor Dance Works: The Dangerous Kitchen: Fertile Meaning: Choreography: Gay Delanghe," Tom Bower <unitdate type="inclusive" normal="2003-06-11">June 11, 2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1301,8 +1301,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>"Freeze Frame" [Images to be projected during performance]</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -2501,8 +2501,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"Spacial Etchings/Smith/Motet/Verlezza/Rampage/French Suite Delanghe,"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>Betacam (TM)</physfacet>
               </physdesc>
             </did>
@@ -2511,8 +2511,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"Ann Arbor Dance Works"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2521,8 +2521,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"Alma Icarus" (spine) "Icarus UM Dc. Co." (tape)</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2531,8 +2531,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"Delanghe/AADW Bach Trio" (spine) "Italian AADW" (tape)</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2541,8 +2541,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"Harpies Popart,"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2551,8 +2551,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"Ann Arbor Dance Works,"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2561,8 +2561,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"Slap Happening,"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2571,8 +2571,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"Lucas Satie/Limon Dub,"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2581,8 +2581,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"Delanghe Dino Sketches,"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2591,8 +2591,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"Interlochen Dancers?,"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2601,8 +2601,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"Fats For Five Dancers Plus One/Fats For Fifteen But One Dancer Missing,"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2611,8 +2611,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"All of a Feather," "U of Mich., AA Dance Works,"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2621,8 +2621,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"Reel to Reel Dub,"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2631,8 +2631,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"Webern,"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2641,8 +2641,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"Motor Tango," "Seven Deadly Sins,"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2651,8 +2651,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"Goreski Work,"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2666,8 +2666,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"Aubade 72," "Satiana 78," "FATS IAC 91," <unitdate type="inclusive" normal="1972/1991">1972-1991</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2676,8 +2676,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"Creation 76," "Tears 75?," <unitdate type="inclusive" normal="1975/1976">1975-1976</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2686,8 +2686,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"SINS," <unitdate type="inclusive" normal="1980">1980</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2696,8 +2696,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"SINS," <unitdate type="inclusive" normal="1980-03-12">March 12, 1980</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2709,8 +2709,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>"NMC Rinaldo, Goler, Rosenfeld, Delanghe #1," <unitdate type="inclusive" normal="1980">1980</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>Betacam (TM)</physfacet>
               </physdesc>
             </did>
@@ -2719,8 +2719,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"NMC #2," <unitdate type="inclusive" normal="1980">1980</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>Betacam (TM)</physfacet>
               </physdesc>
             </did>
@@ -2729,8 +2729,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"NMC Delanghe, Rinaldo, Barreau, Johnson, Van Kuiken, Barreau," <unitdate type="inclusive" normal="1981">1981</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>Betacam (TM)</physfacet>
               </physdesc>
             </did>
@@ -2739,8 +2739,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"Hoving, Power," <unitdate type="inclusive" normal="1981">1981</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2749,8 +2749,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"Gay Delanghe Motor Tango, Liz Bergman Tikal," <unitdate type="inclusive" normal="1981-12">December 1981</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2759,8 +2759,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"Blk Fig, Toccata, Slap, Gp Work Schoenbeg, French 2 Varese/Primordial, Creation," <unitdate type="inclusive" normal="1982">1982</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2769,8 +2769,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"NMC O'Rourke, Van Kuiken, Delanghe," <unitdate type="inclusive" normal="1982">Summer 1982</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>Betacam (TM)</physfacet>
               </physdesc>
             </did>
@@ -2779,8 +2779,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"NMC VanKuiken, Krzyminksi, Lommasson," <unitdate type="inclusive" normal="1983">1983</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>Betacam (TM)</physfacet>
               </physdesc>
             </did>
@@ -2789,8 +2789,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"NMC Vegas on the Lake, Without the Rain, Ceremonial," <unitdate type="inclusive" normal="1984">1984</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>Betacam (TM)</physfacet>
               </physdesc>
             </did>
@@ -2799,8 +2799,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"Fats Rags Chopin Dub Monsters Wilds Vivaldi," <unitdate type="inclusive" normal="1984">1984</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2809,8 +2809,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"NMC Comp Show," <unitdate type="inclusive" normal="1986">1986</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>Betacam (TM)</physfacet>
               </physdesc>
             </did>
@@ -2819,8 +2819,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"Limon Co. "There is a Time," Limon Technique by D. Lewis," <unitdate type="inclusive" normal="1986">1986</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2829,8 +2829,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"Worktape--Boogie, Red/Black and White," "Knock" <unitdate type="inclusive" normal="1986">Fall 1986</unitdate> Fall, <unitdate type="inclusive" normal="1987">1987</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2839,8 +2839,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"NMC Modern Works 1. HVK, 2. BDY, 3. MF," <unitdate type="inclusive" normal="1986">1986</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>Betacam (TM)</physfacet>
               </physdesc>
             </did>
@@ -2849,8 +2849,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"1. Down River, 2. Night and Day: Henry and Gay," <unitdate type="inclusive" normal="1987-11-14">November 14, 1987</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2859,8 +2859,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"Old Rags 88," "Icarus 89 (80)," <unitdate type="inclusive" normal="1988/1989">1988-1989</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2869,8 +2869,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"All of a Feather, Ann Arbor Dance Works #1 and #2," <unitdate type="inclusive" normal="1988-01-18">January 18, 1988</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2879,8 +2879,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"Satie, Market <unitdate type="inclusive" normal="1989">1989</unitdate> AADW <unitdate type="inclusive" normal="1993">1993</unitdate> Gay Steve Linda," <unitdate type="inclusive" normal="1989">1989</unitdate>, <unitdate type="inclusive" normal="1993">1993</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2889,8 +2889,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"Ann Arbor Dance Works 5th Anniversary" <unitdate type="inclusive" normal="1989-12-02">December 2, 1989</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2899,8 +2899,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"Interlochen--Corson Faculty Concert," <unitdate type="inclusive" normal="1990-07-26">July 26, 1990</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>Betacam (TM)</physfacet>
               </physdesc>
             </did>
@@ -2909,8 +2909,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"Dino Dance Gay! Dada-da," <unitdate type="inclusive" normal="1990-02-20">February 20, 1990</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2919,8 +2919,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"Gay Delanghe September Dances," <unitdate type="inclusive" normal="1990">1990</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2929,8 +2929,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>"Dancin' Fats" "Shenandoah Dance Ensemble," <unitdate type="inclusive" normal="1990-05">May, 1990</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2939,8 +2939,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"Pride and Prejudice (1+2)--Power Center," <unitdate type="inclusive" normal="1990">Fall 1990</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2949,8 +2949,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"Interlochen--Corson--Rehearsal," <unitdate type="inclusive" normal="1990-07-23">July 23, 1990</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>Betacam (TM)</physfacet>
               </physdesc>
             </did>
@@ -2959,8 +2959,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"Joplin/Stravinsky/Albright "Not On Here"," <unitdate type="inclusive" normal="1990">1990</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2969,8 +2969,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"Pride and Prejudice Original," <unitdate type="inclusive" normal="1990">1990</unitdate>, <unitdate type="inclusive" normal="1991">1991</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2979,8 +2979,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"Lizzy's Revenge, A2DCWKS," <unitdate type="inclusive" normal="1991">Fall 1991</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -2989,8 +2989,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"Without Amy in Connoisseurs of Chaos" "Ann Arbor Dance Works Studio A, S <unitdate type="inclusive" normal="1993-05-20">May 20, 1993</unitdate></unittitle>
-              <physdesc>
-                <extent>2 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3002,8 +3002,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"Murders Dress Perform, IAC," <unitdate type="inclusive" normal="1994">1994</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3012,8 +3012,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"Play Re-Play, IAA," <unitdate type="inclusive" normal="1994-08-20">August 20, 1994</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3022,8 +3022,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"Migrations, Part II: AADW," <unitdate type="inclusive" normal="1996-04">April, 1996</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3032,8 +3032,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"2. Gorecki, 1. Muybridge Dub 05, 3. Harpies," <unitdate type="inclusive" normal="1996">1996</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3042,8 +3042,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"Tanzmusik" "Serioso Now and Then (Fogel), 2. Waltzscape (Delanghe), 3. Esplanade (Taylor)," <unitdate type="inclusive" normal="1997-02">February 1997</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3052,8 +3052,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"Ann Arbor Dance Works 14th Spring Anniversary Concert," <unitdate type="inclusive" normal="1998-04-24/1998-04-25">April 24-25, 1998</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3062,8 +3062,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"Doris Chase Circle at the Center, KCT-TV Seattle Washington," <unitdate type="inclusive" normal="1999">1999</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3072,8 +3072,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"EEPC Home Season Excerpts," 1999.</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3082,8 +3082,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"University of Michigan School of Dance Ann Arbor Dance Works" <unitdate type="inclusive" normal="2001-06-14/2001-06-15">June 14-15, 2001</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3092,8 +3092,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"AADW 02 Queens-Statues," <unitdate type="inclusive" normal="2002">2002</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3102,8 +3102,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"Delanghe--Interludes," <unitdate type="inclusive" normal="2002-12">December, 2002</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3112,8 +3112,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>"Ann Arbor Dance Works and Detroit Dance Collective In a Shared Concert," <unitdate type="inclusive" normal="2002-06-13">June 13, 2002</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3122,8 +3122,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>"University of Michigan School of Dance, Resonant Rhythms," January 31, 2003</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3132,8 +3132,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>"University of Michigan School of Music, University Dance Company "Dances for Petersburg"," <unitdate type="inclusive" normal="2004">February 5 2004</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3142,8 +3142,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>"Ann Arbor Dance Works 20th Spring Season," <unitdate type="inclusive" normal="2004-06-11">June 11, 2004</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3157,8 +3157,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>"Icarus,"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>U-matic</physfacet>
               </physdesc>
             </did>
@@ -3167,8 +3167,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>"Chase/Delanghe," <unitdate type="inclusive" normal="1979-08-14">August 14, 1979</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>U-matic</physfacet>
               </physdesc>
             </did>
@@ -3177,8 +3177,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>"NMC Faculty Concert Worktape: Little Fugue, Toccata, Big Fugue, VanKuiken, MacDonald, Goler, Delanghe, Rinaldo," <unitdate type="inclusive" normal="1980">1980</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>U-matic</physfacet>
               </physdesc>
             </did>
@@ -3187,8 +3187,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>"Solomons Delanghe Matheke Power," <unitdate type="inclusive" normal="1980">Fall 1980</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>U-matic</physfacet>
               </physdesc>
             </did>
@@ -3197,8 +3197,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>"Power Center Spring Concert 3. Winter Ebb, 4. A Day in the Life of...," <unitdate type="inclusive" normal="1981">1981</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>U-matic</physfacet>
               </physdesc>
             </did>
@@ -3207,8 +3207,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>"David Snyder Part 2, NMC Faculty Concert," <unitdate type="inclusive" normal="1983">1983</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>U-matic</physfacet>
               </physdesc>
             </did>
@@ -3217,8 +3217,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>"Five Teas, Power Center, Gay Delanghe, UM Dance Company," <unitdate type="inclusive" normal="1983">1983</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>U-matic</physfacet>
               </physdesc>
             </did>
@@ -3227,8 +3227,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>"Dancing Fats Choreographer: Gay Delanghe, "Contemporary Dance Theater," <unitdate type="inclusive" normal="1984">1984</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>U-matic</physfacet>
               </physdesc>
             </did>
@@ -3237,8 +3237,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>"Smooth as Glass," For Luci--," <unitdate type="inclusive" normal="1984">Winter 1984</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>U-matic</physfacet>
               </physdesc>
             </did>
@@ -3247,8 +3247,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>"Pre-Classics--Recorded in Studio #A," <unitdate type="inclusive" normal="1978">1978</unitdate></unittitle>
-              <physdesc>
-                <extent>1 video recordings</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 video recordings</extent>
                 <physfacet>open reel videotapes</physfacet>
               </physdesc>
             </did>
@@ -3257,8 +3257,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>"Bach Outside," <unitdate type="inclusive" normal="1978">1978</unitdate></unittitle>
-              <physdesc>
-                <extent>1 video recordings</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 video recordings</extent>
                 <physfacet>open reel videotapes</physfacet>
               </physdesc>
             </did>
@@ -3267,8 +3267,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>"Girlie-Delanghe, Variations-Bergman, Afro,"</unittitle>
-              <physdesc>
-                <extent>1 video recordings</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 video recordings</extent>
                 <physfacet>open reel videotapes</physfacet>
               </physdesc>
             </did>
@@ -3277,8 +3277,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>"1. Tap-Gary, Tears-Gay Delanghe,"</unittitle>
-              <physdesc>
-                <extent>1 video recordings</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 video recordings</extent>
                 <physfacet>open reel videotapes</physfacet>
               </physdesc>
             </did>
@@ -3287,8 +3287,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>"2. Tap-Gary, Tears-Gay Delanghe,"</unittitle>
-              <physdesc>
-                <extent>1 video recordings</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 video recordings</extent>
                 <physfacet>open reel videotapes</physfacet>
               </physdesc>
             </did>
@@ -3297,8 +3297,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>"#4 1. Ballet, 2. Elegy, 3. Delanghe (Lesch) (Power 1972) 24," <unitdate type="inclusive" normal="1972">1972</unitdate></unittitle>
-              <physdesc>
-                <extent>1 video recordings</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 video recordings</extent>
                 <physfacet>open reel videotapes</physfacet>
               </physdesc>
             </did>
@@ -3307,8 +3307,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>"Delanghe Monsters" <unitdate type="inclusive" normal="1988">Winter 1988</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>U-matic</physfacet>
               </physdesc>
             </did>
@@ -3317,8 +3317,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>"Dance Works Tape #2 Gay Delanghe All of a Feather," <unitdate type="inclusive" normal="1988-11">November, 1988</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>U-matic</physfacet>
               </physdesc>
             </did>
@@ -3327,8 +3327,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>"NMC: Delanghe, VanKuiken," <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>U-matic</physfacet>
               </physdesc>
             </did>
@@ -3337,8 +3337,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>"Gay Delanghe A2 Dance Works Going to the Market," <unitdate type="inclusive" normal="1989-04">April 1989</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>U-matic</physfacet>
               </physdesc>
             </did>
@@ -3353,8 +3353,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>"Minstrel Tunes," "White Flag-Blackface-Ragtime," <unitdate type="inclusive" normal="1989-02-04">February 4, 1989</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>U-matic</physfacet>
               </physdesc>
             </did>
@@ -3363,8 +3363,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>"Pride and Prejudice," <unitdate type="inclusive" normal="1990">Fall 1990</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>U-matic</physfacet>
               </physdesc>
             </did>
@@ -3379,8 +3379,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>"Dances by Linda Spriggs, Gay Delanghe Performance," <unitdate type="inclusive" normal="1993-05-20">May 20, 1993</unitdate> S</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3389,8 +3389,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>"Dances by Linda Spriggs, Gay Delanghe Rehearsal," <unitdate type="inclusive" normal="1993-05-19">May 19, 1993</unitdate> S</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3399,8 +3399,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>"Ann Arbor Dance Works: Madonna" <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>U-matic</physfacet>
               </physdesc>
             </did>
@@ -3409,8 +3409,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>"Satiana: Limon Co. Manhattanville," <unitdate type="inclusive" normal="1977-07">July, 1977</unitdate></unittitle>
-              <physdesc>
-                <extent>1 video recordings</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 video recordings</extent>
                 <physfacet>open reel videotapes</physfacet>
               </physdesc>
             </did>
@@ -3419,8 +3419,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>"#4 Bullshot, Slavonic Skaena, Aubade,"</unittitle>
-              <physdesc>
-                <extent>1 video recordings</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 video recordings</extent>
                 <physfacet>open reel videotapes</physfacet>
               </physdesc>
             </did>
@@ -3434,8 +3434,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"Aubade," <unitdate type="inclusive" normal="1973">Summer 1973</unitdate></unittitle>
-              <physdesc>
-                <extent>3 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 film reels</extent>
                 <physfacet>Super 8</physfacet>
               </physdesc>
             </did>
@@ -3444,8 +3444,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"N. Topf Circle," <unitdate type="inclusive" normal="1973">Summer 1973</unitdate></unittitle>
-              <physdesc>
-                <extent>1 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 film reels</extent>
                 <physfacet>Super 8</physfacet>
               </physdesc>
             </did>
@@ -3454,8 +3454,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"Limb NY," <unitdate type="inclusive" normal="1973-06">June, 1973</unitdate></unittitle>
-              <physdesc>
-                <extent>1 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 film reels</extent>
                 <physfacet>Super 8</physfacet>
               </physdesc>
             </did>
@@ -3464,8 +3464,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"Limb Central Park," <unitdate type="inclusive" normal="1974-06">June, 1974</unitdate></unittitle>
-              <physdesc>
-                <extent>1 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 film reels</extent>
                 <physfacet>Super 8</physfacet>
               </physdesc>
             </did>
@@ -3474,8 +3474,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>Untitled</unittitle>
-              <physdesc>
-                <extent>1 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 film reels</extent>
                 <physfacet>Super 8</physfacet>
               </physdesc>
             </did>
@@ -3484,8 +3484,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"Perez," <unitdate type="inclusive" normal="1973">Summer 1973</unitdate></unittitle>
-              <physdesc>
-                <extent>4 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 film reels</extent>
                 <physfacet>Super 8</physfacet>
               </physdesc>
             </did>
@@ -3494,8 +3494,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"Seven Deadly Sins"</unittitle>
-              <physdesc>
-                <extent>6 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">6 film reels</extent>
                 <physfacet>Super 8</physfacet>
               </physdesc>
             </did>
@@ -3504,8 +3504,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"Bassett"</unittitle>
-              <physdesc>
-                <extent>3 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 film reels</extent>
                 <physfacet>Super 8</physfacet>
               </physdesc>
             </did>
@@ -3514,8 +3514,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"Don Davidson, Good Roll"</unittitle>
-              <physdesc>
-                <extent>1 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 film reels</extent>
                 <physfacet>Super 8</physfacet>
               </physdesc>
             </did>
@@ -3524,8 +3524,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"Don Davidson, Bad Roll"</unittitle>
-              <physdesc>
-                <extent>1 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 film reels</extent>
                 <physfacet>Super 8</physfacet>
               </physdesc>
             </did>
@@ -3534,8 +3534,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"H. Delanghe 2975 Beals, Detroit 14, Michigan"</unittitle>
-              <physdesc>
-                <extent>2 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 film reels</extent>
                 <physfacet>Super 8</physfacet>
               </physdesc>
             </did>
@@ -3544,8 +3544,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"Waterman Bob and Carol," <unitdate type="inclusive" normal="1973-05">May 1973</unitdate></unittitle>
-              <physdesc>
-                <extent>1 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 film reels</extent>
                 <physfacet>Super 8</physfacet>
               </physdesc>
             </did>
@@ -3559,8 +3559,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"Ann Arbor Dance Works," <unitdate type="inclusive" normal="2003">2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 film reels</extent>
                 <physfacet>Hi8</physfacet>
               </physdesc>
             </did>
@@ -3569,8 +3569,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"Women Who Rule: Fogel, Setrackian, Sears-Etter, Delanghe," <unitdate type="inclusive" normal="2002-03-17">March 17, 2002</unitdate></unittitle>
-              <physdesc>
-                <extent>1 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 film reels</extent>
                 <physfacet>Hi8</physfacet>
               </physdesc>
             </did>
@@ -3579,8 +3579,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"IAC #1 Perform (No Bonus)," <unitdate type="inclusive" normal="1996">1996</unitdate></unittitle>
-              <physdesc>
-                <extent>1 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 film reels</extent>
                 <physfacet>Hi8</physfacet>
               </physdesc>
             </did>
@@ -3589,8 +3589,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"IAC Nite," <unitdate type="inclusive" normal="1996">1996</unitdate></unittitle>
-              <physdesc>
-                <extent>1 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 film reels</extent>
                 <physfacet>Hi8</physfacet>
               </physdesc>
             </did>
@@ -3599,8 +3599,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"362"</unittitle>
-              <physdesc>
-                <extent>1 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 film reels</extent>
                 <physfacet>Hi8</physfacet>
               </physdesc>
             </did>
@@ -3609,8 +3609,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"#1 Rough Harpies Work, Migrations," <unitdate type="inclusive" normal="1996">1996</unitdate></unittitle>
-              <physdesc>
-                <extent>1 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 film reels</extent>
                 <physfacet>Hi8</physfacet>
               </physdesc>
             </did>
@@ -3619,8 +3619,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"Dance Works Tape #1, Good Harpies No Migrations," <unitdate type="inclusive" normal="1996-04">April, 1996</unitdate></unittitle>
-              <physdesc>
-                <extent>1 film reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 film reels</extent>
                 <physfacet>Hi8</physfacet>
               </physdesc>
             </did>
@@ -3634,8 +3634,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"Hommage a Delanghe Final Short," <unitdate type="inclusive" normal="2006-05-20">May 20, 2006</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVDs</physfacet>
               </physdesc>
             </did>
@@ -3644,8 +3644,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"Icarus Backup"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVDs</physfacet>
               </physdesc>
             </did>
@@ -3654,8 +3654,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>"Gay's Slideshow"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVDs</physfacet>
               </physdesc>
             </did>
@@ -3663,8 +3663,8 @@
           <c03 level="file">
             <did>
               <unittitle>"Hommage á Delanghe (short version)"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVDs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/detroitnews.xml
+++ b/Real_Masters_all/detroitnews.xml
@@ -169,7 +169,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Building Excavation for New Press Room-Exterior Views of Finished Structure, <unitdate type="inclusive" normal="1929">1929</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-2" show="new" actuate="onrequest">
                   <daodesc>
@@ -183,7 +183,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Craftsmanship-Toys, <unitdate type="inclusive" normal="1935">1935</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>5 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">5 negatives</extent>
                 </physdesc>
                 <dao href="2014153-3" show="new" actuate="onrequest">
                   <daodesc>
@@ -219,7 +219,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Experience Column-Carillon, <unitdate type="inclusive" normal="1939">1939</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-6" show="new" actuate="onrequest">
                   <daodesc>
@@ -233,7 +233,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Fair and Square Club-Trophy, <unitdate type="inclusive" normal="1934/1935">1934-1935</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>4 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-7" show="new" actuate="onrequest">
                   <daodesc>
@@ -247,7 +247,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Green, Jerry (Jerome)-Detroit News Emp. Editorial-Sports, <unitdate type="inclusive" normal="1966/1984">1966-1984</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>17 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">17 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -256,7 +256,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Halloween Scenes-Ann Seiter as a Witch, <unitdate type="inclusive" normal="1958">1958</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-9" show="new" actuate="onrequest">
                   <daodesc>
@@ -287,7 +287,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Medal of Valour for Police, <unitdate type="inclusive" normal="1928">1928</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-12" show="new" actuate="onrequest">
                   <daodesc>
@@ -334,7 +334,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Radio-Equipment-Ultra High Frequency Converter Designed and Built by A. B. Allen <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-16" show="new" actuate="onrequest">
                   <daodesc>
@@ -359,7 +359,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Radio-Microphone, <unitdate type="inclusive" normal="1932/1937">1932-1937</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>9 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">9 negatives</extent>
                 </physdesc>
                 <dao href="2014153-18" show="new" actuate="onrequest">
                   <daodesc>
@@ -373,7 +373,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Radio-Mobile Unit #1-Pack Set-Equipment, <unitdate type="inclusive" normal="1937">1937</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>7 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">7 negatives</extent>
                 </physdesc>
                 <dao href="2014153-19" show="new" actuate="onrequest">
                   <daodesc>
@@ -398,7 +398,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Radio-Programs-"Smoothies"-Gail Abbey, Jack Hill, Georgia Leath, Bobette Hall, <unitdate type="inclusive" normal="1935">1935</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>5 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">5 negatives</extent>
                 </physdesc>
                 <dao href="2014153-21" show="new" actuate="onrequest">
                   <daodesc>
@@ -412,7 +412,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Radio-Short Wave Adapter-Equipment, <unitdate type="inclusive" normal="1935/1936">1935-1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-22" show="new" actuate="onrequest">
                   <daodesc>
@@ -440,7 +440,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Radio-Staff-Elwood Ryan, Kurt Schmeissen, Louis Cohen, and Lillian Dixon <unitdate type="inclusive" normal="1937">1937</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-24" show="new" actuate="onrequest">
                   <daodesc>
@@ -479,7 +479,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Schools-Classroom Scenes, <unitdate type="inclusive" normal="1938/1959">1938-1959</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>9 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">9 negatives</extent>
                 </physdesc>
                 <dao href="2014153-27" show="new" actuate="onrequest">
                   <daodesc>
@@ -493,7 +493,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Schools-Classroom Scenes-Doty School, Monteith School, Hubert School, <unitdate type="inclusive" normal="1934/1958">1934-1958</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>5 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">5 negatives</extent>
                 </physdesc>
                 <dao href="2014153-28" show="new" actuate="onrequest">
                   <daodesc>
@@ -516,7 +516,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Spelling Bee-Contestants, <unitdate type="inclusive" normal="1933/1934">1933-1934</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-30" show="new" actuate="onrequest">
                   <daodesc>
@@ -555,7 +555,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Television-Equipment-Antenna on Penobscot Building, <unitdate type="inclusive" normal="1949/1950">1949-1950</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>6 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">6 negatives</extent>
                 </physdesc>
                 <dao href="2014153-33" show="new" actuate="onrequest">
                   <daodesc>
@@ -569,7 +569,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Television-Tower-Construction, <unitdate type="inclusive" normal="1954">1954</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>10 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">10 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -578,7 +578,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Travel Show-Crowds, <unitdate type="inclusive" normal="1950">1950</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-35" show="new" actuate="onrequest">
                   <daodesc>
@@ -592,7 +592,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Warehouse-Lombardo 10/18/1949-Roto 11/20/1949-Photos from Bridge, <unitdate type="inclusive" normal="1949">1949</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>6 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">6 negatives</extent>
                 </physdesc>
                 <dao href="2014153-36" show="new" actuate="onrequest">
                   <daodesc>
@@ -606,7 +606,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Advertising-Detroit News Lettering on Downtown Detroit, <unitdate type="inclusive" normal="1932">1932</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>5 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">5 negatives</extent>
                 </physdesc>
                 <dao href="2014153-37" show="new" actuate="onrequest">
                   <daodesc>
@@ -620,7 +620,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Advertising-Detroit News Sign, <unitdate type="inclusive" normal="1932">1932</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>6 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">6 negatives</extent>
                 </physdesc>
                 <dao href="2014153-38" show="new" actuate="onrequest">
                   <daodesc>
@@ -656,7 +656,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Branch Offices-General Motors Building, <unitdate type="inclusive" normal="1929">1929</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-41" show="new" actuate="onrequest">
                   <daodesc>
@@ -670,7 +670,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Bread Contest, <unitdate type="inclusive" normal="1922">1922</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>7 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">7 negatives</extent>
                 </physdesc>
                 <dao href="2014153-42" show="new" actuate="onrequest">
                   <daodesc>
@@ -698,7 +698,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Carriers, <unitdate type="inclusive" normal="1929">1929</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>20 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">20 negatives</extent>
                 </physdesc>
                 <dao href="2014153-44" show="new" actuate="onrequest">
                   <daodesc>
@@ -723,7 +723,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Chorus, <unitdate type="inclusive" normal="1928">1928</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-46" show="new" actuate="onrequest">
                   <daodesc>
@@ -737,7 +737,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Circulation Department Staff, <unitdate type="inclusive" normal="1930">1930</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-47" show="new" actuate="onrequest">
                   <daodesc>
@@ -751,7 +751,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Cooking School-Crowd-Auditorium, <unitdate type="inclusive" normal="1932">1932</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>4 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-48" show="new" actuate="onrequest">
                   <daodesc>
@@ -765,7 +765,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Cooking School-Crowd in Auditorium, <unitdate type="inclusive" normal="1933">1933</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-49" show="new" actuate="onrequest">
                   <daodesc>
@@ -801,7 +801,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Craftsmanship-Interior View of Workshop, <unitdate type="inclusive" normal="1935">1935</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>11 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">11 negatives</extent>
                 </physdesc>
                 <dao href="2014153-52" show="new" actuate="onrequest">
                   <daodesc>
@@ -815,7 +815,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Delivery Services-Trucks, <unitdate type="inclusive" normal="1929">1929</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>6 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">6 negatives</extent>
                 </physdesc>
                 <dao href="2014153-53" show="new" actuate="onrequest">
                   <daodesc>
@@ -829,7 +829,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Dock, Detroit River, between 1st &amp; 2nd Avenues, <unitdate type="inclusive" normal="1926">1926</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>4 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-54" show="new" actuate="onrequest">
                   <daodesc>
@@ -843,7 +843,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Employees-Department Heads, <unitdate type="inclusive" normal="1938">1938</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>5 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">5 negatives</extent>
                 </physdesc>
                 <dao href="2014153-55" show="new" actuate="onrequest">
                   <daodesc>
@@ -857,7 +857,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Employees-Dinner for "Key Men", <unitdate type="inclusive" normal="1939">1939</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-56" show="new" actuate="onrequest">
                   <daodesc>
@@ -882,7 +882,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Exterior-Lafayette Entrance View Taken from Second and Lafayette, <unitdate type="inclusive" normal="1928/1933">1928-1933</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>5 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">5 negatives</extent>
                 </physdesc>
               </did>
               <odd>
@@ -894,7 +894,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Exterior-Radio Tower, <unitdate type="inclusive" normal="1932">1932</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -909,7 +909,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Exterior-Views Showing News, <unitdate type="inclusive" normal="1926/1940">1926-1940</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>10 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">10 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -918,7 +918,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Exterior-Views of Side Facing Fort Street, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
               </did>
               <odd>
@@ -930,7 +930,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Exterior-Warehouse, <unitdate type="inclusive" normal="1931">1931</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -939,7 +939,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Art Department-New Addition, <unitdate type="inclusive" normal="1940">1940</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -954,7 +954,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Advertising Room, <unitdate type="inclusive" normal="1931/1935">1931-1935</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>7 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">7 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -963,7 +963,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Nancy Brown's Office-Fourth Floor, <unitdate type="inclusive" normal="1939">1939</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -978,7 +978,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Composing Room, <unitdate type="inclusive" normal="1931/1938">1931-1938</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>6 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">6 negatives</extent>
                 </physdesc>
               </did>
               <odd>
@@ -1014,7 +1014,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Library, <unitdate type="inclusive" normal="1931">1931</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1023,7 +1023,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Mailing Room, <unitdate type="inclusive" normal="1923">1923</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>9 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">9 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1032,7 +1032,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Photographers' Studio, <unitdate type="inclusive" normal="1929">1929</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>5 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">5 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1041,7 +1041,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior Views-Photographer's Studio, <unitdate type="inclusive" normal="1933">1933</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>4 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">4 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1050,7 +1050,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Photographic Department, <unitdate type="inclusive" normal="1931/1939">1931-1939</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>24 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">24 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1059,7 +1059,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Press Room-Showing Roto Presses, <unitdate type="inclusive" normal="1932">1932</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>7 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">7 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1068,7 +1068,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Press Room-Views of Presses and Pressmen, <unitdate type="inclusive" normal="1927/1938">1927-1938</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>30 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">30 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1077,7 +1077,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Press Room, Electrical Controls, Board for Presses, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>4 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">4 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1086,7 +1086,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Reference Department, <unitdate type="inclusive" normal="1930/1939">1930-1939</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>10 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">10 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1095,7 +1095,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-Stereotype Room, <unitdate type="inclusive" normal="1938">1938</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
               </did>
               <odd>
@@ -1128,7 +1128,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>New Building-Interior-"Women's Department"-First Floor, <unitdate type="inclusive" normal="1928/1934">1928-1934</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1137,7 +1137,7 @@
                 <container type="box" label="Box">2</container>
                 <unittitle>Old Building-Interior-Cranbrook Press-Owned by George Gough Booth, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-88" show="new" actuate="onrequest">
                   <daodesc>
@@ -1162,7 +1162,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Photo Show-Cedar Pointe, <unitdate type="inclusive" normal="1931">1931</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>4 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-90" show="new" actuate="onrequest">
                   <daodesc>
@@ -1176,7 +1176,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Photo Show-General Motors Building, <unitdate type="inclusive" normal="1931">1931</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>28 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">28 negatives</extent>
                 </physdesc>
                 <dao href="2014153-91" show="new" actuate="onrequest">
                   <daodesc>
@@ -1201,7 +1201,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Radio-Birthday Party-10th Anniversary, <unitdate type="inclusive" normal="1930">1930</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>5 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">5 negatives</extent>
                 </physdesc>
                 <dao href="2014153-93" show="new" actuate="onrequest">
                   <daodesc>
@@ -1259,7 +1259,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Radio-Entertainers-Frank and Ernest, <unitdate type="inclusive" normal="1931">1931</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-98" show="new" actuate="onrequest">
                   <daodesc>
@@ -1295,7 +1295,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Radio-Orchestra, <unitdate type="inclusive" normal="1930/1933">1930-1933</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>10 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">10 negatives</extent>
                 </physdesc>
                 <dao href="2014153-101" show="new" actuate="onrequest">
                   <daodesc>
@@ -1309,7 +1309,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Radio-Orchestra, <unitdate type="inclusive" normal="1932">1932</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>5 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">5 negatives</extent>
                 </physdesc>
                 <dao href="2014153-102" show="new" actuate="onrequest">
                   <daodesc>
@@ -1334,7 +1334,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Radio-Orchestra and String Quartet, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>7 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">7 negatives</extent>
                 </physdesc>
                 <dao href="2014153-104" show="new" actuate="onrequest">
                   <daodesc>
@@ -1359,7 +1359,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Radio-Players-Rita Alcock and William Morrison, <unitdate type="inclusive" normal="1933">1933</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-106" show="new" actuate="onrequest">
                   <daodesc>
@@ -1373,7 +1373,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Radio-Players-Cadillac-Herbert Labadie, <unitdate type="inclusive" normal="1931">1931</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-107" show="new" actuate="onrequest">
                   <daodesc>
@@ -1387,7 +1387,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Radio-Players-Plays, <unitdate type="inclusive" normal="1931">1931</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>8 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">8 negatives</extent>
                 </physdesc>
                 <dao href="2014153-108" show="new" actuate="onrequest">
                   <daodesc>
@@ -1412,7 +1412,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Radio-Players-Dr. B.D. Welling and Glendora Forshee, <unitdate type="inclusive" normal="1933">1933</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-110" show="new" actuate="onrequest">
                   <daodesc>
@@ -1448,7 +1448,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Short Wave-W8XWJ-Lobby, <unitdate type="inclusive" normal="1938/1940">1938-1940</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1457,7 +1457,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Short Wave Station-W8XWJ-Equipment in Penobscot Building, <unitdate type="inclusive" normal="1936/1938">1936-1938</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>11 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">11 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1472,7 +1472,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Construction-Series "B", <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>8 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">8 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1481,7 +1481,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Construction-Series "C", <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>8 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">8 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1490,7 +1490,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Construction-Series "E", <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>9 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">9 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1499,7 +1499,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Construction-Series "F", <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1514,7 +1514,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Equipment, <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>4 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">4 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1523,7 +1523,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Exterior View, <unitdate type="inclusive" normal="1936/1941">1936-1941</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>12 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">12 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1538,7 +1538,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Exterior-Sculpture on East and West Side of Entrance, <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1547,7 +1547,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Interior-Air Conditioning System, <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1562,7 +1562,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Interior-Auditorium Studio and Orchestra, <unitdate type="inclusive" normal="1936/1939">1936-1939</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>5 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">5 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1577,7 +1577,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Interior-Control Room, <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1586,7 +1586,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Interior-Lobby-Main Lobby, <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1601,7 +1601,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Interior-News Room, <unitdate type="inclusive" normal="1938">1938</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1622,7 +1622,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-New-Interior-Studios A, B, C, and D, <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>10 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">10 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1631,7 +1631,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-Old-Equipment, <unitdate type="inclusive" normal="1922/1931">1922-1931</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>19 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">19 negatives</extent>
                 </physdesc>
               </did>
               <odd>
@@ -1643,7 +1643,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Studio-Old-Equipment-Transmitter and Control Room, <unitdate type="inclusive" normal="1921/1930">1921-1930</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>15 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">15 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1664,7 +1664,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Tower-New-On New Transmitting Station, Meyers and Eight Mile Road, <unitdate type="inclusive" normal="1935">1935</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>8 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">8 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1679,7 +1679,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Transmitter-New-Building-Exterior, <unitdate type="inclusive" normal="1936/1941">1936-1941</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>14 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">14 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1706,7 +1706,7 @@
                 <container type="box" label="Box">3</container>
                 <unittitle>Radio-Transmitter-New-Equipment-Scripps Motor, <unitdate type="inclusive" normal="1937">1937</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1727,7 +1727,7 @@
                 <container type="box" label="Box">4</container>
                 <unittitle>Radio-Transmitter-New-Interior-Control Room, <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1736,7 +1736,7 @@
                 <container type="box" label="Box">4</container>
                 <unittitle>Radio-Transmitter-New-Interior-Caretaker's Apartment, <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>5 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">5 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1751,7 +1751,7 @@
                 <container type="box" label="Box">4</container>
                 <unittitle>Radio-Transmitter-New-Interior-Control Room, <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1766,7 +1766,7 @@
                 <container type="box" label="Box">4</container>
                 <unittitle>Radio-Transmitter-New-Interior-Hall and Staircase-New Transmitting Station, <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1775,7 +1775,7 @@
                 <container type="box" label="Box">4</container>
                 <unittitle>Radio-Transmitter-New-Interior-Lobby-Showing Mural, <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1784,7 +1784,7 @@
                 <container type="box" label="Box">4</container>
                 <unittitle>Radio-Transmitter-New-Interior-Murals, <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1799,7 +1799,7 @@
                 <container type="box" label="Box">4</container>
                 <unittitle>Radio-Transmitter-New-Interior-Operators Bunks, <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1814,7 +1814,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Rotogravure Sections-Retouching, <unitdate type="inclusive" normal="1929">1929</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-160" show="new" actuate="onrequest">
                   <daodesc>
@@ -1828,7 +1828,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Spelling Bee, <unitdate type="inclusive" normal="1929">1929</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-161" show="new" actuate="onrequest">
                   <daodesc>
@@ -1842,7 +1842,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Spelling Bee-Coliseum Scenes, <unitdate type="inclusive" normal="1930">1930</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>6 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">6 negatives</extent>
                 </physdesc>
                 <dao href="2014153-162" show="new" actuate="onrequest">
                   <daodesc>
@@ -1856,7 +1856,7 @@
                 <container type="box" label="Box">4</container>
                 <unittitle>Spelling Bee-Coliseum Scenes, <unitdate type="inclusive" normal="1932">1932</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>5 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">5 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1865,7 +1865,7 @@
                 <container type="box" label="Box">4</container>
                 <unittitle>Spelling Bee-Coliseum Scenes, <unitdate type="inclusive" normal="1933">1933</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1886,7 +1886,7 @@
                 <container type="box" label="Box">4</container>
                 <unittitle>Spelling Bee-Coliseum Scenes, <unitdate type="inclusive" normal="1937">1937</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>5 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">5 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1895,7 +1895,7 @@
                 <container type="box" label="Box">4</container>
                 <unittitle>Spelling Bee-Coliseum Scenes, <unitdate type="inclusive" normal="1938">1938</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1904,7 +1904,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Spelling Bee-Group Photo of Contestants, <unitdate type="inclusive" normal="1930">1930</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-169" show="new" actuate="onrequest">
                   <daodesc>
@@ -1918,7 +1918,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Spelling Bee-Group Photo of Contestants, <unitdate type="inclusive" normal="1932">1932</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-170" show="new" actuate="onrequest">
                   <daodesc>
@@ -1943,7 +1943,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Spelling Contest, <unitdate type="inclusive" normal="1927">1927</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>4 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-172" show="new" actuate="onrequest">
                   <daodesc>
@@ -1957,7 +1957,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Spelling Contest, <unitdate type="inclusive" normal="1928">1928</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-173" show="new" actuate="onrequest">
                   <daodesc>
@@ -1971,7 +1971,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Spelling Contest-Vivian Bremer-Winner, <unitdate type="inclusive" normal="1926">1926</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>4 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-174" show="new" actuate="onrequest">
                   <daodesc>
@@ -1985,7 +1985,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Spelling Contest-Dorothy Karrick-Winner, <unitdate type="inclusive" normal="1925">1925</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>9 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">9 negatives</extent>
                 </physdesc>
                 <dao href="2014153-175" show="new" actuate="onrequest">
                   <daodesc>
@@ -2002,7 +2002,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Spelling Contest-Justine Pearsall-Winner, <unitdate type="inclusive" normal="1922">1922</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>16 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">16 negatives</extent>
                 </physdesc>
                 <dao href="2014153-176" show="new" actuate="onrequest">
                   <daodesc>
@@ -2016,7 +2016,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Young Writers' Club, <unitdate type="inclusive" normal="1928">1928</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>7 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">7 negatives</extent>
                 </physdesc>
                 <dao href="2014153-177" show="new" actuate="onrequest">
                   <daodesc>
@@ -2071,7 +2071,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Barbecue-Parade, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>4 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-181" show="new" actuate="onrequest">
                   <daodesc>
@@ -2085,7 +2085,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Barbecue-Mr. George Booth with: Mr. Scott, Mr. George Miller, Mr. M. Bingay, Mr. William Scripps. Mr. Scripps also with Wife and Mother, <unitdate type="inclusive" normal="1923">1923</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-182" show="new" actuate="onrequest">
                   <daodesc>
@@ -2099,7 +2099,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Barbecue-Trip to Grove for Lunch, Meat Roasting Spits, Guests as Tables, Spectators Watching Games-50th Anniversary at Scripps Farm, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-183" show="new" actuate="onrequest">
                   <daodesc>
@@ -2124,7 +2124,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Building Excavation for New Press Room, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-185" show="new" actuate="onrequest">
                   <daodesc>
@@ -2138,7 +2138,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Detroit Riding and Hunt Club-Horses in Paddock, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-186" show="new" actuate="onrequest">
                   <daodesc>
@@ -2152,7 +2152,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Dock, Detroit River, between First and Second Avenues, <unitdate type="inclusive" normal="1926">1926</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-187" show="new" actuate="onrequest">
                   <daodesc>
@@ -2166,7 +2166,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Fish Sale, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-188" show="new" actuate="onrequest">
                   <daodesc>
@@ -2191,7 +2191,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Parades-Beer Parade, <unitdate type="inclusive" normal="1932">1932</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-190" show="new" actuate="onrequest">
                   <daodesc>
@@ -2205,7 +2205,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Radio-Short Wave Station-Antenna on Penobscot Building Tower, <unitdate type="inclusive" normal="1936">1936</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-191" show="new" actuate="onrequest">
                   <daodesc>
@@ -2219,7 +2219,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Radio-Towers-Birds on Tower, <unitdate type="inclusive" normal="1933">1933</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-192" show="new" actuate="onrequest">
                   <daodesc>
@@ -2233,7 +2233,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Rolls of Paper Unloaded from Truck in Warehouse, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-193" show="new" actuate="onrequest">
                   <daodesc>
@@ -2283,7 +2283,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Cigar Factory-Women Making Cigars, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-197" show="new" actuate="onrequest">
                   <daodesc>
@@ -2308,7 +2308,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Fish Campaign, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>7 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">7 negatives</extent>
                 </physdesc>
                 <dao href="2014153-199" show="new" actuate="onrequest">
                   <daodesc>
@@ -2336,7 +2336,7 @@
                 <physloc>Online</physloc>
                 <unittitle>New Building-Construction, <unitdate type="inclusive" normal="1915/1916">1915-1916</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>8 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">8 negatives</extent>
                 </physdesc>
                 <dao href="2014153-200" show="new" actuate="onrequest">
                   <daodesc>
@@ -2350,7 +2350,7 @@
                 <physloc>Online</physloc>
                 <unittitle>New Building-Excavation, <unitdate type="inclusive" normal="1915">1915</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>1 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">1 negatives</extent>
                 </physdesc>
                 <dao href="2014153-201" show="new" actuate="onrequest">
                   <daodesc>
@@ -2367,7 +2367,7 @@
                 <physloc>Online</physloc>
                 <unittitle>New Building-Excavation, <unitdate type="inclusive" normal="1915">1915</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>6 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">6 negatives</extent>
                 </physdesc>
                 <dao href="2014153-201" show="new" actuate="onrequest">
                   <daodesc>
@@ -2395,7 +2395,7 @@
                 <physloc>Online</physloc>
                 <unittitle>New Building-Exterior-Decorated for 32nd Division Reunion, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>5 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">5 negatives</extent>
                 </physdesc>
                 <dao href="2014153-203" show="new" actuate="onrequest">
                   <daodesc>
@@ -2409,7 +2409,7 @@
                 <physloc>Online</physloc>
                 <unittitle>New Building-Exterior-Lafayette Entrance View Taken from Second and Lafayette, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>4 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-58" show="new" actuate="onrequest">
                   <daodesc>
@@ -2448,7 +2448,7 @@
                 <physloc>Online</physloc>
                 <unittitle>New Building-Exterior-Views of Side Facing Fort Street, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-62" show="new" actuate="onrequest">
                   <daodesc>
@@ -2465,7 +2465,7 @@
                 <physloc>Online</physloc>
                 <unittitle>New Building-Exterior-Views of Side Facing Fort Street, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>4 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-62" show="new" actuate="onrequest">
                   <daodesc>
@@ -2482,7 +2482,7 @@
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Art Room (Former One on Third Floor)-Mural Decorations, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>6 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">6 negatives</extent>
                 </physdesc>
                 <dao href="2014153-206" show="new" actuate="onrequest">
                   <daodesc>
@@ -2496,7 +2496,7 @@
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Composing Room, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-69" show="new" actuate="onrequest">
                   <daodesc>
@@ -2513,7 +2513,7 @@
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Dark Room, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>7 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">7 negatives</extent>
                 </physdesc>
                 <dao href="2014153-207" show="new" actuate="onrequest">
                   <daodesc>
@@ -2549,7 +2549,7 @@
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Lobby-Second Floor, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-210" show="new" actuate="onrequest">
                   <daodesc>
@@ -2563,7 +2563,7 @@
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Mailing Room, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>5 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">5 negatives</extent>
                 </physdesc>
                 <dao href="2014153-211" show="new" actuate="onrequest">
                   <daodesc>
@@ -2577,7 +2577,7 @@
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Press Room-New Presses, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>4 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">4 negatives</extent>
                 </physdesc>
                 <dao href="2014153-212" show="new" actuate="onrequest">
                   <daodesc>
@@ -2591,7 +2591,7 @@
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Stereotype Room, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-83" show="new" actuate="onrequest">
                   <daodesc>
@@ -2608,7 +2608,7 @@
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Storage Room for Paper, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-84" show="new" actuate="onrequest">
                   <daodesc>
@@ -2625,7 +2625,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Old Building-Exterior-Delivery Trucks Lined up Outside Old Building, <unitdate type="inclusive" normal="1912">1912</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-213" show="new" actuate="onrequest">
                   <daodesc>
@@ -2639,7 +2639,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Old Building-Exterior-Views of Building on Shelby and Larned, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-214" show="new" actuate="onrequest">
                   <daodesc>
@@ -2653,7 +2653,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Old Building-Interior-Advertising Department-Business Office, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-215" show="new" actuate="onrequest">
                   <daodesc>
@@ -2667,7 +2667,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Old Building-Interior-Art Room, <unitdate type="inclusive" normal="1912">1912</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-216" show="new" actuate="onrequest">
                   <daodesc>
@@ -2681,7 +2681,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Old Building-Interior-Composing Room-Stereotype Room, <unitdate type="inclusive" normal="1912">1912</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>9 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">9 negatives</extent>
                 </physdesc>
                 <dao href="2014153-217" show="new" actuate="onrequest">
                   <daodesc>
@@ -2717,7 +2717,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Old Building-Interior-Photographers' Room, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-220" show="new" actuate="onrequest">
                   <daodesc>
@@ -2731,7 +2731,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Old Building-Interior-Press Room, <unitdate type="inclusive" normal="1910/1912">1910-1912</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">3 negatives</extent>
                 </physdesc>
                 <dao href="2014153-221" show="new" actuate="onrequest">
                   <daodesc>
@@ -2792,7 +2792,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Young Writers' Club, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-177" show="new" actuate="onrequest">
                   <daodesc>
@@ -2820,7 +2820,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Art Department-Kraemer's Corner, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-226" show="new" actuate="onrequest">
                   <daodesc>
@@ -2851,7 +2851,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Bindery, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-228" show="new" actuate="onrequest">
                   <daodesc>
@@ -2882,7 +2882,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Building Exterior, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-230" show="new" actuate="onrequest">
                   <daodesc>
@@ -3089,7 +3089,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Hospital, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-248" show="new" actuate="onrequest">
                   <daodesc>
@@ -3117,7 +3117,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Ink Tank Truck, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-250" show="new" actuate="onrequest">
                   <daodesc>
@@ -3153,7 +3153,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Library-New Building, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-253" show="new" actuate="onrequest">
                   <daodesc>
@@ -3170,7 +3170,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Library-New Building, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>1 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">1 negatives</extent>
                 </physdesc>
                 <dao href="2014153-253" show="new" actuate="onrequest">
                   <daodesc>
@@ -4283,7 +4283,7 @@
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Windows, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-353" show="new" actuate="onrequest">
                   <daodesc>
@@ -4297,7 +4297,7 @@
                 <physloc>Online</physloc>
                 <unittitle>New Building-Interior-Windows, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-354" show="new" actuate="onrequest">
                   <daodesc>
@@ -4604,7 +4604,7 @@
                 <physloc>Online</physloc>
                 <unittitle>Roto, <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 negatives</extent>
+                  <extent altrender="materialtype spaceoccupied">2 negatives</extent>
                 </physdesc>
                 <dao href="2014153-380" show="new" actuate="onrequest">
                   <daodesc>

--- a/Real_Masters_all/devineed.xml
+++ b/Real_Masters_all/devineed.xml
@@ -38,8 +38,8 @@
         <persname source="lcnaf" encodinganalog="100">DeVine, Edmond Francis</persname>
       </origination>
       <unittitle encodinganalog="245"> Edmond DeVine papers <unitdate type="inclusive" encodinganalog="245$f"> 1933-1955 </unitdate></unittitle>
-      <physdesc>
-        <extent encodinganalog="300">0.3 linear feet</extent>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">0.3 linear feet</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number"> 2015052 Aa 2 </unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>

--- a/Real_Masters_all/durbanl.xml
+++ b/Real_Masters_all/durbanl.xml
@@ -6652,7 +6652,7 @@
             <container type="item" label="Item">18</container>
             <unittitle><unitdate type="inclusive">Undated</unitdate> in two parts</unittitle>
             <physdesc altrender="whole">
-              <extent>2 tapes</extent>
+              <extent altrender="materialtype spaceoccupied">2 tapes</extent>
             </physdesc>
           </did>
           <odd>
@@ -6728,7 +6728,7 @@
             <container type="item" label="Item">26</container>
             <unittitle>Unidentified</unittitle>
             <physdesc altrender="whole">
-              <extent>2 tapes</extent>
+              <extent altrender="materialtype spaceoccupied">2 tapes</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/eldersvd.xml
+++ b/Real_Masters_all/eldersvd.xml
@@ -713,8 +713,8 @@
           <did>
             <container type="box" label="Box">5</container>
             <unittitle>Dinner with the Scientific and Azazel Faculty Club to Discuss the University of Michigan Bicentennial in 2017</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>DVD</physfacet>
             </physdesc>
           </did>
@@ -1113,8 +1113,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>"Support for Economic and Political Change in the China Countryside: An Empirical Study of Cadres and Villagers in Four Countries, 1990 and 1996" <unitdate type="inclusive" normal="2001">2001</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-ROMs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/englerj.xml
+++ b/Real_Masters_all/englerj.xml
@@ -28774,11 +28774,10 @@
               <did>
                 <container type="box" label="Box">142</container>
                 <unittitle>"Off the Record," WTVS-TV (PBS), 9:00 pm <unitdate type="inclusive" normal="1993-05-21">May 21, 1993</unitdate></unittitle>
-                <physdesc>
+                <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
-                  <dimensions>30 minutes</dimensions>
-                  <extent>1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
+                  <dimensions>30 minutes</dimensions>
                 </physdesc>
               </did>
               <odd>
@@ -34288,8 +34287,8 @@
               <did>
                 <container type="box" label="Box">157</container>
                 <unittitle>"Superior Court Oral Hearings # 14," <unitdate type="inclusive" normal="1994-10-05">October 5, 1994</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic (small)</physfacet>
                 </physdesc>
               </did>
@@ -34301,8 +34300,8 @@
               <did>
                 <container type="box" label="Box">157</container>
                 <unittitle>"Superior Court Oral Hearings, #8," <unitdate type="inclusive" normal="1994-10-04">October 4, 1994</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic (small)</physfacet>
                 </physdesc>
               </did>
@@ -34314,8 +34313,8 @@
               <did>
                 <container type="box" label="Box">157</container>
                 <unittitle>"Supreme Court, #3," <unitdate type="inclusive">undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic (large)</physfacet>
                 </physdesc>
               </did>
@@ -34333,8 +34332,8 @@
               <did>
                 <container type="box" label="Box">157</container>
                 <unittitle>"Spotlight on the News," Program 403907 <unitdate type="inclusive" normal="1991-02-24">February 24, 1991</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -35183,9 +35182,9 @@
                 <container type="box" label="Box">149</container>
                 <unittitle>"Assorted Nuts," Michigan Department of Transportation Give 'em a Break Public Service Announcement <unitdate type="inclusive">undated</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <dimensions>30 seconds</dimensions>
-                  <extent>1 videotapes</extent>
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
+                  <dimensions>30 seconds</dimensions>
                 </physdesc>
               </did>
               <odd>
@@ -35196,8 +35195,8 @@
               <did>
                 <container type="box" label="Box">149</container>
                 <unittitle>"Investing in Ability," Michigan Department of Labor, Public Service Announcements <unitdate type="inclusive" normal="1992-03-01">March 1, 1992</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -35209,8 +35208,8 @@
               <did>
                 <container type="box" label="Box">149</container>
                 <unittitle>"You Should be in College," Michigan Department of Education Public Service Announcement <unitdate type="inclusive">undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -35222,8 +35221,8 @@
               <did>
                 <container type="box" label="Box">149</container>
                 <unittitle>"Video Profile: Sen. Connie Binsfeld," Senate Republican News Office <unitdate type="inclusive" normal="1990-10-11">October 11, 1990</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -35235,8 +35234,8 @@
               <did>
                 <container type="box" label="Box">149</container>
                 <unittitle>Engler Spots, 2x :30 <unitdate type="inclusive" normal="1990-03">March 1990</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -35248,8 +35247,8 @@
               <did>
                 <container type="box" label="Box">149</container>
                 <unittitle>"Governor John Engler's State of the State 1991" <unitdate type="inclusive" normal="1991-02-11">February 11, 1991</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -35261,8 +35260,8 @@
               <did>
                 <container type="box" label="Box">149</container>
                 <unittitle>"1994 State of the State Raw Tape," <unitdate type="inclusive" normal="1994">1994</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -35274,8 +35273,8 @@
               <did>
                 <container type="box" label="Box">149</container>
                 <unittitle>"Last Day of Session," <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -35287,8 +35286,8 @@
               <did>
                 <container type="box" label="Box">149</container>
                 <unittitle>"Shell-game, Rhodes, Parks and Sleep," Spot #23, 24, 25, Tele-Color Productions, Inc., Alexandria, Virginia</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -35303,8 +35302,8 @@
                 <physdesc altrender="whole">
                   <dimensions>4:26</dimensions>
                 </physdesc>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -35317,9 +35316,9 @@
                 <container type="box" label="Box">149</container>
                 <unittitle>"I'm at Risk/K-Mart," Michigan Department of Public Health, Brogan &amp; Partners <unitdate type="inclusive" normal="1993-03-15">March 15, 1993</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <dimensions>30 seconds</dimensions>
-                  <extent>1 videotapes</extent>
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
+                  <dimensions>30 seconds</dimensions>
                 </physdesc>
               </did>
               <odd>
@@ -35330,8 +35329,8 @@
               <did>
                 <container type="box" label="Box">149</container>
                 <unittitle>"Changing Lifestyles: A Five Part Series on Health &amp; Aging," Healthy Older People, Office of Disease Prevention and Health Promotion, Public Health Service, U.S. Department of Health and Human Services <unitdate type="inclusive">undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -35343,8 +35342,8 @@
               <did>
                 <container type="box" label="Box">149</container>
                 <unittitle>"Project Find," Public Service Announcements, State of Michigan Department of Education <unitdate type="inclusive" normal="1992-08">August 1992</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -35357,9 +35356,9 @@
                 <container type="box" label="Box">149</container>
                 <unittitle>"I'm at Risk/MDPH," Michigan Department of Public Health, Brogan &amp; Partners <unitdate type="inclusive" normal="1993-03-15">March 15, 1993</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <dimensions>30 seconds</dimensions>
-                  <extent>1 videotapes</extent>
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
+                  <dimensions>30 seconds</dimensions>
                 </physdesc>
               </did>
               <odd>
@@ -35370,8 +35369,8 @@
               <did>
                 <container type="box" label="Box">149</container>
                 <unittitle>Gov's Show, December, no year given</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -35395,8 +35394,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:18:44</dimensions>
                   </physdesc>
@@ -35409,8 +35408,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -35432,8 +35431,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:47:41</dimensions>
                   </physdesc>
@@ -35446,8 +35445,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -35469,8 +35468,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:22:40</dimensions>
                   </physdesc>
@@ -35483,8 +35482,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -35506,8 +35505,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>18:55</dimensions>
                   </physdesc>
@@ -35520,8 +35519,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -35543,8 +35542,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>15:29</dimensions>
                   </physdesc>
@@ -35557,8 +35556,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -35580,8 +35579,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:21:3</dimensions>
                   </physdesc>
@@ -35594,8 +35593,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -35617,8 +35616,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:12:35</dimensions>
                   </physdesc>
@@ -35631,8 +35630,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -35654,8 +35653,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:32:50</dimensions>
                   </physdesc>
@@ -35668,8 +35667,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -35691,8 +35690,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                   </physdesc>
                 </did>
@@ -35704,8 +35703,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -35727,8 +35726,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>32:37</dimensions>
                   </physdesc>
@@ -35741,8 +35740,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -35764,8 +35763,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>40:42</dimensions>
                   </physdesc>
@@ -35778,8 +35777,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -35801,8 +35800,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:30:00</dimensions>
                   </physdesc>
@@ -35815,8 +35814,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -35838,8 +35837,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>32:00</dimensions>
                   </physdesc>
@@ -35852,8 +35851,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -35875,8 +35874,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:24:27</dimensions>
                   </physdesc>
@@ -35889,8 +35888,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -35912,8 +35911,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>30:43</dimensions>
                   </physdesc>
@@ -35926,8 +35925,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -35949,8 +35948,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:28:50</dimensions>
                   </physdesc>
@@ -35963,8 +35962,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -35986,8 +35985,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                   </physdesc>
                 </did>
@@ -35998,8 +35997,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36013,8 +36012,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:32:26</dimensions>
                   </physdesc>
@@ -36027,8 +36026,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36050,8 +36049,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:37:12</dimensions>
                   </physdesc>
@@ -36064,8 +36063,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36087,8 +36086,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>26:47</dimensions>
                   </physdesc>
@@ -36101,8 +36100,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36124,8 +36123,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>12:44</dimensions>
                   </physdesc>
@@ -36138,8 +36137,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36161,8 +36160,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:17:21</dimensions>
                   </physdesc>
@@ -36175,8 +36174,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36198,8 +36197,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:19:26</dimensions>
                   </physdesc>
@@ -36212,8 +36211,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36235,8 +36234,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:19:26</dimensions>
                   </physdesc>
@@ -36249,8 +36248,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36272,8 +36271,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:15:08</dimensions>
                   </physdesc>
@@ -36286,8 +36285,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36309,8 +36308,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:29:23</dimensions>
                   </physdesc>
@@ -36323,8 +36322,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36346,8 +36345,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:31:16</dimensions>
                   </physdesc>
@@ -36360,8 +36359,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36383,8 +36382,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:22:36</dimensions>
                   </physdesc>
@@ -36397,8 +36396,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36420,8 +36419,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>17:13</dimensions>
                   </physdesc>
@@ -36434,8 +36433,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36457,8 +36456,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:17:46</dimensions>
                   </physdesc>
@@ -36471,8 +36470,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36494,8 +36493,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>8:47</dimensions>
                   </physdesc>
@@ -36508,8 +36507,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36531,8 +36530,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>26:13</dimensions>
                   </physdesc>
@@ -36545,8 +36544,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36568,8 +36567,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>34:18</dimensions>
                   </physdesc>
@@ -36582,8 +36581,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36605,8 +36604,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>29:12</dimensions>
                   </physdesc>
@@ -36619,8 +36618,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36642,8 +36641,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>16:56</dimensions>
                   </physdesc>
@@ -36656,8 +36655,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36679,8 +36678,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>16:39</dimensions>
                   </physdesc>
@@ -36693,8 +36692,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36716,8 +36715,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>14:14</dimensions>
                   </physdesc>
@@ -36730,8 +36729,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36753,8 +36752,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>25:33</dimensions>
                   </physdesc>
@@ -36767,8 +36766,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36790,8 +36789,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>30:31</dimensions>
                   </physdesc>
@@ -36804,8 +36803,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36827,8 +36826,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>30:31</dimensions>
                   </physdesc>
@@ -36841,8 +36840,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36864,8 +36863,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>18:00</dimensions>
                   </physdesc>
@@ -36878,8 +36877,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36901,8 +36900,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>26:29</dimensions>
                   </physdesc>
@@ -36915,8 +36914,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36938,8 +36937,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>23:30</dimensions>
                   </physdesc>
@@ -36952,8 +36951,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -36975,8 +36974,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>22:07</dimensions>
                   </physdesc>
@@ -36989,8 +36988,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37012,8 +37011,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>28:32</dimensions>
                   </physdesc>
@@ -37026,8 +37025,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37049,8 +37048,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>11:36</dimensions>
                   </physdesc>
@@ -37063,8 +37062,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37086,8 +37085,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>38:30</dimensions>
                   </physdesc>
@@ -37100,8 +37099,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37123,8 +37122,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>36:09</dimensions>
                   </physdesc>
@@ -37136,8 +37135,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37151,8 +37150,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>36:13</dimensions>
                   </physdesc>
@@ -37164,8 +37163,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37179,8 +37178,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:04:53</dimensions>
                   </physdesc>
@@ -37193,8 +37192,8 @@
                 <did>
                   <container type="box" label="DVD Box">11</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37216,8 +37215,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:15:57</dimensions>
                   </physdesc>
@@ -37230,8 +37229,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37253,8 +37252,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:45:56</dimensions>
                   </physdesc>
@@ -37267,8 +37266,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37290,8 +37289,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:19:32</dimensions>
                   </physdesc>
@@ -37304,8 +37303,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37327,8 +37326,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:28:00</dimensions>
                   </physdesc>
@@ -37341,8 +37340,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37364,8 +37363,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:04:24</dimensions>
                   </physdesc>
@@ -37378,8 +37377,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37401,8 +37400,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:30:00</dimensions>
                   </physdesc>
@@ -37415,8 +37414,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37438,8 +37437,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>5:45</dimensions>
                   </physdesc>
@@ -37452,8 +37451,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37475,8 +37474,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>01:22:25</dimensions>
                   </physdesc>
@@ -37489,8 +37488,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37512,8 +37511,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:31:00</dimensions>
                   </physdesc>
@@ -37526,8 +37525,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37549,8 +37548,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:31:07</dimensions>
                   </physdesc>
@@ -37563,8 +37562,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37586,8 +37585,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>18:00</dimensions>
                   </physdesc>
@@ -37600,8 +37599,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37623,8 +37622,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>20:10</dimensions>
                   </physdesc>
@@ -37637,8 +37636,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37660,8 +37659,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:14:27</dimensions>
                   </physdesc>
@@ -37674,8 +37673,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37697,8 +37696,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>19:29</dimensions>
                   </physdesc>
@@ -37711,8 +37710,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37734,8 +37733,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>ca. 24:00</dimensions>
                   </physdesc>
@@ -37748,8 +37747,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37771,8 +37770,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:23:00</dimensions>
                   </physdesc>
@@ -37785,8 +37784,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37808,8 +37807,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:32:20</dimensions>
                   </physdesc>
@@ -37822,8 +37821,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37845,8 +37844,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:18:36</dimensions>
                   </physdesc>
@@ -37859,8 +37858,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37882,8 +37881,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>27:00</dimensions>
                   </physdesc>
@@ -37896,8 +37895,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37919,8 +37918,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:25:45</dimensions>
                   </physdesc>
@@ -37933,8 +37932,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37956,8 +37955,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:24:01</dimensions>
                   </physdesc>
@@ -37970,8 +37969,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -37993,8 +37992,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>20:30</dimensions>
                   </physdesc>
@@ -38007,8 +38006,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38030,8 +38029,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:33:57</dimensions>
                   </physdesc>
@@ -38044,8 +38043,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38067,8 +38066,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>ca. 50:00</dimensions>
                   </physdesc>
@@ -38081,8 +38080,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38104,8 +38103,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:34:02</dimensions>
                   </physdesc>
@@ -38118,8 +38117,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38141,8 +38140,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>39:32</dimensions>
                   </physdesc>
@@ -38155,8 +38154,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38178,8 +38177,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>32:33</dimensions>
                   </physdesc>
@@ -38192,8 +38191,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38215,8 +38214,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:26:20</dimensions>
                   </physdesc>
@@ -38229,8 +38228,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38252,8 +38251,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>ca. 27:30</dimensions>
                   </physdesc>
@@ -38266,8 +38265,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38289,8 +38288,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:25:45</dimensions>
                   </physdesc>
@@ -38303,8 +38302,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38326,8 +38325,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:32:26</dimensions>
                   </physdesc>
@@ -38340,8 +38339,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38363,8 +38362,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>ca. 34:30</dimensions>
                   </physdesc>
@@ -38377,8 +38376,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38400,8 +38399,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:32:49</dimensions>
                   </physdesc>
@@ -38414,8 +38413,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38437,8 +38436,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:28:10</dimensions>
                   </physdesc>
@@ -38451,8 +38450,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38474,8 +38473,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:23:58</dimensions>
                   </physdesc>
@@ -38488,8 +38487,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38511,8 +38510,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:28:30</dimensions>
                   </physdesc>
@@ -38525,8 +38524,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38548,8 +38547,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:21:17</dimensions>
                   </physdesc>
@@ -38562,8 +38561,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38585,8 +38584,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:27:43</dimensions>
                   </physdesc>
@@ -38599,8 +38598,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38622,8 +38621,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>30:37</dimensions>
                   </physdesc>
@@ -38636,8 +38635,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38659,8 +38658,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>30:44</dimensions>
                   </physdesc>
@@ -38673,8 +38672,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38696,8 +38695,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>ca. 19:00</dimensions>
                   </physdesc>
@@ -38710,8 +38709,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38733,8 +38732,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>20:00</dimensions>
                   </physdesc>
@@ -38747,8 +38746,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38770,8 +38769,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:21:17</dimensions>
                   </physdesc>
@@ -38784,8 +38783,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38807,8 +38806,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:03:18</dimensions>
                   </physdesc>
@@ -38821,8 +38820,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38844,8 +38843,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:05:51</dimensions>
                   </physdesc>
@@ -38858,8 +38857,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38881,8 +38880,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>ca. 13:00</dimensions>
                   </physdesc>
@@ -38895,8 +38894,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -38918,8 +38917,8 @@
               <c05 level="otherlevel" otherlevel="item-part">
                 <did>
                   <unittitle>Original:</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>Betacam TM, color, sound</physfacet>
                     <dimensions>00:08:47</dimensions>
                   </physdesc>
@@ -38932,8 +38931,8 @@
                 <did>
                   <container type="box" label="DVD Box">12</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -41427,8 +41426,8 @@
           <c03 level="subseries">
             <did>
               <unittitle>Reel-to-Reel Tape</unittitle>
-              <physdesc>
-                <extent>4 audiotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 audiotapes</extent>
                 <physfacet>reel-to-reel tapes</physfacet>
               </physdesc>
             </did>
@@ -78892,8 +78891,8 @@
           <c03 level="file">
             <did>
               <unittitle>CD Roms</unittitle>
-              <physdesc>
-                <extent>11 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">11 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/fayzalli.xml
+++ b/Real_Masters_all/fayzalli.xml
@@ -123,8 +123,8 @@
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Background/History <unitdate type="inclusive" normal="1988/2009">1988-2009</unitdate></unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-Rs</physfacet>
             </physdesc>
           </did>
@@ -288,8 +288,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>Dearborn Mayor Michael A. Guido's Trip to Lebanon <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/flounder.xml
+++ b/Real_Masters_all/flounder.xml
@@ -191,8 +191,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>Christmas <unitdate type="inclusive" normal="2000">2000</unitdate> and Pool <unitdate type="inclusive" normal="2001">2001</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -201,8 +201,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>Clippings and Miscellaneous <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -211,8 +211,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>Email Pictures and CB Scans <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -223,8 +223,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1995-06/1997-06">June 1995-June 1997</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -238,8 +238,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>75th Anniversary <unitdate type="inclusive" normal="2003">2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/fordri.xml
+++ b/Real_Masters_all/fordri.xml
@@ -5759,8 +5759,8 @@
           <c03 level="file">
             <did>
               <unittitle>Untitled Zip Disk</unittitle>
-              <physdesc>
-                <extent>1 zip disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 zip disks</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/frenchgeo.xml
+++ b/Real_Masters_all/frenchgeo.xml
@@ -39,7 +39,7 @@
       </origination>
       <unittitle encodinganalog="245"> George W. French Papers <unitdate type="inclusive" encodinganalog="245$f"> 1864-1906 </unitdate> <unitdate type="bulk" encodinganalog="245$g"> 1864-1865 </unitdate> </unittitle>
       <physdesc altrender="whole">
-        <extent encodinganalog="300">0.75 linear feet</extent>
+        <extent altrender="materialtype spaceoccupied">0.75 linear feet</extent>
         <extent altrender="carrier">in 2 boxes</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number"> 0012 Aa 2 </unitid>
@@ -121,8 +121,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Quartermaster reports </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/gamua.xml
+++ b/Real_Masters_all/gamua.xml
@@ -49,14 +49,14 @@
         <corpname source="lcnaf" encodinganalog="110">Michigamua.</corpname>
       </origination>
       <unittitle encodinganalog="245">Michigamua Records <unitdate type="inclusive" encodinganalog="245$f" normal="1902/1992">1902-1992</unitdate></unittitle>
-      <physdesc>
-        <extent encodinganalog="300">4.1 linear feet</extent>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">6 oversize folders</extent>
       </physdesc>
-      <physdesc>
-        <extent encodinganalog="300">1 oversize boxes</extent>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">1 oversize boxes</extent>
       </physdesc>
-      <physdesc>
-        <extent encodinganalog="300">6 oversize folders</extent>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">4.1 linear feet</extent>
       </physdesc>
       <abstract>University of Michigan senior honors society with initiation rites, costumes and other rituals based on supposed Native Amerincan traditions; records include chronological "tribe" files, minutes of meetings, topical files, visual materials, and printed materials.</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">87248; Bimu F42 2; UBImul F42</unitid>
@@ -150,8 +150,8 @@
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Tribe of 1922 </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -755,8 +755,8 @@
             <unittitle>
               <unitdate type="inclusive">1957/1958-1965/1966</unitdate>
             </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -822,8 +822,8 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>General, <unitdate type="inclusive">1923 undated</unitdate> (includes The Great Charter) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1001,8 +1001,8 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Building Fund, <unitdate type="inclusive" normal="1933/1934">1933-1934</unitdate></unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1041,8 +1041,8 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Michigamua Plaza, <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>1 photographs</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 photographs</extent>
                 <physfacet>color Polaroid print</physfacet>
               </physdesc>
             </did>
@@ -1060,8 +1060,8 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Reunion, <unitdate type="inclusive" normal="1961">1961</unitdate> (includes totem pole)</unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 <physfacet>black and white positive prints</physfacet>
               </physdesc>
             </did>
@@ -1079,8 +1079,8 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Totem Pole, <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>1 photographs</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 photographs</extent>
                 <physfacet>black and white positive print</physfacet>
               </physdesc>
             </did>
@@ -1162,8 +1162,8 @@
                 <did>
                   <container type="box" label="Box">3</container>
                   <unittitle>50th reunion, <unitdate type="inclusive" normal="1951">1951</unitdate></unittitle>
-                  <physdesc>
-                    <extent>2 copies</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 copies</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -1176,8 +1176,8 @@
                 <did>
                   <container type="box" label="Box">5</container>
                   <unittitle>Tribe of, (undated)</unittitle>
-                  <physdesc>
-                    <extent>2 prints</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 prints</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -1265,8 +1265,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1908/1980">1908-1980</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>8 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">8 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1296,8 +1296,8 @@
               <did>
                 <container type="box" label="Box">4</container>
                 <unittitle><title render="italic">Tower Talk</title>, <unitdate type="inclusive" normal="1920/1991">1920-1991</unitdate></unittitle>
-                <physdesc>
-                  <extent>13 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">13 folders</extent>
                 </physdesc>
               </did>
             </c04>

--- a/Real_Masters_all/gbassoc.xml
+++ b/Real_Masters_all/gbassoc.xml
@@ -41983,8 +41983,7 @@
                 <container type="box" label="Box">80</container>
                 <unittitle>Construction Photographs by Win Brunner Photographer <unitdate type="inclusive" normal="1976-05-04/1979-03-02">5/4/1976-3/2/1979</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent altrender="materialtype spaceoccupied">3 folders</extent>
-                  <extent>138 prints</extent>
+                  <extent altrender="materialtype spaceoccupied">138 prints</extent>
                   <physfacet>black and white</physfacet>
                   <dimensions>8 x 10-inch</dimensions>
                 </physdesc>

--- a/Real_Masters_all/ghouse.xml
+++ b/Real_Masters_all/ghouse.xml
@@ -2150,8 +2150,8 @@
           <did>
             <container type="box" label="Box">9</container>
             <unittitle>Honduras Reunion, Board Meeting, and Tarps Away Photographs <unitdate type="inclusive" normal="2005">2005</unitdate></unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-Rs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/gramlich.xml
+++ b/Real_Masters_all/gramlich.xml
@@ -960,8 +960,8 @@
         <c02 level="file">
           <did>
             <unittitle>DVD Recordings</unittitle>
-            <physdesc>
-              <extent>3 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 optical disks</extent>
               <physfacet>DVDs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/grandhot.xml
+++ b/Real_Masters_all/grandhot.xml
@@ -3835,8 +3835,8 @@
         <c02 level="file">
           <did>
             <unittitle>DVD Videos</unittitle>
-            <physdesc>
-              <extent>10 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">10 optical disks</extent>
               <physfacet>DVDs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/granholm.xml
+++ b/Real_Masters_all/granholm.xml
@@ -3652,8 +3652,8 @@
               <did>
                 <container type="box" label="Box">10</container>
                 <unittitle>Burial Information, Gerald Ford <unitdate type="inclusive" normal="2003/2007">2003-2007</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -5625,8 +5625,8 @@
                     <unittitle>
                       <unitdate type="inclusive" normal="2004">2004</unitdate>
                     </unittitle>
-                    <physdesc>
-                      <extent>1 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                       <physfacet>CD-Rs</physfacet>
                     </physdesc>
                   </did>
@@ -9143,8 +9143,8 @@
               <did>
                 <container type="box" label="Box">26</container>
                 <unittitle>Exhibits 23-30 in the Matter of the Request for the Removal of Kwame M. Kilpatrick From the Office of Mayor of the city of Detroit <unitdate type="inclusive" normal="2008-08-25">August 25, 2008</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -18183,8 +18183,8 @@
                     <did>
                       <container type="box" label="Box">58</container>
                       <unittitle>General <unitdate type="inclusive" normal="2007">2007</unitdate></unittitle>
-                      <physdesc>
-                        <extent>1 optical disks</extent>
+                      <physdesc altrender="whole">
+                        <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                         <physfacet>CD-Rs</physfacet>
                       </physdesc>
                     </did>
@@ -20987,12 +20987,12 @@
             <did>
               <container type="box" label="Box">68</container>
               <unittitle>National Training Conference on Amber Alert, 2003</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
-                <physfacet>CD-Rs</physfacet>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+                <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
             <odd>
@@ -22415,8 +22415,8 @@
                 <did>
                   <container type="box" label="Box">77</container>
                   <unittitle>Issue Memos <unitdate type="inclusive" normal="2005">2005</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>CD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -30036,8 +30036,8 @@
             <did>
               <container type="box" label="Box">100</container>
               <unittitle>Hate Crimes -- Michigan Alliance Against Hate Crimes <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -30201,8 +30201,8 @@
               <did>
                 <container type="box" label="Box">101</container>
                 <unittitle>National Response Plan <unitdate type="inclusive" normal="2004">2004</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -39196,8 +39196,8 @@
                 <did>
                   <container type="box" label="Box">125</container>
                   <unittitle>National Association of State chief Information Officers (NASCIO) <unitdate type="inclusive" normal="2008">2008</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>CD-Rs</physfacet>
                   </physdesc>
                 </did>
@@ -40376,11 +40376,11 @@
                 <container type="box" label="Box">132</container>
                 <unittitle>CDs and DVDs <unitdate type="inclusive" normal="2000/2007">2000-2007</unitdate></unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 folders</extent>
+                  <extent altrender="materialtype spaceoccupied">9 optical discs</extent>
+                  <physfacet>DVDs</physfacet>
                 </physdesc>
                 <physdesc altrender="whole">
-                  <extent>9 optical discs</extent>
-                  <physfacet>DVDs</physfacet>
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -40437,8 +40437,8 @@
             <did>
               <container type="box" label="Box">132</container>
               <unittitle>Metro Region <unitdate type="inclusive" normal="2009">2009</unitdate> High Impact Presentation, <unitdate type="inclusive" normal="2009">2009</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -40456,8 +40456,8 @@
             <did>
               <container type="box" label="Box">132</container>
               <unittitle>Michigan Trails <unitdate type="inclusive" normal="2007/2009">2007-2009</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -42731,8 +42731,8 @@
             <did>
               <container type="box" label="Box">143</container>
               <unittitle>Algebra Initiative <unitdate type="inclusive" normal="2008/2009">2008-2009</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -48675,8 +48675,8 @@
               <did>
                 <container type="box" label="Box">157</container>
                 <unittitle>Gibbs -- High Speed Amphibian Technology <unitdate type="inclusive" normal="2005" certainty="approximate">circa 2005</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -49818,8 +49818,8 @@
               <did>
                 <container type="box" label="Box">159</container>
                 <unittitle>Michigan Emergency Management Plan (MEMP) <unitdate type="inclusive" normal="2005/2006">2005-2006</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -72441,8 +72441,8 @@
             <did>
               <container type="box" label="Box">203</container>
               <unittitle>Sulfide Mining -- Legislation, etc. <unitdate type="inclusive" normal="2004/2005">2004-2005</unitdate></unittitle>
-              <physdesc>
-                <extent>2 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -73948,8 +73948,8 @@
                 <did>
                   <physloc>Online</physloc>
                   <unittitle>America 24/7 <unitdate type="inclusive" normal="2003">2003</unitdate> (2 CDs)</unittitle>
-                  <physdesc>
-                    <extent>2 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                     <physfacet>CDs</physfacet>
                   </physdesc>
                 </did>
@@ -77890,8 +77890,8 @@
               <did>
                 <container type="box" label="Box">217</container>
                 <unittitle>Finance <unitdate type="inclusive" normal="2005/2006">2005-2006</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>

--- a/Real_Masters_all/greenbmaurice.xml
+++ b/Real_Masters_all/greenbmaurice.xml
@@ -1,145 +1,145 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE ead PUBLIC "+//ISBN 1-931666-00-8//DTD ead.dtd (Encoded Archival Description (EAD) Version 2002)//EN" "ead.dtd">
 <ead>
-
-<eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
-
-<eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::greenbmaurice.xml//EN" encodinganalog="Identifier">
+  <eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
+    <eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::greenbmaurice.xml//EN" encodinganalog="Identifier">
 umich-bhl-2016001</eadid>
-
-<filedesc><titlestmt><titleproper encodinganalog="Title">Finding Aid for 
+    <filedesc>
+      <titlestmt>
+        <titleproper encodinganalog="Title">Finding Aid for 
 Maurice C. Greenbaum papers
 
 </titleproper>
-<author encodinganalog="Creator">Collection processed and finding aid created by 
-Elizabeth Carron </author></titlestmt>
-
-<publicationstmt><publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
-<date encodinganalog="Date" normal="2016">
-2016</date></publicationstmt></filedesc>
-
-<profiledesc>
-<creation>Encoded finding aid created by 
+        <author encodinganalog="Creator">Collection processed and finding aid created by 
+Elizabeth Carron </author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
+        <date encodinganalog="Date" normal="2016">
+2016</date>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>Encoded finding aid created by 
 Olga Virakhovskaya 
 <date>2015</date></creation>
-
-<langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage><descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules></profiledesc>
-
-<revisiondesc><change><date>2016-01-19</date><item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item></change></revisiondesc></eadheader>
-
-<frontmatter><titlepage>
-
-<publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
-
-<titleproper>Finding aid for<lb/>
+      <langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage>
+      <descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules>
+    </profiledesc>
+    <revisiondesc>
+      <change>
+        <date>2016-01-19</date>
+        <item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item>
+      </change>
+    </revisiondesc>
+  </eadheader>
+  <frontmatter>
+    <titlepage>
+      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <titleproper>Finding aid for<lb/>
 Maurice C. Greenbaum papers
 </titleproper>
-
-<author>Finding aid created by<lb/> 
+      <author>Finding aid created by<lb/> 
 Elizabeth Carron, January 2016
 </author>
-
-</titlepage>
-</frontmatter>
-
-<archdesc level="collection" audience="external" type="inventory" relatedencoding="MARC21"><did>
-
-<origination>
-<corpname source="lcnaf" encodinganalog="110">
+    </titlepage>
+  </frontmatter>
+  <archdesc level="collection" audience="external" type="inventory" relatedencoding="MARC21">
+    <did>
+      <origination>
+        <corpname source="lcnaf" encodinganalog="110">
 Greenbaum, Maurice Coleman, 1918-2009
-</corpname></origination>
-
-<unittitle encodinganalog="245">
+</corpname>
+      </origination>
+      <unittitle encodinganalog="245">
 Maurice C. Greenbaum papers
 <unitdate type="inclusive" encodinganalog="245$f">
 1940 - 1941
 </unitdate>
  
 </unittitle>
-
-<physdesc><extent encodinganalog="300">
+      <physdesc>
+        <extent encodinganalog="300">
 0.25 linear feet
-</extent></physdesc>
-
-<unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
+</extent>
+      </physdesc>
+      <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2016001 Aa 2
 </unitid>
-
-<langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
-
-<abstract>
+      <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
+      <abstract>
 University of Michigan Class of 1941 Law School graduate and lawyer. Collection includes correspondence concerning student life, career prospects, and World War II.  
 </abstract>
-
-
-<repository><corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
-<extptr href="bhladd" show="embed" actuate="onload"/></repository></did>
-
-<descgrp type="admin">
-<acqinfo encodinganalog="541"><p>
+      <repository>
+        <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
+        <extptr href="bhladd" show="embed" actuate="onload"/>
+      </repository>
+    </did>
+    <descgrp type="admin">
+      <acqinfo encodinganalog="541">
+        <p>
 Donated by Brian A. Williams (donor no. <num type="donor" encodinganalog="541$e">8335</num>),  in January, 2016. 
  
-</p></acqinfo>
-
- 
-
-<accruals encodinganalog="584"><p>
+</p>
+      </acqinfo>
+      <accruals encodinganalog="584">
+        <p>
 No further additions to the papers are expected.
-</p></accruals><accessrestrict encodinganalog="506">
-<p>The collection is open without restriction.</p>
- </accessrestrict>
-
-
-<userestrict encodinganalog="540"><p>
-Copyright is held by the Regents of the University of Michigan.</p></userestrict>
-
-
-<prefercite encodinganalog="524"><p>[item], folder, box,
-Maurice C. Greenbau, Bentley Historical Library, University of Michigan</p></prefercite>
- </descgrp>
-
-<bioghist encodinganalog="545">
-<p>Maurice Coleman Greenbaum was born in Detroit on April 3, 1918 to Harry and Eva Greenbaum. After graduating from Wayne State University in 1938, he entered the University of Michigan Law School as a member of the Class of 1941. He served as a Major in the U.S. Army during World War II. When the war ended, he relocated to New York where he became a senior partner at the law firms of Greenbaum, Wolff and Ernst, Rosenman and Colin and Katten Muchin Rosenman. He later served as the Magistrate for the village of Kings Point, New York for 34 years. He passed way October 23, 2009.</p>
-
-<p>The correspondence is addressed to his future wife, Beatrice Weiner. Born May 31, 1919 to Israel and Rose Weiner, she was a graduate of New York University. She and her future husband met during her studies towards Masters' degrees in Health and Public Policy from the University of Michigan and Sarah Lawrence College. A life-long advocate for compassionate end-of-life care, she established and supported numerous projects throughout her life. She passed away on April 5, 2014.</p>
-
-
-
-</bioghist>
-
-<arrangement encodinganalog="351">
-<p>The materials are arranged in chronological order and are housed in two (2) folders. </p>
-</arrangement>
- 
-<scopecontent encodinganalog="520">
-<p>The Maurice C. Greenbaum papers were written by him to his fiancée, Beatrice Weiner, during the 1940 -- 1941 academic year. Measuring 0.25 (1 box), the correspondence captures student life and activity at the University of Michigan on the precipice of World War II. Topics include collegiate football, academic life, social events, career prospects, travel and military action from the perspective of a young Jewish male.</p></scopecontent>
-
-<controlaccess><p><extptr href="accnote" show="embed" actuate="onload"/></p><controlaccess><head>Subjects:</head>
-
-<persname source="lcnaf" encodinganalog="600">Greenbaum, Maurice Coleman, 1918-2009.</persname>
-<subject source="lcsh" encodinganalog="650">Jewish students--Michigan--Ann Arbor.</subject>
-<corpname source="lcnaf" encodinganalog="610">University of Michigan. Law School--Students.</corpname>
-<corpname source="lcnaf" encodinganalog="610">University of Michigan--Students--Social life and customs.</corpname>
-<subject source="lcsh" encodinganalog="650">World War, 1939-1945--Education and the war.</subject>
- 
-
-</controlaccess>
- 
- 
-</controlaccess>
-
-
-<dsc type="combined">
-<c01 level="series"><did><unittitle>Maurice C. Greenbaum papers</unittitle></did>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Correspondence, <unitdate type="inclusive">1940-1941</unitdate></unittitle></did></c02></c01>
-
-</dsc><descgrp type="add"><relatedmaterial><head>Related Materials</head>
-
-<p>The Montana State University holds additional letters written by Maurice C. Greenbaum to his fiancée. These letters were written during the summer of 1940 while he worked as a ranger for Yellowstone National Park. </p></relatedmaterial></descgrp>
-
-
-</archdesc>
-
-
-
+</p>
+      </accruals>
+      <accessrestrict encodinganalog="506">
+        <p>The collection is open without restriction.</p>
+      </accessrestrict>
+      <userestrict encodinganalog="540">
+        <p>
+Copyright is held by the Regents of the University of Michigan.</p>
+      </userestrict>
+      <prefercite encodinganalog="524">
+        <p>[item], folder, box,
+Maurice C. Greenbau, Bentley Historical Library, University of Michigan</p>
+      </prefercite>
+    </descgrp>
+    <bioghist encodinganalog="545">
+      <p>Maurice Coleman Greenbaum was born in Detroit on April 3, 1918 to Harry and Eva Greenbaum. After graduating from Wayne State University in 1938, he entered the University of Michigan Law School as a member of the Class of 1941. He served as a Major in the U.S. Army during World War II. When the war ended, he relocated to New York where he became a senior partner at the law firms of Greenbaum, Wolff and Ernst, Rosenman and Colin and Katten Muchin Rosenman. He later served as the Magistrate for the village of Kings Point, New York for 34 years. He passed way October 23, 2009.</p>
+      <p>The correspondence is addressed to his future wife, Beatrice Weiner. Born May 31, 1919 to Israel and Rose Weiner, she was a graduate of New York University. She and her future husband met during her studies towards Masters' degrees in Health and Public Policy from the University of Michigan and Sarah Lawrence College. A life-long advocate for compassionate end-of-life care, she established and supported numerous projects throughout her life. She passed away on April 5, 2014.</p>
+    </bioghist>
+    <arrangement encodinganalog="351">
+      <p>The materials are arranged in chronological order and are housed in two (2) folders. </p>
+    </arrangement>
+    <scopecontent encodinganalog="520">
+      <p>The Maurice C. Greenbaum papers were written by him to his fiancée, Beatrice Weiner, during the 1940 -- 1941 academic year. Measuring 0.25 (1 box), the correspondence captures student life and activity at the University of Michigan on the precipice of World War II. Topics include collegiate football, academic life, social events, career prospects, travel and military action from the perspective of a young Jewish male.</p>
+    </scopecontent>
+    <controlaccess>
+      <p>
+        <extptr href="accnote" show="embed" actuate="onload"/>
+      </p>
+      <controlaccess>
+        <head>Subjects:</head>
+        <persname source="lcnaf" encodinganalog="600">Greenbaum, Maurice Coleman, 1918-2009.</persname>
+        <subject source="lcsh" encodinganalog="650">Jewish students--Michigan--Ann Arbor.</subject>
+        <corpname source="lcnaf" encodinganalog="610">University of Michigan. Law School--Students.</corpname>
+        <corpname source="lcnaf" encodinganalog="610">University of Michigan--Students--Social life and customs.</corpname>
+        <subject source="lcsh" encodinganalog="650">World War, 1939-1945--Education and the war.</subject>
+      </controlaccess>
+    </controlaccess>
+    <dsc type="combined">
+      <c01 level="series">
+        <did>
+          <unittitle>Maurice C. Greenbaum papers</unittitle>
+        </did>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Correspondence, <unitdate type="inclusive">1940-1941</unitdate></unittitle>
+          </did>
+        </c02>
+      </c01>
+    </dsc>
+    <descgrp type="add">
+      <relatedmaterial>
+        <head>Related Materials</head>
+        <p>The Montana State University holds additional letters written by Maurice C. Greenbaum to his fiancée. These letters were written during the summer of 1940 while he worked as a ranger for Yellowstone National Park. </p>
+      </relatedmaterial>
+    </descgrp>
+  </archdesc>
 </ead>

--- a/Real_Masters_all/greenbmaurice.xml
+++ b/Real_Masters_all/greenbmaurice.xml
@@ -58,10 +58,8 @@ Maurice C. Greenbaum papers
 </unitdate>
  
 </unittitle>
-      <physdesc>
-        <extent encodinganalog="300">
-0.25 linear feet
-</extent>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">0.25 linear feet</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2016001 Aa 2

--- a/Real_Masters_all/hartjane.xml
+++ b/Real_Masters_all/hartjane.xml
@@ -312,8 +312,8 @@
               <physdesc>
                 <physfacet>7 in.; <genreform normal="Sound recordings">reel-to-reel audio tape</genreform></physfacet>
               </physdesc>
-              <physdesc>
-                <extent>2 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -328,8 +328,8 @@
               <physdesc>
                 <physfacet>CD-R</physfacet>
               </physdesc>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -338,8 +338,8 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Dedication of the Philip A. Hart Senate Office Building <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/hollandj.xml
+++ b/Real_Masters_all/hollandj.xml
@@ -1,285 +1,849 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE ead PUBLIC "+//ISBN 1-931666-00-8//DTD ead.dtd (Encoded Archival Description (EAD) Version 2002)//EN" "ead.dtd">
 <ead>
-
-<eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
-
-<eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::hollandj.xml//EN" encodinganalog="Identifier">
+  <eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
+    <eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::hollandj.xml//EN" encodinganalog="Identifier">
 umich-bhl-2010206</eadid>
-
-<filedesc><titlestmt><titleproper encodinganalog="Title">Finding Aid for 
+    <filedesc>
+      <titlestmt>
+        <titleproper encodinganalog="Title">Finding Aid for 
 John H. Holland papers
 
 </titleproper>
-<author encodinganalog="Creator">Collection processed and finding aid created by 
-Natalie Bond </author></titlestmt>
-
-<publicationstmt><publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
-<date encodinganalog="Date" normal="2016">
-2016</date></publicationstmt></filedesc>
-
-<profiledesc>
-<creation>Encoded finding aid created by 
+        <author encodinganalog="Creator">Collection processed and finding aid created by 
+Natalie Bond </author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
+        <date encodinganalog="Date" normal="2016">
+2016</date>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>Encoded finding aid created by 
 Olga Virakhovskaya 
 <date>2016</date></creation>
-
-<langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage><descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules></profiledesc>
-
-<revisiondesc><change><date>2016-02-02</date><item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item></change></revisiondesc></eadheader>
-
-<frontmatter><titlepage>
-
-<publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
-
-<titleproper>Finding aid for<lb/>
+      <langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage>
+      <descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules>
+    </profiledesc>
+    <revisiondesc>
+      <change>
+        <date>2016-02-02</date>
+        <item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item>
+      </change>
+    </revisiondesc>
+  </eadheader>
+  <frontmatter>
+    <titlepage>
+      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <titleproper>Finding aid for<lb/>
 John H. Holland papers
 </titleproper>
-
-<author>Finding aid created by<lb/> 
+      <author>Finding aid created by<lb/> 
 Natalie Bond, November 2010
 </author>
-
-</titlepage>
-</frontmatter>
-
-<archdesc level="collection" audience="external" type="inventory" relatedencoding="MARC21"><did>
-
-<origination>
-<persname source="lcnaf" encodinganalog="100">
+    </titlepage>
+  </frontmatter>
+  <archdesc level="collection" audience="external" type="inventory" relatedencoding="MARC21">
+    <did>
+      <origination>
+        <persname source="lcnaf" encodinganalog="100">
 Holland, John H. (John Henry), 1929-
 
-</persname></origination>  
-
-<unittitle encodinganalog="245">
+</persname>
+      </origination>
+      <unittitle encodinganalog="245">
 John H. Holland papers
 <unitdate type="inclusive" encodinganalog="245$f">
 1956-1982
 </unitdate>
  
 </unittitle>
-
-<physdesc><extent encodinganalog="300">
+      <physdesc>
+        <extent encodinganalog="300">
 4.50 linear feet
-</extent></physdesc>
-
-<unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
+</extent>
+      </physdesc>
+      <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2010206 Aa 2
 </unitid>
-
-<langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
-
-<abstract>
+      <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
+      <abstract>
 Professor of psychology, electrical engineering, and computer science at the University of Michigan beginning in 1959.  Holland developed the concept of "genetic algorithms," research specializations in complex adaptive systems and artificial intelligence.  First recipient of a computer science PhD at the University of Michigan, and a 1992 recipient of a MacArthur Fellowship.  Papers consist primarily of departmental records pertaining to his professorial career, as well as research papers, notes, and correspondence.</abstract>
-
-
-<repository><corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
-<extptr href="bhladd" show="embed" actuate="onload"/></repository></did>
-
-<descgrp type="admin">
-<acqinfo encodinganalog="541"><p>
+      <repository>
+        <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
+        <extptr href="bhladd" show="embed" actuate="onload"/>
+      </repository>
+    </did>
+    <descgrp type="admin">
+      <acqinfo encodinganalog="541">
+        <p>
 The papers were received from John Holland (donor no. <num type="donor" encodinganalog="541$e">10391</num>, in June 2010.
  
-</p></acqinfo>
-
-<accruals encodinganalog="584"><p>Periodic additions to the records expected.</p></accruals>
-
- <accessrestrict encodinganalog="506">
-<p>The John H. Holland papers are open for research except for certain records restricted by statute or university policy.  Restricted material includes personnel-related files, including search, review, promotion, and tenure files; student educational records; client/patient records; and records of executive officers of the university.</p>
-<p></p>  
-<p>The John H. Holland papers include  restricted material in the following categories: 
-<list type="simple">
- <item>Student Academic Records -- Box 5</item>
- 
-</list></p>
-
-<p><extptr href="uarpacc" show="embed" actuate="onload"/></p></accessrestrict>
-
-
-<userestrict encodinganalog="540"><p>
+</p>
+      </acqinfo>
+      <accruals encodinganalog="584">
+        <p>Periodic additions to the records expected.</p>
+      </accruals>
+      <accessrestrict encodinganalog="506">
+        <p>The John H. Holland papers are open for research except for certain records restricted by statute or university policy.  Restricted material includes personnel-related files, including search, review, promotion, and tenure files; student educational records; client/patient records; and records of executive officers of the university.</p>
+        <p/>
+        <p>The John H. Holland papers include  restricted material in the following categories: 
+<list type="simple"><item>Student Academic Records -- Box 5</item></list></p>
+        <p>
+          <extptr href="uarpacc" show="embed" actuate="onload"/>
+        </p>
+      </accessrestrict>
+      <userestrict encodinganalog="540">
+        <p>
 Copyright has not been assigned.
-</p></userestrict>
-
-
-<prefercite encodinganalog="524"><p>[item], folder, box,
-John H. Holland papers, Bentley Historical Library, University of Michigan</p></prefercite>
-<processinfo><p>[Delete this set of tags if not needed for digital material processing]</p>
-<p><extptr href="digitalproc" show="embed" actuate="onload"/></p>
-</processinfo></descgrp>
-
-<bioghist encodinganalog="545">
-<p>John Henry Holland, a University of Michigan professor of psychology, electrical engineering, and computer science, helped pioneer the fields of artificial intelligence and the theory of complex adaptive systems.  He is often called the father of genetic algorithms, having written a ground-breaking book on the subject in 1975 titled <title render="italic">Adaptation in Natural and Artificial Systems</title>.</p>
-
-<p>Holland was born on February 2, 1929, in Fort Wayne, Indiana, and was raised in Ohio.  He was educated at the Massachusetts Institute of Technology, where he received a B.S. in physics in 1950, and the University of Michigan, where he received a M.A. in mathematics in 1954 and was the first recipient of a PhD in Computer Science at the University of Michigan in 1959.  He joined the University of Michigan faculty in 1959, where he received the Louis E. Levy Medal of the Franklin Institute in 1961, as well as the UM Distinguished Faculty Achievement Award in 1987.  A notable distinction in Holland's career was the bestowal of the prestigious MacArthur Foundation Fellowship in 1992, totaling $369,000 over a five year period.</p>
-
-<p>In 1961 Holland became an assistant professor in communication sciences, and was promoted to professor in 1967.  He became a professor of electrical engineering and computer science in 1984 when communication sciences became part of the College of Engineering.  In 1988, he was named a professor of psychology, in addition to being appointed as professor of electrical engineering and computer science.  Besides working at UM, Holland served as a consultant to the Los Alamos National Laboratory, and served as a member of the Board of Trustees and Science Board of the Santa Fe Institute.  He was a research associate at the Carnegie Institution in Washington, D.C. and a consultant to Argonne National Laboratory, and was made a fellow of the World Economic Forum.</p>
-
-<p>Holland's research expanded beyond computer science and mathematics, extending into the fields of psychology and communication sciences.  He was a member of the pioneering group that programmed the earliest IBM computers in the 1950s, and studied how computers can evolve in noticeably human ways.  His development of the concept of genetic algorithms was groundbreaking in the fields of computer science, communication science, psychology, and biology.  These algorithms refer to a set of instructions that enable a computer to essentially learn, taking what it knows and making new rules, and adapting to new circumstances.  Using computer models, Holland studied the process of adaptation in complex adaptive systems ranging from human organisms to the economy.  These systems, he found, are constantly evolving, changing and interacting mechanisms that control everything from how people learn, to how advanced computers process information, to global economics and politics.  </p>
-
-<p>Holland is the author of a number of books, and has written and published countless articles and research papers.</p>
-
-
-</bioghist>
-
-<arrangement encodinganalog="351">
-<p>
+</p>
+      </userestrict>
+      <prefercite encodinganalog="524">
+        <p>[item], folder, box,
+John H. Holland papers, Bentley Historical Library, University of Michigan</p>
+      </prefercite>
+      <processinfo>
+        <p>[Delete this set of tags if not needed for digital material processing]</p>
+        <p>
+          <extptr href="digitalproc" show="embed" actuate="onload"/>
+        </p>
+      </processinfo>
+    </descgrp>
+    <bioghist encodinganalog="545">
+      <p>John Henry Holland, a University of Michigan professor of psychology, electrical engineering, and computer science, helped pioneer the fields of artificial intelligence and the theory of complex adaptive systems.  He is often called the father of genetic algorithms, having written a ground-breaking book on the subject in 1975 titled <title render="italic">Adaptation in Natural and Artificial Systems</title>.</p>
+      <p>Holland was born on February 2, 1929, in Fort Wayne, Indiana, and was raised in Ohio.  He was educated at the Massachusetts Institute of Technology, where he received a B.S. in physics in 1950, and the University of Michigan, where he received a M.A. in mathematics in 1954 and was the first recipient of a PhD in Computer Science at the University of Michigan in 1959.  He joined the University of Michigan faculty in 1959, where he received the Louis E. Levy Medal of the Franklin Institute in 1961, as well as the UM Distinguished Faculty Achievement Award in 1987.  A notable distinction in Holland's career was the bestowal of the prestigious MacArthur Foundation Fellowship in 1992, totaling $369,000 over a five year period.</p>
+      <p>In 1961 Holland became an assistant professor in communication sciences, and was promoted to professor in 1967.  He became a professor of electrical engineering and computer science in 1984 when communication sciences became part of the College of Engineering.  In 1988, he was named a professor of psychology, in addition to being appointed as professor of electrical engineering and computer science.  Besides working at UM, Holland served as a consultant to the Los Alamos National Laboratory, and served as a member of the Board of Trustees and Science Board of the Santa Fe Institute.  He was a research associate at the Carnegie Institution in Washington, D.C. and a consultant to Argonne National Laboratory, and was made a fellow of the World Economic Forum.</p>
+      <p>Holland's research expanded beyond computer science and mathematics, extending into the fields of psychology and communication sciences.  He was a member of the pioneering group that programmed the earliest IBM computers in the 1950s, and studied how computers can evolve in noticeably human ways.  His development of the concept of genetic algorithms was groundbreaking in the fields of computer science, communication science, psychology, and biology.  These algorithms refer to a set of instructions that enable a computer to essentially learn, taking what it knows and making new rules, and adapting to new circumstances.  Using computer models, Holland studied the process of adaptation in complex adaptive systems ranging from human organisms to the economy.  These systems, he found, are constantly evolving, changing and interacting mechanisms that control everything from how people learn, to how advanced computers process information, to global economics and politics.  </p>
+      <p>Holland is the author of a number of books, and has written and published countless articles and research papers.</p>
+    </bioghist>
+    <arrangement encodinganalog="351">
+      <p>
 The files are divided into six series: Correspondence, Departmental Records, Grants and Proposals, Presentations and Publications, Research, and Teaching.</p>
-</arrangement>
-
-<scopecontent encodinganalog="520">
-<p>The papers document the academic and professional aspects of John H. Holland's career as professor and researcher, from 1956-1982.  </p></scopecontent>
-
-<controlaccess><p><extptr href="accnote" show="embed" actuate="onload"/></p><controlaccess><head>Subjects:</head>
-<subject source="lcsh" encodinganalog="650">Artificial intelligence.</subject>
-<subject source="lcsh" encodinganalog="650">Computer science.</subject>
-<subject source="lcsh" encodinganalog="650">Computers--Study and teaching.</subject>
-<persname source="lcnaf" encodinganalog="600">Holland, John H. (John Henry), 1929-2015.</persname>
-<subject source="lcsh" encodinganalog="650">Machine theory.</subject>
-<corpname source="lcnaf" encodinganalog="610">University of Michigan. Dept. of Computer and Communication Sciences.</corpname>
-<corpname source="lcnaf" encodinganalog="610">University of Michigan. Department of Electrical Engineering and Computer Science.</corpname>
-<corpname source="lcnaf" encodinganalog="610">University of Michigan--Faculty.</corpname>
-
-</controlaccess>
-
-</controlaccess>
-
-
-<dsc type="combined">
-<c01 level="series"><did><unittitle>Correspondence</unittitle></did><scopecontent><p>The Correspondence series contains letters, both incoming and outgoing, during the period from 1963 to 1978.  These letters reflect John Holland's many research initiatives and intellectual collaboration with other academics and professionals, both nationally and internationally.  They also document his various publications, projects, and presentations at conferences and panels, and are arranged in chronological order.</p></scopecontent>
-
-
- 
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle><unitdate type="inclusive">1963</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle><unitdate type="inclusive">1964</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle><unitdate type="inclusive">1965</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle><unitdate type="inclusive">1967</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle><unitdate type="inclusive">1969</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle><unitdate type="inclusive">1971</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle><unitdate type="inclusive">1975</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle><unitdate type="inclusive">1976</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle><unitdate type="inclusive">1977</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle><unitdate type="inclusive">1978</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Letters of Recommendation, Colleagues, <unitdate type="inclusive">1973-1979</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">5</container><unittitle>Letters of Recommendation, Students, <unitdate type="inclusive">1969-1977</unitdate></unittitle></did> <accessrestrict><p>[SR Restricted until  July 1, <date type="restriction" normal="2052-07-01">2052</date>]</p></accessrestrict></c02>
-
-</c01>
-
-<c01 level="series"><did><unittitle>Departmental Records</unittitle></did><scopecontent><p>The Departmental Records series documents Holland's professorial and administrative career at the University of Michigan, spanning the years between 1961 and 1982.  This is the largest series in the collection, and its records are organized thematically.  The General Departmental records partly consist of memos within the Committee on the Degree Program in Communication Studies from 1961-1981, of which Holland was a member.  They also contain information regarding program and course requirements, exam schedules, professorial appointments, and course structure.</p>
-
-<p>This series also contains documents regarding departmental budget, pertaining mostly to the School of Communication Sciences.  These include memos, salary schedules, teaching load and corresponding budget information for Computer and Communication Sciences faculty members.  Within this series is documentation of Holland's participation in the Center for Cognitive Science at the University of Chicago and the University of Michigan, from 1980 to 1982.</p>
-
-<p>Holland was a member of the Executive Committee and the Policy Committee for the Communication Studies Program, records from both of which are found in this series, dating from 1966 to 1981.  These include memos, curriculum changes, Masters and PhD requirements, course and program evaluation reports, school statistics, and grading, admission, and advising guidelines.</p>
-</scopecontent>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>General, <unitdate type="inclusive">1961-1963</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Budget, <unitdate type="inclusive">1972-1975</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Center for Cognitive Science at University of Chicago &amp; University of Michigan, <unitdate type="inclusive">1980-1982</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">2</container><unittitle>General, <unitdate type="inclusive">1963-1981</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">2</container><unittitle>Executive Committee, <unitdate type="inclusive">1968</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">2</container><unittitle>Executive Committee, <unitdate type="inclusive">1974-1976</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">2</container><unittitle>Executive Committee, <unitdate type="inclusive">1978-1979</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">2</container><unittitle>Faculty Business/Early University Appointments, <unitdate type="inclusive">1963-1966</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">2</container><unittitle>Policy Committee, <unitdate type="inclusive">1967-1969</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">2</container><unittitle>Policy Committee, <unitdate type="inclusive">1974-1979</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">2</container><unittitle>Policy Committee, <unitdate type="inclusive">1980-1981</unitdate></unittitle></did></c02></c01>
-
-
-<c01 level="series"><did><unittitle>Grants and Proposals</unittitle></did><scopecontent><p>Grants and Proposals is a series of records covering the period from 1956 to 1978 documenting the various grants and proposals with which Holland was involved.  These include grants from NASA, The National Science Foundation and the EDG Advisory Group on Polymorphic Computers, and multiple proposals to the Office of Scientific Research.</p></scopecontent>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>Communication Sciences Center--Proposal and Correspondence, <unitdate type="inclusive">1961</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>Grant Applications, General, <unitdate type="inclusive">1963-1971</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>Initial drafts and original biographies for Office of Scientific Research Proposal, <unitdate type="inclusive">1957</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>NASA Grant [NSG 1176], "Comparative Analyses of Genetic Algorithms in Relation to Other Multimodal Function Optimization Techniques", <unitdate type="inclusive">1973-1976</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>NSF Grant [GM 12236-09], "Computer Simulation in Biology: Theory and Practice", <unitdate type="inclusive">1971-1978</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>NSF Grant [MCS 76-04297], "Formal Theory of Multi-Dimensional, Nonlinear Systems, with Inter-Disciplinary Applications", <unitdate type="inclusive">1971-1978</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>Office of Scientific Research Proposal and Correspondence (1 copy of Logical Design Proposal), <unitdate type="inclusive">1956-1957</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>Office of Scientific Research Proposal, Masters, <unitdate type="inclusive">1956-1957</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>EDG Advisory Group on Polymorphic Computers, "A Proposal for the Investigation of Advanced Logical Design Methods for Computers Used in Large Scale Systems", <unitdate type="inclusive">1960</unitdate></unittitle></did></c02></c01>
-
-
-<c01 level="series"><did><unittitle>Presentations and Publications</unittitle></did><scopecontent><p>The Presentations and Publications series consists of documents pertaining to Holland's attendance and/or presentations at various symposiums and conferences, as well as documents regarding his many published papers.  The series includes invitations, publications, reprint requests, symposium and conference pamphlets, and correspondence between Holland and event organizers.  The records are organized alphabetically.</p></scopecontent>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>Harvard Switching Theory Symposium, <unitdate type="inclusive">1957</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>Information Symposium and Proposal on Self-Organizing Work Leading to Office of Scientific Research Proposal, <unitdate type="inclusive">1956</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>IMMD Convocation (Institut Für Mathematische Maschinen und Datenverarbeitung), <unitdate type="inclusive">1976</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>Journal Association of Computing Machinery-"a logical theory...", <unitdate type="inclusive">1961-1962</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>List of principle reports, papers, and publications of Logic of Computers Group,   <unitdate type="inclusive">January 1964-June 30, 1965</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>Masters/copy of 1956 Information Symposium paper, <unitdate type="inclusive">1956</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>Memoranda on Artificial Intelligence; Inter-Disciplinary Seminar, <unitdate type="inclusive">1958-1959</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>New Zealand Embassy, <unitdate type="inclusive">1961-1962</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>Original-Western Joint Computer Conference paper, <unitdate type="inclusive">1960</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>Papers, <unitdate type="inclusive">1958-1960</unitdate> </unittitle> <physdesc><extent>4 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>Philosophy of Science Association Meeting, <unitdate type="inclusive">1976</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>Reprint requests for <unitdate type="inclusive">1959</unitdate> Eastern Joint Computer Conference paper, <unitdate type="inclusive">1959</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>Reprint requests for <unitdate type="inclusive">1960</unitdate> Western Joint Computer Conference paper, <unitdate type="inclusive">1960</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>Seminar at Blaricum, <unitdate type="inclusive">1959-1962</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3</container><unittitle>Western Joint Computer Conference, <unitdate type="inclusive">1960</unitdate></unittitle></did></c02></c01>
-
-
-<c01 level="series"><did><unittitle>Research</unittitle></did><scopecontent><p>The Research series contains various papers by Holland, as well as reviews of colleagues' publications, personal research notes, and rough calculations.  Notes on self-organizing models, the simplex method, and the distribution problem are included.  The series extends from 1956 to 1962, and is arranged alphabetically.</p>
-
-</scopecontent>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>Ashby's paper and review, "What is an Intelligent Machine?," <unitdate type="inclusive">1961</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>Carnegie Institution of Washington, <unitdate type="inclusive">1960-1962</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>Central Nervous System Simulation/Research Computer, <unitdate type="inclusive">1962</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>Committee on Communication Science (Minutes, etc.), <unitdate type="inclusive">Before 1960</unitdate>  </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>Discussion of Burkes-Wane paper, <unitdate type="inclusive">1956</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>Distribution Problem (Linear Prog. Approach)</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>Institute of Science and Technology-Systems research, <unitdate type="inclusive">1960-1962</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>Rough calculations concerning <title render="italic"> Perceptron</title> (Cornell Aerospace Lab)</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>Self-Organizing Models, <unitdate type="inclusive">1956-1958</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>Simplex Method</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>Student Programs and Summaries (prior to prelims),  <unitdate type="inclusive">1959-?</unitdate> </unittitle> <physdesc><extent>4 folders</extent></physdesc></did></c02></c01>
-
-<c01 level="series"><did><unittitle>Teaching</unittitle></did><scopecontent>
-<p>The last series consists of Holland's Teaching records.  These include course packs for various Computer and Communication Sciences courses, as well as notes, class material, and course evaluations.  The series also contains documents pertaining to summer conference courses from 1960-1961.  Included in the series as well are papers from doctoral committees on which Holland served, as well as PhD students' summary reports for which he sat on the examination panel.  The entire series covers the period from 1963 to 1980, and is arranged chronologically.  Some content in this series is restricted.</p>
-</scopecontent>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>Course packs, CCS 805 (Computer and Communication Sciences), <unitdate type="inclusive">1970-1971</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>CS 200</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>CS 510 Signal Theory</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>CS 565</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>CS 410 Communication Electronics, <unitdate type="inclusive">1963</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>CS 580, <unitdate type="inclusive">1966</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>CS 400 Introduction to the Communication Sciences, <unitdate type="inclusive">1968</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>CS 624 Theory of Adaptive Systems, <unitdate type="inclusive">1968</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>CS 805 Seminar in Adaptive Systems Theory, <unitdate type="inclusive">1969-1980</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>CS 422 Introduction to Artificial Intelligence, <unitdate type="inclusive">1970</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>CS 550, <unitdate type="inclusive">1977-1980</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>CS 526, <unitdate type="inclusive">1978-1980</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>CCS 385 LISP Mini-Course, <unitdate type="inclusive">1980</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>Course Evaluations CS 101</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>Course Evaluations CS 550, <unitdate type="inclusive">1978</unitdate></unittitle></did></c02>
-
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>Summer Conference Course, <unitdate type="inclusive">1960</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>Summer Conference Course, <unitdate type="inclusive">1961</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>Doctoral Committees, <unitdate type="inclusive">1963-1969</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">4</container><unittitle>Preliminary questions, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="item"><did><container type="box" label="Box">4</container><unittitle>Summary Reports (John Holland  was one of the panel members), <unitdate type="inclusive">1974-1979</unitdate> </unittitle> <physdesc><extent>4 folders</extent></physdesc></did></c02> 
-<c02 level="file"><did><container type="box" label="Box">5</container><unittitle>Early Papers by CCS Students Later Recognized, <unitdate type="inclusive">1966</unitdate></unittitle></did> <accessrestrict><p>[SR Restricted until  July 1, <date type="restriction" normal="2041-07-01">2041</date>]</p></accessrestrict></c02>
-<c02 level="file"><did><container type="box" label="Box">5</container><unittitle>Student Records, <unitdate type="inclusive">1961-1962</unitdate></unittitle></did> <accessrestrict><p>[SR Restricted until  July 1, <date type="restriction" normal="2037-07-01">2037</date>]</p></accessrestrict></c02>
-<c02 level="file"><did><container type="box" label="Box">5</container><unittitle>Student Records, <unitdate type="inclusive">1962-1963</unitdate></unittitle></did> <accessrestrict><p>[SR Restricted until  July 1, <date type="restriction" normal="2038-07-01">2038</date>]</p></accessrestrict></c02>
-<c02 level="file"><did><container type="box" label="Box">5</container><unittitle>Student Records, <unitdate type="inclusive">1963-1964</unitdate></unittitle></did> <accessrestrict><p>[SR Restricted until  July 1, <date type="restriction" normal="2039-07-01">2039</date>]</p></accessrestrict></c02>
-<c02 level="file"><did><container type="box" label="Box">5</container><unittitle>Student Records, <unitdate type="inclusive">1964-1965</unitdate></unittitle></did> <accessrestrict><p>[SR Restricted until  July 1, <date type="restriction" normal="2040-07-01">2040</date>]</p></accessrestrict></c02>
-<c02 level="file"><did><container type="box" label="Box">5</container><unittitle>Student Records, <unitdate type="inclusive">1966-1967</unitdate></unittitle></did> <accessrestrict><p>[SR Restricted until  July 1, <date type="restriction" normal="2042-07-01">2042</date>]</p></accessrestrict></c02>
-<c02 level="file"><did><container type="box" label="Box">5</container><unittitle>Student Records, <unitdate type="inclusive">1968</unitdate></unittitle></did> <accessrestrict><p>[SR Restricted until  July 1, <date type="restriction" normal="2043-07-01">2043</date>]</p></accessrestrict></c02>
-<c02 level="file"><did><container type="box" label="Box">5</container><unittitle>Student Records, <unitdate type="inclusive">1969</unitdate></unittitle></did> <accessrestrict><p>[SR Restricted until  July 1, <date type="restriction" normal="2044-07-01">2044</date>]</p></accessrestrict></c02>
-<c02 level="file"><did><container type="box" label="Box">5</container><unittitle>Student Records, <unitdate type="inclusive">1974</unitdate></unittitle></did> <accessrestrict><p>[SR Restricted until  July 1, <date type="restriction" normal="2049-07-01">2049</date>]</p></accessrestrict></c02>
-<c02 level="file"><did><container type="box" label="Box">5</container><unittitle>Student Records, <unitdate type="inclusive">1975-1976</unitdate></unittitle></did> <accessrestrict><p>[SR Restricted until  July 1, <date type="restriction" normal="2051-07-01">2051</date>]</p></accessrestrict></c02>
-<c02 level="file"><did><container type="box" label="Box">5</container><unittitle>Student Records, <unitdate type="inclusive">1976-1977</unitdate></unittitle></did> <accessrestrict><p>[SR Restricted until  July 1, <date type="restriction" normal="2052-07-01">2052</date>]</p></accessrestrict></c02>
-<c02 level="file"><did><container type="box" label="Box">5</container><unittitle>Student Records, 1978-79  </unittitle></did> <accessrestrict><p>[SR Restricted until  July 1, <date type="restriction" normal="2054-07-01">2054</date>]</p></accessrestrict></c02>
-<c02 level="file"><did><container type="box" label="Box">5</container><unittitle>Student Records, <unitdate type="inclusive">1978-1981</unitdate></unittitle></did> <accessrestrict><p>[SR Restricted until  July 1, <date type="restriction" normal="2056-07-01">2056</date>]</p></accessrestrict></c02>
-<c02 level="file"><did><container type="box" label="Box">5</container><unittitle>Student Records, <unitdate type="inclusive">1980-1981</unitdate></unittitle></did> <accessrestrict><p>[SR Restricted until  July 1, <date type="restriction" normal="2056-07-01">2056</date>]</p></accessrestrict></c02>
-
-
- 
-
-
-
-</c01>
-
-
-
-</dsc>
-
-</archdesc>
-
-
-
+    </arrangement>
+    <scopecontent encodinganalog="520">
+      <p>The papers document the academic and professional aspects of John H. Holland's career as professor and researcher, from 1956-1982.  </p>
+    </scopecontent>
+    <controlaccess>
+      <p>
+        <extptr href="accnote" show="embed" actuate="onload"/>
+      </p>
+      <controlaccess>
+        <head>Subjects:</head>
+        <subject source="lcsh" encodinganalog="650">Artificial intelligence.</subject>
+        <subject source="lcsh" encodinganalog="650">Computer science.</subject>
+        <subject source="lcsh" encodinganalog="650">Computers--Study and teaching.</subject>
+        <persname source="lcnaf" encodinganalog="600">Holland, John H. (John Henry), 1929-2015.</persname>
+        <subject source="lcsh" encodinganalog="650">Machine theory.</subject>
+        <corpname source="lcnaf" encodinganalog="610">University of Michigan. Dept. of Computer and Communication Sciences.</corpname>
+        <corpname source="lcnaf" encodinganalog="610">University of Michigan. Department of Electrical Engineering and Computer Science.</corpname>
+        <corpname source="lcnaf" encodinganalog="610">University of Michigan--Faculty.</corpname>
+      </controlaccess>
+    </controlaccess>
+    <dsc type="combined">
+      <c01 level="series">
+        <did>
+          <unittitle>Correspondence</unittitle>
+        </did>
+        <scopecontent>
+          <p>The Correspondence series contains letters, both incoming and outgoing, during the period from 1963 to 1978.  These letters reflect John Holland's many research initiatives and intellectual collaboration with other academics and professionals, both nationally and internationally.  They also document his various publications, projects, and presentations at conferences and panels, and are arranged in chronological order.</p>
+        </scopecontent>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>
+              <unitdate type="inclusive">1963</unitdate>
+            </unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>
+              <unitdate type="inclusive">1964</unitdate>
+            </unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>
+              <unitdate type="inclusive">1965</unitdate>
+            </unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>
+              <unitdate type="inclusive">1967</unitdate>
+            </unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>
+              <unitdate type="inclusive">1969</unitdate>
+            </unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>
+              <unitdate type="inclusive">1971</unitdate>
+            </unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>
+              <unitdate type="inclusive">1975</unitdate>
+            </unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>
+              <unitdate type="inclusive">1976</unitdate>
+            </unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>
+              <unitdate type="inclusive">1977</unitdate>
+            </unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>
+              <unitdate type="inclusive">1978</unitdate>
+            </unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Letters of Recommendation, Colleagues, <unitdate type="inclusive">1973-1979</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">5</container>
+            <unittitle>Letters of Recommendation, Students, <unitdate type="inclusive">1969-1977</unitdate></unittitle>
+          </did>
+          <accessrestrict>
+            <p>[SR Restricted until  July 1, <date type="restriction" normal="2052-07-01">2052</date>]</p>
+          </accessrestrict>
+        </c02>
+      </c01>
+      <c01 level="series">
+        <did>
+          <unittitle>Departmental Records</unittitle>
+        </did>
+        <scopecontent>
+          <p>The Departmental Records series documents Holland's professorial and administrative career at the University of Michigan, spanning the years between 1961 and 1982.  This is the largest series in the collection, and its records are organized thematically.  The General Departmental records partly consist of memos within the Committee on the Degree Program in Communication Studies from 1961-1981, of which Holland was a member.  They also contain information regarding program and course requirements, exam schedules, professorial appointments, and course structure.</p>
+          <p>This series also contains documents regarding departmental budget, pertaining mostly to the School of Communication Sciences.  These include memos, salary schedules, teaching load and corresponding budget information for Computer and Communication Sciences faculty members.  Within this series is documentation of Holland's participation in the Center for Cognitive Science at the University of Chicago and the University of Michigan, from 1980 to 1982.</p>
+          <p>Holland was a member of the Executive Committee and the Policy Committee for the Communication Studies Program, records from both of which are found in this series, dating from 1966 to 1981.  These include memos, curriculum changes, Masters and PhD requirements, course and program evaluation reports, school statistics, and grading, admission, and advising guidelines.</p>
+        </scopecontent>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>General, <unitdate type="inclusive">1961-1963</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Budget, <unitdate type="inclusive">1972-1975</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Center for Cognitive Science at University of Chicago &amp; University of Michigan, <unitdate type="inclusive">1980-1982</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2</container>
+            <unittitle>General, <unitdate type="inclusive">1963-1981</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2</container>
+            <unittitle>Executive Committee, <unitdate type="inclusive">1968</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2</container>
+            <unittitle>Executive Committee, <unitdate type="inclusive">1974-1976</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2</container>
+            <unittitle>Executive Committee, <unitdate type="inclusive">1978-1979</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2</container>
+            <unittitle>Faculty Business/Early University Appointments, <unitdate type="inclusive">1963-1966</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2</container>
+            <unittitle>Policy Committee, <unitdate type="inclusive">1967-1969</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2</container>
+            <unittitle>Policy Committee, <unitdate type="inclusive">1974-1979</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2</container>
+            <unittitle>Policy Committee, <unitdate type="inclusive">1980-1981</unitdate></unittitle>
+          </did>
+        </c02>
+      </c01>
+      <c01 level="series">
+        <did>
+          <unittitle>Grants and Proposals</unittitle>
+        </did>
+        <scopecontent>
+          <p>Grants and Proposals is a series of records covering the period from 1956 to 1978 documenting the various grants and proposals with which Holland was involved.  These include grants from NASA, The National Science Foundation and the EDG Advisory Group on Polymorphic Computers, and multiple proposals to the Office of Scientific Research.</p>
+        </scopecontent>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>Communication Sciences Center--Proposal and Correspondence, <unitdate type="inclusive">1961</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>Grant Applications, General, <unitdate type="inclusive">1963-1971</unitdate> </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>Initial drafts and original biographies for Office of Scientific Research Proposal, <unitdate type="inclusive">1957</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>NASA Grant [NSG 1176], "Comparative Analyses of Genetic Algorithms in Relation to Other Multimodal Function Optimization Techniques", <unitdate type="inclusive">1973-1976</unitdate> </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>NSF Grant [GM 12236-09], "Computer Simulation in Biology: Theory and Practice", <unitdate type="inclusive">1971-1978</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>NSF Grant [MCS 76-04297], "Formal Theory of Multi-Dimensional, Nonlinear Systems, with Inter-Disciplinary Applications", <unitdate type="inclusive">1971-1978</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>Office of Scientific Research Proposal and Correspondence (1 copy of Logical Design Proposal), <unitdate type="inclusive">1956-1957</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>Office of Scientific Research Proposal, Masters, <unitdate type="inclusive">1956-1957</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>EDG Advisory Group on Polymorphic Computers, "A Proposal for the Investigation of Advanced Logical Design Methods for Computers Used in Large Scale Systems", <unitdate type="inclusive">1960</unitdate></unittitle>
+          </did>
+        </c02>
+      </c01>
+      <c01 level="series">
+        <did>
+          <unittitle>Presentations and Publications</unittitle>
+        </did>
+        <scopecontent>
+          <p>The Presentations and Publications series consists of documents pertaining to Holland's attendance and/or presentations at various symposiums and conferences, as well as documents regarding his many published papers.  The series includes invitations, publications, reprint requests, symposium and conference pamphlets, and correspondence between Holland and event organizers.  The records are organized alphabetically.</p>
+        </scopecontent>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>Harvard Switching Theory Symposium, <unitdate type="inclusive">1957</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>Information Symposium and Proposal on Self-Organizing Work Leading to Office of Scientific Research Proposal, <unitdate type="inclusive">1956</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>IMMD Convocation (Institut Für Mathematische Maschinen und Datenverarbeitung), <unitdate type="inclusive">1976</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>Journal Association of Computing Machinery-"a logical theory...", <unitdate type="inclusive">1961-1962</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>List of principle reports, papers, and publications of Logic of Computers Group,   <unitdate type="inclusive">January 1964-June 30, 1965</unitdate> </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>Masters/copy of 1956 Information Symposium paper, <unitdate type="inclusive">1956</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>Memoranda on Artificial Intelligence; Inter-Disciplinary Seminar, <unitdate type="inclusive">1958-1959</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>New Zealand Embassy, <unitdate type="inclusive">1961-1962</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>Original-Western Joint Computer Conference paper, <unitdate type="inclusive">1960</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>Papers, <unitdate type="inclusive">1958-1960</unitdate> </unittitle>
+            <physdesc>
+              <extent>4 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>Philosophy of Science Association Meeting, <unitdate type="inclusive">1976</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>Reprint requests for <unitdate type="inclusive">1959</unitdate> Eastern Joint Computer Conference paper, <unitdate type="inclusive">1959</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>Reprint requests for <unitdate type="inclusive">1960</unitdate> Western Joint Computer Conference paper, <unitdate type="inclusive">1960</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>Seminar at Blaricum, <unitdate type="inclusive">1959-1962</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3</container>
+            <unittitle>Western Joint Computer Conference, <unitdate type="inclusive">1960</unitdate></unittitle>
+          </did>
+        </c02>
+      </c01>
+      <c01 level="series">
+        <did>
+          <unittitle>Research</unittitle>
+        </did>
+        <scopecontent>
+          <p>The Research series contains various papers by Holland, as well as reviews of colleagues' publications, personal research notes, and rough calculations.  Notes on self-organizing models, the simplex method, and the distribution problem are included.  The series extends from 1956 to 1962, and is arranged alphabetically.</p>
+        </scopecontent>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Ashby's paper and review, "What is an Intelligent Machine?," <unitdate type="inclusive">1961</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Carnegie Institution of Washington, <unitdate type="inclusive">1960-1962</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Central Nervous System Simulation/Research Computer, <unitdate type="inclusive">1962</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Committee on Communication Science (Minutes, etc.), <unitdate type="inclusive">Before 1960</unitdate>  </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Discussion of Burkes-Wane paper, <unitdate type="inclusive">1956</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Distribution Problem (Linear Prog. Approach)</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Institute of Science and Technology-Systems research, <unitdate type="inclusive">1960-1962</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Rough calculations concerning <title render="italic"> Perceptron</title> (Cornell Aerospace Lab)</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Self-Organizing Models, <unitdate type="inclusive">1956-1958</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Simplex Method</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Student Programs and Summaries (prior to prelims),  <unitdate type="inclusive">1959-?</unitdate> </unittitle>
+            <physdesc>
+              <extent>4 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+      </c01>
+      <c01 level="series">
+        <did>
+          <unittitle>Teaching</unittitle>
+        </did>
+        <scopecontent>
+          <p>The last series consists of Holland's Teaching records.  These include course packs for various Computer and Communication Sciences courses, as well as notes, class material, and course evaluations.  The series also contains documents pertaining to summer conference courses from 1960-1961.  Included in the series as well are papers from doctoral committees on which Holland served, as well as PhD students' summary reports for which he sat on the examination panel.  The entire series covers the period from 1963 to 1980, and is arranged chronologically.  Some content in this series is restricted.</p>
+        </scopecontent>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Course packs, CCS 805 (Computer and Communication Sciences), <unitdate type="inclusive">1970-1971</unitdate> </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>CS 200</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>CS 510 Signal Theory</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>CS 565</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>CS 410 Communication Electronics, <unitdate type="inclusive">1963</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>CS 580, <unitdate type="inclusive">1966</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>CS 400 Introduction to the Communication Sciences, <unitdate type="inclusive">1968</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>CS 624 Theory of Adaptive Systems, <unitdate type="inclusive">1968</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>CS 805 Seminar in Adaptive Systems Theory, <unitdate type="inclusive">1969-1980</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>CS 422 Introduction to Artificial Intelligence, <unitdate type="inclusive">1970</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>CS 550, <unitdate type="inclusive">1977-1980</unitdate> </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>CS 526, <unitdate type="inclusive">1978-1980</unitdate> </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>CCS 385 LISP Mini-Course, <unitdate type="inclusive">1980</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Course Evaluations CS 101</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Course Evaluations CS 550, <unitdate type="inclusive">1978</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Summer Conference Course, <unitdate type="inclusive">1960</unitdate> </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Summer Conference Course, <unitdate type="inclusive">1961</unitdate> </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Doctoral Committees, <unitdate type="inclusive">1963-1969</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Preliminary questions, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="item">
+          <did>
+            <container type="box" label="Box">4</container>
+            <unittitle>Summary Reports (John Holland  was one of the panel members), <unitdate type="inclusive">1974-1979</unitdate> </unittitle>
+            <physdesc>
+              <extent>4 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">5</container>
+            <unittitle>Early Papers by CCS Students Later Recognized, <unitdate type="inclusive">1966</unitdate></unittitle>
+          </did>
+          <accessrestrict>
+            <p>[SR Restricted until  July 1, <date type="restriction" normal="2041-07-01">2041</date>]</p>
+          </accessrestrict>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">5</container>
+            <unittitle>Student Records, <unitdate type="inclusive">1961-1962</unitdate></unittitle>
+          </did>
+          <accessrestrict>
+            <p>[SR Restricted until  July 1, <date type="restriction" normal="2037-07-01">2037</date>]</p>
+          </accessrestrict>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">5</container>
+            <unittitle>Student Records, <unitdate type="inclusive">1962-1963</unitdate></unittitle>
+          </did>
+          <accessrestrict>
+            <p>[SR Restricted until  July 1, <date type="restriction" normal="2038-07-01">2038</date>]</p>
+          </accessrestrict>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">5</container>
+            <unittitle>Student Records, <unitdate type="inclusive">1963-1964</unitdate></unittitle>
+          </did>
+          <accessrestrict>
+            <p>[SR Restricted until  July 1, <date type="restriction" normal="2039-07-01">2039</date>]</p>
+          </accessrestrict>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">5</container>
+            <unittitle>Student Records, <unitdate type="inclusive">1964-1965</unitdate></unittitle>
+          </did>
+          <accessrestrict>
+            <p>[SR Restricted until  July 1, <date type="restriction" normal="2040-07-01">2040</date>]</p>
+          </accessrestrict>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">5</container>
+            <unittitle>Student Records, <unitdate type="inclusive">1966-1967</unitdate></unittitle>
+          </did>
+          <accessrestrict>
+            <p>[SR Restricted until  July 1, <date type="restriction" normal="2042-07-01">2042</date>]</p>
+          </accessrestrict>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">5</container>
+            <unittitle>Student Records, <unitdate type="inclusive">1968</unitdate></unittitle>
+          </did>
+          <accessrestrict>
+            <p>[SR Restricted until  July 1, <date type="restriction" normal="2043-07-01">2043</date>]</p>
+          </accessrestrict>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">5</container>
+            <unittitle>Student Records, <unitdate type="inclusive">1969</unitdate></unittitle>
+          </did>
+          <accessrestrict>
+            <p>[SR Restricted until  July 1, <date type="restriction" normal="2044-07-01">2044</date>]</p>
+          </accessrestrict>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">5</container>
+            <unittitle>Student Records, <unitdate type="inclusive">1974</unitdate></unittitle>
+          </did>
+          <accessrestrict>
+            <p>[SR Restricted until  July 1, <date type="restriction" normal="2049-07-01">2049</date>]</p>
+          </accessrestrict>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">5</container>
+            <unittitle>Student Records, <unitdate type="inclusive">1975-1976</unitdate></unittitle>
+          </did>
+          <accessrestrict>
+            <p>[SR Restricted until  July 1, <date type="restriction" normal="2051-07-01">2051</date>]</p>
+          </accessrestrict>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">5</container>
+            <unittitle>Student Records, <unitdate type="inclusive">1976-1977</unitdate></unittitle>
+          </did>
+          <accessrestrict>
+            <p>[SR Restricted until  July 1, <date type="restriction" normal="2052-07-01">2052</date>]</p>
+          </accessrestrict>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">5</container>
+            <unittitle>Student Records, 1978-79  </unittitle>
+          </did>
+          <accessrestrict>
+            <p>[SR Restricted until  July 1, <date type="restriction" normal="2054-07-01">2054</date>]</p>
+          </accessrestrict>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">5</container>
+            <unittitle>Student Records, <unitdate type="inclusive">1978-1981</unitdate></unittitle>
+          </did>
+          <accessrestrict>
+            <p>[SR Restricted until  July 1, <date type="restriction" normal="2056-07-01">2056</date>]</p>
+          </accessrestrict>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">5</container>
+            <unittitle>Student Records, <unitdate type="inclusive">1980-1981</unitdate></unittitle>
+          </did>
+          <accessrestrict>
+            <p>[SR Restricted until  July 1, <date type="restriction" normal="2056-07-01">2056</date>]</p>
+          </accessrestrict>
+        </c02>
+      </c01>
+    </dsc>
+  </archdesc>
 </ead>

--- a/Real_Masters_all/hollandj.xml
+++ b/Real_Masters_all/hollandj.xml
@@ -59,10 +59,8 @@ John H. Holland papers
 </unitdate>
  
 </unittitle>
-      <physdesc>
-        <extent encodinganalog="300">
-4.50 linear feet
-</extent>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">4.50 linear feet</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2010206 Aa 2
@@ -337,8 +335,8 @@ The files are divided into six series: Correspondence, Departmental Records, Gra
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Grant Applications, General, <unitdate type="inclusive">1963-1971</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -352,8 +350,8 @@ The files are divided into six series: Correspondence, Departmental Records, Gra
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>NASA Grant [NSG 1176], "Comparative Analyses of Genetic Algorithms in Relation to Other Multimodal Function Optimization Techniques", <unitdate type="inclusive">1973-1976</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -423,8 +421,8 @@ The files are divided into six series: Correspondence, Departmental Records, Gra
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>List of principle reports, papers, and publications of Logic of Computers Group,   <unitdate type="inclusive">January 1964-June 30, 1965</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -456,8 +454,8 @@ The files are divided into six series: Correspondence, Departmental Records, Gra
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Papers, <unitdate type="inclusive">1958-1960</unitdate> </unittitle>
-            <physdesc>
-              <extent>4 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -521,8 +519,8 @@ The files are divided into six series: Correspondence, Departmental Records, Gra
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Committee on Communication Science (Minutes, etc.), <unitdate type="inclusive">Before 1960</unitdate>  </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -566,8 +564,8 @@ The files are divided into six series: Correspondence, Departmental Records, Gra
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Student Programs and Summaries (prior to prelims),  <unitdate type="inclusive">1959-?</unitdate> </unittitle>
-            <physdesc>
-              <extent>4 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -583,8 +581,8 @@ The files are divided into six series: Correspondence, Departmental Records, Gra
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Course packs, CCS 805 (Computer and Communication Sciences), <unitdate type="inclusive">1970-1971</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -646,8 +644,8 @@ The files are divided into six series: Correspondence, Departmental Records, Gra
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>CS 550, <unitdate type="inclusive">1977-1980</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -655,8 +653,8 @@ The files are divided into six series: Correspondence, Departmental Records, Gra
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>CS 526, <unitdate type="inclusive">1978-1980</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -682,8 +680,8 @@ The files are divided into six series: Correspondence, Departmental Records, Gra
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Summer Conference Course, <unitdate type="inclusive">1960</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -691,8 +689,8 @@ The files are divided into six series: Correspondence, Departmental Records, Gra
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Summer Conference Course, <unitdate type="inclusive">1961</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -712,8 +710,8 @@ The files are divided into six series: Correspondence, Departmental Records, Gra
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Summary Reports (John Holland  was one of the panel members), <unitdate type="inclusive">1974-1979</unitdate> </unittitle>
-            <physdesc>
-              <extent>4 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/holljeep.xml
+++ b/Real_Masters_all/holljeep.xml
@@ -3145,8 +3145,8 @@
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>A-Square Compilation</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-Rs</physfacet>
             </physdesc>
           </did>
@@ -3154,8 +3154,8 @@
         <c02 level="file">
           <did>
             <unittitle>Brownsville Station</unittitle>
-            <physdesc>
-              <extent>2 phonograph records</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 phonograph records</extent>
               <physfacet>45rpm</physfacet>
             </physdesc>
           </did>
@@ -3176,8 +3176,8 @@
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>Catfish, "Down in the Flood," (B side; "Witchcraft")</unittitle>
-            <physdesc>
-              <extent>1 phonograph records</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
               <physfacet>45rpm</physfacet>
             </physdesc>
           </did>
@@ -3186,8 +3186,8 @@
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>Commander Cody and the Lost Planet Airmen, "Watch My .38," (B side; "Semi-Truck") <unitdate type="inclusive" normal="1973">1973</unitdate></unittitle>
-            <physdesc>
-              <extent>1 phonograph records</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
               <physfacet>45rpm</physfacet>
             </physdesc>
           </did>
@@ -3196,8 +3196,8 @@
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>Mr. Curt, "Write Down Your Number," (B side; "I'm Going Blind") <unitdate type="inclusive" normal="1978">1978</unitdate></unittitle>
-            <physdesc>
-              <extent>1 phonograph records</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
               <physfacet>45rpm</physfacet>
             </physdesc>
           </did>
@@ -3206,8 +3206,8 @@
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>Ray Paul, "Lady Be Mine Tonight," (B side; "Hold It") <unitdate type="inclusive" normal="1977">1977</unitdate></unittitle>
-            <physdesc>
-              <extent>1 phonograph records</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
               <physfacet>45rpm</physfacet>
             </physdesc>
           </did>
@@ -3216,8 +3216,8 @@
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>Plain Brown Wrapper, "Stretch Out Your Hand," (B side; "Stretch Out Your Hand (2)")</unittitle>
-            <physdesc>
-              <extent>1 phonograph records</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
               <physfacet>45rpm</physfacet>
             </physdesc>
           </did>
@@ -3226,8 +3226,8 @@
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>Rain like the Sound of Trains, "Bad Man's Grave," (B side; "Cookin With Anger") <unitdate type="inclusive" normal="1993">1993</unitdate></unittitle>
-            <physdesc>
-              <extent>1 phonograph records</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
               <physfacet>45rpm</physfacet>
             </physdesc>
           </did>
@@ -3236,8 +3236,8 @@
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>The UP, "Just Like and Aborigine," (B side; "Hassan I Sabbah") <unitdate type="inclusive" normal="1970">1970</unitdate></unittitle>
-            <physdesc>
-              <extent>1 phonograph records</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
               <physfacet>45rpm</physfacet>
             </physdesc>
           </did>
@@ -3245,8 +3245,8 @@
         <c02 level="file">
           <did>
             <unittitle>Miscellaneous</unittitle>
-            <physdesc>
-              <extent>2 phonograph records</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 phonograph records</extent>
               <physfacet>45rpm</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/hopkinsalv.xml
+++ b/Real_Masters_all/hopkinsalv.xml
@@ -1,55 +1,57 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE ead PUBLIC "+//ISBN 1-931666-00-8//DTD ead.dtd (Encoded Archival Description (EAD) Version 2002)//EN" "ead.dtd">
 <ead>
-
-<eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
-
-<eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::hopkinsalv.xml//EN" encodinganalog="Identifier">
+  <eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
+    <eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::hopkinsalv.xml//EN" encodinganalog="Identifier">
 umich-bhl-2016012</eadid>
-
-<filedesc><titlestmt><titleproper encodinganalog="Title">Finding Aid for 
+    <filedesc>
+      <titlestmt>
+        <titleproper encodinganalog="Title">Finding Aid for 
 Alvah S. Hopkins papers 
 
 </titleproper>
-<author encodinganalog="Creator">Collection processed and finding aid created by 
-Elizabeth Carron </author></titlestmt>
-
-<publicationstmt><publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
-<date encodinganalog="Date" normal="2016">
-2016</date></publicationstmt></filedesc>
-
-<profiledesc>
-<creation>Encoded finding aid created by 
+        <author encodinganalog="Creator">Collection processed and finding aid created by 
+Elizabeth Carron </author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
+        <date encodinganalog="Date" normal="2016">
+2016</date>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>Encoded finding aid created by 
 Olga Virakhovskaya 
 <date>2016</date></creation>
-
-<langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage><descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules></profiledesc>
-
-<revisiondesc><change><date>2016-01-29</date><item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item></change></revisiondesc></eadheader>
-
-<frontmatter><titlepage>
-
-<publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
-
-<titleproper>Finding aid for<lb/>
+      <langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage>
+      <descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules>
+    </profiledesc>
+    <revisiondesc>
+      <change>
+        <date>2016-01-29</date>
+        <item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item>
+      </change>
+    </revisiondesc>
+  </eadheader>
+  <frontmatter>
+    <titlepage>
+      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <titleproper>Finding aid for<lb/>
 Alvah S. Hopkins papers 
 </titleproper>
-
-<author>Finding aid created by<lb/> 
+      <author>Finding aid created by<lb/> 
 Elizabeth Carron in January 2016
 </author>
-
-</titlepage>
-</frontmatter>
-
-<archdesc level="recordgrp" audience="external" type="inventory" relatedencoding="MARC21"><did>
-
-<origination>
-<corpname source="lcnaf" encodinganalog="110">
+    </titlepage>
+  </frontmatter>
+  <archdesc level="recordgrp" audience="external" type="inventory" relatedencoding="MARC21">
+    <did>
+      <origination>
+        <corpname source="lcnaf" encodinganalog="110">
 Hopkins, Alvah S.
-</corpname></origination>
-
-<unittitle encodinganalog="245">
+</corpname>
+      </origination>
+      <unittitle encodinganalog="245">
 Alvah S. Hopkins papers 
 <unitdate type="inclusive" encodinganalog="245$f">
 1894-1951
@@ -59,99 +61,101 @@ Alvah S. Hopkins papers
 1894-1895
 </unitdate>
 </unittitle>
-
-<physdesc><extent encodinganalog="300">
+      <physdesc>
+        <extent encodinganalog="300">
 0.25 linear feet 
-</extent></physdesc>
-
-<unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
+</extent>
+      </physdesc>
+      <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2016012 Aa 2
 </unitid>
-
-<langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
-
-<abstract>
+      <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
+      <abstract>
 Graduate of the University of Michigan Law School, Class of 1896. Diary and photographs.
 </abstract>
-
-
-<repository><corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
-<extptr href="bhladd" show="embed" actuate="onload"/></repository></did>
-
-<descgrp type="admin">
-<acqinfo encodinganalog="541"><p>
+      <repository>
+        <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
+        <extptr href="bhladd" show="embed" actuate="onload"/>
+      </repository>
+    </did>
+    <descgrp type="admin">
+      <acqinfo encodinganalog="541">
+        <p>
 Donated by John Pfeiffer (donor no. 
 <num type="donor" encodinganalog="541$e">11412</num>), in December, 2015. 
  
-</p></acqinfo>
-
-
-
-<accruals encodinganalog="584"><p>
+</p>
+      </acqinfo>
+      <accruals encodinganalog="584">
+        <p>
 No further additions to the records are expected.
-</p></accruals>
-
-
-<accessrestrict encodinganalog="506">
-<p>The collection is open without restriction.</p>
-</accessrestrict>
-
-
-<userestrict encodinganalog="540"><p>
-Copyright has been transferred to the Regents of the University of Michigan.</p></userestrict>
-
-
-<prefercite encodinganalog="524"><p>[item], folder, box,
-Alvah S. Hopkins papers, Bentley Historical Library, University of Michigan</p></prefercite>
-</descgrp>
-
-<bioghist encodinganalog="545">
-<p>Alvah Stanton Hopkins was born in Homer, Illinois on December 23, 1874 to Richard and Dama Hopkins. He was a student of the University of Michigan Law School, during which time he belonged to Kappa Sigma Alpha, Epsilon chapter. </p>
-
-<p>Hopkins engaged in a variety of extracurricular activities and was particularly fond of football. His diary features a firsthand account of the football game in which Michigan's 12-4 victory over Cornell marked the first time in collegiate football history that a western school defeated an eastern rival.</p>
-
-<p>After receiving his degree in 1896, he returned to Chicago and spent his career in leather goods manufacturing as a managing director for Hopkins and Hopkins. In 1906 he married Lela Gill, with whom he had three children. He died in Chicago, 1962.  </p>
-
-
-</bioghist>
- 
-<scopecontent encodinganalog="520">
-<p>The collection contains Hopkins' diary, dating November 1894 through June 1895, and a reproduction of the original volume.  Also included photographs featuring Alvah Hopkins and identified Class 1896 alumni from the 1946 50th reunion (1946) and the 1951 Homecoming Weekend</p></scopecontent>
-
-<controlaccess><p><extptr href="accnote" show="embed" actuate="onload"/></p><controlaccess><head>Subjects:</head>
- 
-
-<persname source="lcnaf" encodinganalog="600">Hopkins, Alvah S.</persname>
- 
-<corpname source="lcnaf" encodinganalog="610">University of Michigan--Football.</corpname>
-<corpname source="lcnaf" encodinganalog="610">University of Michigan. Law School--Students.</corpname>
-<corpname source="lcnaf" encodinganalog="610">University of Michigan--Students--Social life and customs--1891-1900.</corpname>
-
-</controlaccess>
-
-<controlaccess><head>Subjects - Visual Materials:</head>
-
-<subject source="lctgm" encodinganalog="650">Alumni--1891-1900.</subject>
- </controlaccess>
- 
-<controlaccess><head>Genre Terms:</head>
-<genreform source="aat" encodinganalog="655">Diaries.</genreform>
-<genreform source="aat" encodinganalog="655">Photographs.</genreform>
-</controlaccess>
-
-</controlaccess>
-
-
-<dsc type="combined">
-<c01 level="series"><did><unittitle>Alvah S. Hopkins papers</unittitle></did>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Diary</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Diary, reproduction</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Photographs</unittitle></did></c02></c01>
-
-</dsc>
-
-</archdesc>
-
-
-
+</p>
+      </accruals>
+      <accessrestrict encodinganalog="506">
+        <p>The collection is open without restriction.</p>
+      </accessrestrict>
+      <userestrict encodinganalog="540">
+        <p>
+Copyright has been transferred to the Regents of the University of Michigan.</p>
+      </userestrict>
+      <prefercite encodinganalog="524">
+        <p>[item], folder, box,
+Alvah S. Hopkins papers, Bentley Historical Library, University of Michigan</p>
+      </prefercite>
+    </descgrp>
+    <bioghist encodinganalog="545">
+      <p>Alvah Stanton Hopkins was born in Homer, Illinois on December 23, 1874 to Richard and Dama Hopkins. He was a student of the University of Michigan Law School, during which time he belonged to Kappa Sigma Alpha, Epsilon chapter. </p>
+      <p>Hopkins engaged in a variety of extracurricular activities and was particularly fond of football. His diary features a firsthand account of the football game in which Michigan's 12-4 victory over Cornell marked the first time in collegiate football history that a western school defeated an eastern rival.</p>
+      <p>After receiving his degree in 1896, he returned to Chicago and spent his career in leather goods manufacturing as a managing director for Hopkins and Hopkins. In 1906 he married Lela Gill, with whom he had three children. He died in Chicago, 1962.  </p>
+    </bioghist>
+    <scopecontent encodinganalog="520">
+      <p>The collection contains Hopkins' diary, dating November 1894 through June 1895, and a reproduction of the original volume.  Also included photographs featuring Alvah Hopkins and identified Class 1896 alumni from the 1946 50th reunion (1946) and the 1951 Homecoming Weekend</p>
+    </scopecontent>
+    <controlaccess>
+      <p>
+        <extptr href="accnote" show="embed" actuate="onload"/>
+      </p>
+      <controlaccess>
+        <head>Subjects:</head>
+        <persname source="lcnaf" encodinganalog="600">Hopkins, Alvah S.</persname>
+        <corpname source="lcnaf" encodinganalog="610">University of Michigan--Football.</corpname>
+        <corpname source="lcnaf" encodinganalog="610">University of Michigan. Law School--Students.</corpname>
+        <corpname source="lcnaf" encodinganalog="610">University of Michigan--Students--Social life and customs--1891-1900.</corpname>
+      </controlaccess>
+      <controlaccess>
+        <head>Subjects - Visual Materials:</head>
+        <subject source="lctgm" encodinganalog="650">Alumni--1891-1900.</subject>
+      </controlaccess>
+      <controlaccess>
+        <head>Genre Terms:</head>
+        <genreform source="aat" encodinganalog="655">Diaries.</genreform>
+        <genreform source="aat" encodinganalog="655">Photographs.</genreform>
+      </controlaccess>
+    </controlaccess>
+    <dsc type="combined">
+      <c01 level="series">
+        <did>
+          <unittitle>Alvah S. Hopkins papers</unittitle>
+        </did>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Diary</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Diary, reproduction</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Photographs</unittitle>
+          </did>
+        </c02>
+      </c01>
+    </dsc>
+  </archdesc>
 </ead>

--- a/Real_Masters_all/hopkinsalv.xml
+++ b/Real_Masters_all/hopkinsalv.xml
@@ -61,10 +61,8 @@ Alvah S. Hopkins papers
 1894-1895
 </unitdate>
 </unittitle>
-      <physdesc>
-        <extent encodinganalog="300">
-0.25 linear feet 
-</extent>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">0.25 linear feet</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2016012 Aa 2

--- a/Real_Masters_all/howellsal.xml
+++ b/Real_Masters_all/howellsal.xml
@@ -1,55 +1,57 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE ead PUBLIC "+//ISBN 1-931666-00-8//DTD ead.dtd (Encoded Archival Description (EAD) Version 2002)//EN" "ead.dtd">
 <ead>
-
-<eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
-
-<eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::howellsal.xml//EN" encodinganalog="Identifier">
+  <eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
+    <eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::howellsal.xml//EN" encodinganalog="Identifier">
 umich-bhl-2016013</eadid>
-
-<filedesc><titlestmt><titleproper encodinganalog="Title">Finding Aid for 
+    <filedesc>
+      <titlestmt>
+        <titleproper encodinganalog="Title">Finding Aid for 
 Sally Howell papers
 
 </titleproper>
-<author encodinganalog="Creator">Collection processed and finding aid created by 
-Ben Bond</author></titlestmt>
-
-<publicationstmt><publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
-<date encodinganalog="Date" normal="2016">
-2016</date></publicationstmt></filedesc>
-
-<profiledesc>
-<creation>Encoded finding aid created by 
+        <author encodinganalog="Creator">Collection processed and finding aid created by 
+Ben Bond</author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
+        <date encodinganalog="Date" normal="2016">
+2016</date>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>Encoded finding aid created by 
 Olga Virakhovskaya 
 <date>2016</date></creation>
-
-<langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage><descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules></profiledesc>
-
-<revisiondesc><change><date>2016-01-29</date><item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item></change></revisiondesc></eadheader>
-
-<frontmatter><titlepage>
-
-<publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
-
-<titleproper>Finding aid for<lb/>
+      <langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage>
+      <descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules>
+    </profiledesc>
+    <revisiondesc>
+      <change>
+        <date>2016-01-29</date>
+        <item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item>
+      </change>
+    </revisiondesc>
+  </eadheader>
+  <frontmatter>
+    <titlepage>
+      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <titleproper>Finding aid for<lb/>
 Sally Howell papers
 </titleproper>
-
-<author>Finding aid created by<lb/> 
+      <author>Finding aid created by<lb/> 
 Ben Bond, in January, 2016
 </author>
-
-</titlepage>
-</frontmatter>
-
-<archdesc level="recordgrp" audience="external" type="inventory" relatedencoding="MARC21"><did>
-
-<origination>
-<corpname source="lcnaf" encodinganalog="110">
+    </titlepage>
+  </frontmatter>
+  <archdesc level="recordgrp" audience="external" type="inventory" relatedencoding="MARC21">
+    <did>
+      <origination>
+        <corpname source="lcnaf" encodinganalog="110">
 Howell, Sally
-</corpname></origination>
-
-<unittitle encodinganalog="245">
+</corpname>
+      </origination>
+      <unittitle encodinganalog="245">
 Sally Howell papers
 <unitdate type="inclusive" encodinganalog="245$f">
 1986-2005
@@ -59,164 +61,467 @@ Sally Howell papers
 1994-1997
 </unitdate>
 </unittitle>
-
-<physdesc><extent encodinganalog="300">
+      <physdesc>
+        <extent encodinganalog="300">
 1.6 linear feet
-</extent></physdesc>
-
-<unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
+</extent>
+      </physdesc>
+      <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2016013 Aa 2
 </unitid>
-
-<langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
-
-<abstract>
+      <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
+      <abstract>
 Sally Howell is an associate professor of history and Arab American Studies at the University of Michigan-Dearborn. The collection includes papers and photos dealing with her work in ACCESS (Arab Community Center for Economic and Social Services); as well as various lectures and museum exhibitions that she has prepared. </abstract>
-
-
-<repository><corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
-<extptr href="bhladd" show="embed" actuate="onload"/></repository></did>
-
-<descgrp type="admin">
-<acqinfo encodinganalog="541"><p>
+      <repository>
+        <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
+        <extptr href="bhladd" show="embed" actuate="onload"/>
+      </repository>
+    </did>
+    <descgrp type="admin">
+      <acqinfo encodinganalog="541">
+        <p>
 Donated by Sally Howell (donor no. 
 <num type="donor" encodinganalog="541$e">10840</num>), in November, 2015.  
  
-</p></acqinfo>
-
-<accruals encodinganalog="584"><p>Periodic additions to the papers are expected.</p></accruals>
-
- <accessrestrict encodinganalog="506">
-<p>TThe collection is open without restriction.</p>
- </accessrestrict>
-
-
-<userestrict encodinganalog="540"><p>
+</p>
+      </acqinfo>
+      <accruals encodinganalog="584">
+        <p>Periodic additions to the papers are expected.</p>
+      </accruals>
+      <accessrestrict encodinganalog="506">
+        <p>TThe collection is open without restriction.</p>
+      </accessrestrict>
+      <userestrict encodinganalog="540">
+        <p>
 Copyright is held by the Regents of the University of Michigan.
-</p></userestrict>
-
-
-<prefercite encodinganalog="524"><p>[item], folder, box,
-Sally Howell papers, Bentley Historical Library, University of Michigan</p></prefercite>
- </descgrp>
-
-<bioghist encodinganalog="545">
- <p>Sally Howell received her B.A. in Middle Eastern Studies from Davidson College in 1985. She then worked with ACCESS in Dearborn, MI from 1987 to 2000, serving as Cultural Arts Director as well as consultant and grant writer. In 2002 she was awarded a M.A. in American Culture from the University of Michigan and in 2009 was awarded a Ph.D. in American Culture from the University of Michigan. </p>
- 
- <p>From September of 2009 to May of 2015, Howell held the position of Assistant Professor of History at the University of Michigan- Dearborn, working in the Center for Arab American Studies. As of May 2015 she has begun work as Associate professor.</p>
- 
- <p>Howell's teaching and research interests include: history of Islam in the United States, Arab American history and culture, Detroit history and culture, citizenship and migration, and The War on Terror and its impact on Arab and Muslim Americans.</p>
- 
-
-
-</bioghist>
-
-<arrangement encodinganalog="351">
-<p>
+</p>
+      </userestrict>
+      <prefercite encodinganalog="524">
+        <p>[item], folder, box,
+Sally Howell papers, Bentley Historical Library, University of Michigan</p>
+      </prefercite>
+    </descgrp>
+    <bioghist encodinganalog="545">
+      <p>Sally Howell received her B.A. in Middle Eastern Studies from Davidson College in 1985. She then worked with ACCESS in Dearborn, MI from 1987 to 2000, serving as Cultural Arts Director as well as consultant and grant writer. In 2002 she was awarded a M.A. in American Culture from the University of Michigan and in 2009 was awarded a Ph.D. in American Culture from the University of Michigan. </p>
+      <p>From September of 2009 to May of 2015, Howell held the position of Assistant Professor of History at the University of Michigan- Dearborn, working in the Center for Arab American Studies. As of May 2015 she has begun work as Associate professor.</p>
+      <p>Howell's teaching and research interests include: history of Islam in the United States, Arab American history and culture, Detroit history and culture, citizenship and migration, and The War on Terror and its impact on Arab and Muslim Americans.</p>
+    </bioghist>
+    <arrangement encodinganalog="351">
+      <p>
 Arranged into four series: Museums, Lectures and Tours; Grants and Awards;  Arab Community Center for Economic and Social Services; and  Business Directories.
 </p>
-</arrangement>
-
-<scopecontent encodinganalog="520">
-<p>Included are documents and photos relating to Howell and her work with Arab Community Center for Economic and Social Services (ACCESS) in Southeast Michigan. These documents range from plans for anniversary events for ACCESS, lecture tours Howell gave, museum exhibitions, administrative information on ACCESS, and miscellaneous information pertaining to Detroit and its Arab American population. </p></scopecontent>
-
-<controlaccess><p><extptr href="accnote" show="embed" actuate="onload"/></p><controlaccess><head>Subjects:</head>
-<subject source="lcsh" encodinganalog="650">Arab Americans--Michigan--Detroit.</subject>
-<corpname source="lcnaf" encodinganalog="610">Arab Community Center for Economic and Social Services.</corpname>
-<subject source="lcsh" encodinganalog="650">Communities--Michigan--Detroit</subject>
-<persname source="lcnaf" encodinganalog="600">Howell, Sally.</persname>
-<subject source="lcsh" encodinganalog="650">Immigrants--Michigan--Detroit.</subject>
-<subject source="lcsh" encodinganalog="650">Minorities--Michigan--Detroit.</subject>
-<subject source="lcsh" encodinganalog="650">Museum exhibitions--Michigan.</subject>
-<corpname source="lcnaf" encodinganalog="610">University of Michigan--Dearborn. Department of History.</corpname>
-<corpname source="lcnaf" encodinganalog="610">University of Michigan--Dearborn--Faculty.</corpname>
-
-
-</controlaccess>
- 
-<controlaccess><head>Genre Terms:</head>
-<genreform source="aat" encodinganalog="655">Commercial directories.</genreform>
-<genreform source="aat" encodinganalog="655">Photographs.</genreform>
-
-</controlaccess>
-
-</controlaccess>
-
-
-<dsc type="combined">
-<c01 level="series"><did><unittitle>Museums, Lectures, and Tours</unittitle></did><scopecontent> <p>The Museums, Lectures, and Tours series (0.6 linear feet, 1994-2001) contains papers on Howell's various speaking engagements and museums exhibitions. Venues include the National Museum of American History (NMAH), The Castellani Art Museum of Niagara University, The Museum of the City of New York (MCNY) and the Michigan State University Museum (MSUM). Various folk art exhibitions and tours are also highlighted, as well photos and slides of Arab Americans in Detroit and relevant museum exhibitions. </p></scopecontent>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>NMAH exhibit photos (gallery), <unitdate type="inclusive">1995</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>NMAH final text, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>NMAH exhibition plan, <unitdate type="inclusive">1996</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>NMAH miscellaneous, <unitdate type="inclusive">1994-1995</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Smithsonian list of artifacts, <unitdate type="inclusive">1997</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Michigan State University (MSU) loan and ethics forms, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>English 679, <unitdate type="inclusive">1998-1999</unitdate> (college course)</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Cultural forum participants, <unitdate type="inclusive">2000</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Castellani, <unitdate type="inclusive">1999</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Castellani showing, <unitdate type="inclusive">1997-1998</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Niagara University, <unitdate type="inclusive">1999</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Folkart and fieldwork, <unitdate type="inclusive">1997</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Folkart contacts, <unitdate type="inclusive">1997</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Tour AT&amp;T, <unitdate type="inclusive">1995</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Tour support, <unitdate type="inclusive">1997</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Tour support letters, <unitdate type="inclusive">1996</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Tour work, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>National Endowment for the Arts (NEA) tour, <unitdate type="inclusive">1996</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Tour-Smith collection, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Canaw, <unitdate type="inclusive">1998</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Nabeel slides, <unitdate type="inclusive">1995</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>AWM, <unitdate type="inclusive">1995</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>MSUM miscellaneous materials, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>MSU labels, <unitdate type="inclusive">1997</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>MCNY, <unitdate type="inclusive">1997</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Arab Theatrical Arts Guild (ATAG), <unitdate type="inclusive">2001</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Museum pamphlets, <unitdate type="inclusive">1993-1998</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Arab Detroit photos, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Jelia photos and slides, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02></c01>
-
-
-<c01 level="series"><did><unittitle>Grants and Awards</unittitle></did><scopecontent> <p>Grants and Awards series (0.4 linear feet, 1987-2001) consists of the varied funding sources appealed to by Howell on behalf of ACCESS. The organizations included are The National Endowment for the Humanities, the National Endowment for the Arts, Lila Wallace, and Skillman funds. In addition, a recognition letter for the Glen Taggart award is included. </p></scopecontent>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Sumnist/ National Endowment for the Arts (NEA), <unitdate type="inclusive">1997</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Glen Taggert award, <unitdate type="inclusive">1994</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Lila Wallace, <unitdate type="inclusive">1997</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>National Endowment for the Humanities (NEH), <unitdate type="inclusive">1997</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Unlikely funding sources, <unitdate type="inclusive">1987-1994</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Rockefeller 96, <unitdate type="inclusive">1996</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Rockefeller fund, <unitdate type="inclusive">1997</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Skillman, <unitdate type="inclusive">1996</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Strategic plan, <unitdate type="inclusive">1996</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Balch Institute, <unitdate type="inclusive">2000</unitdate></unittitle></did></c02></c01>
-
-
-<c01 level="series"><did><unittitle> Arab Community Center for Economic and Social Services</unittitle></did><scopecontent> <p>The ACCESS series (0.3 linear feet, 1987- 2005) includes administrative records, as well has the plans for anniversary dinners and papers pertaining to Howell's film<title render="italic">Tales from Arab Detroit</title> . </p></scopecontent>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Promotional materials, <unitdate type="inclusive">1994</unitdate>, <unitdate type="inclusive">1995</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Miscellaneous materials, <unitdate type="inclusive">1996-2001</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Public comments, <unitdate type="inclusive">1999</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Arts program books, <unitdate type="inclusive">1987-1996</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Dinner, <unitdate type="inclusive">1997</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Dinner art, <unitdate type="inclusive">1996</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Imani Ali, <unitdate type="inclusive">1999</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Detroit (DET) history, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle><title render="italic"> Tales from Arab Detroit</title> materials, <unitdate type="inclusive">1997</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">2</container><unittitle>Arab World Mosaic, <unitdate type="inclusive">1994</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">2</container><unittitle>Archive project, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">2</container><unittitle>Archival ideas, <unitdate type="inclusive">2005</unitdate></unittitle></did></c02></c01>
-
-<c01 level="series"><did><unittitle>Business Directories</unittitle></did><scopecontent><p>Business Directories series (0.3 linear feet, 1993-2005) contains editions of Arab American yellow pages from Southeast Michigan. </p></scopecontent>
-<c02 level="file"><did><container type="box" label="Box">2</container><unittitle>JEI business directory, <unitdate type="inclusive">2000</unitdate></unittitle></did></c02>
-<c02 level="file"><did><unittitle>American Arab Business Directory</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">2</container><unittitle><unitdate type="inclusive">1993-1997</unitdate> </unittitle> <physdesc><extent>4 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">2</container><unittitle><unitdate type="inclusive">2001-2002</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">2</container><unittitle><unitdate type="inclusive">2005</unitdate></unittitle></did></c03></c02></c01>
-
-</dsc><descgrp type="add"><relatedmaterial><head>Related Materials</head><p>Bentley Historical Library holds
+    </arrangement>
+    <scopecontent encodinganalog="520">
+      <p>Included are documents and photos relating to Howell and her work with Arab Community Center for Economic and Social Services (ACCESS) in Southeast Michigan. These documents range from plans for anniversary events for ACCESS, lecture tours Howell gave, museum exhibitions, administrative information on ACCESS, and miscellaneous information pertaining to Detroit and its Arab American population. </p>
+    </scopecontent>
+    <controlaccess>
+      <p>
+        <extptr href="accnote" show="embed" actuate="onload"/>
+      </p>
+      <controlaccess>
+        <head>Subjects:</head>
+        <subject source="lcsh" encodinganalog="650">Arab Americans--Michigan--Detroit.</subject>
+        <corpname source="lcnaf" encodinganalog="610">Arab Community Center for Economic and Social Services.</corpname>
+        <subject source="lcsh" encodinganalog="650">Communities--Michigan--Detroit</subject>
+        <persname source="lcnaf" encodinganalog="600">Howell, Sally.</persname>
+        <subject source="lcsh" encodinganalog="650">Immigrants--Michigan--Detroit.</subject>
+        <subject source="lcsh" encodinganalog="650">Minorities--Michigan--Detroit.</subject>
+        <subject source="lcsh" encodinganalog="650">Museum exhibitions--Michigan.</subject>
+        <corpname source="lcnaf" encodinganalog="610">University of Michigan--Dearborn. Department of History.</corpname>
+        <corpname source="lcnaf" encodinganalog="610">University of Michigan--Dearborn--Faculty.</corpname>
+      </controlaccess>
+      <controlaccess>
+        <head>Genre Terms:</head>
+        <genreform source="aat" encodinganalog="655">Commercial directories.</genreform>
+        <genreform source="aat" encodinganalog="655">Photographs.</genreform>
+      </controlaccess>
+    </controlaccess>
+    <dsc type="combined">
+      <c01 level="series">
+        <did>
+          <unittitle>Museums, Lectures, and Tours</unittitle>
+        </did>
+        <scopecontent>
+          <p>The Museums, Lectures, and Tours series (0.6 linear feet, 1994-2001) contains papers on Howell's various speaking engagements and museums exhibitions. Venues include the National Museum of American History (NMAH), The Castellani Art Museum of Niagara University, The Museum of the City of New York (MCNY) and the Michigan State University Museum (MSUM). Various folk art exhibitions and tours are also highlighted, as well photos and slides of Arab Americans in Detroit and relevant museum exhibitions. </p>
+        </scopecontent>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>NMAH exhibit photos (gallery), <unitdate type="inclusive">1995</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>NMAH final text, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>NMAH exhibition plan, <unitdate type="inclusive">1996</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>NMAH miscellaneous, <unitdate type="inclusive">1994-1995</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Smithsonian list of artifacts, <unitdate type="inclusive">1997</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Michigan State University (MSU) loan and ethics forms, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>English 679, <unitdate type="inclusive">1998-1999</unitdate> (college course)</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Cultural forum participants, <unitdate type="inclusive">2000</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Castellani, <unitdate type="inclusive">1999</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Castellani showing, <unitdate type="inclusive">1997-1998</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Niagara University, <unitdate type="inclusive">1999</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Folkart and fieldwork, <unitdate type="inclusive">1997</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Folkart contacts, <unitdate type="inclusive">1997</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Tour AT&amp;T, <unitdate type="inclusive">1995</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Tour support, <unitdate type="inclusive">1997</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Tour support letters, <unitdate type="inclusive">1996</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Tour work, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>National Endowment for the Arts (NEA) tour, <unitdate type="inclusive">1996</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Tour-Smith collection, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Canaw, <unitdate type="inclusive">1998</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Nabeel slides, <unitdate type="inclusive">1995</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>AWM, <unitdate type="inclusive">1995</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>MSUM miscellaneous materials, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>MSU labels, <unitdate type="inclusive">1997</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>MCNY, <unitdate type="inclusive">1997</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Arab Theatrical Arts Guild (ATAG), <unitdate type="inclusive">2001</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Museum pamphlets, <unitdate type="inclusive">1993-1998</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Arab Detroit photos, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Jelia photos and slides, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+      </c01>
+      <c01 level="series">
+        <did>
+          <unittitle>Grants and Awards</unittitle>
+        </did>
+        <scopecontent>
+          <p>Grants and Awards series (0.4 linear feet, 1987-2001) consists of the varied funding sources appealed to by Howell on behalf of ACCESS. The organizations included are The National Endowment for the Humanities, the National Endowment for the Arts, Lila Wallace, and Skillman funds. In addition, a recognition letter for the Glen Taggart award is included. </p>
+        </scopecontent>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Sumnist/ National Endowment for the Arts (NEA), <unitdate type="inclusive">1997</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Glen Taggert award, <unitdate type="inclusive">1994</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Lila Wallace, <unitdate type="inclusive">1997</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>National Endowment for the Humanities (NEH), <unitdate type="inclusive">1997</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Unlikely funding sources, <unitdate type="inclusive">1987-1994</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Rockefeller 96, <unitdate type="inclusive">1996</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Rockefeller fund, <unitdate type="inclusive">1997</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Skillman, <unitdate type="inclusive">1996</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Strategic plan, <unitdate type="inclusive">1996</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Balch Institute, <unitdate type="inclusive">2000</unitdate></unittitle>
+          </did>
+        </c02>
+      </c01>
+      <c01 level="series">
+        <did>
+          <unittitle> Arab Community Center for Economic and Social Services</unittitle>
+        </did>
+        <scopecontent>
+          <p>The ACCESS series (0.3 linear feet, 1987- 2005) includes administrative records, as well has the plans for anniversary dinners and papers pertaining to Howell's film<title render="italic">Tales from Arab Detroit</title> . </p>
+        </scopecontent>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Promotional materials, <unitdate type="inclusive">1994</unitdate>, <unitdate type="inclusive">1995</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Miscellaneous materials, <unitdate type="inclusive">1996-2001</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Public comments, <unitdate type="inclusive">1999</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Arts program books, <unitdate type="inclusive">1987-1996</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Dinner, <unitdate type="inclusive">1997</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Dinner art, <unitdate type="inclusive">1996</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Imani Ali, <unitdate type="inclusive">1999</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Detroit (DET) history, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle><title render="italic"> Tales from Arab Detroit</title> materials, <unitdate type="inclusive">1997</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2</container>
+            <unittitle>Arab World Mosaic, <unitdate type="inclusive">1994</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2</container>
+            <unittitle>Archive project, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2</container>
+            <unittitle>Archival ideas, <unitdate type="inclusive">2005</unitdate></unittitle>
+          </did>
+        </c02>
+      </c01>
+      <c01 level="series">
+        <did>
+          <unittitle>Business Directories</unittitle>
+        </did>
+        <scopecontent>
+          <p>Business Directories series (0.3 linear feet, 1993-2005) contains editions of Arab American yellow pages from Southeast Michigan. </p>
+        </scopecontent>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2</container>
+            <unittitle>JEI business directory, <unitdate type="inclusive">2000</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>American Arab Business Directory</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">2</container>
+              <unittitle>
+                <unitdate type="inclusive">1993-1997</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>4 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">2</container>
+              <unittitle>
+                <unitdate type="inclusive">2001-2002</unitdate>
+              </unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">2</container>
+              <unittitle>
+                <unitdate type="inclusive">2005</unitdate>
+              </unittitle>
+            </did>
+          </c03>
+        </c02>
+      </c01>
+    </dsc>
+    <descgrp type="add">
+      <relatedmaterial>
+        <head>Related Materials</head>
+        <p>Bentley Historical Library holds
 
 <title render="italic">Tales from Arab Detroit,</title> a documentary film co-created by Howell, and Arab Community Center for Economic and Social Services records.
-</p></relatedmaterial></descgrp>
-
-</archdesc>
-
-
-
+</p>
+      </relatedmaterial>
+    </descgrp>
+  </archdesc>
 </ead>

--- a/Real_Masters_all/howellsal.xml
+++ b/Real_Masters_all/howellsal.xml
@@ -61,10 +61,8 @@ Sally Howell papers
 1994-1997
 </unitdate>
 </unittitle>
-      <physdesc>
-        <extent encodinganalog="300">
-1.6 linear feet
-</extent>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">1.6 linear feet</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2016013 Aa 2
@@ -490,8 +488,8 @@ Arranged into four series: Museums, Lectures and Tours; Grants and Awards;  Arab
               <unittitle>
                 <unitdate type="inclusive">1993-1997</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/hullfam.xml
+++ b/Real_Masters_all/hullfam.xml
@@ -46,13 +46,13 @@
       </origination>
       <unittitle encodinganalog="245"> Hull Family Papers, <unitdate type="inclusive" encodinganalog="245$f" normal="1869/1984">1869-1984</unitdate>, <unitdate type="bulk" encodinganalog="245$g" normal="1869/1960">1869-1960</unitdate></unittitle>
       <physdesc altrender="part">
-        <extent encodinganalog="300">4 linear feet</extent>
+        <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent encodinganalog="300">3 oversize volumes</extent>
+        <extent altrender="materialtype spaceoccupied">3 oversize volumes</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent encodinganalog="300">1 phonograph records</extent>
+        <extent altrender="materialtype spaceoccupied">4 linear feet</extent>
       </physdesc>
       <unitid encodinganalog="099" repositorycode="miu-h" countrycode="us" type="call number"> 91437 Aa 2 </unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
@@ -227,8 +227,8 @@
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Travel accounts, <unitdate type="inclusive" normal="1923/1951">1923-1951</unitdate> (sister of Dr. Leroy Hull) </unittitle>
-            <physdesc>
-              <extent>4 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -361,8 +361,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Miscellaneous Correspondence, <unitdate type="inclusive" normal="1942/1979">1942-1979</unitdate> and <unitdate type="inclusive">undated</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -471,8 +471,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>American Dependent Schools Employment documents, <unitdate type="inclusive" normal="1953/1959">1953-1959</unitdate></unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -480,8 +480,8 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Correspondence from Jean Hull, <unitdate type="inclusive" normal="1942/1957">1942-1957</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -513,8 +513,8 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Research Papers and Notes, <unitdate type="inclusive">undated</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -550,8 +550,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Eliza Darling Hull, Albums </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -565,8 +565,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>Dr. Leroy Hull </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -580,8 +580,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>George M. Hull </unittitle>
-                <physdesc>
-                  <extent>3 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -599,8 +599,8 @@
                 <did>
                   <container type="box" label="Box">3</container>
                   <unittitle>Miscellaneous Photos, <unitdate type="inclusive">undated</unitdate></unittitle>
-                  <physdesc>
-                    <extent>3 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">3 folders</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -608,8 +608,8 @@
                 <did>
                   <container type="box" label="Box">4</container>
                   <unittitle>Unidentified Negatives </unittitle>
-                  <physdesc>
-                    <extent>2 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -647,8 +647,8 @@
               <did>
                 <container type="box" label="Box">4</container>
                 <unittitle>Camp McGill, Japan </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>

--- a/Real_Masters_all/icc.xml
+++ b/Real_Masters_all/icc.xml
@@ -5917,8 +5917,8 @@
             <did>
               <container type="box" label="Box">17</container>
               <unittitle>Photographs of demolition <unitdate type="inclusive" normal="1994">1994</unitdate> also CD-ROM, <unitdate type="inclusive" normal="2004">2004</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/icpj.xml
+++ b/Real_Masters_all/icpj.xml
@@ -6547,8 +6547,8 @@
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">10 folders</extent>
             </physdesc>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-Rs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/imagamer.xml
+++ b/Real_Masters_all/imagamer.xml
@@ -105,8 +105,8 @@
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 volumes</extent>
             </physdesc>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-Rs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/ioepub.xml
+++ b/Real_Masters_all/ioepub.xml
@@ -508,7 +508,7 @@
             <container type="box" label="Box">2</container>
             <unittitle>Chronological Files, <unitdate type="inclusive" normal="1978/1993">1978-1993</unitdate></unittitle>
             <physdesc altrender="whole">
-              <extent>7 folders</extent>
+              <extent altrender="materialtype spaceoccupied">7 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -527,7 +527,7 @@
                   <unitdate type="inclusive" normal="1974/1976">1974-1976</unitdate>
                 </unittitle>
                 <physdesc altrender="whole">
-                  <extent>2 folders</extent>
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -538,7 +538,7 @@
                   <unitdate type="inclusive" normal="1974/1976">1974-1976</unitdate>
                 </unittitle>
                 <physdesc altrender="whole">
-                  <extent>3 folders</extent>
+                  <extent altrender="materialtype spaceoccupied">3 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -556,7 +556,7 @@
               <container type="box" label="Box">2</container>
               <unittitle>Financial Aid Committee, <unitdate type="inclusive" normal="1974/1976">1974-1976</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent>3 folders</extent>
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -565,7 +565,7 @@
               <container type="box" label="Box">2</container>
               <unittitle>Admissions, Financial Aid, and Graduate Programs, <unitdate type="inclusive" normal="1976/1979">1976-1979</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent>3 folders</extent>
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -574,7 +574,7 @@
               <container type="box" label="Box">2</container>
               <unittitle>Ph.D. Committee, <unitdate type="inclusive" normal="1972">1972</unitdate>, <unitdate type="inclusive" normal="1974">1974</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent>3 folders</extent>
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -589,7 +589,7 @@
               <container type="box" label="Box">2</container>
               <unittitle>Steering Review, <unitdate type="inclusive" normal="1968/1981">1968-1981</unitdate></unittitle>
               <physdesc altrender="whole">
-                <extent>26 folders</extent>
+                <extent altrender="materialtype spaceoccupied">26 folders</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/isroral.xml
+++ b/Real_Masters_all/isroral.xml
@@ -502,8 +502,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>CD-R (650 megabytes) of ISR Oral History Transcripts (Microsoft Word, PDF, and TXT file formats)</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/jayphil.xml
+++ b/Real_Masters_all/jayphil.xml
@@ -172,8 +172,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>B </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -397,8 +397,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>Dean, Dr. H. T. </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -682,8 +682,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>H</unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1015,8 +1015,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>M</unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1108,8 +1108,8 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>P </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1213,8 +1213,8 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>R </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1276,8 +1276,8 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>S </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1471,8 +1471,8 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>W </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1835,8 +1835,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>T--Z </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/jickling.xml
+++ b/Real_Masters_all/jickling.xml
@@ -1026,8 +1026,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Y2K Jickling Family Yearbook, includes CD-ROM</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/johnstondona.xml
+++ b/Real_Masters_all/johnstondona.xml
@@ -47,7 +47,7 @@
       </origination>
       <unittitle encodinganalog="245"> Donald A. Johnston papers <unitdate type="inclusive" encodinganalog="245$f" normal="1979/2012"> 1979-2012 </unitdate> <unitdate type="bulk" encodinganalog="245$g" normal="1989/2012"> 1989-2012 </unitdate> </unittitle>
       <physdesc altrender="whole">
-        <extent encodinganalog="300">12.5 linear feet</extent>
+        <extent altrender="materialtype spaceoccupied">12.5 linear feet</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number"> 2015029 Aa 2 </unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
@@ -116,8 +116,8 @@
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Felony sentences, <unitdate type="inclusive" normal="1989/1992">1989-1992</unitdate> </unittitle>
-            <physdesc>
-              <extent>23 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">23 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -125,8 +125,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Felony sentences, <unitdate type="inclusive" normal="1993/1996">1993-1996</unitdate> </unittitle>
-            <physdesc>
-              <extent>20 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">20 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -134,8 +134,8 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Felony sentences, <unitdate type="inclusive" normal="1997/1999">1997-1999</unitdate> </unittitle>
-            <physdesc>
-              <extent>22 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">22 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -143,8 +143,8 @@
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Felony sentences, <unitdate type="inclusive" normal="2000/2003">2000-2003</unitdate> </unittitle>
-            <physdesc>
-              <extent>26 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">26 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -152,8 +152,8 @@
           <did>
             <container type="box" label="Box">8</container>
             <unittitle>Day sheets for trials and sentences, <unitdate type="inclusive" normal="2001/2004">2001-2004</unitdate> </unittitle>
-            <physdesc>
-              <extent>14 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">14 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -161,8 +161,8 @@
           <did>
             <container type="box" label="Box">5</container>
             <unittitle>Felony sentences, <unitdate type="inclusive" normal="2004/2007">2004-2007</unitdate> </unittitle>
-            <physdesc>
-              <extent>26 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">26 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -170,8 +170,8 @@
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>Felony sentences, <unitdate type="inclusive" normal="2008/2011">2008-2011</unitdate> </unittitle>
-            <physdesc>
-              <extent>25 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">25 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -179,8 +179,8 @@
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>Felony sentences, <unitdate type="inclusive" normal="2012">2012</unitdate> </unittitle>
-            <physdesc>
-              <extent>7 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">7 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -196,8 +196,8 @@
           <did>
             <container type="box" label="Box">9</container>
             <unittitle>Court of Appeals and Michigan Supreme Court appeals decisions, <unitdate type="inclusive" normal="1990/2005">1990-2005</unitdate> </unittitle>
-            <physdesc>
-              <extent>21 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">21 folders</extent>
             </physdesc>
           </did>
           <odd>
@@ -208,8 +208,8 @@
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>Court of Appeals and Michigan Supreme Court appeals decisions, <unitdate type="inclusive" normal="2006/2012">2006-2012</unitdate> </unittitle>
-            <physdesc>
-              <extent>7 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">7 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -217,8 +217,8 @@
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>SAI Boot Camp responses, <unitdate type="inclusive" normal="2006/2012">2006-2012</unitdate> </unittitle>
-            <physdesc>
-              <extent>1 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -226,8 +226,8 @@
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>Commutation responses, <unitdate type="inclusive" normal="2009/2010">2009-2010</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -245,8 +245,8 @@
             <unittitle>
               <unitdate type="inclusive" normal="1979/1986">1979-1986</unitdate>
             </unittitle>
-            <physdesc>
-              <extent>10 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">10 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -256,8 +256,8 @@
             <unittitle>
               <unitdate type="inclusive" normal="1988/1999">1988-1999</unitdate>
             </unittitle>
-            <physdesc>
-              <extent>16 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">16 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -267,8 +267,8 @@
             <unittitle>
               <unitdate type="inclusive" normal="2000/2010">2000-2010</unitdate>
             </unittitle>
-            <physdesc>
-              <extent>15 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">15 folders</extent>
             </physdesc>
           </did>
           <odd>

--- a/Real_Masters_all/kahnalb.xml
+++ b/Real_Masters_all/kahnalb.xml
@@ -1789,8 +1789,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>Gold Medal Submission Booklets <unitdate type="inclusive" normal="2002-05-29">5/29/2002</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/kaufmans.xml
+++ b/Real_Masters_all/kaufmans.xml
@@ -511,8 +511,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Media</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -594,8 +594,8 @@
               <did>
                 <container type="box" label="Box">4</container>
                 <unittitle>Michigan Women's Summit <unitdate type="inclusive" normal="2005">2005</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>

--- a/Real_Masters_all/kevorkian.xml
+++ b/Real_Masters_all/kevorkian.xml
@@ -559,11 +559,11 @@
                 <physdesc>
                   <extent>3 photos</extent>
                 </physdesc>
-              <dao href="2014106-p-3" show="new" actuate="onrequest">
-                <daodesc>
-                  <p>[access items]</p>
-                </daodesc>
-              </dao>
+                <dao href="2014106-p-3" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[access items]</p>
+                  </daodesc>
+                </dao>
               </did>
               <odd>
                 <p>(bl019105-bl019108)</p>
@@ -3326,38 +3326,38 @@
             <physdesc>
               <extent>3 folders</extent>
             </physdesc>
-          <dao href="2014106-35" show="new" actuate="onrequest">
-            <daodesc>
-              <p>[access item]</p>
-            </daodesc>
-          </dao>
-        </did>
-          </c02>
+            <dao href="2014106-35" show="new" actuate="onrequest">
+              <daodesc>
+                <p>[access item]</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">8</container>
             <unittitle>Medicide families </unittitle>
-          <dao href="2014106-35" show="new" actuate="onrequest">
-            <daodesc>
-              <p>[access item]</p>
-            </daodesc>
-          </dao>
-        </did>
+            <dao href="2014106-35" show="new" actuate="onrequest">
+              <daodesc>
+                <p>[access item]</p>
+              </daodesc>
+            </dao>
+          </did>
           <odd>
             <p>(includes photographs)</p>
           </odd>
-          </c02>
+        </c02>
         <c02 level="file">
           <did>
             <container type="box" label="Box">8</container>
             <unittitle>Presentation slides</unittitle>
-          <dao href="2014106-35" show="new" actuate="onrequest">
-            <daodesc>
-              <p>[access item]</p>
-            </daodesc>
-          </dao>
-        </did>
-          </c02>
+            <dao href="2014106-35" show="new" actuate="onrequest">
+              <daodesc>
+                <p>[access item]</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c02>
       </c01>
     </dsc>
   </archdesc>

--- a/Real_Masters_all/kevorkian.xml
+++ b/Real_Masters_all/kevorkian.xml
@@ -46,28 +46,28 @@
         <persname source="lcnaf" encodinganalog="100">Kevorkian, Jack </persname>
       </origination>
       <unittitle encodinganalog="245"> Jack Kevorkian papers<unitdate type="inclusive" encodinganalog="245$f"> 1911-2014 </unitdate> <unitdate type="bulk" encodinganalog="245$g"> 1990-2011 </unitdate> </unittitle>
-      <physdesc altrender="part">
-        <extent encodinganalog="300">8 linear feet</extent>
+      <physdesc>
+        <physfacet>Digital files (online)</physfacet>
       </physdesc>
       <physdesc altrender="part">
-        <extent encodinganalog="300">1 oversize boxes</extent>
+        <extent altrender="materialtype spaceoccupied">1 web sites</extent>
+        <physfacet>online</physfacet>
       </physdesc>
       <physdesc altrender="part">
-        <extent encodinganalog="300">40 laminated placards</extent>
+        <extent altrender="materialtype spaceoccupied">1 portraits</extent>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">1 framed photographs</extent>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">40 laminated placards</extent>
         <dimensions>36" x 36"</dimensions>
       </physdesc>
       <physdesc altrender="part">
-        <extent encodinganalog="300">1 framed photographs</extent>
+        <extent altrender="materialtype spaceoccupied">1 oversize boxes</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent encodinganalog="300">1 framed portraits</extent>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent encodinganalog="300">1 archived websites</extent>
-        <physfacet>online</physfacet>
-      </physdesc>
-      <physdesc>
-        <physfacet>Digital files (online)</physfacet>
+        <extent altrender="materialtype spaceoccupied">8 linear feet</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number"> 2014106 Aa 2 </unitid>
       <langmaterial>The material is mostly in <language langcode="eng" encodinganalog="041">English</language>; some correspondence, collected material, and 1 audio recording are in <language langcode="arm" encodinganalog="041">Armenian;</language> select items are in <language langcode="ger" encodinganalog="041">German</language> and other languages.</langmaterial>
@@ -259,8 +259,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>Correspondence, <unitdate type="inclusive" normal="1950/1993">1950-1993</unitdate> </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <odd>
@@ -491,8 +491,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1930/1979" certainty="approximate">1930s-1970s</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -502,8 +502,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1980/1999" certainty="approximate">1980s-1990s</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -556,8 +556,8 @@
               <did>
                 <physloc>Online</physloc>
                 <unittitle>Passport photos, <unitdate type="inclusive" normal="1990">1990</unitdate> and <unitdate type="inclusive">undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>3 photos</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 photographs</extent>
                 </physdesc>
                 <dao href="2014106-p-3" show="new" actuate="onrequest">
                   <daodesc>
@@ -671,8 +671,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Newspaper clippings, <unitdate type="inclusive" normal="1950/2014" certainty="approximate">1950s-2014</unitdate> </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -729,8 +729,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1982/2011">1982-2011</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -779,8 +779,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Photographs, <unitdate type="inclusive" normal="1960/2019" certainty="approximate">1960s-2010s</unitdate> and <unitdate type="inclusive">undated</unitdate> </unittitle>
-            <physdesc>
-              <extent>9 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">9 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -839,8 +839,8 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Research Medicide folder and drafts </unittitle>
-            <physdesc>
-              <extent>5 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">5 folders</extent>
             </physdesc>
           </did>
           <odd>
@@ -886,8 +886,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Articles, published, <unitdate type="inclusive" normal="1950/2009" certainty="approximate">1950s-2000s</unitdate> and <unitdate type="inclusive">undated</unitdate> </unittitle>
-              <physdesc>
-                <extent>7 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">7 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2023,8 +2023,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1982/1998">1982-1998</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2128,8 +2128,8 @@
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>Research files </unittitle>
-            <physdesc>
-              <extent>6 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">6 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2179,8 +2179,8 @@
               <did>
                 <container type="box" label="Box">8 A</container>
                 <unittitle><unitdate type="inclusive" normal="1994/1999">1994-1999</unitdate>, <unitdate type="inclusive" normal="2008">2008</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3323,8 +3323,8 @@
           <did>
             <container type="box" label="Box">8</container>
             <unittitle>Correspondence, <unitdate type="inclusive" normal="1995/1998">1995-1998</unitdate> </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
             <dao href="2014106-35" show="new" actuate="onrequest">
               <daodesc>

--- a/Real_Masters_all/lesinski.xml
+++ b/Real_Masters_all/lesinski.xml
@@ -4847,8 +4847,8 @@
           <did>
             <container type="box" label="Box">27</container>
             <unittitle>Photographs of "Leskinski's grandparents"</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-Rs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/lewisre.xml
+++ b/Real_Masters_all/lewisre.xml
@@ -760,8 +760,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>CD of "Alphabet Odyssey," a program on the <title render="italic">MED</title> on the Canadian Broadcasting Company radio program "Ideas," <unitdate type="inclusive" normal="2004">2004</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-ROMs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/lgbtum.xml
+++ b/Real_Masters_all/lgbtum.xml
@@ -1157,7 +1157,7 @@
             <container type="box" label="Box">6</container>
             <unittitle>Clippings </unittitle>
             <physdesc altrender="whole">
-              <extent>2 folders</extent>
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
           <accessrestrict>
@@ -1261,7 +1261,7 @@
             <container type="box" label="Box">6</container>
             <unittitle>Personal papers </unittitle>
             <physdesc altrender="whole">
-              <extent>4 folders</extent>
+              <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
           <accessrestrict>
@@ -1282,7 +1282,7 @@
             <container type="box" label="Box">6</container>
             <unittitle>Publications </unittitle>
             <physdesc altrender="whole">
-              <extent>2 folders</extent>
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
           <accessrestrict>

--- a/Real_Masters_all/littmann.xml
+++ b/Real_Masters_all/littmann.xml
@@ -866,8 +866,8 @@
         <c02 level="file">
           <did>
             <unittitle>DVDs</unittitle>
-            <physdesc>
-              <extent>2 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
               <physfacet>DVDs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/lwva2.xml
+++ b/Real_Masters_all/lwva2.xml
@@ -133,8 +133,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1947">1947</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -176,8 +176,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1954">1954</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -187,8 +187,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1955">1955</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -198,8 +198,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1956">1956</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -209,8 +209,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1957">1957</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -228,8 +228,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1959">1959</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -247,8 +247,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1964">1964</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -295,8 +295,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1953">1953</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -314,8 +314,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1955">1955</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -324,8 +324,8 @@
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Ann Arbor Public Schools Files, <unitdate type="inclusive" normal="1947/1959">1947-1959</unitdate></unittitle>
-            <physdesc>
-              <extent>4 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -345,8 +345,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1960">1960</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -356,8 +356,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1961">1961</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -435,8 +435,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Voters Guides </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -444,8 +444,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Candidates interviews </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -453,8 +453,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Membership lists </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -487,8 +487,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Correspondence, <unitdate type="inclusive" normal="1969/1972">1969-1972</unitdate></unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -496,8 +496,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Meetings, minutes, and resolutions, <unitdate type="inclusive" normal="1967/1972">1967-1972</unitdate></unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -511,8 +511,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Reports and memos, <unitdate type="inclusive" normal="1966/1972">1966-1972</unitdate></unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -543,8 +543,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Board of Commissioners reports, <unitdate type="inclusive" normal="1969/1972">1969-1972</unitdate></unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -552,8 +552,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Medical Care Study Committee reports, <unitdate type="inclusive" normal="1968/1969">1968-1969</unitdate></unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -608,8 +608,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Reports and memos, <unitdate type="inclusive" normal="1966/1972">1966-1972</unitdate></unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -698,8 +698,8 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Reports and memos, <unitdate type="inclusive" normal="1966/1972">1966-1972</unitdate></unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -779,8 +779,8 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Health care, national issues (scattered dates) </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -794,8 +794,8 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Clippings largely concerning hospitals and health care, <unitdate type="inclusive" normal="1966/1973">1966-1973</unitdate></unittitle>
-            <physdesc>
-              <extent>6 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">6 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -811,8 +811,8 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Annual meetings, <unitdate type="inclusive" normal="1951/1983">1951-1983</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -832,8 +832,8 @@
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Annual reports, <unitdate type="inclusive" normal="1954/1990">1954-1990</unitdate> (some gaps) </unittitle>
-            <physdesc>
-              <extent>5 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">5 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -841,8 +841,8 @@
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Annual reports to state office, <unitdate type="inclusive" normal="1947/1981">1947-1981</unitdate> (some gaps) </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -868,8 +868,8 @@
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Board meetings, <unitdate type="inclusive" normal="1935/1950">1935-1950</unitdate> (scattered) and <unitdate type="inclusive" normal="1971/1989">1971-1989</unitdate></unittitle>
-            <physdesc>
-              <extent>8 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">8 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -877,8 +877,8 @@
           <did>
             <container type="box" label="Box">5</container>
             <unittitle>Treasurer's reports, <unitdate type="inclusive" normal="1980/1989" certainty="approximate">1980s</unitdate> (some gaps) </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -904,8 +904,8 @@
           <did>
             <container type="box" label="Box">5</container>
             <unittitle>Bulletins, <unitdate type="inclusive" normal="1944/1989">1944-1989</unitdate></unittitle>
-            <physdesc>
-              <extent>13 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">13 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -949,8 +949,8 @@
           <did>
             <container type="box" label="Box">5</container>
             <unittitle>Fund raising correspondence, <unitdate type="inclusive" normal="1950/1969">1950-1969</unitdate>, <unitdate type="inclusive" normal="1975/1989">1975-1989</unitdate> (with gaps) </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1000,8 +1000,8 @@
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>Merger with Ypsilanti LWV, <unitdate type="inclusive" normal="1973/1974">1973-1974</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1075,8 +1075,8 @@
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>State conventions, <unitdate type="inclusive" normal="1979/1981">1979-1981</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1134,8 +1134,8 @@
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>Candidate meetings, <unitdate type="inclusive" normal="1959/1965">1959-1965</unitdate></unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1167,8 +1167,8 @@
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>City and county government elections, <unitdate type="inclusive" normal="1946/1972">1946-1972</unitdate></unittitle>
-            <physdesc>
-              <extent>12 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">12 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1176,8 +1176,8 @@
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>City and county government elections, <unitdate type="inclusive" normal="1973/1979">1973-1979</unitdate></unittitle>
-            <physdesc>
-              <extent>11 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">11 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1236,8 +1236,8 @@
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>School board and millage, <unitdate type="inclusive" normal="1949/1951">1949-1951</unitdate>, <unitdate type="inclusive" normal="1960/1965">1960-1965</unitdate>, <unitdate type="inclusive" normal="1970/1977">1970-1977</unitdate></unittitle>
-            <physdesc>
-              <extent>12 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">12 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1245,8 +1245,8 @@
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>State and national, <unitdate type="inclusive" normal="1946/1978">1946-1978</unitdate> (scattered) </unittitle>
-            <physdesc>
-              <extent>8 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">8 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1275,8 +1275,8 @@
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>Voter registration, <unitdate type="inclusive" normal="1960/1975">1960-1975</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1284,8 +1284,8 @@
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>"Your Government Officials," <unitdate type="inclusive" normal="1965/1989">1965-1989</unitdate></unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1415,8 +1415,8 @@
           <did>
             <container type="box" label="Box">8</container>
             <unittitle>Civil rights, <unitdate type="inclusive" normal="1971/1979">1971-1979</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1478,8 +1478,8 @@
           <did>
             <container type="box" label="Box">8</container>
             <unittitle>Education, <unitdate type="inclusive" normal="1949/1961">1949-1961</unitdate> and <unitdate type="inclusive" normal="1972/1977">1972-1977</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1565,8 +1565,8 @@
           <did>
             <container type="box" label="Box">9</container>
             <unittitle>Financing local government, <unitdate type="inclusive" normal="1972/1975">1972-1975</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1616,8 +1616,8 @@
           <did>
             <container type="box" label="Box">9</container>
             <unittitle>Human Relations Commission, <unitdate type="inclusive" normal="1959/1969">1959-1969</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1637,8 +1637,8 @@
           <did>
             <container type="box" label="Box">9</container>
             <unittitle>Huron River Watershed Council, <unitdate type="inclusive" normal="1958/1968">1958-1968</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1670,8 +1670,8 @@
           <did>
             <container type="box" label="Box">9</container>
             <unittitle>Juvenile delinquency, <unitdate type="inclusive" normal="1952/1957">1952-1957</unitdate>, <unitdate type="inclusive" normal="1984">1984</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1679,8 +1679,8 @@
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>Lake Erie Basin, <unitdate type="inclusive" normal="1962/1978">1962-1978</unitdate> (with gaps) </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1706,8 +1706,8 @@
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>Legislative correspondence, <unitdate type="inclusive" normal="1952/1965">1952-1965</unitdate> and <unitdate type="inclusive" normal="1973/1974">1973-1974</unitdate></unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1733,8 +1733,8 @@
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>Miscellaneous, <unitdate type="inclusive" normal="1952/1965">1952-1965</unitdate> and <unitdate type="inclusive" normal="1969/1977">1969-1977</unitdate></unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1790,8 +1790,8 @@
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>Parks, <unitdate type="inclusive" normal="1962/1967">1962-1967</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1805,8 +1805,8 @@
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>Planning, <unitdate type="inclusive" normal="1950/1978">1950-1978</unitdate> (scattered dates) </unittitle>
-            <physdesc>
-              <extent>5 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">5 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1928,8 +1928,8 @@
           <did>
             <container type="box" label="Box">11</container>
             <unittitle>State taxation, <unitdate type="inclusive" normal="1945/1980">1945-1980</unitdate></unittitle>
-            <physdesc>
-              <extent>4 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1979,8 +1979,8 @@
           <did>
             <container type="box" label="Box">11</container>
             <unittitle>Urban renewal, <unitdate type="inclusive" normal="1956/1961">1956-1961</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2006,8 +2006,8 @@
           <did>
             <container type="box" label="Box">11</container>
             <unittitle>Zoning, <unitdate type="inclusive" normal="1956/1962">1956-1962</unitdate> and <unitdate type="inclusive" normal="1964">1964</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2029,8 +2029,8 @@
           <did>
             <container type="box" label="Box">12</container>
             <unittitle>Ann Arbor Transportation Authority litigation, <unitdate type="inclusive" normal="1974/1975">1974-1975</unitdate></unittitle>
-            <physdesc>
-              <extent>5 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">5 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2062,8 +2062,8 @@
           <did>
             <container type="box" label="Box">12</container>
             <unittitle>Memoranda, statements, reports, etc. </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2115,8 +2115,8 @@
           <did>
             <container type="box" label="Box">12</container>
             <unittitle>"Know your city," <unitdate type="inclusive" normal="1977">1977</unitdate>, <unitdate type="inclusive" normal="1986">1986</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2136,8 +2136,8 @@
           <did>
             <container type="box" label="Box">12</container>
             <unittitle>"Know your town," <unitdate type="inclusive" normal="1953">1953</unitdate>, <unitdate type="inclusive" normal="1963">1963</unitdate>, <unitdate type="inclusive" normal="1966/1967">1966-1967</unitdate></unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2145,8 +2145,8 @@
           <did>
             <container type="box" label="Box">12</container>
             <unittitle>Newsletter, <unitdate type="inclusive" normal="1990/1997">1990-1997</unitdate>, <unitdate type="inclusive" normal="1999/2009">1999-2009</unitdate></unittitle>
-            <physdesc>
-              <extent>5 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">5 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2184,8 +2184,8 @@
             <did>
               <container type="box" label="Box">13</container>
               <unittitle>Board meetings agenda and minutes, <unitdate type="inclusive" normal="1990/2009">1990-2009</unitdate></unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2193,8 +2193,8 @@
             <did>
               <container type="box" label="Box">13</container>
               <unittitle>Annual reports, 1990/1991-2008/2009 with gaps </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2202,8 +2202,8 @@
             <did>
               <container type="box" label="Box">13</container>
               <unittitle>Treasurer's reports, <unitdate type="inclusive" normal="1992/2009">1992-2009</unitdate></unittitle>
-              <physdesc>
-                <extent>5 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">5 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2217,8 +2217,8 @@
             <did>
               <container type="box" label="Box">13</container>
               <unittitle>Correspondence, <unitdate type="inclusive" normal="1990/2009">1990-2009</unitdate></unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2226,8 +2226,8 @@
             <did>
               <container type="box" label="Box">13</container>
               <unittitle>Members lists, <unitdate type="inclusive" normal="1991/1999">1991-1999</unitdate>, <unitdate type="inclusive" normal="2001/2009">2001-2009</unitdate></unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2318,8 +2318,8 @@
             <did>
               <container type="box" label="Box">14</container>
               <unittitle>Voter guides and information, <unitdate type="inclusive" normal="1990/2000">1990-2000</unitdate> with gaps </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
             <odd>
@@ -2330,8 +2330,8 @@
             <did>
               <container type="box" label="Box">14</container>
               <unittitle>Voter service, <unitdate type="inclusive" normal="1991/2004">1991-2004</unitdate>, <unitdate type="inclusive" normal="2006/2010">2006-2010</unitdate></unittitle>
-              <physdesc>
-                <extent>8 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">8 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2380,8 +2380,8 @@
             <did>
               <container type="box" label="Box">14</container>
               <unittitle>Judicial system, <unitdate type="inclusive" normal="2002">2002</unitdate>, <unitdate type="inclusive" normal="2004">2004</unitdate>, <unitdate type="inclusive" normal="2007/2008">2007-2008</unitdate></unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2401,8 +2401,8 @@
             <did>
               <container type="box" label="Box">14</container>
               <unittitle>Physician's aid in dying, <unitdate type="inclusive" normal="1996/1999">1996-1999</unitdate></unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2421,8 +2421,8 @@
             <did>
               <container type="box" label="Box">14</container>
               <unittitle>Annual report, <unitdate type="inclusive" normal="1997">1997</unitdate></unittitle>
-              <physdesc>
-                <extent>1 floppy disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
                 <physfacet>3.5"</physfacet>
               </physdesc>
             </did>
@@ -2431,8 +2431,8 @@
             <did>
               <container type="box" label="Box">14</container>
               <unittitle>Annual report, <unitdate type="inclusive" normal="2000">2000</unitdate></unittitle>
-              <physdesc>
-                <extent>1 floppy disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
                 <physfacet>3.5"</physfacet>
               </physdesc>
             </did>
@@ -2441,8 +2441,8 @@
             <did>
               <container type="box" label="Box">14</container>
               <unittitle>YEO <unitdate type="inclusive" normal="2000">2000</unitdate> brochure</unittitle>
-              <physdesc>
-                <extent>1 floppy disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
                 <physfacet>3.5"</physfacet>
               </physdesc>
             </did>
@@ -2451,8 +2451,8 @@
             <did>
               <container type="box" label="Box">14</container>
               <unittitle>Final draft letter to accompany YEOs, <unitdate type="inclusive" normal="2003">2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 floppy disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
                 <physfacet>3.5"</physfacet>
               </physdesc>
             </did>
@@ -2461,8 +2461,8 @@
             <did>
               <container type="box" label="Box">14</container>
               <unittitle>League of Women Voters of the Ann Arbor Area minutes, <unitdate type="inclusive" normal="1997/2009">1997-2009</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-ROMs</physfacet>
               </physdesc>
             </did>
@@ -2471,8 +2471,8 @@
             <did>
               <container type="box" label="Box">14</container>
               <unittitle>"85th anniversary making democracy work," <unitdate type="inclusive" normal="2005">2005</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -2481,8 +2481,8 @@
             <did>
               <container type="box" label="Box">14</container>
               <unittitle>"Affirmative action: access and opportunity," <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-ROMs</physfacet>
               </physdesc>
             </did>
@@ -2491,8 +2491,8 @@
             <did>
               <container type="box" label="Box">14</container>
               <unittitle>"The 21st century voter: promoting Michigan voter power," </unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/magnaghi.xml
+++ b/Real_Masters_all/magnaghi.xml
@@ -907,12 +907,12 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Asikainen, Charlotte</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
-                <physfacet>CD-Rs</physfacet>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 transcript</extent>
               </physdesc>
-              <physdesc>
-                <extent>1 transcript</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+                <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -920,12 +920,12 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Chapman, Newton</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
-                <physfacet>CD-Rs</physfacet>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 transcript</extent>
               </physdesc>
-              <physdesc>
-                <extent>1 transcript</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+                <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -933,15 +933,15 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Dagner, Fred</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 transcript</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
-              </physdesc>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
-              </physdesc>
-              <physdesc>
-                <extent>1 transcript</extent>
               </physdesc>
             </did>
           </c03>
@@ -949,15 +949,15 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Goetz, Dorothy; Painter, Dorothy; Mullins, Betsy</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 transcript</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
-              </physdesc>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
-              </physdesc>
-              <physdesc>
-                <extent>1 transcript</extent>
               </physdesc>
             </did>
           </c03>
@@ -965,15 +965,15 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Hayner, Russell</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 transcript</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
-              </physdesc>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
-              </physdesc>
-              <physdesc>
-                <extent>1 transcript</extent>
               </physdesc>
             </did>
           </c03>
@@ -981,15 +981,15 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Heidmann, Karl</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 transcript</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
-              </physdesc>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
-              </physdesc>
-              <physdesc>
-                <extent>1 transcript</extent>
               </physdesc>
             </did>
           </c03>
@@ -997,15 +997,15 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Hopp, Martha and Harold</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 transcript</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
-              </physdesc>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
-              </physdesc>
-              <physdesc>
-                <extent>1 transcript</extent>
               </physdesc>
             </did>
           </c03>
@@ -1013,15 +1013,15 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Horn, Charlie; Peacock, Richard</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 transcript</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
-              </physdesc>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
-              </physdesc>
-              <physdesc>
-                <extent>1 transcript</extent>
               </physdesc>
             </did>
           </c03>
@@ -1029,15 +1029,15 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Peacock, Donna; Horn, Nancy</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 transcript</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
-              </physdesc>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
-              </physdesc>
-              <physdesc>
-                <extent>1 transcript</extent>
               </physdesc>
             </did>
           </c03>
@@ -1045,15 +1045,15 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Klann, Harvey</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 transcript</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
-              </physdesc>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
-              </physdesc>
-              <physdesc>
-                <extent>1 transcript</extent>
               </physdesc>
             </did>
           </c03>
@@ -1061,12 +1061,12 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Micketti, Grace</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
-                <physfacet>CD-Rs</physfacet>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 transcript</extent>
               </physdesc>
-              <physdesc>
-                <extent>1 transcript</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+                <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -1074,12 +1074,12 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Micketti, Tony and Lorraine</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
-                <physfacet>CD-Rs</physfacet>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 transcript</extent>
               </physdesc>
-              <physdesc>
-                <extent>1 transcript</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+                <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -1087,15 +1087,15 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Przybyla, Helen and Anthony</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 transcript</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
-              </physdesc>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
-              </physdesc>
-              <physdesc>
-                <extent>1 transcript</extent>
               </physdesc>
             </did>
           </c03>
@@ -1103,12 +1103,12 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Radtke, Irene</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
-                <physfacet>CD-Rs</physfacet>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 transcript</extent>
               </physdesc>
-              <physdesc>
-                <extent>1 transcript</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+                <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -1116,12 +1116,12 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Rasche, Emil</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
-                <physfacet>CD-Rs</physfacet>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 transcript</extent>
               </physdesc>
-              <physdesc>
-                <extent>1 transcript</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+                <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -1129,12 +1129,12 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Rubeo, Terry</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
-                <physfacet>CD-Rs</physfacet>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 transcript</extent>
               </physdesc>
-              <physdesc>
-                <extent>1 transcript</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+                <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -1142,12 +1142,12 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Santini, Ralph</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
-                <physfacet>CD-Rs</physfacet>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 transcript</extent>
               </physdesc>
-              <physdesc>
-                <extent>1 transcript</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+                <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -1155,15 +1155,15 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Sogenfrei, Lorene</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 transcript</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
-              </physdesc>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
-              </physdesc>
-              <physdesc>
-                <extent>1 transcript</extent>
               </physdesc>
             </did>
           </c03>
@@ -1172,8 +1172,8 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Microsoft Word files (doc and docx) for transcripts</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-ROM</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/massab.xml
+++ b/Real_Masters_all/massab.xml
@@ -427,8 +427,8 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Thesis Committees <unitdate type="inclusive" normal="1989/2000">1989-2000</unitdate> (includes a 3.5" floppy disc, WordPerfect files)</unittitle>
-            <physdesc>
-              <extent>1 floppy disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
               <physfacet>3.5"</physfacet>
             </physdesc>
           </did>
@@ -2827,8 +2827,8 @@
                   <unitdate type="inclusive" normal="1977/1981">1977-1981</unitdate>
                   <unitdate type="inclusive" normal="1990/1991">1990-1991</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>2 notebooks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 volumes</extent>
                 </physdesc>
               </did>
               <accessrestrict>
@@ -4308,9 +4308,8 @@
               <did>
                 <container type="box" label="Box">28</container>
                 <unittitle>Mice, Ferrets and Rabbits <unitdate type="inclusive" normal="1966/1970">1966-1970</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
-                  <extent>2 notebooks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 volumes</extent>
                 </physdesc>
               </did>
               <accessrestrict>
@@ -4366,8 +4365,8 @@
               <did>
                 <container type="box" label="Box">29</container>
                 <unittitle>Recombination Experiment <unitdate type="inclusive" normal="1970/1973">1970-1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>extent3 notebooks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">extent3 notebooks</extent>
                 </physdesc>
               </did>
               <accessrestrict>
@@ -4405,8 +4404,8 @@
               <did>
                 <container type="box" label="Box">29</container>
                 <unittitle>Type B Influenza <unitdate type="inclusive" normal="1973/1987">1973-1987</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 notebooks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 volumes</extent>
                 </physdesc>
               </did>
               <accessrestrict>
@@ -4462,8 +4461,8 @@
               <did>
                 <container type="box" label="Box">29</container>
                 <unittitle>MDCK Plaquing <unitdate type="inclusive" normal="1978/1981">1978-1981</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 notebooks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 volumes</extent>
                 </physdesc>
               </did>
               <accessrestrict>
@@ -4510,8 +4509,8 @@
               <did>
                 <container type="box" label="Box">29</container>
                 <unittitle>Persistence Types B and C <unitdate type="inclusive" normal="1984/1999">1984-1999</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 notebooks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 volumes</extent>
                 </physdesc>
               </did>
             </c04>

--- a/Real_Masters_all/matthaei.xml
+++ b/Real_Masters_all/matthaei.xml
@@ -3057,8 +3057,8 @@
           <did>
             <container type="box" label="Box">8</container>
             <unittitle>Matthaei By Moonlight <unitdate type="inclusive" normal="2003">2003</unitdate></unittitle>
-            <physdesc>
-              <extent>2 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
               <physfacet>CDs of .jpg's and printed thumbnails</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/mbotclub.xml
+++ b/Real_Masters_all/mbotclub.xml
@@ -46,7 +46,7 @@
       </origination>
       <unittitle encodinganalog="245">Michigan Botanical Club Records <unitdate type="inclusive" encodinganalog="245$f" normal="1941/2009">1941-2009</unitdate></unittitle>
       <physdesc altrender="whole">
-        <extent>6 linear feet</extent>
+        <extent altrender="materialtype spaceoccupied">6 linear feet</extent>
       </physdesc>
       <abstract>Organization formed in 1941 with the purpose of conserving all plants native to Michigan. The name of the organization was originally the Michigan Wildflower Association. The name was changed in 1949. Series in record group include: History and constitution; Membership records; Minutes; Reports; Newsletters; Financial materials; Correspondence; Chapter records; and Activities files.</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">9440 Bn 2</unitid>
@@ -142,8 +142,8 @@
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Membership, <unitdate type="inclusive" normal="1947/1993">1947-1993</unitdate> (except 1986-1988) </unittitle>
-            <physdesc>
-              <extent>9 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">9 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -161,8 +161,8 @@
             <unittitle>
               <unitdate type="inclusive" normal="1941/1993">1941-1993</unitdate>
             </unittitle>
-            <physdesc>
-              <extent>41 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">41 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -172,8 +172,8 @@
             <unittitle>
               <unitdate type="inclusive" normal="1998/2005">1998-2005</unitdate>
             </unittitle>
-            <physdesc>
-              <extent>8 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">8 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -317,8 +317,8 @@
             <unittitle>
               <unitdate type="inclusive" normal="1970/1979">1970-1979</unitdate>
             </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -328,8 +328,8 @@
             <unittitle>
               <unitdate type="inclusive" normal="1980/1989">1980-1989</unitdate>
             </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -454,8 +454,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle><unitdate type="inclusive" normal="1951/1959">1951-1959</unitdate> (except 1953-1954) </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -465,8 +465,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1960/1969">1960-1969</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -476,8 +476,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1970/1979">1970-1979</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -487,8 +487,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1980/1989">1980-1989</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -519,8 +519,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle><unitdate type="inclusive" normal="1950/1959">1950-1959</unitdate> (except 1951-1953) </unittitle>
-            <physdesc>
-              <extent>6 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">6 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -528,8 +528,8 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle><unitdate type="inclusive" normal="1960/1988">1960-1988</unitdate> (except 1979-1980) </unittitle>
-            <physdesc>
-              <extent>9 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">9 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -602,8 +602,8 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Records, <unitdate type="inclusive" normal="1970/1993">1970-1993</unitdate></unittitle>
-              <physdesc>
-                <extent>23 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">23 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -623,8 +623,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>Spring Forays, <unitdate type="inclusive" normal="1985/1989">1985-1989</unitdate></unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -632,8 +632,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>News, <unitdate type="inclusive" normal="1978/2007">1978-2007</unitdate></unittitle>
-              <physdesc>
-                <extent>30 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">30 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -665,8 +665,8 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Records <unitdate type="inclusive" normal="1960/1969">1960-1969</unitdate> (except 1962) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -760,8 +760,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1960/1969">1960-1969</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -769,8 +769,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle><unitdate type="inclusive" normal="1970/1978">1970-1978</unitdate> (except <unitdate type="inclusive" normal="1973">1973</unitdate> and 1977) </unittitle>
-              <physdesc>
-                <extent>7 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">7 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -778,8 +778,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle><unitdate type="inclusive" normal="1981/1988">1981-1988</unitdate> (except <unitdate type="inclusive" normal="1982">1982</unitdate> and 1985) </unittitle>
-              <physdesc>
-                <extent>5 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">5 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -800,8 +800,8 @@
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>Horner Woods, <unitdate type="inclusive" normal="1964/1966">1964-1966</unitdate></unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -860,8 +860,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1966/1976">1966-1976</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -888,8 +888,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1962/1965">1962-1965</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -945,8 +945,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle><unitdate type="inclusive" normal="1949/1959">1949-1959</unitdate> (except 1952) </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1212,8 +1212,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1960/1969">1960-1969</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/mccrackp.xml
+++ b/Real_Masters_all/mccrackp.xml
@@ -46,11 +46,11 @@
         <persname source="lcnaf" encodinganalog="100">McCracken, Paul Winston, 1915-</persname>
       </origination>
       <unittitle encodinganalog="245"> Paul Winston McCracken papers <unitdate type="inclusive" encodinganalog="245$f"> 1940-2011 </unitdate> <unitdate type="bulk" encodinganalog="245$g"> 1959-1990 </unitdate> </unittitle>
-      <physdesc>
-        <extent encodinganalog="300">52 linear feet</extent>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>
       </physdesc>
-      <physdesc>
-        <extent encodinganalog="300">1 oversize folders</extent>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">52 linear feet</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">85311 Aa 2 Ac</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
@@ -235,8 +235,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>A (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -244,8 +244,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>B (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -253,8 +253,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>C (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -286,8 +286,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>F (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -295,8 +295,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>G (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -334,8 +334,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>M (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -349,8 +349,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>N (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -358,8 +358,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>P (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1230,8 +1230,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>American Enterprise Institute </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1269,8 +1269,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>F (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1302,8 +1302,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Japan Correspondence </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1323,8 +1323,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>M (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1338,8 +1338,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>Michigan, University of </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1353,8 +1353,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>P (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1374,8 +1374,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>Tax Foundation </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1389,8 +1389,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>Water Refining Company, Inc. </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1411,8 +1411,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>Albion College </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1420,8 +1420,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>American Enterprise Institute </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1429,8 +1429,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>B (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1456,8 +1456,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>Economic Expansion Council </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1465,8 +1465,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>Energy Commission </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1510,8 +1510,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>Japan Correspondence </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1519,8 +1519,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>K (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1528,8 +1528,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>Kresge (S.S.) Company </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1543,8 +1543,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>Layman's National Bible Week </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1552,8 +1552,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>Lincoln National Corporation, Fort Wayne </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1591,8 +1591,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>S (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1624,8 +1624,8 @@
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>Youth for Understanding </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1646,8 +1646,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>American Enterprise Institute </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1655,8 +1655,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>B (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1664,8 +1664,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>C (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1685,8 +1685,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>Detroit Edison </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1712,8 +1712,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>G (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1721,8 +1721,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>Government Departments </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1730,8 +1730,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>H (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1745,8 +1745,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>I (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1754,8 +1754,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>Japan Correspondence </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1775,8 +1775,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>M (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1784,8 +1784,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>Memoranda </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1799,8 +1799,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>McCracken, Paul, personal </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1826,8 +1826,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>R (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1835,8 +1835,8 @@
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>S (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1844,8 +1844,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>Standard Oil Company, Cleveland </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1871,8 +1871,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>Trilateral Commission </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1886,8 +1886,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>W (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1895,8 +1895,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>Wall Street Journal </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1910,8 +1910,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>White House Memoranda </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2600,8 +2600,8 @@
             <did>
               <container type="box" label="Box">19</container>
               <unittitle>Texas Instruments </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2632,8 +2632,8 @@
             <did>
               <container type="box" label="Box">20</container>
               <unittitle>B (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2677,8 +2677,8 @@
             <did>
               <container type="box" label="Box">20</container>
               <unittitle>H (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2704,8 +2704,8 @@
             <did>
               <container type="box" label="Box">20</container>
               <unittitle>L (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2713,8 +2713,8 @@
             <did>
               <container type="box" label="Box">21</container>
               <unittitle>M (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2758,8 +2758,8 @@
             <did>
               <container type="box" label="Box">21</container>
               <unittitle>S (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2767,8 +2767,8 @@
             <did>
               <container type="box" label="Box">21</container>
               <unittitle>T (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2865,8 +2865,8 @@
             <did>
               <container type="box" label="Box">22</container>
               <unittitle>International Management and Development Institute (IDMI), <unitdate type="inclusive" normal="1976/1979">1976-1979</unitdate></unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2880,8 +2880,8 @@
             <did>
               <container type="box" label="Box">22</container>
               <unittitle>Japan, <unitdate type="inclusive" normal="1979/1981">1979-1981</unitdate></unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2937,8 +2937,8 @@
             <did>
               <container type="box" label="Box">22</container>
               <unittitle>S (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -3044,8 +3044,8 @@
             <did>
               <container type="box" label="Box">23</container>
               <unittitle>Fowler-McCracken Commission </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -3071,8 +3071,8 @@
             <did>
               <container type="box" label="Box">23</container>
               <unittitle>International Management and Development Institute </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -3110,8 +3110,8 @@
             <did>
               <container type="box" label="Box">24</container>
               <unittitle>Memoranda Received </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -3131,8 +3131,8 @@
             <did>
               <container type="box" label="Box">24</container>
               <unittitle>National Bureau of Economic Research </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -3152,8 +3152,8 @@
             <did>
               <container type="box" label="Box">24</container>
               <unittitle>S (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -3174,8 +3174,8 @@
             <did>
               <container type="box" label="Box">24</container>
               <unittitle>Tax Foundation </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -3195,8 +3195,8 @@
             <did>
               <container type="box" label="Box">25</container>
               <unittitle>U.S. Congress </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -3210,8 +3210,8 @@
             <did>
               <container type="box" label="Box">25</container>
               <unittitle>W-Z (Miscellaneous) </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -3225,8 +3225,8 @@
             <did>
               <container type="box" label="Box">25</container>
               <unittitle>Woodrow Wilson Center </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -4433,8 +4433,8 @@
             <did>
               <container type="box" label="Box">34</container>
               <unittitle>Faculty Bibliography </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -4653,8 +4653,8 @@
             <did>
               <container type="box" label="Box">34</container>
               <unittitle>International Management and Development Institute </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -7260,8 +7260,8 @@
           <did>
             <container type="box" label="Box">13</container>
             <unittitle>Clippings, <unitdate type="inclusive" normal="1968/1984">1968-1984</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
           <odd>
@@ -7272,8 +7272,8 @@
           <did>
             <container type="box" label="Box">45</container>
             <unittitle>Clippings, <unitdate type="inclusive" normal="1945/2000">1945-2000</unitdate> (scattered, mostly 1950s-1980s) </unittitle>
-            <physdesc>
-              <extent>9 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">9 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -7652,8 +7652,8 @@
               <unittitle>
                 <unitdate type="inclusive">January 1969-December 1970</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>24 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">24 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -7663,8 +7663,8 @@
               <unittitle>
                 <unitdate type="inclusive">January 1971-December 1971</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>12 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">12 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -7820,8 +7820,8 @@
               <unittitle>
                 <unitdate type="inclusive">December 1968-July 1971</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>41 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">41 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -7842,8 +7842,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1959/1962">1959-1962</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -7853,8 +7853,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1964/1967">1964-1967</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -7862,8 +7862,8 @@
             <did>
               <container type="box" label="Box">16</container>
               <unittitle>Economic Outlook, Notes on Meetings, <unitdate type="inclusive" normal="1963/1981">1963-1981</unitdate></unittitle>
-              <physdesc>
-                <extent>5 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">5 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -9682,8 +9682,8 @@
             <did>
               <container type="box" label="Box">46</container>
               <unittitle>Business Cycles by Schumpeter, <unitdate type="inclusive" normal="1948">1948</unitdate></unittitle>
-              <physdesc>
-                <extent>2 volumes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 volumes</extent>
               </physdesc>
             </did>
           </c03>
@@ -9826,8 +9826,8 @@
             <did>
               <container type="box" label="Box">47</container>
               <unittitle>Report to the National Commission on Productivity by the Council of Economic Advisors, <unitdate type="inclusive" normal="1970/1980">1970-1980</unitdate></unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -10336,8 +10336,8 @@
           <did>
             <container type="box" label="Box">48</container>
             <unittitle>Notebooks </unittitle>
-            <physdesc>
-              <extent>4 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -10357,8 +10357,8 @@
           <did>
             <container type="box" label="Box">48</container>
             <unittitle>Unlabeled Notebooks </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -11524,8 +11524,8 @@
           <did>
             <container type="box" label="Box">26</container>
             <unittitle>"Can the U.S. Regain its Capability for Orderly Expansion" </unittitle>
-            <physdesc>
-              <extent>4 audiocassettes</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">4 audiocassettes</extent>
             </physdesc>
           </did>
         </c02>
@@ -11533,8 +11533,8 @@
           <did>
             <container type="box" label="Box">26</container>
             <unittitle>Hillsdale College Center for Constructive Alternatives Conference </unittitle>
-            <physdesc>
-              <extent>9 audiocassettes</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">9 audiocassettes</extent>
               <extent altrender="carrier">in case</extent>
             </physdesc>
           </did>

--- a/Real_Masters_all/mcnamedh.xml
+++ b/Real_Masters_all/mcnamedh.xml
@@ -274,8 +274,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>First Episode, "Future of the Region at End of Coleman Young's Mayoral Stint", with guest Jon Pepper, Detroit News columnist</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -287,8 +287,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>"Malice Green Trial Outcome", with guest Kym Worthy, Assistant Prosecutor</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -300,8 +300,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>"Campaign Fundraising", with guest Geoffrey Fieger, attorney to Jack Kevorkian</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -313,8 +313,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>With guest Governor John Engler <unitdate type="inclusive" normal="1993">1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -333,8 +333,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1992">1992</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -348,8 +348,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="2000">2000</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -363,8 +363,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="2001">2001</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -378,8 +378,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="2003">2003</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -398,8 +398,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1989">1989</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -413,8 +413,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1990">1990</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -428,8 +428,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1991">1991</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -446,8 +446,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>"Perceptions" <unitdate type="inclusive" normal="1985">1985</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -459,8 +459,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>"Issues Livonia" <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -472,8 +472,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>"Up Front"</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -490,8 +490,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>"Family" <unitdate type="inclusive" normal="1994">1994</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -503,8 +503,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>"Tolerance" <unitdate type="inclusive" normal="2001">2001</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -516,8 +516,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>"Airport Security" <unitdate type="inclusive" normal="2001">2001</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -529,8 +529,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>"Metro Airport-Now Open" <unitdate type="inclusive" normal="2002">2002</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -547,8 +547,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>"Farewell, Mayor McNamara" <unitdate type="inclusive" normal="1986">1986</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -560,8 +560,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>"Presidential Ground Breaking, Metro Airport" <unitdate type="inclusive" normal="1996">1996</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -573,8 +573,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>"Spotlight-Newsmakers of the Year" <unitdate type="inclusive" normal="1996">1996</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>DVDs</physfacet>
                 </physdesc>
               </did>
@@ -586,8 +586,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>"Press Conference, 'He Will Not Run'" <unitdate type="inclusive" normal="2001">2001</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>DVDs</physfacet>
                 </physdesc>
               </did>
@@ -599,8 +599,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>"Spotlight-Edward H. McNamara, 1926-2006" <unitdate type="inclusive" normal="2006">2006</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>DVDs</physfacet>
                 </physdesc>
               </did>
@@ -612,8 +612,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>"Michigan Legislator's Tributes to Edward McNamara <unitdate type="inclusive" normal="2006">2006</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>DVDs</physfacet>
                 </physdesc>
               </did>
@@ -625,8 +625,8 @@
               <did>
                 <container type="box" label="Box">3</container>
                 <unittitle>"Ed McNamara Terminal Dedication" <unitdate type="inclusive" normal="2006">2006</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>DVDs</physfacet>
                 </physdesc>
               </did>

--- a/Real_Masters_all/mdaily.xml
+++ b/Real_Masters_all/mdaily.xml
@@ -37638,8 +37638,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>" <unitdate type="inclusive" normal="1993-10/1995-12">October 1993-December 1995</unitdate>"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -37648,8 +37648,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Photo Archive <unitdate type="inclusive" normal="1993/1994">1993-1994</unitdate> Copy</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -37661,8 +37661,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Complete Archive 1993-1995"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-RAM, type 1</physfacet>
               </physdesc>
             </did>
@@ -37681,8 +37681,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"1994"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -37701,8 +37701,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Photo Archive <unitdate type="inclusive" normal="1995">1995</unitdate> Part 1 copy"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -37711,8 +37711,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Photo Archive Part 2"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -37721,8 +37721,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"1995 Part C"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -37734,8 +37734,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Photo Archive <unitdate type="inclusive" normal="1994">1994</unitdate> v. 2 &amp; 3"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>magneto-optical disk (5.25"; Maxoptix)</physfacet>
               </physdesc>
             </did>
@@ -37744,8 +37744,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Photo Archive <unitdate type="inclusive" normal="1995">1995</unitdate> v. 4"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>magneto-optical disk (5.25"; 3M)</physfacet>
               </physdesc>
             </did>
@@ -37754,8 +37754,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Photo Archive #1"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>magneto-optical disk (5.25"; Maxoptix)</physfacet>
               </physdesc>
             </did>
@@ -37764,8 +37764,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Photo Archive #2"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>magneto-optical disk (5.25"; Maxoptix)</physfacet>
               </physdesc>
             </did>
@@ -37774,8 +37774,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Photo Archive #3"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>magneto-optical disk (5.25"; Maxoptix)</physfacet>
               </physdesc>
             </did>
@@ -37791,8 +37791,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Michigan Daily <unitdate type="inclusive" normal="1996">1996</unitdate> #1"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -37801,8 +37801,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Photo Archive <unitdate type="inclusive" normal="1996">1996</unitdate> Part 1"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -37811,8 +37811,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Photo Archive <unitdate type="inclusive" normal="1996">1996</unitdate> #3 COPY"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -37821,8 +37821,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Photo Archive <unitdate type="inclusive" normal="1996">1996</unitdate> #4"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -37838,8 +37838,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Jan-Oct '97"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -37854,8 +37854,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Photo archive Oct 97-Mar 98"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -37867,8 +37867,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Editor Jpegs; NSE; Applications; 97 part 3"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -37880,8 +37880,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Jan-Oct <unitdate type="inclusive" normal="1997">1997</unitdate> &amp; <unitdate type="inclusive" normal="1997-09/1997-12">September-December 1997</unitdate>"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-RAM, type 1</physfacet>
               </physdesc>
             </did>
@@ -37900,8 +37900,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Mar 98-Dec 98"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -37925,8 +37925,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Jan 99-Oct 99"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -37935,8 +37935,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Aug 99-Dec 99"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -37945,8 +37945,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>" August-December 1999 &amp; Jan-Sept 2000"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-RAM, type 1</physfacet>
               </physdesc>
             </did>
@@ -37965,8 +37965,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>" April-Sept 2000"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -37975,8 +37975,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Oct-Dec 2000"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -37992,8 +37992,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"2001 and 'specials 1'"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -38002,8 +38002,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>" October 2001"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -38012,8 +38012,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>" November 2001"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -38038,8 +38038,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"2002"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -38048,8 +38048,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Photo Archive Jan-Aug <unitdate type="inclusive" normal="2002">2002</unitdate> &amp; Sept-Dec 2002"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-RAM, type 1</physfacet>
               </physdesc>
             </did>
@@ -38068,8 +38068,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Sports Archive 2001-2003"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -38081,8 +38081,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Photo Archive 2003"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -38098,8 +38098,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Photo Archive <unitdate type="inclusive" normal="2000-10/2000-12">October-December 2000</unitdate>" "Photo Archive Specials vol.1 2004"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-RAM, type 1</physfacet>
               </physdesc>
             </did>
@@ -38111,8 +38111,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Michigan Daily Photo Archive Jan-Jun 2004"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -38121,8 +38121,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Michigan Daily Photo Archive July-Nov '04"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -38138,8 +38138,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Oct-Dec 2006"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -38161,8 +38161,8 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>"Michigan Daily Photo"</unittitle>
-              <physdesc>
-                <extent>1 SqQuest removable hard disk</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 SqQuest removable hard disk</extent>
                 <physfacet>SyQuest 44 MB 5.25" removable cartridge</physfacet>
               </physdesc>
             </did>
@@ -38171,20 +38171,20 @@
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>[Misc. other material]</unittitle>
-              <physdesc>
-                <extent>5 optical disks</extent>
-                <physfacet>CD-Rs</physfacet>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">14 empty CD cases</extent>
               </physdesc>
-              <physdesc>
-                <extent>3 optical disks</extent>
-                <physfacet>DVD-RAMs</physfacet>
-              </physdesc>
-              <physdesc>
-                <extent>1 floppy disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
                 <physfacet>3.5"</physfacet>
               </physdesc>
-              <physdesc>
-                <extent>14 empty CD cases</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 optical disks</extent>
+                <physfacet>DVD-RAMs</physfacet>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">5 optical disks</extent>
+                <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/meampub.xml
+++ b/Real_Masters_all/meampub.xml
@@ -129,8 +129,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle><title render="italic">125 Years of Mechanical Engineering at the University of Michigan</title>, <unitdate type="inclusive" normal="1992/1993">1992-1993</unitdate></unittitle>
-              <physdesc>
-                <extent>2 copies</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 copies</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/meddcdo.xml
+++ b/Real_Masters_all/meddcdo.xml
@@ -242,8 +242,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>E-Learning Course <unitdate type="inclusive" normal="2004">2004</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-ROMs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/medschl.xml
+++ b/Real_Masters_all/medschl.xml
@@ -22124,8 +22124,8 @@
               <did>
                 <container type="box" label="Box">120</container>
                 <unittitle>Student Evaluation (by Faculty) Subcommittee <unitdate type="inclusive" normal="1973/1974">1973-1974</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 volumes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 volumes</extent>
                 </physdesc>
               </did>
             </c04>

--- a/Real_Masters_all/meredithgeo.xml
+++ b/Real_Masters_all/meredithgeo.xml
@@ -39,7 +39,7 @@
       </origination>
       <unittitle encodinganalog="245">George E. Meredith papers <unitdate type="inclusive" encodinganalog="245$f"> 1932-1936 </unitdate> </unittitle>
       <physdesc altrender="whole">
-        <extent encodinganalog="300">1 folders</extent>
+        <extent altrender="materialtype spaceoccupied">1 folders</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">2015066 Aa 1 </unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>

--- a/Real_Masters_all/merit.xml
+++ b/Real_Masters_all/merit.xml
@@ -4543,8 +4543,8 @@
             <did>
               <container type="box" label="Box">54</container>
               <unittitle>Merit -- Regional Network Consortium</unittitle>
-              <physdesc>
-                <extent>2 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
               </physdesc>
             </did>
           </c03>
@@ -4552,8 +4552,8 @@
             <did>
               <container type="box" label="Box">54</container>
               <unittitle>Unlabeled</unittitle>
-              <physdesc>
-                <extent>2 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
               </physdesc>
             </did>
           </c03>
@@ -4605,8 +4605,8 @@
               <did>
                 <container type="box" label="Box">54</container>
                 <unittitle>Unlabeled</unittitle>
-                <physdesc>
-                  <extent>3 tapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 tapes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4625,8 +4625,8 @@
               <did>
                 <container type="box" label="Box">54</container>
                 <unittitle>Unlabeled</unittitle>
-                <physdesc>
-                  <extent>3 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -4670,8 +4670,8 @@
               <did>
                 <container type="box" label="Box">55</container>
                 <unittitle>Advanced NSFNET workshop <unitdate type="inclusive" normal="1989-03-08/1989-03-09">March 8-9, 1989</unitdate></unittitle>
-                <physdesc>
-                  <extent>6 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">6 videotapes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4679,8 +4679,8 @@
               <did>
                 <container type="box" label="Box">55</container>
                 <unittitle>"Connecting to the rest of the world," <unitdate type="inclusive" normal="1989-07">July 1989</unitdate></unittitle>
-                <physdesc>
-                  <extent>6 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">6 videotapes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4688,8 +4688,8 @@
               <did>
                 <container type="box" label="Box">55</container>
                 <unittitle>Advanced topics seminar <unitdate type="inclusive" normal="1989-08">August 1989</unitdate></unittitle>
-                <physdesc>
-                  <extent>5 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">5 videotapes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4697,8 +4697,8 @@
               <did>
                 <container type="box" label="Box">55</container>
                 <unittitle>Jim Sweeton, OSI layers <unitdate type="inclusive" normal="1989-09-12">September 12, 1989</unitdate></unittitle>
-                <physdesc>
-                  <extent>3 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 videotapes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4754,8 +4754,8 @@
               <did>
                 <container type="box" label="Box">56</container>
                 <unittitle>Randy Frank, "EECS 489: Computer Networks &amp; Protocols" <unitdate type="inclusive" normal="1990-01/1990-04">January-April 1990</unitdate></unittitle>
-                <physdesc>
-                  <extent>20 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">20 videotapes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -4784,8 +4784,8 @@
               <did>
                 <container type="box" label="Box">56</container>
                 <unittitle>Tom Libert, parts III and IV <unitdate type="inclusive" normal="1990-03">March 1990</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 videotapes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4793,8 +4793,8 @@
               <did>
                 <container type="box" label="Box">56</container>
                 <unittitle>Road Show <unitdate type="inclusive">undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>6 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">6 videotapes</extent>
                 </physdesc>
               </did>
             </c04>

--- a/Real_Masters_all/mgleecl.xml
+++ b/Real_Masters_all/mgleecl.xml
@@ -521,8 +521,8 @@
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>1988-89 (live recordings)</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CDs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/michacad.xml
+++ b/Real_Masters_all/michacad.xml
@@ -103,8 +103,8 @@
             <unittitle>
               <unitdate type="inclusive" normal="1894/1905">1894-1905</unitdate>
             </unittitle>
-            <physdesc>
-              <extent>1 columes</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 columes</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/michcitizen.xml
+++ b/Real_Masters_all/michcitizen.xml
@@ -39,15 +39,15 @@
       </origination>
       <unittitle encodinganalog="245"> Michigan Citizen Records<unitdate type="inclusive" encodinganalog="245$f"> 1933-2015 </unitdate> <unitdate type="bulk" encodinganalog="245$g"> 1990-2010 </unitdate></unittitle>
       <physdesc altrender="part">
-        <extent encodinganalog="300">30 linear feet</extent>
-        <extent altrender="carrier">in 57 boxes; including oversize</extent>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent encodinganalog="300">5 microfilms</extent>
-      </physdesc>
-      <physdesc altrender="part">
-        <extent encodinganalog="300">189.2 MB</extent>
+        <extent altrender="materialtype spaceoccupied">189.2 MB</extent>
         <physfacet>online</physfacet>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">5 microfilms</extent>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">30 linear feet</extent>
+        <extent altrender="carrier">in 57 boxes; including oversize</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number"> 2009137 Bj 2 </unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
@@ -138,8 +138,8 @@
             <unittitle>
               <unitdate type="inclusive" normal="1978/1994">1978-1994</unitdate>
             </unittitle>
-            <physdesc>
-              <extent>5 microfilms</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">5 microfilms</extent>
             </physdesc>
           </did>
           <accessrestrict>
@@ -3883,8 +3883,8 @@
           <did>
             <container type="box" label="Box">45</container>
             <unittitle>Letters to the Editor, <unitdate type="inclusive" normal="2000/2014">2000-2014</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3892,8 +3892,8 @@
           <did>
             <container type="box" label="Box">45</container>
             <unittitle>Prisoner's Letters, <unitdate type="inclusive" normal="2010/2015">2010-2015</unitdate></unittitle>
-            <physdesc>
-              <extent>6 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">6 folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/micrgunown.xml
+++ b/Real_Masters_all/micrgunown.xml
@@ -38,8 +38,9 @@
         <corpname source="lcnaf" encodinganalog="110"> Michigan Coalition for Responsible Gun Owners </corpname>
       </origination>
       <unittitle encodinganalog="245"> Michigan Coalition for Responsible Gun Owners records <unitdate type="inclusive" encodinganalog="245$f"> 1994-2007 </unitdate> </unittitle>
-      <physdesc>
-        <extent encodinganalog="300"> 1.09 GB (online) and 1 archived website (online) </extent>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">1.09 GB</extent>
+        <physfacet>online</physfacet>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number"> 2008027 Bj 2 </unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
@@ -116,8 +117,9 @@
           <did>
             <physloc>Online </physloc>
             <unittitle>MCRGO documents and lists, <unitdate type="inclusive">2001-2007</unitdate></unittitle>
-            <physdesc>
-              <extent>.ZIP file</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">digital files</extent>
+              <physfacet>ZIP files</physfacet>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/113277" show="new" actuate="onrequest">
               <daodesc>
@@ -130,8 +132,8 @@
           <did>
             <physloc>Online</physloc>
             <unittitle>Minutes, <unitdate type="inclusive">2001-2003</unitdate></unittitle>
-            <physdesc>
-              <extent>(.ZIP file</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">(.ZIP file</extent>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/113278" show="new" actuate="onrequest">
               <daodesc>
@@ -144,8 +146,9 @@
           <did>
             <physloc>Online</physloc>
             <unittitle>Bills, <unitdate type="inclusive">1999-2006</unitdate></unittitle>
-            <physdesc>
-              <extent>.ZIP file</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">digital files</extent>
+              <physfacet>ZIP files</physfacet>
             </physdesc>
             <dao href="http://hdl.handle.net/2027.42/113279" show="new" actuate="onrequest">
               <daodesc>

--- a/Real_Masters_all/micround.xml
+++ b/Real_Masters_all/micround.xml
@@ -396,8 +396,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>Anniversary <genreform normal="CD-ROMs">CD-ROM</genreform>: "The First 75 Years", <unitdate type="inclusive" normal="2007">2007</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-ROMs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/mienvc.xml
+++ b/Real_Masters_all/mienvc.xml
@@ -3924,8 +3924,8 @@
           <did>
             <container type="box" label="Box">22</container>
             <unittitle>Immaculate Heart of Mary <unitdate type="inclusive" normal="2003">2003</unitdate></unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-ROMs</physfacet>
             </physdesc>
           </did>
@@ -4168,8 +4168,8 @@
               <did>
                 <container type="box" label="Box">24</container>
                 <unittitle>General <unitdate type="inclusive" normal="1997/2003">1997-2003</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 floppy disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
                   <physfacet>3.5"</physfacet>
                 </physdesc>
               </did>
@@ -6655,8 +6655,8 @@
               <did>
                 <container type="box" label="Box">34</container>
                 <unittitle>Writings (and Supporting Materials) <unitdate type="inclusive" normal="1999/2002">1999-2002</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 floppy disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
                   <physfacet>3.5"</physfacet>
                 </physdesc>
               </did>
@@ -8693,8 +8693,8 @@
             <did>
               <container type="box" label="Box">37</container>
               <unittitle>Photographs <unitdate type="inclusive" normal="2001/2002">2001-2002</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-ROMs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/migheal.xml
+++ b/Real_Masters_all/migheal.xml
@@ -1616,8 +1616,8 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">3 folders</extent>
                 </physdesc>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>

--- a/Real_Masters_all/milanahs.xml
+++ b/Real_Masters_all/milanahs.xml
@@ -143,8 +143,8 @@
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Photographs (some with identifications) by Martha Churchill detailing the history and development of downtown Milan <unitdate type="inclusive" normal="2007">2007</unitdate></unittitle>
-            <physdesc>
-              <extent>12 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">12 optical disks</extent>
               <physfacet>CD-ROMs</physfacet>
             </physdesc>
           </did>
@@ -153,8 +153,8 @@
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Photo indexes</unittitle>
-            <physdesc>
-              <extent>3 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 optical disks</extent>
               <physfacet>CD-ROMs</physfacet>
             </physdesc>
           </did>
@@ -173,11 +173,11 @@
               <container type="box" label="Box">1</container>
               <unittitle>Index to images</unittitle>
               <physdesc>
-                <extent>1 optical disks</extent>
-                <physfacet>CD-ROMs</physfacet>
-              </physdesc>
-              <physdesc>
                 <physfacet>1 print-out</physfacet>
+              </physdesc>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+                <physfacet>CD-ROMs</physfacet>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/mimediaf.xml
+++ b/Real_Masters_all/mimediaf.xml
@@ -33136,7 +33136,7 @@
             <did>
               <unittitle>Original:</unittitle>
               <physdesc>
-                <physfacet>2-inxch video, Tape #569</physfacet>
+                <physfacet>2-inch video, Tape #569</physfacet>
               </physdesc>
             </did>
           </c03>
@@ -33766,7 +33766,7 @@
             <did>
               <unittitle>Original:</unittitle>
               <physdesc>
-                <physfacet>cassette #B135</physfacet>
+                <physfacet>videocassette #B135</physfacet>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/mipolhis.xml
+++ b/Real_Masters_all/mipolhis.xml
@@ -135,8 +135,8 @@
           <unittitle>
             <genreform normal="Oral histories">Oral History Interviews</genreform>
           </unittitle>
-          <physdesc>
-            <extent>28 optical disks</extent>
+          <physdesc altrender="whole">
+            <extent altrender="materialtype spaceoccupied">28 optical disks</extent>
             <physfacet>DVDs</physfacet>
           </physdesc>
         </did>

--- a/Real_Masters_all/miseagra.xml
+++ b/Real_Masters_all/miseagra.xml
@@ -1396,8 +1396,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>Institutional and Public Policy Gaming Simulation Models (Walrus Simulation) (R/S-PS-2) <unitdate type="inclusive" normal="1971/1973">1971-1973</unitdate></unittitle>
-              <physdesc>
-                <extent>4 volumes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 volumes</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/moodyb.xml
+++ b/Real_Masters_all/moodyb.xml
@@ -2356,8 +2356,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1940-01-01">January 1, 1940</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16"</physfacet>
                 </physdesc>
               </did>
@@ -2373,8 +2373,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1940-01-27">January 27, 1940</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16"</physfacet>
                 </physdesc>
               </did>
@@ -2385,8 +2385,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1940-02-09">February 9, 1940</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16 in.</physfacet>
                 </physdesc>
               </did>
@@ -2397,8 +2397,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1940-02-16">February 16, 1940</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16 in.</physfacet>
                 </physdesc>
               </did>
@@ -2409,8 +2409,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1940-02-25">February 25, 1940</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16 in.</physfacet>
                 </physdesc>
               </did>
@@ -2421,8 +2421,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1940-03-03">March 3, 1940</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16 in.</physfacet>
                 </physdesc>
               </did>
@@ -2433,8 +2433,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1940-03-10">March 10, 1940</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16 in.</physfacet>
                 </physdesc>
               </did>
@@ -2445,8 +2445,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1940-03-17">March 17, 1940</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16 in.</physfacet>
                 </physdesc>
               </did>
@@ -2455,8 +2455,8 @@
               <did>
                 <physloc>Sound discs</physloc>
                 <unittitle><unitdate type="inclusive" normal="1940-03-24">March 24, 1940</unitdate> (with Walter Karig)</unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16 in.</physfacet>
                 </physdesc>
               </did>
@@ -2465,8 +2465,8 @@
               <did>
                 <physloc>Sound discs</physloc>
                 <unittitle><unitdate type="inclusive" normal="1940-03-31">March 31, 1940</unitdate> (with Walter Karig)</unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16 in.</physfacet>
                 </physdesc>
               </did>
@@ -2477,8 +2477,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1940-04-07">April 7, 1940</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16 in.</physfacet>
                 </physdesc>
               </did>
@@ -2489,8 +2489,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1940-04-14">April 14, 1940</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16 in.</physfacet>
                 </physdesc>
               </did>
@@ -2501,8 +2501,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1940-04-18">April 18, 1940</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16 in.</physfacet>
                 </physdesc>
               </did>
@@ -2516,8 +2516,8 @@
               <did>
                 <physloc>Sound discs</physloc>
                 <unittitle><unitdate>Undated</unitdate> ("Your Washington Correspondent")</unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16 in.</physfacet>
                 </physdesc>
               </did>
@@ -2528,8 +2528,8 @@
                 <unittitle>
                   <unitdate>Undated</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16 in.</physfacet>
                 </physdesc>
               </did>
@@ -2540,8 +2540,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1940-09-20">September 20, 1940</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>12 in.</physfacet>
                 </physdesc>
               </did>
@@ -2552,8 +2552,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1940-09-27">September 27, 1940</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>12 in.</physfacet>
                 </physdesc>
               </did>
@@ -2564,8 +2564,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1940-10-03">October 3, 1940</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>12 in.</physfacet>
                 </physdesc>
               </did>
@@ -2576,8 +2576,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1940-10-10">October 10, 1940</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16 in.</physfacet>
                 </physdesc>
               </did>
@@ -2588,8 +2588,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1940-10-25">October 25, 1940</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16 in.</physfacet>
                 </physdesc>
               </did>
@@ -2600,8 +2600,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1940-10-31">October 31, 1940</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16 in.</physfacet>
                 </physdesc>
               </did>
@@ -2704,8 +2704,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1947-04-13">April 13, 1947</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>16 in.</physfacet>
                 </physdesc>
               </did>
@@ -2780,8 +2780,8 @@
               <did>
                 <physloc>Sound discs</physloc>
                 <unittitle>Radio broadcast <unitdate type="inclusive" normal="1946-01-20">January 20, 1946</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>12 in.</physfacet>
                 </physdesc>
               </did>

--- a/Real_Masters_all/mooregeo.xml
+++ b/Real_Masters_all/mooregeo.xml
@@ -43,13 +43,13 @@
       </origination>
       <unittitle encodinganalog="245">George William Moore papers<unitdate type="inclusive" encodinganalog="245$f" normal="1859/1956">1859-1956</unitdate></unittitle>
       <physdesc altrender="part">
-        <extent encodinganalog="300">7 linear feet</extent>
+        <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent encodinganalog="300">5 oversize volumes</extent>
+        <extent altrender="materialtype spaceoccupied">5 oversize volumes</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent encodinganalog="300">1 oversize folders</extent>
+        <extent altrender="materialtype spaceoccupied">7 linear feet</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">07167 Aa 2; UAm</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
@@ -249,8 +249,8 @@
               <did>
                 <container type="box" label="Box">1</container>
                 <unittitle>General (alphabetical file), <unitdate type="inclusive" normal="1927/1947">1927-1947</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -343,8 +343,8 @@
                 <did>
                   <container type="box" label="Box">1</container>
                   <unittitle>Account Balances, <unitdate type="inclusive" normal="1894/1899">1894-1899</unitdate></unittitle>
-                  <physdesc>
-                    <extent>2 ledgers</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 ledgers</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -352,8 +352,8 @@
                 <did>
                   <container type="box" label="Box">1</container>
                   <unittitle>Investments, <unitdate type="inclusive" normal="1894/1899">1894-1899</unitdate></unittitle>
-                  <physdesc>
-                    <extent>2 ledgers</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 ledgers</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -480,8 +480,8 @@
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>Correspondence (letterpress books), <unitdate type="inclusive" normal="1909/1911">1909-1911</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 volumes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 volumes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -543,8 +543,8 @@
               <did>
                 <container type="box" label="Box">2</container>
                 <unittitle>Correspondence (alphabetical file), <unitdate type="inclusive" normal="1927/1939">1927-1939</unitdate></unittitle>
-                <physdesc>
-                  <extent>5 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">5 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -669,8 +669,8 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Alphabetical File, <unitdate type="inclusive" normal="1925/1926">1925-1926</unitdate></unittitle>
-              <physdesc>
-                <extent>5 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">5 folders</extent>
               </physdesc>
             </did>
             <odd>

--- a/Real_Masters_all/motoliq.xml
+++ b/Real_Masters_all/motoliq.xml
@@ -1,145 +1,164 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE ead PUBLIC "+//ISBN 1-931666-00-8//DTD ead.dtd (Encoded Archival Description (EAD) Version 2002)//EN" "ead.dtd">
 <ead>
-
-<eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
-
-<eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::motoliq.xml//EN" encodinganalog="Identifier">
+  <eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
+    <eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::motoliq.xml//EN" encodinganalog="Identifier">
 umich-bhl-2013139</eadid>
-
-<filedesc><titlestmt><titleproper encodinganalog="Title">Finding Aid for 
+    <filedesc>
+      <titlestmt>
+        <titleproper encodinganalog="Title">Finding Aid for 
 General Motors Bankruptcy Collection Web Archives
 </titleproper>
-<author encodinganalog="Creator">Collection processed and finding aid created by 
-Max Eckard</author></titlestmt>
-
-<publicationstmt><publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
-<date encodinganalog="Date" normal="2016">
-2016</date></publicationstmt></filedesc>
-
-<profiledesc>
-<creation>Encoded finding aid created by 
+        <author encodinganalog="Creator">Collection processed and finding aid created by 
+Max Eckard</author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
+        <date encodinganalog="Date" normal="2016">
+2016</date>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>Encoded finding aid created by 
 Olga Virakhovskaya 
 <date>2016</date></creation>
-
-<langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage><descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules></profiledesc>
-
-<revisiondesc><change><date>2016-01-11</date><item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item></change></revisiondesc></eadheader>
-
-<frontmatter><titlepage>
-
-<publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
-
-<titleproper>Finding aid for<lb/>
+      <langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage>
+      <descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules>
+    </profiledesc>
+    <revisiondesc>
+      <change>
+        <date>2016-01-11</date>
+        <item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item>
+      </change>
+    </revisiondesc>
+  </eadheader>
+  <frontmatter>
+    <titlepage>
+      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <titleproper>Finding aid for<lb/>
 General Motors Bankruptcy Collection Web Archives. 
 </titleproper>
-
-<author>Finding aid created by<lb/> 
+      <author>Finding aid created by<lb/> 
 Max Eckard, in January, 2016.
 </author>
-
-</titlepage>
-</frontmatter>
-
-<archdesc level="recordgrp" audience="external" type="inventory" relatedencoding="MARC21"><did>
-
-<origination>
-<corpname source="lcnaf" encodinganalog="110">Motors Liquidation Company
-</corpname></origination>
-
-<unittitle encodinganalog="245">
+    </titlepage>
+  </frontmatter>
+  <archdesc level="recordgrp" audience="external" type="inventory" relatedencoding="MARC21">
+    <did>
+      <origination>
+        <corpname source="lcnaf" encodinganalog="110">Motors Liquidation Company
+</corpname>
+      </origination>
+      <unittitle encodinganalog="245">
 General Motors Bankruptcy Collection Web Archives
 <unitdate type="inclusive" encodinganalog="245$f">
 2009-ongoing
 </unitdate>
  
 </unittitle>
-
-<physdesc><extent encodinganalog="300">
+      <physdesc>
+        <extent encodinganalog="300">
 1.03 GB (online) and 2 archived websites (online)
-</extent></physdesc>
-
-<unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
+</extent>
+      </physdesc>
+      <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2013139 Aa 3
 </unitid>
-
-<langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
-
-<abstract>
+      <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
+      <abstract>
 The Motors Liquidation Company was the company left to settle past liability claims from the government-endorsed General Motors Chapter 11 reorganization which sold the assets of automobile manufacturer General Motors and some of its subsidiaries to NGMCO, Inc. ("New GM"). The collection includes archived websites of the Motors Liquidation Company, containing court documents and a claims register.</abstract>
-
-
-<repository><corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
-<extptr href="bhladd" show="embed" actuate="onload"/></repository></did>
-
-<descgrp type="admin">
-<acqinfo encodinganalog="541"><p>
+      <repository>
+        <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
+        <extptr href="bhladd" show="embed" actuate="onload"/>
+      </repository>
+    </did>
+    <descgrp type="admin">
+      <acqinfo encodinganalog="541">
+        <p>
 Donated by Motors Liquidation Company (donor no. <num type="donor" encodinganalog="541$e">11017</num>), in August, 2009. 
  
-</p></acqinfo>
- 
-<accessrestrict encodinganalog="506">
-<p>The collection is open without restriction</p></accessrestrict>
-
-
-<userestrict encodinganalog="540"><p>
-Copyright has  not been transferred to the Regents of the University of Michigan.</p></userestrict>
-
-
-<prefercite encodinganalog="524"><p>[item], General Motors Bankruptcy Collection Web Archives, Bentley Historical Library, University of Michigan.</p></prefercite>
-<processinfo> 
-<p><extptr href="digitalproc" show="embed" actuate="onload"/></p>
-</processinfo></descgrp>
-
-<bioghist encodinganalog="545">
-<p>Motors Liquidation Company, formerly General Motors Corporation, was the company left to settle past liability claims from General Motors Chapter 11 reorganization. </p>
-
-<p>On June 1, 2009, General Motors Corporation and some of its subsidiaries filed for bankruptcy protection in the United States Bankruptcy Court for the Southern District of New York. General Motors' attorneys preferred to file in the federal courts in New York because of their reputation for expertise in bankruptcy. This was followed swiftly by press conferences by General Motors' Chief Executive Officer, Fritz Henderson, who outlined a plan for NGMCO, Inc. ("New GM") and stressed that he intended for the process to move quickly, and President of the United States Barack Obama, who presented a rescue plan.</p>
-
-<p>In the bankruptcy case, <title render="italic">In re General Motors Corp.</title>, case number 09-50026 in the Southern District, Manhattan, New York, General Motors was represented by Weil, Gotshal and Manges, a specialist law firm in New York and was declared to be a debtor in possession. The United States Treasury and an ad hoc group of the bondholders of General Motors Corporation were also represented in court. After voiding the leases on seven corporate jets and a corporate aircraft hangar, on June 1, 2009, the court gave interim approval to GM's request to borrow $15 billion as debtor-in-possession financing, the company having only $2 billion cash in hand. The United States Treasury would be the source of that debtor in possession funding.</p>
-
-<p>Later that year, General Motors' good assets were sold to NCGMO, Inc. ("New GM"), a company that had been formed by the United States government with a 60% stake and others. "Old GM" was renamed Motors Liquidation Company. On July 10, 2009, the purchase of the ongoing operational assets--with the exception of Hummer, Saturn and Saab--and trade name of "old GM" was completed and NGMCO Inc. changed its name to "General Motors Company LLC" after the purchase. </p>
-
-<p>Motors Liquidation Company exited bankruptcy on March 31, 2011 only to be carved into four trusts; the first to settle the claims of unsecured, the second to handle environmental response for Motors Liquidation Company's remaining assets, a third to handle present and future asbestos-related claims and a fourth for litigation claims.</p>
-
-
-</bioghist>
-
-
-
-<scopecontent encodinganalog="520">
-<p>Motors Liquidation Company bankruptcy website is evidence of the automotive industry crisis of 2008-2010, caused in part by the confluence of the global financial turndown of the late-2000s recession, record oil prices, a severe global automotive sales decline due to the global financial crisis of 2008--2009. This collection of archived websites contains court documents and a claims register for the company left to settle past liability claims from General Motors Chapter 11 reorganization, and is arranged in a single series, Archived Websites.</p>
-</scopecontent>
-
-<controlaccess><p><extptr href="accnote" show="embed" actuate="onload"/></p><controlaccess><head>Subjects:</head>
-
-<corpname source="lcnaf" encodinganalog="610">General Motors Corporation.</corpname>
-<subject source="lcsh" encodinganalog="650">Bankruptcy--Michigan--Detroit.</subject>
-<subject source="lcsh" encodinganalog="650">Liquidation--Michigan--Detroit.</subject>
-<subject source="lcsh" encodinganalog="650">Corporations--Michigan--Detroit.</subject>
-<geogname source="lcsh" encodinganalog="651">Michigan.</geogname>
-<geogname source="lcsh" encodinganalog="651">Detroit (Mich.)</geogname>
-<subject source="local" encodinganalog="690">Commerce and industry.</subject>
-
-</controlaccess>
- 
-<controlaccess><head>Genre Terms:</head>
-<genreform source="aat" encodinganalog="655">Web sites.</genreform></controlaccess>
-
-</controlaccess>
-
-
-<dsc type="combined">
-<c01 level="series"><did><unittitle>Archived Websites</unittitle></did>
-<c02 level="file"><did><physloc>Online </physloc><unittitle><unitdate type="inclusive">2009</unitdate> </unittitle><dao href="http://hdl.handle.net/2027.42/116381" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c02>
-<c02 level="file"><did><unittitle>2010-ongoing</unittitle></did>
-<c03 level="file"><did><physloc>Online </physloc><unittitle>Motors Liquidation Company website </unittitle><dao href="2014025-w-1" show="new" actuate="onrequest"><daodesc><p>[view item]</p></daodesc></dao></did></c03>
-</c02></c01>
-
-</dsc>
-
-</archdesc>
-
-
-
+</p>
+      </acqinfo>
+      <accessrestrict encodinganalog="506">
+        <p>The collection is open without restriction</p>
+      </accessrestrict>
+      <userestrict encodinganalog="540">
+        <p>
+Copyright has  not been transferred to the Regents of the University of Michigan.</p>
+      </userestrict>
+      <prefercite encodinganalog="524">
+        <p>[item], General Motors Bankruptcy Collection Web Archives, Bentley Historical Library, University of Michigan.</p>
+      </prefercite>
+      <processinfo>
+        <p>
+          <extptr href="digitalproc" show="embed" actuate="onload"/>
+        </p>
+      </processinfo>
+    </descgrp>
+    <bioghist encodinganalog="545">
+      <p>Motors Liquidation Company, formerly General Motors Corporation, was the company left to settle past liability claims from General Motors Chapter 11 reorganization. </p>
+      <p>On June 1, 2009, General Motors Corporation and some of its subsidiaries filed for bankruptcy protection in the United States Bankruptcy Court for the Southern District of New York. General Motors' attorneys preferred to file in the federal courts in New York because of their reputation for expertise in bankruptcy. This was followed swiftly by press conferences by General Motors' Chief Executive Officer, Fritz Henderson, who outlined a plan for NGMCO, Inc. ("New GM") and stressed that he intended for the process to move quickly, and President of the United States Barack Obama, who presented a rescue plan.</p>
+      <p>In the bankruptcy case, <title render="italic">In re General Motors Corp.</title>, case number 09-50026 in the Southern District, Manhattan, New York, General Motors was represented by Weil, Gotshal and Manges, a specialist law firm in New York and was declared to be a debtor in possession. The United States Treasury and an ad hoc group of the bondholders of General Motors Corporation were also represented in court. After voiding the leases on seven corporate jets and a corporate aircraft hangar, on June 1, 2009, the court gave interim approval to GM's request to borrow $15 billion as debtor-in-possession financing, the company having only $2 billion cash in hand. The United States Treasury would be the source of that debtor in possession funding.</p>
+      <p>Later that year, General Motors' good assets were sold to NCGMO, Inc. ("New GM"), a company that had been formed by the United States government with a 60% stake and others. "Old GM" was renamed Motors Liquidation Company. On July 10, 2009, the purchase of the ongoing operational assets--with the exception of Hummer, Saturn and Saab--and trade name of "old GM" was completed and NGMCO Inc. changed its name to "General Motors Company LLC" after the purchase. </p>
+      <p>Motors Liquidation Company exited bankruptcy on March 31, 2011 only to be carved into four trusts; the first to settle the claims of unsecured, the second to handle environmental response for Motors Liquidation Company's remaining assets, a third to handle present and future asbestos-related claims and a fourth for litigation claims.</p>
+    </bioghist>
+    <scopecontent encodinganalog="520">
+      <p>Motors Liquidation Company bankruptcy website is evidence of the automotive industry crisis of 2008-2010, caused in part by the confluence of the global financial turndown of the late-2000s recession, record oil prices, a severe global automotive sales decline due to the global financial crisis of 2008--2009. This collection of archived websites contains court documents and a claims register for the company left to settle past liability claims from General Motors Chapter 11 reorganization, and is arranged in a single series, Archived Websites.</p>
+    </scopecontent>
+    <controlaccess>
+      <p>
+        <extptr href="accnote" show="embed" actuate="onload"/>
+      </p>
+      <controlaccess>
+        <head>Subjects:</head>
+        <corpname source="lcnaf" encodinganalog="610">General Motors Corporation.</corpname>
+        <subject source="lcsh" encodinganalog="650">Bankruptcy--Michigan--Detroit.</subject>
+        <subject source="lcsh" encodinganalog="650">Liquidation--Michigan--Detroit.</subject>
+        <subject source="lcsh" encodinganalog="650">Corporations--Michigan--Detroit.</subject>
+        <geogname source="lcsh" encodinganalog="651">Michigan.</geogname>
+        <geogname source="lcsh" encodinganalog="651">Detroit (Mich.)</geogname>
+        <subject source="local" encodinganalog="690">Commerce and industry.</subject>
+      </controlaccess>
+      <controlaccess>
+        <head>Genre Terms:</head>
+        <genreform source="aat" encodinganalog="655">Web sites.</genreform>
+      </controlaccess>
+    </controlaccess>
+    <dsc type="combined">
+      <c01 level="series">
+        <did>
+          <unittitle>Archived Websites</unittitle>
+        </did>
+        <c02 level="file">
+          <did>
+            <physloc>Online </physloc>
+            <unittitle>
+              <unitdate type="inclusive">2009</unitdate>
+            </unittitle>
+            <dao href="http://hdl.handle.net/2027.42/116381" show="new" actuate="onrequest">
+              <daodesc>
+                <p>[download item]</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>2010-ongoing</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <physloc>Online </physloc>
+              <unittitle>Motors Liquidation Company website </unittitle>
+              <dao href="2014025-w-1" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[view item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+        </c02>
+      </c01>
+    </dsc>
+  </archdesc>
 </ead>

--- a/Real_Masters_all/motoliq.xml
+++ b/Real_Masters_all/motoliq.xml
@@ -56,10 +56,9 @@ General Motors Bankruptcy Collection Web Archives
 </unitdate>
  
 </unittitle>
-      <physdesc>
-        <extent encodinganalog="300">
-1.03 GB (online) and 2 archived websites (online)
-</extent>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">1.03 GB</extent>
+        <physfacet>online</physfacet>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2013139 Aa 3

--- a/Real_Masters_all/mowbrayc.xml
+++ b/Real_Masters_all/mowbrayc.xml
@@ -571,8 +571,8 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Social Work 819-Promoting Well-Being: Poverty, Race-Ethnicity &amp; Mental Health <unitdate type="inclusive" normal="2002">2002</unitdate></unittitle>
-            <physdesc>
-              <extent>1 zip disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 zip disks</extent>
             </physdesc>
           </did>
         </c02>
@@ -580,8 +580,8 @@
           <did>
             <container type="box" label="Box">3</container>
             <unittitle>Social Work 831-Program Evaluation <unitdate type="inclusive" normal="1999">1999</unitdate></unittitle>
-            <physdesc>
-              <extent>1 floppy disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
               <physfacet>3.5"</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/murphyi.xml
+++ b/Real_Masters_all/murphyi.xml
@@ -22,7 +22,8 @@
       <change>
         <date>20160209</date>
         <item>Added digitized audio</item>
-      </change><change>
+      </change>
+      <change>
         <date>2007-03-20</date>
         <item>Original encoding from Word 2000 file using Word macros and Xmetal.</item>
       </change>
@@ -47,9 +48,10 @@
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">3.2 linear feet</extent>
       </physdesc>
-       <physdesc altrender="part">
+      <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">502 MB</extent>
-      </physdesc><repository>
+      </physdesc>
+      <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
         <extptr href="bhladd" show="embed" actuate="onload"/>
       </repository>
@@ -60,8 +62,9 @@
       </acqinfo>
       <accessrestrict encodinganalog="506">
         <p>The collection is open to research.</p>
-      <p>The collection contains audio tapes from which digital copies have been made. Source tapes are for staff use only. Audio files are only available in the Bentley Historical Library reading room on designated Bentley Library computers.
-</p></accessrestrict>
+        <p>The collection contains audio tapes from which digital copies have been made. Source tapes are for staff use only. Audio files are only available in the Bentley Historical Library reading room on designated Bentley Library computers.
+</p>
+      </accessrestrict>
       <userestrict encodinganalog="540">
         <p>Copyright is held by the Regents of the University of Michigan.</p>
       </userestrict>
@@ -69,12 +72,15 @@
         <p>[item], folder, box,
 Irene Ellis Murphy papers, Bentley Historical Library, University of Michigan</p>
       </prefercite>
-    <altformavail>
-  <p><emph render="bold">Digitization:</emph> The Library has undertaken the digitization of a number of sound recordings within this collection. The resulting audio files are available for playback only in the Bentley Library Reading Room. Links to item images and additional information are available within this finding aid.  Original sound recordings are only available for staff use.</p>
-</altformavail>
-
-<processinfo><p><extptr href="digitalproc" show="embed" actuate="onload"/></p>
-</processinfo></descgrp>
+      <altformavail>
+        <p><emph render="bold">Digitization:</emph> The Library has undertaken the digitization of a number of sound recordings within this collection. The resulting audio files are available for playback only in the Bentley Library Reading Room. Links to item images and additional information are available within this finding aid.  Original sound recordings are only available for staff use.</p>
+      </altformavail>
+      <processinfo>
+        <p>
+          <extptr href="digitalproc" show="embed" actuate="onload"/>
+        </p>
+      </processinfo>
+    </descgrp>
     <bioghist encodinganalog="545">
       <p>Irene Ellis Murphy was born in Connersville, Indiana in the years 1900. She received her M.A. from the University of Michigan in 1928 and began a career as a social worker with the Detroit Department of Public Welfare and the Council of Social Agencies. She worked here until 1945.</p>
       <p>In 1929, she had married J. Harold Murphy, the brother of then Detroit Mayor Frank Murphy. When Murphy left to become Governor General of the Philippine Islands (1933-1935), he took many members of his family with him. From her stay in the Philippines in the mid-1930s, Irene Murphy would develop a life-long interest in the people and politics of the Islands.</p>
@@ -529,11 +535,34 @@ Irene Ellis Murphy papers, Bentley Historical Library, University of Michigan</p
             <genreform normal="Sound recordings">Sound recording</genreform>
           </unittitle>
         </did>
-        
-      
-<accessrestrict><p>[Digitized audio files are only available in the Bentley Historical Library reading room on designated Bentley Library computers.]</p>
-</accessrestrict><c02 level="otherlevel" otherlevel="item-main"><did><unittitle>Irene Murphy interviewed by Voice of America, <unitdate type="inclusive">1959 June 08</unitdate></unittitle><physdesc><physfacet>Audio Reel-to-Reel, 7 inch, 7 1/2 ips</physfacet></physdesc></did><c03 level="otherlevel" otherlevel="item-part"><did><physloc>Online</physloc><unittitle>[Part 1]</unittitle><unitid>[851917-SR-1-1]</unitid><physdesc><physfacet>mp3 file</physfacet></physdesc><dao href="851917-SR-1-1" show="new" actuate="onrequest"><daodesc><p>[access item]</p></daodesc></dao> <abstract>(Alan Strong from Voice of America interviews Irene Murphy. She discusses her stays in the Philippines, including her work as a social worker and in nurturing village industries after World War II.)</abstract></did></c03></c02>	
-		</c01>
+        <accessrestrict>
+          <p>[Digitized audio files are only available in the Bentley Historical Library reading room on designated Bentley Library computers.]</p>
+        </accessrestrict>
+        <c02 level="otherlevel" otherlevel="item-main">
+          <did>
+            <unittitle>Irene Murphy interviewed by Voice of America, <unitdate type="inclusive">1959 June 08</unitdate></unittitle>
+            <physdesc>
+              <physfacet>Audio Reel-to-Reel, 7 inch, 7 1/2 ips</physfacet>
+            </physdesc>
+          </did>
+          <c03 level="otherlevel" otherlevel="item-part">
+            <did>
+              <physloc>Online</physloc>
+              <unittitle>[Part 1]</unittitle>
+              <unitid>[851917-SR-1-1]</unitid>
+              <physdesc>
+                <physfacet>mp3 file</physfacet>
+              </physdesc>
+              <dao href="851917-SR-1-1" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[access item]</p>
+                </daodesc>
+              </dao>
+              <abstract>(Alan Strong from Voice of America interviews Irene Murphy. She discusses her stays in the Philippines, including her work as a social worker and in nurturing village industries after World War II.)</abstract>
+            </did>
+          </c03>
+        </c02>
+      </c01>
       <c01 level="series">
         <did>
           <unittitle>

--- a/Real_Masters_all/nisphoto.xml
+++ b/Real_Masters_all/nisphoto.xml
@@ -11054,8 +11054,8 @@
           <did>
             <container type="box" label="Box">G1</container>
             <unittitle>Negative Reels of Aerial Survey, Urban and Rural Washtenaw County (?) including some U-M campus</unittitle>
-            <physdesc>
-              <extent>3 reels</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 reels</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/nurshist.xml
+++ b/Real_Masters_all/nurshist.xml
@@ -329,8 +329,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Oral History Tapes <unitdate type="inclusive" normal="1996">1996</unitdate></unittitle>
-            <physdesc>
-              <extent>2 tapes</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 tapes</extent>
               <physfacet>7 inch, 7-1/2 ips and unknown ips</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/oksen.xml
+++ b/Real_Masters_all/oksen.xml
@@ -7255,8 +7255,8 @@
             <did>
               <container type="box" label="Box">35</container>
               <unittitle>Interview with Oksenberg about Carter Administration China Policy, interviewer unknown (Richard Solomon?) <unitdate type="inclusive" normal="1982-10">October 1982</unitdate></unittitle>
-              <physdesc>
-                <extent>2 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
               </physdesc>
             </did>
           </c03>
@@ -7273,8 +7273,8 @@
             <did>
               <container type="box" label="Box">35</container>
               <unittitle>Woodcock, Leonard-Interview Transcripts, part of "Carter Administration China Policy Oral History Project" <unitdate type="inclusive" normal="1981/1982">1981-1982</unitdate></unittitle>
-              <physdesc>
-                <extent>7 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">7 folders</extent>
                 <extent altrender="carrier">38 tape transcripts; transcript missing for tape #39; also two cassettes of LW press conference</extent>
               </physdesc>
             </did>

--- a/Real_Masters_all/onemich.xml
+++ b/Real_Masters_all/onemich.xml
@@ -190,8 +190,8 @@
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Website capture and printout on <unitdate type="inclusive" normal="2006-12-15">December 15, 2006</unitdate></unittitle>
-            <physdesc>
-              <extent>2 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
               <physfacet>CDs</physfacet>
             </physdesc>
           </did>
@@ -202,8 +202,8 @@
           <unittitle>
             <genreform normal="DVDs">Digital Video Discs</genreform>
           </unittitle>
-          <physdesc>
-            <extent>6 optical disks</extent>
+          <physdesc altrender="whole">
+            <extent altrender="materialtype spaceoccupied">6 optical disks</extent>
             <physfacet>DVDs</physfacet>
           </physdesc>
         </did>

--- a/Real_Masters_all/ovpr.xml
+++ b/Real_Masters_all/ovpr.xml
@@ -44782,8 +44782,8 @@
             <did>
               <container type="box" label="Box">169</container>
               <unittitle>YOHA CD-ROM <unitdate type="inclusive" normal="1998-06-30">June 30, 1998</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-ROMs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/ovshinskysr.xml
+++ b/Real_Masters_all/ovshinskysr.xml
@@ -1,55 +1,57 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE ead PUBLIC "+//ISBN 1-931666-00-8//DTD ead.dtd (Encoded Archival Description (EAD) Version 2002)//EN" "ead.dtd">
 <ead>
-
-<eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
-
-<eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::ovshinskysr.xml//EN" encodinganalog="Identifier">
+  <eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
+    <eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::ovshinskysr.xml//EN" encodinganalog="Identifier">
 umich-bhl-2014092</eadid>
-
-<filedesc><titlestmt><titleproper encodinganalog="Title">Finding Aid for 
+    <filedesc>
+      <titlestmt>
+        <titleproper encodinganalog="Title">Finding Aid for 
 Stanford R. Ovshinsky papers
 
 </titleproper>
-<author encodinganalog="Creator">Collection processed and finding aid created by 
-Shae Rafferty and Emily Riippa </author></titlestmt>
-
-<publicationstmt><publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
-<date encodinganalog="Date" normal="2016">
-2016</date></publicationstmt></filedesc>
-
-<profiledesc>
-<creation>Encoded finding aid created by 
+        <author encodinganalog="Creator">Collection processed and finding aid created by 
+Shae Rafferty and Emily Riippa </author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
+        <date encodinganalog="Date" normal="2016">
+2016</date>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>Encoded finding aid created by 
 Olga Virakhovskaya 
 <date>2016</date></creation>
-
-<langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage><descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules></profiledesc>
-
-<revisiondesc><change><date>2016-01-15</date><item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item></change></revisiondesc></eadheader>
-
-<frontmatter><titlepage>
-
-<publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
-
-<titleproper>Finding aid for<lb/>
+      <langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage>
+      <descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules>
+    </profiledesc>
+    <revisiondesc>
+      <change>
+        <date>2016-01-15</date>
+        <item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item>
+      </change>
+    </revisiondesc>
+  </eadheader>
+  <frontmatter>
+    <titlepage>
+      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <titleproper>Finding aid for<lb/>
 Stanford R. Ovshinsky papers
 </titleproper>
-
-<author>Finding aid created by<lb/> 
+      <author>Finding aid created by<lb/> 
 Shae Rafferty and Emily Riippa, in 2014-2015.
 </author>
-
-</titlepage>
-</frontmatter>
-
-<archdesc level="collection" audience="external" type="inventory" relatedencoding="MARC21"><did>
-
-<origination>
-<corpname source="lcnaf" encodinganalog="110">
+    </titlepage>
+  </frontmatter>
+  <archdesc level="collection" audience="external" type="inventory" relatedencoding="MARC21">
+    <did>
+      <origination>
+        <corpname source="lcnaf" encodinganalog="110">
 Ovshinsky, Stanford R.
-</corpname></origination>
-
-<unittitle encodinganalog="245">
+</corpname>
+      </origination>
+      <unittitle encodinganalog="245">
 Stanford R. Ovshinsky papers
 <unitdate type="inclusive" encodinganalog="245$f">
 1922-2012
@@ -59,1732 +61,11065 @@ Stanford R. Ovshinsky papers
 1950-2012
 </unitdate>
 </unittitle>
-
-<physdesc><extent encodinganalog="300">
+      <physdesc>
+        <extent encodinganalog="300">
 97.4 linear feet (in 108 boxes), 6 oversize boxes, 3 oversize volumes, and 41.7 GB (online)
-</extent></physdesc>
-
-<unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
+</extent>
+      </physdesc>
+      <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2014092 Aa 2
 </unitid>
-
-<langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
-
-<abstract>
+      <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
+      <abstract>
 Collection documents the personal and professional life of Stanford R. Ovshinsky, Michigan inventor and pioneer in the field of amorphous materials; his work emphasized photovoltaics and batteries, among other areas. Includes correspondence, business files, technical publications and presentations, and related records documenting Ovshinsky's life, activities, accomplishments, and interests. 
 </abstract>
-
-
-<repository><corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
-<extptr href="bhladd" show="embed" actuate="onload"/></repository></did>
-
-<descgrp type="admin">
-<acqinfo encodinganalog="541"><p>
+      <repository>
+        <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
+        <extptr href="bhladd" show="embed" actuate="onload"/>
+      </repository>
+    </did>
+    <descgrp type="admin">
+      <acqinfo encodinganalog="541">
+        <p>
 The record group was donated in five installments by Rosa Ovshinsky (donor no. 
 <num type="donor" encodinganalog="541$e">10903</num>), Harvey Ovshinsky (donor no. <num type="donor" encodinganalog="541$e">10907</num>), and Elihu Upham (donor no. <num type="donor" encodinganalog="541$e">10906</num>, in March-May, 2013.
  
-</p></acqinfo>
-
-<accessrestrict encodinganalog="506">
-<p>The collection is open without restriction</p>
- 
-
-<p><extptr href="uarpacc" show="embed" actuate="onload"/></p></accessrestrict>
-
-
-<userestrict encodinganalog="540"><p>
-Copyright is held by the Regents of the University of Michigan.</p></userestrict>
-
-
-<prefercite encodinganalog="524"><p>[item], folder, box,
-Stanford R. Ovshinsky papers, Bentley Historical Library, University of Michigan</p></prefercite>
-<processinfo><p></p>
-<p><extptr href="digitalproc" show="embed" actuate="onload"/></p>
-</processinfo></descgrp>
-
-<bioghist encodinganalog="545">
-<p>Stanford ("Stan") Robert Ovshinsky was born November 24, 1922 in Akron, Ohio, to Benjamin and Bertha (Munitz) Ovshinsky, immigrants from Lithuania and Poland.  He had two siblings, Herbert ("Herb") and Myrtle ("Mashie"), who was later known as Sandra.  Ovshinsky married three times. On August 9, 1942, he was united in marriage with childhood friend Norma Rifkin; the relationship ended in divorce in 1959. To this union were born three sons, Benjamin, Harvey, and Dale. Ovshinsky subsequently wed Dr. Iris L. Dibner (née Miroy) in Toledo, Ohio, on March 30, 1962.  Iris--an accomplished scientist with degrees in zoology, biology, and biochemistry--brought to their relationship two children of her own, Robin and Steven. Stan and Iris Ovshinsky worked successfully together for the long and happy duration of their marriage, crediting their combined advances in science to their loving relationship. Iris Ovshinsky's unexpected death in August 2006 devastated Ovshinsky.  In late 2007, he married Dr. Rosa Young, whom he had known for more than twenty years through her work with Energy Conversion Devices. Stanford R. Ovshinsky passed away on October 17, 2012 at his home in Bloomfield Hills, Michigan, leaving behind a wife, three children, four stepchildren, and several grandchildren.  </p>
-
-<p>Ovshinsky began his working life at Tann Corporation in the Congress Controls Division and served as Vice President of Cytrol Corporation before turning his attention to other areas of study. At the dawn of his career, Ovshinsky's lack of college credentials and the radical nature of his theories in the field of amorphous materials hindered the acceptance of his ideas by the scientific community, but his persistent dedication to his research eventually bore fruit. In 1968, Ovshinsky announced that he had discovered what was subsequently dubbed the Ovshinsky Effect, a phenomenon concerning the transformation of a nonconductive glassy thin film to a semiconductor with the application of a certain minimum voltage. This discovery, repeatedly corroborated by other researchers after Ovshinsky's announcement, marked a turning point in his life as a scientist. </p>
-
-<p>By the 1970s, Ovshisky's writings on the subject of amorphous materials and memory had become cornerstones of an expanding, promising field and made his name a common one in scientific circles. Invitations to speak at technical conferences and at university commencements, where he was awarded a number of honorary degrees, took Stan and Iris Ovshinsky around the world and brought them into contact with many preeminent scientists. Over the course of his career, Ovshinsky  earned his own remarkable place in the ranks of accomplishment, obtaining over 400 U.S. patents and penning more than 300 publications. He actively participated in research and continued to write technical articles, many of which he presented publicly, into his late eighties. The astonishing breadth and innovation of this work led prominent British newspaper<title render="italic"> The Economist</title>  to propose that Ovshinsky be considered "the Edison of our age." </p>
-
-<p>A driven entrepreneur, Ovshinsky established numerous companies during his working life, building partnerships with a variety of national and international corporations.  He started his first enterprise, Stanford Roberts Machine Company, around 1948.  From this business was born one of Ovshinsky's first inventions, the Benjamin Center Drive lathe. Ovshinsky paid tribute his late father by naming the highly flexible, multipurpose machine in his honor. When the United States entered the Korean War in 1950, this lathe became a crucial and profitable tool in the production of massive amounts of shells for the American armed forces. Shortly before the beginning of the war, however, Ovshinsky sold both the Benjamin Center Drive and his business to the New Britain Machine Company, which was incorporated into Northrup Grumman after a series of acquisitions. In 1951, he accepted a new position with Hupp Motor Company as Director of Research and moved to the Detroit area, where he would reside for the rest of his life. At Hupp, Ovshinsky worked extensively in the development of improved power steering systems. On his own initiative, he also began studying the brain and principles of neurophysiology. This new interest prompted Ovshinsky and his brother Herb to found a business of their own, General Automation, where they created the Ovitron, a mechanical model of a nerve cell that functioned as a hybrid solid state/liquid state switching device. Stan and Herb Ovshinsky patented and publicized the machine, a pioneering example of nanostructures, in 1959. Around this time, General Automation was renamed Ovitron Corporation in honor of its groundbreaking invention.</p>
-
-<p>Ovshinsky's entrepreneurship reached new heights in 1960, when he established Energy Conversion Laboratory with his future wife Iris. In 1964, the company changed its name to Energy Conversion Devices, Inc. (ECD). ECD underwent tremendous expansion over the subsequent decades, creating numerous subsidiary companies and forging business connections around the globe, including partnerships with General Motors, Chevron, and Texaco. Seeking to solve critical social and environmental problems through cutting-edge research, the company focused primarily on energy generation, energy storage, and information technology.  ECD applied new knowledge and techniques of amorphous materials to improve solar energy collection and use, nickel-metal hydride batteries (prominently used in hybrid cars), imaging film and display, and a host of other technologies. Over the years, the company and its subsidiaries attracted many brilliant people as employees, board members, consultants, and investors. Robert C. Stempel, formerly CEO of and automotive engineer with General Motors, joined Energy Conversion Devices as an advisor and quickly became its chairman, a position he held for 12 years. Hellmut Fritzsche, another prominent scientist and long-time researcher at the University of Chicago, became an ECD board member in 1969 and later served as vice president until his resignation in 2003. Fritzsche also worked with two of the company's subsidiaries, joining United Solar Systems as a member of their Board of Directors and Ovonic Battery Company as Chief Operating Officer. Other prominent scientists involved with ECD included David Adler, a celebrated physicist at Massachusetts Institute of Technology, and Sir Nevill Mott, a distinguished British scientist and Nobel Prize winner in physics. While working at ECD, Ovshinsky also founded the Institute for Amorphous Studies (IAS), bringing together many of the scientists working in the field of amorphous materials and hosting lectures offered by members of the institute. Among the speakers who presented at IAS were at least five Nobel Laureates, a contributor to the Manhattan Project, and a pantheon of prominent academics at some of the world's top universities, colleges, and research organizations.</p>
-
-<p>In 2007, following company disputes, Ovshinsky retired from ECD and began another enterprise, Ovshinsky Innovation LLC, with fellow scientist Rosa Young; he and Rosa married later that year. Ovshinsky led this company until his death from cancer in 2012, just one month shy of his 90th birthday. Shortly before Ovshinsky passed away, Energy Conversion Devices filed for bankruptcy, announced plans to dissolve, and liquidated its remaining assets. </p>
-
-
-
-</bioghist>
-
-<arrangement encodinganalog="351">
-<p>
+</p>
+      </acqinfo>
+      <accessrestrict encodinganalog="506">
+        <p>The collection is open without restriction</p>
+        <p>
+          <extptr href="uarpacc" show="embed" actuate="onload"/>
+        </p>
+      </accessrestrict>
+      <userestrict encodinganalog="540">
+        <p>
+Copyright is held by the Regents of the University of Michigan.</p>
+      </userestrict>
+      <prefercite encodinganalog="524">
+        <p>[item], folder, box,
+Stanford R. Ovshinsky papers, Bentley Historical Library, University of Michigan</p>
+      </prefercite>
+      <processinfo>
+        <p/>
+        <p>
+          <extptr href="digitalproc" show="embed" actuate="onload"/>
+        </p>
+      </processinfo>
+    </descgrp>
+    <bioghist encodinganalog="545">
+      <p>Stanford ("Stan") Robert Ovshinsky was born November 24, 1922 in Akron, Ohio, to Benjamin and Bertha (Munitz) Ovshinsky, immigrants from Lithuania and Poland.  He had two siblings, Herbert ("Herb") and Myrtle ("Mashie"), who was later known as Sandra.  Ovshinsky married three times. On August 9, 1942, he was united in marriage with childhood friend Norma Rifkin; the relationship ended in divorce in 1959. To this union were born three sons, Benjamin, Harvey, and Dale. Ovshinsky subsequently wed Dr. Iris L. Dibner (née Miroy) in Toledo, Ohio, on March 30, 1962.  Iris--an accomplished scientist with degrees in zoology, biology, and biochemistry--brought to their relationship two children of her own, Robin and Steven. Stan and Iris Ovshinsky worked successfully together for the long and happy duration of their marriage, crediting their combined advances in science to their loving relationship. Iris Ovshinsky's unexpected death in August 2006 devastated Ovshinsky.  In late 2007, he married Dr. Rosa Young, whom he had known for more than twenty years through her work with Energy Conversion Devices. Stanford R. Ovshinsky passed away on October 17, 2012 at his home in Bloomfield Hills, Michigan, leaving behind a wife, three children, four stepchildren, and several grandchildren.  </p>
+      <p>Ovshinsky began his working life at Tann Corporation in the Congress Controls Division and served as Vice President of Cytrol Corporation before turning his attention to other areas of study. At the dawn of his career, Ovshinsky's lack of college credentials and the radical nature of his theories in the field of amorphous materials hindered the acceptance of his ideas by the scientific community, but his persistent dedication to his research eventually bore fruit. In 1968, Ovshinsky announced that he had discovered what was subsequently dubbed the Ovshinsky Effect, a phenomenon concerning the transformation of a nonconductive glassy thin film to a semiconductor with the application of a certain minimum voltage. This discovery, repeatedly corroborated by other researchers after Ovshinsky's announcement, marked a turning point in his life as a scientist. </p>
+      <p>By the 1970s, Ovshisky's writings on the subject of amorphous materials and memory had become cornerstones of an expanding, promising field and made his name a common one in scientific circles. Invitations to speak at technical conferences and at university commencements, where he was awarded a number of honorary degrees, took Stan and Iris Ovshinsky around the world and brought them into contact with many preeminent scientists. Over the course of his career, Ovshinsky  earned his own remarkable place in the ranks of accomplishment, obtaining over 400 U.S. patents and penning more than 300 publications. He actively participated in research and continued to write technical articles, many of which he presented publicly, into his late eighties. The astonishing breadth and innovation of this work led prominent British newspaper<title render="italic"> The Economist</title>  to propose that Ovshinsky be considered "the Edison of our age." </p>
+      <p>A driven entrepreneur, Ovshinsky established numerous companies during his working life, building partnerships with a variety of national and international corporations.  He started his first enterprise, Stanford Roberts Machine Company, around 1948.  From this business was born one of Ovshinsky's first inventions, the Benjamin Center Drive lathe. Ovshinsky paid tribute his late father by naming the highly flexible, multipurpose machine in his honor. When the United States entered the Korean War in 1950, this lathe became a crucial and profitable tool in the production of massive amounts of shells for the American armed forces. Shortly before the beginning of the war, however, Ovshinsky sold both the Benjamin Center Drive and his business to the New Britain Machine Company, which was incorporated into Northrup Grumman after a series of acquisitions. In 1951, he accepted a new position with Hupp Motor Company as Director of Research and moved to the Detroit area, where he would reside for the rest of his life. At Hupp, Ovshinsky worked extensively in the development of improved power steering systems. On his own initiative, he also began studying the brain and principles of neurophysiology. This new interest prompted Ovshinsky and his brother Herb to found a business of their own, General Automation, where they created the Ovitron, a mechanical model of a nerve cell that functioned as a hybrid solid state/liquid state switching device. Stan and Herb Ovshinsky patented and publicized the machine, a pioneering example of nanostructures, in 1959. Around this time, General Automation was renamed Ovitron Corporation in honor of its groundbreaking invention.</p>
+      <p>Ovshinsky's entrepreneurship reached new heights in 1960, when he established Energy Conversion Laboratory with his future wife Iris. In 1964, the company changed its name to Energy Conversion Devices, Inc. (ECD). ECD underwent tremendous expansion over the subsequent decades, creating numerous subsidiary companies and forging business connections around the globe, including partnerships with General Motors, Chevron, and Texaco. Seeking to solve critical social and environmental problems through cutting-edge research, the company focused primarily on energy generation, energy storage, and information technology.  ECD applied new knowledge and techniques of amorphous materials to improve solar energy collection and use, nickel-metal hydride batteries (prominently used in hybrid cars), imaging film and display, and a host of other technologies. Over the years, the company and its subsidiaries attracted many brilliant people as employees, board members, consultants, and investors. Robert C. Stempel, formerly CEO of and automotive engineer with General Motors, joined Energy Conversion Devices as an advisor and quickly became its chairman, a position he held for 12 years. Hellmut Fritzsche, another prominent scientist and long-time researcher at the University of Chicago, became an ECD board member in 1969 and later served as vice president until his resignation in 2003. Fritzsche also worked with two of the company's subsidiaries, joining United Solar Systems as a member of their Board of Directors and Ovonic Battery Company as Chief Operating Officer. Other prominent scientists involved with ECD included David Adler, a celebrated physicist at Massachusetts Institute of Technology, and Sir Nevill Mott, a distinguished British scientist and Nobel Prize winner in physics. While working at ECD, Ovshinsky also founded the Institute for Amorphous Studies (IAS), bringing together many of the scientists working in the field of amorphous materials and hosting lectures offered by members of the institute. Among the speakers who presented at IAS were at least five Nobel Laureates, a contributor to the Manhattan Project, and a pantheon of prominent academics at some of the world's top universities, colleges, and research organizations.</p>
+      <p>In 2007, following company disputes, Ovshinsky retired from ECD and began another enterprise, Ovshinsky Innovation LLC, with fellow scientist Rosa Young; he and Rosa married later that year. Ovshinsky led this company until his death from cancer in 2012, just one month shy of his 90th birthday. Shortly before Ovshinsky passed away, Energy Conversion Devices filed for bankruptcy, announced plans to dissolve, and liquidated its remaining assets. </p>
+    </bioghist>
+    <arrangement encodinganalog="351">
+      <p>
 This collection is divided into eight series: Personal; Correspondence; Research and Subject Files; Publications; Business Administration; Talks and Recognition; Visual Materials; and Lake Angelus Observatory.</p>
-</arrangement>
-
-<scopecontent encodinganalog="520">
-<p>The Stanford R. Ovshinsky papers comprise materials documenting his long scientific career.  Though the collection includes some information about his personal life, the files primarily provide insight into Ovshinsky's professional activities and involvement in the field of amorphous materials.  </p>
-</scopecontent>
-
-<controlaccess><p><extptr href="accnote" show="embed" actuate="onload"/></p><controlaccess><head>Subjects:</head>
-<subject source="lcsh" encodinganalog="650">Alternative fuel vehicles.</subject>
-<subject source="lcsh" encodinganalog="650">Amorphous substances.</subject>
-<subject source="lcsh" encodinganalog="650">Electric vehicles--Batteries.</subject>
-<corpname source="lcnaf" encodinganalog="610">Energy Conversion Devices, Inc.</corpname>
-<subject source="lcsh" encodinganalog="650">EV1 automobile--Research.</subject>
-<subject source="lcsh" encodinganalog="650">Inventors--Michigan.</subject>
-<subject source="lcsh" encodinganalog="650">Inventors--United States.</subject>
-<subject source="lcsh" encodinganalog="650">Nickel-metal hydride batteries--Research.</subject>
-<persname source="lcnaf" encodinganalog="600">Ovshinsky, Stanford R.</persname>
-<subject source="lcsh" encodinganalog="650">Phase change memory--Research.</subject>
-<subject source="lcsh" encodinganalog="650">Prius automobile--Research.</subject>
-<subject source="lcsh" encodinganalog="650">Scientists--Michigan.</subject>
-<subject source="lcsh" encodinganalog="650">Scientists--United States.</subject>
-<subject source="lcsh" encodinganalog="650">Solar energy--Research.</subject>
-
-</controlaccess>
- 
- 
-
-<controlaccess><head>Genre Terms:</head>
-<genreform source="aat" encodinganalog="655">CDs.</genreform>
-<genreform source="aat" encodinganalog="655">Color negatives.</genreform>
-<genreform source="aat" encodinganalog="655">Digital file formats.</genreform>
-<genreform source="aat" encodinganalog="655">Photographs.</genreform>
-<genreform source="aat" encodinganalog="655">Video recordings.</genreform>
-<genreform source="aat" encodinganalog="655">Videocassettes.</genreform>
-</controlaccess>
-
-</controlaccess>
-
-
-<dsc type="combined">
-
-<c01 level="series"><did><unittitle>Personal</unittitle></did><scopecontent><p>The Personal series (2.2 linear feet, 1 oversize box, and digital files; 1922-2012) contains information about Stanford Ovshinsky's life outside of work.  This includes a wide variety of documents, beginning with his birth certificate, high school materials, and photographs from his childhood and marriage to his first wife Norma.  A copy of Ovshinsky's FBI file, which he requested through the Freedom of Information and Privacy Act (FOIPA), is also available in this section, along with documents and correspondence demonstrating his political leanings and involvement. Family communication and financial records, a love letter from Iris Ovshinsky and the couple's marriage certificate, a book of remembrances from Ovshinsky's 80th birthday, his early efforts at poetry, selected excerpts from works about Ovshinsky's life, and his autobiographical drafts also appear in this series. </p></scopecontent>
-<c02 level="file"><did><container type="box" label="Box">95</container><unittitle>70th birthday </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>80th birthday remembrance book excerpts, <unitdate type="inclusive">2002</unitdate></unittitle></did></c02>
-<c02 level="file"><did><physloc> Online </physloc><unittitle>80th birthday reminiscences, appreciations, and photographs, <unitdate type="inclusive">2002</unitdate> </unittitle> <physdesc><physfacet>.ZIP file</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116162" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c02>
-<c02 level="file"><did><physloc> Online </physloc><unittitle>Autobiography and political essays, <unitdate type="inclusive">1990-1992</unitdate> </unittitle> <physdesc><physfacet>.ZIP file</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116168" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Autobiography, <unitdate type="inclusive">1992-1997</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Autobiography, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Autobiography notes, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Certificates -- birth and marriage, <unitdate type="inclusive">1922</unitdate> and <unitdate type="inclusive">1962</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Correspondence, <unitdate type="inclusive">1961-1963</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Early poems, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><unittitle>Education</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">1</container><unittitle>Buchtel High School -- class of '41, <unitdate type="inclusive">1939-2001</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">1</container><unittitle>University of Akron, <unitdate type="inclusive">1941-1942</unitdate></unittitle></did></c03></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Family tree, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Favored cartoons and quotes, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><unittitle>Mementos</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">1</container><unittitle><unitdate type="inclusive">1970s</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">1</container><unittitle><unitdate type="inclusive">1980s</unitdate></unittitle></did></c03></c02>
-<c02 level="file"><did><unittitle>Finances</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">1</container><unittitle>Iris Ovshinsky's estate, <unitdate type="inclusive">2009</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">1</container><unittitle>Real estate appraisal, <unitdate type="inclusive">2007</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Revocable trust</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">1</container><unittitle>Agreement, <unitdate type="inclusive">2007-2008</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">1</container><unittitle>Demand notices, <unitdate type="inclusive">2008-2012</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">1</container><unittitle>Promissory note, <unitdate type="inclusive">2011</unitdate></unittitle></did></c04></c03></c02>
-<c02 level="file"><did><unittitle>Family correspondence</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">1</container><unittitle>Dibner, Rob and Lora, <unitdate type="inclusive">2003</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">1</container><unittitle>Dibner, Steven, <unitdate type="inclusive">1999-2012</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">1</container><unittitle>Goddard, Angela, <unitdate type="inclusive">2007</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">1</container><unittitle>Harper, Dani, <unitdate type="inclusive">2011-2012</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">1</container><unittitle>Murphy, Natasha and Dave, <unitdate type="inclusive">2007-2011</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">2</container><unittitle>Ovshinsky, Ben</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">2</container><unittitle><unitdate type="inclusive">2010</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">2</container><unittitle><unitdate type="inclusive">2011-2012</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">2</container><unittitle>Ovshinsky, Dale, <unitdate type="inclusive">2007-2012</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">2</container><unittitle>Ovshinsky, Harvey, <unitdate type="inclusive">2010-2012</unitdate></unittitle></did></c03></c02>
-<c02 level="file"><did><unittitle>Iris Ovshinsky</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">2</container><unittitle>Boston University, <unitdate type="inclusive">2003</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">2</container><unittitle>Death, <unitdate type="inclusive">August 2006</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">2</container><unittitle>Identification card-University of Michigan, <unitdate type="inclusive">1947-1948</unitdate></unittitle></did></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>Video memorial tribute, <unitdate type="inclusive">2006</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116150" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03>
-<c03 level="file"><did><container type="box" label="Box">2</container><unittitle>Resume and travel list, <unitdate type="inclusive">1960-1978</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">88</container><unittitle>Vacation in Canada with Stan Ovshinsky, <unitdate type="inclusive">October 7, 1991</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03></c02>
-<c02 level="file"><did><container type="box" label="Box">2</container><unittitle>Miscellaneous, <unitdate type="inclusive">1944-2004</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did> <note><p>(resumes -- Robin Dibner and SRO, personal letters, neuro research &amp; correspondence, gardening information)</p></note></c02>
-<c02 level="file"><did><container type="box" label="Box">2</container><unittitle>Miscellaneous, <unitdate type="inclusive">May-July 2009</unitdate> </unittitle></did> <note><p>(medical exam, notes, family history -- Lithuania, photo of Stan and Rosa Ovshinsky)</p></note></c02>
-<c02 level="file"><did><container type="box" label="Box">2</container><unittitle>Photographs of Ovshinsky family, 1937-1955(?)</unittitle></did></c02>
-<c02 level="file"><did><unittitle>Political</unittitle></did>
-<c03 level="file"><did><unittitle>Bergman, Walter</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">2</container><unittitle><unitdate type="inclusive">1962</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">2</container><unittitle><unitdate type="inclusive">1962-1981</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">94</container><unittitle>Ovshinsky speaking at Bergman's memorial service, <unitdate type="inclusive">October 9, 1999</unitdate> </unittitle> <physdesc><physfacet>Betacam SP videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Oversize">109</container><unittitle>Bergman memorabilia album </unittitle></did> <note><p>(letters from numerous activists and dignitaries, photographs and articles to 1962 dinner programs, 1962, 1963, and 1982 memorial service program, 1999)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">2</container><unittitle>Testimonial dinner commemorative binder, <unitdate type="inclusive">1962</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">2</container><unittitle>Congress on Racial Equality (CORE), <unitdate type="inclusive">1959-1961</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">2</container><unittitle>Correspondence, <unitdate type="inclusive">1962-1966</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">2</container><unittitle>Dissent, <unitdate type="inclusive">1956-1963</unitdate> </unittitle></did> <note><p>(correspondence, publications, and a love letter from Iris Ovshinsky)</p></note></c03>
-<c03 level="file"><did><unittitle>FBI file</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">2</container><unittitle>Central Industrial Personnel Security Board, <unitdate type="inclusive">1953-1970</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">2</container><unittitle>Michigan State Police complaints, <unitdate type="inclusive">1961-1969</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">2</container><unittitle>Ovshinsky miscellaneous information, <unitdate type="inclusive">1953-1985</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">2</container><unittitle>Ovshinsky, Stanford, <unitdate type="inclusive">1982</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">2</container><unittitle>SRO file released under FOIPA, <unitdate type="inclusive">1969-1983</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">2</container><unittitle>Involvement, <unitdate type="inclusive">1944-1965</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">2</container><unittitle>Politics notes and writings, <unitdate type="inclusive">1964-1968</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">2</container><unittitle>Socialist membership cards, <unitdate type="inclusive">1940-1941</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">2</container><unittitle>Thoughts on underdeveloped countries, <unitdate type="inclusive">1960-1964</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">2</container><unittitle>Workmen's Circle -- Detroit, <unitdate type="inclusive">1966</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">94</container><unittitle>Workmen's Circle </unittitle> <physdesc><physfacet>4 Sony DVCAM videocassettes</physfacet></physdesc></did></c03></c02></c01>
-
-
-
-<c01 level="series"><did><unittitle>Correspondence, <unitdate type="inclusive">1954-2012</unitdate></unittitle></did><scopecontent><p>The Correspondence series (22 linear feet and digital files; 1954-2012) is divided into two subseries: Companies and Individuals. The majority of this series contains letters and emails that relate to business dealings or scientific topics.</p>  </scopecontent>
-
-
-<c02 level="subseries"><did><unittitle>Companies, <unitdate type="inclusive">1965-2012</unitdate></unittitle></did><scopecontent><p>The Companies subseries documents Ovshinsky's collaboration and involvement with a variety of corporations, institutions, and community organizations.  </p></scopecontent>
-<c03 level="file"><did><container type="box" label="Box">3</container><unittitle>A-B, <unitdate type="inclusive">1988-2012</unitdate> bulk dates <unitdate type="inclusive">2003-2011</unitdate> </unittitle> <physdesc><extent>30 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>Automation Alley video, <unitdate type="inclusive">2008</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116143" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03>
-<c03 level="file"><did><container type="box" label="Box">4</container><unittitle>C-Ch, <unitdate type="inclusive">2003-2011</unitdate> bulk dates <unitdate type="inclusive">2007-2011</unitdate> </unittitle> <physdesc><extent>20 folders</extent></physdesc></did> <note><p>(Photos: Chile-Stan and Iris Ovshinsky)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">5</container><unittitle>Cix-En. <unitdate type="inclusive">1965-2012</unitdate> bulk dates <unitdate type="inclusive">2005-2007</unitdate> </unittitle> <physdesc><extent>35 folders</extent></physdesc></did> <note><p>(Photos: ECD travel postcards)</p></note></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>Electric Battery Bicycle Company report, <unitdate type="inclusive">2007</unitdate> </unittitle> <physdesc><physfacet>PDF</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116139" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03>
-<c03 level="file"><did><container type="box" label="Box">6</container><unittitle>En-G, <unitdate type="inclusive">1981-2012</unitdate> bulk dates <unitdate type="inclusive">2002-2008</unitdate> </unittitle> <physdesc><extent>29 folders</extent></physdesc></did> <note><p>(Photographs: Euro Med.  CD-R: First Energy Presentation Jan 26, 2007.)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">7</container><unittitle>H-In, <unitdate type="inclusive">1997-2012</unitdate> bulk dates <unitdate type="inclusive">2006-2010</unitdate> </unittitle> <physdesc><extent>23 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">8</container><unittitle>In-Misc., <unitdate type="inclusive">1988-2012</unitdate> bulk dates <unitdate type="inclusive">2005-2008</unitdate> </unittitle> <physdesc><extent>38 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">9</container><unittitle>Misc.-Oh, <unitdate type="inclusive">1985-2011</unitdate> bulk dates <unitdate type="inclusive">2005-2008</unitdate> </unittitle> <physdesc><extent>24 folders</extent></physdesc></did> <note><p>(Nasdaq-Stan and Iris Ovshinsky; Oakland University-Stan Ovshinsky)</p></note></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>"Walter Bergman, Freedom Rider" </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116144" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03>
-<c03 level="file"><did><container type="box" label="Box">10</container><unittitle>Ol-Se, <unitdate type="inclusive">1988-2012</unitdate> bulk dates <unitdate type="inclusive">1995-2011</unitdate> </unittitle> <physdesc><extent>25 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">11</container><unittitle>Sh-T, <unitdate type="inclusive">1991-2012</unitdate> bulk dates <unitdate type="inclusive">2004-2007</unitdate> </unittitle> <physdesc><extent>19 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">12</container><unittitle>U-Wa, <unitdate type="inclusive">1955-2012</unitdate> bulk dates <unitdate type="inclusive">1999-2012</unitdate> </unittitle> <physdesc><extent>24 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">13</container><unittitle>Workmen's Circle, <unitdate type="inclusive">2000-2012</unitdate> </unittitle> <physdesc><extent>8 folders</extent></physdesc></did></c03></c02>
-
-
-<c02 level="subseries"><did><unittitle>Individuals, <unitdate type="inclusive">1954-2012</unitdate></unittitle></did><scopecontent><p>The Individuals subseries contains correspondence from professors, scientists, friends, employees, consultants, and admirers.  There are a number of letters from politicians in this subseries as well, such as Amalia Solórzano de Cárdenas, former First Lady of Mexico, Carl Levin, a long-serving United States Senator from Michigan, and Mark Schauer, a former United States Representative from the Detroit area and subsequently a Michigan gubernatorial candidate. The subseries also includes materials Ovshinsky gathered for his biographer Lillian Hoddeson, professor emerita of history at the University of Illinois and historian of Fermilab.</p></scopecontent>
-<c03 level="file"><did><container type="box" label="Box">13</container><unittitle>A-Bray, <unitdate type="inclusive">1986-2012</unitdate> bulk dates <unitdate type="inclusive">2000-2012</unitdate> </unittitle> <physdesc><extent>16 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">14</container><unittitle>Brockman-C, <unitdate type="inclusive">1960-2011</unitdate> bulk dates <unitdate type="inclusive">2000-2010</unitdate> </unittitle> <physdesc><extent>22 folders</extent></physdesc></did> <note><p> (Photograph: Cardenas, Lazaro and Amalia -- Lazaro former President of Mexico)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">15</container><unittitle>D-F, <unitdate type="inclusive">1963-2012</unitdate> bulk dates <unitdate type="inclusive">2005-2012</unitdate> </unittitle> <physdesc><extent>34 folders</extent></physdesc></did> <note><p>(Photographs: Del Bosque, Homero; Dang, Vijay-Ovshinsky's 90th birthday; Dhar, Subhash.  CD: Ellison, Tom)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">16</container><unittitle>G-Hoddeson </unittitle> <physdesc><extent>32 folders</extent></physdesc></did> <note><p>(Photographs: Garlovsky, David -- Stan and Iris Ovshinsky; Gasiorowski, Paul -- thick film deposits.  CD: Gibson, Peter -- BSO carb zts folder; Heckeroth, Steve-PowerPoint Uni-Solar and sc roofing; Photographs: Hoddeson, Lillian -- biography materials 3.  CD: Hoddeson, Lillian-biography materials 3 -- Ovonic Quantum Control Device media briefing)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">17</container><unittitle>Hoffer-I, <unitdate type="inclusive">1954-2012</unitdate> bulk dates <unitdate type="inclusive">2002-2012</unitdate> </unittitle> <physdesc><extent>19 folders</extent></physdesc></did> <note><p>(Howard, George -- Book appendix, SRO files)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">18</container><unittitle>J-K, <unitdate type="inclusive">1972-2012</unitdate> bulk dates <unitdate type="inclusive">2001-2012</unitdate> </unittitle> <physdesc><extent>26 folders</extent></physdesc></did> <note><p>(Photographs: Kane, Gordon-Stan Ovshinsky; Kolobov, Alex --Stan Ovshinsky; Kumar, Arun-Stan Ovshinsky)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">19</container><unittitle>L-Mi, <unitdate type="inclusive">1955-2012</unitdate> bulk dates <unitdate type="inclusive">2000-2012</unitdate> </unittitle> <physdesc><extent>30 folders</extent></physdesc></did> <note><p>(Photographs: Levin, Carl.)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">20</container><unittitle>Mi-Ovshinsky, 1960-2012(27 folders) </unittitle></did> <note><p>(Photographs: Mitchell, Tom &amp; Roseanne -- Stan Ovshinsky; Mott, Nevill P. -- statue of Mott; Ohta, Takeo-Stan Ovshinsky)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">21</container><unittitle>Ovshinsky-Pi, <unitdate type="inclusive">1983-2012</unitdate> </unittitle> <physdesc><extent>17 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">22</container><unittitle>Popescu-Slangerup, <unitdate type="inclusive">1969-2012</unitdate> bulk dates <unitdate type="inclusive">2003-2010</unitdate> </unittitle> <physdesc><extent>31 folders</extent></physdesc></did> <note><p>(Photographs: Shaiken, Harley 2000-2008, Shi, Luping-Stan Ovshinsky)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">23</container><unittitle>Smaga-T, <unitdate type="inclusive">1983-2012</unitdate> bulk dates <unitdate type="inclusive">2003-2011</unitdate> </unittitle> <physdesc><extent>26 folders</extent></physdesc></did> <note><p>(Photograph: Stempel, Robert 1 -- Stan Ovshinsky; Thiessen, Klaus-Stan Ovshinsky.  CD: Takagi, Yasuo -- photographs and PowerPoint; Tamaka, Veiji -- photograph with Stan Ovshinsky.)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">107</container><unittitle>Sm-Za (supplemental), <unitdate type="inclusive">1986-2000</unitdate> bulk dates <unitdate type="inclusive">1996-2000</unitdate> </unittitle> <physdesc><extent>4 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">24</container><unittitle>V-Z, <unitdate type="inclusive">1992-2012</unitdate> </unittitle> <physdesc><extent>27 folders</extent></physdesc></did> <note><p>(Photographs: Winkelman, Margaret -- Stan Ovshinsky; Zeisel, Eva)</p></note></c03></c02></c01>
-
-
-
-<c01 level="series"><did><unittitle>Research and Subject Files, <unitdate type="inclusive">1955-2010</unitdate></unittitle></did><scopecontent><p>The Research and Subject Files series (5.2 linear feet; 1955-2010) contains documents from Ovshinsky's research and collaboration with other scientists on a variety of technical subjects.  Research notes, correspondence, and academic papers constitute the majority of the documents found in this series.  These files highlight the wide range of Ovshinsky's interests, with topics ranging from the brain and neurophysiology to optical memory.  While research files exist throughout the collection, this series holds documents that, for the most part, are not directly connected to one of his many businesses. Of the subject areas in the series, files pertaining to cosmology and superconductivity have the largest number of documents and contain substantial amounts of collaborative correspondence between Ovshinsky, Morrel Cohen, and Hellmut Fritzsche.</p></scopecontent>
-<c02 level="file"><did><container type="box" label="Box">25</container><unittitle>Filing Index, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">25</container><unittitle>Aeroviroment, <unitdate type="inclusive">July 1981</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">25</container><unittitle>Angstrom, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">25</container><unittitle>Blood, 1955-1963(?) </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">25</container><unittitle>Brain, <unitdate type="inclusive">1955-1996</unitdate> </unittitle> <physdesc><extent>4 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">25</container><unittitle>Catalysts, <unitdate type="inclusive">1979-1980</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">25</container><unittitle>Cerebellum, <unitdate type="inclusive">ca. 1955</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">25</container><unittitle>Chemical Bonding, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">25</container><unittitle>Chemical Modification, <unitdate type="inclusive">1977-1981</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">25</container><unittitle>Cognitive Computer, <unitdate type="inclusive">1955-2010</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">25</container><unittitle>Cosmology, <unitdate type="inclusive">1985-2007</unitdate> </unittitle> <physdesc><extent>11 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">26</container><unittitle>Cosmology, <unitdate type="inclusive">1985-2007</unitdate> </unittitle> <physdesc><extent>11 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">26</container><unittitle>Encryption, <unitdate type="inclusive">1996-2000</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">26</container><unittitle>Fluorine, <unitdate type="inclusive">1978</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">26</container><unittitle>Fuel cells, <unitdate type="inclusive">1979</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">26</container><unittitle>Fusion, <unitdate type="inclusive">1989</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">26</container><unittitle>Greenhouse Gasses, <unitdate type="inclusive">1989-1997</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">26</container><unittitle>Hydrogen, <unitdate type="inclusive">1979</unitdate>, <unitdate type="inclusive">1997</unitdate>, <unitdate type="inclusive">2003</unitdate> </unittitle> <physdesc><extent>3 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">26</container><unittitle>Imaging, <unitdate type="inclusive">1970</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">26</container><unittitle>Intelligence, <unitdate type="inclusive">1950-1962</unitdate> </unittitle> <physdesc><extent>3 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">27</container><unittitle>Introns</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">27</container><unittitle>Magnetic particle control</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">27</container><unittitle>Memristors, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">27</container><unittitle>Miscellaneous, <unitdate type="inclusive">1971-1979</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">27</container><unittitle>Neurophysiology, <unitdate type="inclusive">1955-1965</unitdate> </unittitle> <physdesc><extent>7 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">27</container><unittitle>Optical Memory, <unitdate type="inclusive">1977-2001</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">27</container><unittitle>Photovoltaic, <unitdate type="inclusive">1980-2008</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">27</container><unittitle>Physical Theory, <unitdate type="inclusive">1965-1968</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">27</container><unittitle>Semiconductors, <unitdate type="inclusive">1955-1968</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">103</container><unittitle>Sony chairman Morita interview, <unitdate type="inclusive">April 1990</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">28</container><unittitle>Superconductivity, <unitdate type="inclusive">1975-1994</unitdate> </unittitle> <physdesc><extent>15 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">29</container><unittitle>Superconductivity, <unitdate type="inclusive">1965-1995</unitdate> </unittitle> <physdesc><extent>31 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">29</container><unittitle>Superconductivity, <unitdate type="inclusive">1977-1990</unitdate> </unittitle> <physdesc><extent>26 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">29</container><unittitle>"Superconductors," Channel 2 (name of channel not specified), <unitdate type="inclusive">July 21, 1987</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">61</container><unittitle>Switching, <unitdate type="inclusive">1959-1970</unitdate> </unittitle> <physdesc><extent>9 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">61</container><unittitle>Thermoelectricity, <unitdate type="inclusive">1960s-1970s</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">61</container><unittitle>Vision, <unitdate type="inclusive">1998</unitdate></unittitle></did></c02></c01>
-
-
-
-<c01 level="series"><did><unittitle>Publications</unittitle></did><scopecontent><p>The Publications series (13.4 linear feet and 3 oversize volumes; 1955-2012) includes both scientific and popular printed works. Technical papers written by Ovshinsky and ECD employees or directors comprise a significant portion of the series; these works, which primarily derive from the period between 1968 and 1995, document the research interests of Ovshinsky and other scientists with whom he worked in his heyday. On occasion, original drafts, collaborative correspondence, and handwritten research notes accompany the articles. Materials produced by business magazines, Detroit-area newspapers, and other accessible publishers help to contextualize the technical developments and situate them in the vocabulary of the lay reader.</p></scopecontent>
-
-
-<c02 level="subseries"><did><unittitle>Technical Publications -- Ovshinsky and ECD</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">30</container><unittitle><unitdate type="inclusive">1955</unitdate> -- <unitdate type="inclusive">1970</unitdate> </unittitle> <physdesc><extent>83 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">31</container><unittitle><unitdate type="inclusive">1971</unitdate> -- <unitdate type="inclusive">1975</unitdate> </unittitle> <physdesc><extent>61 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">32</container><unittitle><unitdate type="inclusive">1976</unitdate> -- <unitdate type="inclusive">1981</unitdate> </unittitle> <physdesc><extent>70 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">107</container><unittitle><unitdate type="inclusive">1975-1980</unitdate> supplemental publications </unittitle> <physdesc><extent>9 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">33</container><unittitle><unitdate type="inclusive">1982</unitdate> -- <unitdate type="inclusive">1984</unitdate> </unittitle> <physdesc><extent>81 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">34</container><unittitle><unitdate type="inclusive">1985</unitdate> -- <unitdate type="inclusive">1986</unitdate> </unittitle> <physdesc><extent>75 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">35</container><unittitle><unitdate type="inclusive">1987</unitdate> -- <unitdate type="inclusive">1993</unitdate> </unittitle> <physdesc><extent>80 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">36</container><unittitle><unitdate type="inclusive">1994</unitdate> -- <unitdate type="inclusive">2000</unitdate> </unittitle> <physdesc><extent>68 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">37</container><unittitle><unitdate type="inclusive">2001</unitdate> -- <unitdate type="inclusive">2012</unitdate> </unittitle> <physdesc><extent>42 folders</extent></physdesc></did></c03></c02>
-
-
-<c02 level="subseries"><did><unittitle>Newspapers, Magazines, and Books, <unitdate type="inclusive">1963-2012</unitdate></unittitle></did>
-
-<c03 level="file"><did><container type="box" label="Box">37</container><unittitle><unitdate type="inclusive">1966-2012</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">38</container> 
-
-
-
-<unittitle>Akron Beacon Journal, 2005-ECD, <unitdate type="inclusive">1963-1967</unitdate> </unittitle> <physdesc><extent>50 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">39</container><unittitle>ECD, <unitdate type="inclusive">1967-1977</unitdate> </unittitle> <physdesc><extent>23 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">40</container><unittitle>ECD, 1978-2002-H </unittitle> <physdesc><extent>30 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">41</container><unittitle>I-Optical Memory News </unittitle> <physdesc><extent>48 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">42</container><unittitle>Ovonic Link -- Z </unittitle> <physdesc><extent>38 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="volume" label="Oversize"> 1</container><unittitle>Newspaper clippings scrapbook, <unitdate type="inclusive">1963</unitdate>, <unitdate type="inclusive">1966</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="volume" label="Oversize"> 2</container><unittitle>Newspaper clippings scrapbook, <unitdate type="inclusive">1963</unitdate>, <unitdate type="inclusive">1968</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="volume" label="Oversize">  3</container><unittitle>Newspaper clippings scrapbook, <unitdate type="inclusive">1969-1996</unitdate> (with gaps)</unittitle></did></c03></c02></c01>
-
-
-
-<c01 level="series"><did><unittitle>Business Administration, <unitdate type="inclusive">1943-2009</unitdate></unittitle></did><scopecontent><p>The Business Administration series (26.9 linear feet, 4 oversize boxes, and digital files; 1943-2012) contains materials that extensively document Stanford Ovshinsky's commercial ventures. This series is divided into four subseries based on Ovshinsky's early career, his work with Energy Conversion Devices, and activities of the Institute for Amorphous Studies.  Product literature espousing the benefits of new developments, business and technical materials documenting the evolution of these products, and shareholder reports comprise a significant portion of the series. Prominently represented as well are meeting minutes from the Board of Directors of the Institute for Amorphous Studies (IAS), advertisements and information about the IAS lecture series, and materials regarding Ovshinsky's participation in symposia around the world and festschrifts honoring David Adler, Hellmut Fritzsche, Nevill Mott, and Heinz Henisch. Internal correspondence, discussions of employee discontent, and audits also appear in the Business Administration series. </p></scopecontent>
-<c02 level="subseries"><did><unittitle>General, <unitdate type="inclusive">1952-2007</unitdate></unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">43</container><unittitle>Audit and internal investigations, <unitdate type="inclusive">1993-2005</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">43</container><unittitle>Automation Alley, <unitdate type="inclusive">2007</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">43</container><unittitle>Business cards-Stan Ovshinsky, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">43</container><unittitle>Correspondence and miscellaneous, <unitdate type="inclusive">1952-1962</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Early business</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">43</container><unittitle>Amgears, Hupp Corp., General Automation, and personal correspondence, <unitdate type="inclusive">1952-1957</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">43</container><unittitle>Ovitron, Stanford Roberts, New Britain, Hupp-Servo steer, magnet ball controls, switches and relays, <unitdate type="inclusive">1949-1959</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">107</container><unittitle>Tann Corporation agreements, press releases, promotional literature, proofs of concepts, scientific schematics, Stan and Herbert Ovshinsky patent applications and related correspondence, <unitdate type="inclusive">1955-1959</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">43</container><unittitle>Early neuroscience research, <unitdate type="inclusive">1957 (?)</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">43</container><unittitle>History, <unitdate type="inclusive">1962-1983</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did> <note><p>(Folder 1 contains photographs)</p></note></c03>
-<c03 level="file"><did><unittitle>Hupp Corporation</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">43</container><unittitle>Amgears -- no back survey report, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">43</container><unittitle>Power steering and ServO steer, <unitdate type="inclusive">1953 (?)</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">43</container><unittitle>ServOsteer division, <unitdate type="inclusive">1952-1957</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><unittitle>Itineraries</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">43</container><unittitle><unitdate type="inclusive">2005</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">43</container><unittitle><unitdate type="inclusive">2006</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><unittitle>Notes</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">43</container><unittitle><unitdate type="inclusive">December 1959</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">43</container><unittitle>Presented paper from bedroom, <unitdate type="inclusive">2012</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><unittitle>Ovitron </unittitle></did> <note><p>(formerly General Automation)</p></note>
-<c04 level="file"><did><container type="box" label="Box">43</container><unittitle><unitdate type="inclusive">1958-1959</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">43</container><unittitle><unitdate type="inclusive">1959-1969</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">43</container><unittitle>Clippings, <unitdate type="inclusive">1959</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">44</container><unittitle>Correspondence, <unitdate type="inclusive">1959-1962</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">44</container><unittitle>Correspondence, <unitdate type="inclusive">1960-1967</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">44</container><unittitle>Financial Statements, <unitdate type="inclusive">1959-1960</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>General Automation, Inc.</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">44</container><unittitle>Correspondence, <unitdate type="inclusive">1958-1959</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">44</container><unittitle>Option, License Agreement, and Mechanical Products Agreements,  June -- August 1958</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">44</container><unittitle>Tann Corporation litigation, <unitdate type="inclusive">1963</unitdate> </unittitle></did> <note><p>(patent issue)</p></note></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">44</container><unittitle>History, <unitdate type="inclusive">1958-1967</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">44</container><unittitle>Legal, <unitdate type="inclusive">1959-1961</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">44</container><unittitle>Literature, <unitdate type="inclusive">1959</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">44</container><unittitle>Memos, <unitdate type="inclusive">1959</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">44</container><unittitle>Miscellaneous, <unitdate type="inclusive">1959-1960</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">44</container><unittitle>Nerve cell, <unitdate type="inclusive">1959</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">44</container><unittitle>Patents, <unitdate type="inclusive">1959-1961</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">44</container><unittitle>Press, <unitdate type="inclusive">1959</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">44</container><unittitle>Stockholders reports, <unitdate type="inclusive">1961-1962</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">44</container><unittitle>Ovshinsky effect, <unitdate type="inclusive">1974-1975</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">44</container><unittitle>Ovshinsky energy converter (OEC), <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Ovshinsky Innovation LLC</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">44</container><unittitle>Schedule and presentations, <unitdate type="inclusive">2008-2009</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">44</container><unittitle>Tours and visitors, <unitdate type="inclusive">2008-2010</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><unittitle>Patents</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">44</container><unittitle><unitdate type="inclusive">1966</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">44</container><unittitle>Most significant, Ovshinsky's favorites, and certificate of appreciation, <unitdate type="inclusive">1952-2004</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><unittitle>Resume and CV</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">44</container><unittitle>Early work, <unitdate type="inclusive">1946-1960</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">44</container><unittitle>Iris Ovshinsky, <unitdate type="inclusive">1981-2001</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Stanford R. Ovshinsky</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">44</container><unittitle>Biographical sketch and backgrounders of SRO and Julius Harwood, <unitdate type="inclusive">1984</unitdate> </unittitle></did> <note><p>(Harwood was President of Ovonic Synthetic Materials.  Contains photographs of Ovshinsky and Harwood)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">44</container><unittitle>Long and short CV, <unitdate type="inclusive">2000</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">44</container><unittitle>Long resume and phase change optical memory history, <unitdate type="inclusive">1998-2001</unitdate> </unittitle></did> <note><p>(Contains a photograph and 2 floppy disks)</p></note></c05></c04></c03></c02>
-<c02 level="subseries"><did><unittitle>Stanford Roberts Manufacturing Corporation, <unitdate type="inclusive">1943-1960</unitdate></unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">44</container><unittitle>Benjamin Auto Tract, <unitdate type="inclusive">1952-1953</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">44</container><unittitle>Benjamin Center Drive-General Electric, <unitdate type="inclusive">1948-1960</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">44</container><unittitle>Benjamin Center Drive-New Britain, <unitdate type="inclusive">1943-1958</unitdate> </unittitle></did> <note><p>(Contains photograph)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">44</container><unittitle>Memorandums and reports, <unitdate type="inclusive">May 1950</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">44</container><unittitle>New Britain Machine Company, <unitdate type="inclusive">1950s</unitdate></unittitle></did></c03>
-
-<c03 level="file"><did><container type="box" label="Box">44</container><unittitle>Reports on Center Drive machines in regard to Cartridge case production-New Britain, <unitdate type="inclusive">November 1954</unitdate> </unittitle></did> <note><p>(Contains photographs)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">44</container><unittitle>Stock certificate,  January 5, 1948</unittitle></did></c03></c02>
-
-
-<c02 level="subseries"><did><unittitle>Energy Conversion Devices, Inc.</unittitle></did>
-<c03 level="file"> <did><container type="box" label="Box">44</container><unittitle>Administrative, <unitdate type="inclusive">1961-1982</unitdate> </unittitle></did> <note><p>(Statement of funds, management, misc. project notes, + personal history SRO)</p></note></c03>
-
-<c03 level="file"> <did><container type="box" label="Box">44</container><unittitle>
- Advertising, <unitdate type="inclusive">May-September 1982</unitdate> </unittitle></did> <note><p>(Contains a cassette tape)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">45</container><unittitle>American Physical Society material for panel, <unitdate type="inclusive">1978-1979</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Board of Directors</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">45</container><unittitle><unitdate type="inclusive">September 1982</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">45</container><unittitle>Meeting, <unitdate type="inclusive">September 1994</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">106</container><unittitle>Annual meeting, <unitdate type="inclusive">1996</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">89</container><unittitle>Annual meeting, <unitdate type="inclusive">1997</unitdate> </unittitle> <physdesc><physfacet>Betacam SP videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">89</container><unittitle>Annual meeting, <unitdate type="inclusive">1998</unitdate> </unittitle> <physdesc><physfacet>Betacam SP videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">96</container><unittitle>Annual meeting video production materials, <unitdate type="inclusive">1996-1998</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">95</container><unittitle>Annual meeting, <unitdate type="inclusive">1999</unitdate> </unittitle> <physdesc><physfacet>2 Betacam SP videocassettes</physfacet></physdesc></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">45</container><unittitle>Brochures, <unitdate type="inclusive">1974-2004</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">45</container><unittitle>Budget review -- Central Analytical Laboratory, <unitdate type="inclusive">August 5, 1997</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Business proposals and reports</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">45</container><unittitle><unitdate type="inclusive">1970</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>A clean new business for New York City: electric vehicle/battery manufacturing and operation in NYC, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">45</container><unittitle>Advanced Research Project Agency (ARPA) proposals,1971(?)</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">45</container><unittitle>Analysis-Energy conversion and superconductivity and their impact on Japan, 1977(?)</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">45</container><unittitle>Applications of superconductivity to the power industry, <unitdate type="inclusive">September 1977</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">45</container><unittitle>Automotive Thermoelectric Generator for General Motors Corporation, <unitdate type="inclusive">May 1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">45</container><unittitle>Biological and medical aspects of Ovonic mechanism, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Business plan</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">45</container><unittitle>Lithium battery for ANR Energy Technology Company, <unitdate type="inclusive">November 1983</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">45</container><unittitle>Next generation computer systems, optical fiber and ceramics, <unitdate type="inclusive">January 1985</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">45</container><unittitle>Ovonic Solid State Heat Pump, <unitdate type="inclusive">October 1985</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">45</container><unittitle>Business plan and strategy, <unitdate type="inclusive">December 2004</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">45</container><unittitle>Cost analysis-Ovonic photovoltaic manufacturing, <unitdate type="inclusive">February 1981</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">45</container><unittitle>Development of an integrated circuit for remote meter reading equipment, <unitdate type="inclusive">1964</unitdate> </unittitle></did> <note><p>(for Line Materials Industries of McGraw Edis Company)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">45</container><unittitle>Examination of mechanical problems associated with the initially proposed packages, <unitdate type="inclusive">January 1968</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">45</container><unittitle>Limited contract -- thin film active devices based on the original quantrol concept, <unitdate type="inclusive">February-March 1984</unitdate> </unittitle></did> <note><p>(Electronic Machine Company Ltd.)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">45</container><unittitle>Microfilm Development, <unitdate type="inclusive">January-April 1972</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">45</container><unittitle>Miscellaneous proposals, <unitdate type="inclusive">1971-1978</unitdate> &amp; <unitdate type="inclusive">2001</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">45</container><unittitle>Miscellaneous proposals, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>New companies</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">45</container><unittitle>Nonsilver Graphic Arts film, <unitdate type="inclusive">April 1980</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">45</container><unittitle>Ovonic Hydrogen-Akron, LLC, <unitdate type="inclusive">June 2005-2007</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">45</container><unittitle>Ovonic Microelectronic devices, <unitdate type="inclusive">April 1981</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">45</container><unittitle>Ovonic photovoltaic devices for consumer applications, <unitdate type="inclusive">May 1981</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">46</container><unittitle>Ovonic photovoltaic systems for U.S. commercial market, <unitdate type="inclusive">March 1981</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">46</container><unittitle>Photo products, <unitdate type="inclusive">March 1973</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">46</container><unittitle>New High Temperature Superconductors research and development program, <unitdate type="inclusive">February 1989</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">46</container><unittitle>Outline on Ovonic solid state heat pump, <unitdate type="inclusive">October 1985</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">46</container><unittitle>Outline Thermocouple project, <unitdate type="inclusive">May 1960</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">46</container><unittitle>Ovonic Battery Company-Business plan: Small Rechargeable Sealed Cells, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Ovonic Cognitive Computer</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">46</container><unittitle>Capabilities, <unitdate type="inclusive">2000</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">46</container><unittitle>Report, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">46</container><unittitle>Ovonic energy programs, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">46</container><unittitle>Perspectives on medical imaging, <unitdate type="inclusive">January 1975</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">46</container><unittitle>Physical analogs of physiological communicative and control systems, <unitdate type="inclusive">November-December 1960</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">46</container><unittitle>Plan of operations, <unitdate type="inclusive">1967</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">46</container><unittitle>Plan of work-commercialization of hydrogen bulk materials and systems application, <unitdate type="inclusive">October 1981</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">46</container><unittitle>Progress reports-energy research projects, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">46</container><unittitle>Proposed projects, <unitdate type="inclusive">June 1989</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">46</container><unittitle>Public relations program, <unitdate type="inclusive">May 1984</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Sovonics </unittitle></did> <note><p>(Sovonics Solar Energy Company)</p></note>
-<c05 level="file"><did><container type="box" label="Box">46</container><unittitle>Business plan-manufacturing photovoltaics in Michigan, <unitdate type="inclusive">March 1986</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">46</container><unittitle>Commercialization plan for SOHIO-ECD photovoltaic program, <unitdate type="inclusive">October 1981</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">46</container><unittitle>Marketing activities summary, <unitdate type="inclusive">March 1984</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">46</container><unittitle>Status report -- photovoltaic systems for the utility market, <unitdate type="inclusive">January 1986</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">46</container><unittitle>Thin-film semiconductor devices report to Fairchild Research Center, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Uni-Solar </unittitle></did> <note><p>(United Solar Systems Corp.)</p></note>
-<c05 level="file"><did><container type="box" label="Box">46</container><unittitle>Business plan development, <unitdate type="inclusive">1997-1999</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">46</container><unittitle>BIPV market driven strategy, <unitdate type="inclusive">December 2000</unitdate></unittitle></did></c05></c04></c03>
-<c03 level="item"><did><container type="box" label="Box">47</container><unittitle>Consultants</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">47</container><unittitle><unitdate type="inclusive">1984-1987</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">47</container><unittitle>Adler, David, <unitdate type="inclusive">1974-1997</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><unittitle>Corporate partners</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">47</container><unittitle>Fuji agreement and meetings, <unitdate type="inclusive">April 1973</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Joint ventures</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">47</container><unittitle><unitdate type="inclusive">1971-2004</unitdate> </unittitle></did> <note><p>(Contains photographs) </p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">47</container><unittitle>Inland Steel, <unitdate type="inclusive">1989</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">94</container><unittitle>Sovlux Plant Tour, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">47</container><unittitle>United Nuclear, <unitdate type="inclusive">1977-1978</unitdate> </unittitle> <physdesc><physfacet>Includes litigation</physfacet></physdesc></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">47</container><unittitle>Partners and affiliations, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">47</container><unittitle>Relations with Japan, <unitdate type="inclusive">2001</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><unittitle>Correspondence</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">47</container><unittitle>Important various letters, <unitdate type="inclusive">1992-2007</unitdate> </unittitle></did> <note><p>(Includes Board of Directors decision to remove Ovshinsky) </p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">47</container><unittitle>Inter-office memos, <unitdate type="inclusive">1963-1979</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">47</container><unittitle>Internal memos, <unitdate type="inclusive">1966-1986</unitdate> </unittitle></did> <note><p>(Includes documents regarding United Nuclear litigation)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">47</container><unittitle>Kolomiets, B.T., <unitdate type="inclusive">December 1969</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">47</container><unittitle>Miscellaneous, <unitdate type="inclusive">1967-1977</unitdate> </unittitle></did> <note><p>(History)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">47</container><unittitle>Spanenberg, Charles regarding patent, <unitdate type="inclusive">1968</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">47</container><unittitle>Watanabe, Y, <unitdate type="inclusive">November 1989</unitdate> and <unitdate type="inclusive">January 1990</unitdate> </unittitle></did> <note><p>(Tokyo Institute of Technology)</p></note></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">47</container><unittitle>Development and lab incident, <unitdate type="inclusive">1968-1974</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">103</container><unittitle>ECD Japan 5th Anniversary Celebration, <unitdate type="inclusive">January 28, 1986</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">47</container><unittitle>Energy Conversion Laboratories, <unitdate type="inclusive">1961</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Fritzsche</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">47</container><unittitle>80th birthday symposium, <unitdate type="inclusive">February 2007</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc> <physdesc><physfacet>2 CDs</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">47</container><unittitle>Correspondence-Physical Review letters, <unitdate type="inclusive">1968</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">47</container><unittitle>Correspondence, <unitdate type="inclusive">1995-1999</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">47</container><unittitle>Inventory-technology, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">47</container><unittitle>Memory patent, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Ovonic Hydrogen Technology</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">47</container><unittitle>Fuel cylinder assembly process, <unitdate type="inclusive">1999</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">47</container><unittitle>Hydride, <unitdate type="inclusive">1999</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">47</container><unittitle>Ovonic information images, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Research</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">47</container><unittitle>Early <unitdate type="inclusive">1990s</unitdate> optical media, ovonic memory, 1991-1992(?)</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle><unitdate type="inclusive">1995</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle><unitdate type="inclusive">1995-1996</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle><unitdate type="inclusive">1996-1998</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle><unitdate type="inclusive">1997-1998</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle><unitdate type="inclusive">1999-2000</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle><unitdate type="inclusive">2001</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle><unitdate type="inclusive">2004</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle><unitdate type="inclusive">2004-2005</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle><unitdate type="inclusive">2005</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Circuit diagrams, <unitdate type="inclusive">1984-1985</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Compensated a-Si:H, <unitdate type="inclusive">1992-2000</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Compensated a-Si:H -- 4S213, <unitdate type="inclusive">1995</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Cooling cathode vespel information, <unitdate type="inclusive">2002-2004</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Dewars, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Frequency difference monitor, <unitdate type="inclusive">1969-1975</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Glow discharge apparatus, <unitdate type="inclusive">2004 (?)</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Hydrogen, <unitdate type="inclusive">1999-2000</unitdate> </unittitle></did> <note><p>(Stan and Rosa Ovshinsky)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Hydrogenated MF139Z alloy, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Indium(III) Oxide (In2O3), <unitdate type="inclusive">1994-1996</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Memory, <unitdate type="inclusive">1995-1996</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Memory switching, <unitdate type="inclusive">2001</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Miscellaneous, <unitdate type="inclusive">1996-2012</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Passivation, <unitdate type="inclusive">2004-2007</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Patents, <unitdate type="inclusive">1969-1997</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>PDS manual and deposition system, <unitdate type="inclusive">1993-2003</unitdate> </unittitle></did> <note><p>(Photothermal Deflection Spectroscopy)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Photoconductivity, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><unittitle>Published material</unittitle></did>
-<c06 level="file"><did><container type="box" label="Box">48</container><unittitle>Chalcogenides, <unitdate type="inclusive">1978-1985 (?)</unitdate></unittitle></did></c06>
-<c06 level="file"><did><container type="box" label="Box">48</container><unittitle>Light-Induced Structural Changes in Glasses, <unitdate type="inclusive">1999</unitdate> </unittitle></did> <note><p>(Ch 10 of<title render="italic"> Insulating and Semiconducting Glasses</title>)</p></note></c06>
-<c06 level="file"><did><container type="box" label="Box">48</container><unittitle>Physics and Chemistry of Glasses, <unitdate type="inclusive">September 2005</unitdate></unittitle></did></c06></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Standards and constants, <unitdate type="inclusive">1967-1985</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>SWE viewgraphs, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(Overheads)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Switching, On-state, <unitdate type="inclusive">2004</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">48</container><unittitle>Theory of Photoconductivity, <unitdate type="inclusive">1982-1983</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">49</container><unittitle>Transients, <unitdate type="inclusive">1995</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle>Sirius workshop, <unitdate type="inclusive">September 20-24, 1999</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle>Talk outline, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle>Tanaka and Kikuchi research and correspondence, <unitdate type="inclusive">1973-1976</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Uni-Solar </unittitle></did> <note><p>(United Solar Systems Corporation)</p></note>
-<c05 level="file"><did><container type="box" label="Box">49</container><unittitle>Back reflector studies, <unitdate type="inclusive">1990-2005</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">49</container><unittitle>P-chamber cooling, <unitdate type="inclusive">2003-2004</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">49</container><unittitle>Plasma Emission Monitor, <unitdate type="inclusive">2000-2004</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">49</container><unittitle>Production problems   <unitdate type="inclusive">1997-2000</unitdate></unittitle><physdesc><extent>2 folders</extent></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">49</container><unittitle>Shunt studies, <unitdate type="inclusive">2004</unitdate></unittitle></did></c05></c04></c03>
-<c03 level="item"><did><unittitle>History</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle>Background, <unitdate type="inclusive">1980-1984</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle>Company history, <unitdate type="inclusive">1960-1984</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle>Encyclopedia, <unitdate type="inclusive">1969-1971</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle>First Ovonic Photocopier Drum(?) and operating Ovonic Live Imager, <unitdate type="inclusive">1985</unitdate> </unittitle></did> <note><p>(signed by creators)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle>First Three-terminal OTS device from new lab, <unitdate type="inclusive">December 2002</unitdate> </unittitle></did> <note><p>(Contains photograph)</p></note></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">49</container><unittitle>Hydrogen project potential investors, <unitdate type="inclusive">2006</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">49</container><unittitle>Identification card-Stan Ovshinsky, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">49</container><unittitle>Information package, <unitdate type="inclusive">1968</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">49</container><unittitle>Laboratory notebooks -- Henry Berger, <unitdate type="inclusive">1982-1984</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Magazine articles</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle>American Men and Women of Science, <unitdate type="inclusive">1981</unitdate> and <unitdate type="inclusive">1985</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle>Corporate Detroit--Stempel's Renewed Energy, <unitdate type="inclusive">October 1996</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle>The Detroit Engineer -- Adventures into Amorphous Materials, <unitdate type="inclusive">April 1974</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle>Discover -- The Amorphous Man, <unitdate type="inclusive">November 1984</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle>EEE -- Thin-film Semis, At Last, <unitdate type="inclusive">May 1966</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle>The Fifth Estate -- Letters to My Children, <unitdate type="inclusive">November 1966</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle>Marquis Who's Who in America, <unitdate type="inclusive">1972-2003</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Scientific American</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">49</container><unittitle>Amorphous-semiconductor Devices, <unitdate type="inclusive">May 1977</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle>TIME -- Heroes for the Planet, <unitdate type="inclusive">February 1999</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>Manufacturing Technology and Building Division presentations, dated <unitdate type="inclusive">April 11, 2005</unitdate> (two PowerPoint presentations) </unittitle> <physdesc><physfacet>.ZIP file</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116172" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03>
-<c03 level="file"><did><container type="box" label="Box">49</container><unittitle>Materials Research Society (MRS) -- Phase change data storage, <unitdate type="inclusive">December 2003</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">49</container><unittitle>Memory, <unitdate type="inclusive">1995-2001</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Miscellaneous</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle><unitdate type="inclusive">1963-2002</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle><unitdate type="inclusive">1986-1993</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">49</container><unittitle><unitdate type="inclusive">1993-1995</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">50</container><unittitle>Binder -- Core business, role of disorder, cartoons, quotations, and publications, <unitdate type="inclusive">1985-2007</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">50</container><unittitle>Model shop closing, <unitdate type="inclusive">2007</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Notes</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">50</container><unittitle><unitdate type="inclusive">1976-1979</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">50</container><unittitle>Work and meetings, <unitdate type="inclusive">1976-1979</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">50</container><unittitle>Ideas and Notes, <unitdate type="inclusive">1979-1981</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">50</container><unittitle>2002(?)</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">50</container><unittitle><unitdate type="inclusive">2005-2006</unitdate> </unittitle></did> <note><p>(Includes an organizational chart)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">50</container><unittitle>Ovonics application, <unitdate type="inclusive">1964</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">50</container><unittitle>Nuclear and solar commercialization, 1977(?)</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">50</container><unittitle>Ovonic Memory, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">50</container><unittitle>P-project binder, <unitdate type="inclusive">2007</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">50</container><unittitle>Patent application map, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">50</container><unittitle>Photovoltaics, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">50</container><unittitle>Presentations and talks, <unitdate type="inclusive">1969-2009</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Press kits</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">50</container><unittitle>EV Global Motors Company, <unitdate type="inclusive">1998</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">50</container><unittitle>House of Commons-London, <unitdate type="inclusive">July 5, 1977</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">107</container><unittitle>House of Representatives testimony transcript, <unitdate type="inclusive">May 18, 1978</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">50</container><unittitle>Matsushita press conference, <unitdate type="inclusive">May 11, 1983</unitdate></unittitle></did></c04>
-<c04 level="file"><did><physloc> Online </physloc><unittitle>Texaco Ovonic Battery Systems press conference highlights, <unitdate type="inclusive">July 18, 2001</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116135" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c04>
-<c04 level="file"><did><container type="box" label="Box">96</container><unittitle>Transcripts of interviews (SRO and Stempel), GM press conference, and Texaco Ovonic Systems press conference, <unitdate type="inclusive">1998-2002</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">50</container><unittitle>Ovonic Battery, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">50</container><unittitle>Ovonic Quantum Control device, <unitdate type="inclusive">June 6, 2006</unitdate> </unittitle></did> <note><p>(Contains CD-ROM)</p></note></c04>
-<c04 level="file"><did><unittitle>Press releases</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">50</container><unittitle><unitdate type="inclusive">1982-1997</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">50</container><unittitle><unitdate type="inclusive">1993-2007</unitdate> </unittitle></did> <note><p>(Includes announcement of Stan Ovshinsky leaving ECD)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">50</container><unittitle><unitdate type="inclusive">2007-2009</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">50</container><unittitle><unitdate type="inclusive">2010</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">95</container><unittitle>Freedom Car Press Announcement, <unitdate type="inclusive">January 9, 2002</unitdate> </unittitle> <physdesc><physfacet>Betacam SP videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">94</container><unittitle>Sharp-ECD Solar Inc. Ovonic Photovoltatic Processor, <unitdate type="inclusive">August 1982</unitdate> </unittitle> <physdesc><physfacet>U-matic videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">51</container><unittitle>Sharp-ECD Solar Inc.-Japan press conference, <unitdate type="inclusive">February 3, 1983</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">94</container><unittitle>Sharp-ECD Solar Inc. Industrial presentation, <unitdate type="inclusive">May 20, 1983</unitdate> </unittitle> <physdesc><physfacet>U-matic videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">51</container><unittitle>Sovonics, <unitdate type="inclusive">February-March, 1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">51</container><unittitle>Sovonics -- new release solar frontier -- 100 module, <unitdate type="inclusive">March 7, 1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">51</container><unittitle>Switches, <unitdate type="inclusive">1964-1968</unitdate> </unittitle></did> <note><p>(Contains photographs)</p></note></c04></c03>
-<c03 level="file"><did><unittitle>Product literature</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">51</container><unittitle>Amorphous materials and superconductors, 1978-1981(?)</unittitle></did></c04>
-<c04 level="file"><did><unittitle>Automotive</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Automotive thermoelectric generator-final phase, <unitdate type="inclusive">1986</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Cars, batteries, buses, and trucks, 2002-2005(?)</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Miscellaneous, <unitdate type="inclusive">1985-1986</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Power assist steering, <unitdate type="inclusive">1995</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Power steering, <unitdate type="inclusive">2006</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><unittitle>Batteries</unittitle></did>
-<c05 level="file"><did><unittitle>Nickel-metal hydride</unittitle></did>
-<c06 level="file"><did><container type="box" label="Box">51</container><unittitle>1988(?)</unittitle></did></c06>
-<c06 level="file"><did><container type="box" label="Box">51</container><unittitle><unitdate type="inclusive">1998</unitdate></unittitle></did></c06></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Ovonic rechargeable batteries, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Texaco Ovonic Battery Systems, 2003(?) </unittitle></did> <note><p>(becomes Cobasys LLC)</p></note></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">51</container><unittitle>Charts and graphics, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Coatings</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Diamond Black, <unitdate type="inclusive">1984-1986</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Ovonic Wear coating, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Precision coldalloys, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">51</container><unittitle>Electrochemistry, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(Contains photographs)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">51</container><unittitle>Electrochemistry and hydrogen energy technology, <unitdate type="inclusive">1979</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">51</container><unittitle>Electrovonic Print Heads-24x, <unitdate type="inclusive">July 29, 1977</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">51</container><unittitle>Fuel cell, <unitdate type="inclusive">2004-2005</unitdate> </unittitle></did> <note><p>(Ovonic Fuel Cell Company LLC)</p></note></c04>
-<c04 level="file"><did><physloc> Online </physloc><unittitle>Fuel cell brochures and papers, <unitdate type="inclusive">2004-2005</unitdate> </unittitle> <physdesc><physfacet>.ZIP file</physfacet></physdesc> <note><p>(Ovonic Fuel Cell Company LLC)</p></note></did></c04>
-<c04 level="file"><did><physloc> Online </physloc><unittitle></unittitle><dao href="http://hdl.handle.net/2027.42/116151" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c04>
-<c04 level="file"><did><container type="box" label="Box">51</container><unittitle>High-Low units, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Hydrogen</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Hydrogen, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><unittitle>Binder</unittitle></did>
-<c06 level="file"><did><container type="box" label="Box">51</container><unittitle><unitdate type="inclusive">2005</unitdate></unittitle></did></c06>
-<c06 level="file"><did><container type="box" label="Box">51</container><unittitle>Hydrogen and photovoltaic, <unitdate type="inclusive">2001-2004</unitdate></unittitle></did></c06></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Car, <unitdate type="inclusive">2006-2011</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Prius -- reports and master video, <unitdate type="inclusive">2003</unitdate> </unittitle></did> <note><p>(Contains photographs)</p></note></c05>
-<c05 level="file"><did><physloc> Online </physloc><unittitle>Ovonic Solid Hydrogen ICE Vehicle test drive and ECD interviews, <unitdate type="inclusive">August 22, 2003</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116178" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c05>
-<c05 level="file"><did><container type="box" label="Box">106 </container><unittitle>"Ovonic Solid Hydrogen ICE Vehicle: Ready for a Test Drive," <unitdate type="inclusive">October 22, 2003</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><physloc> Online </physloc><unittitle>Prius Phase I status report, <unitdate type="inclusive">October 2002</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/ 2027.42/116131" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c05>
-<c05 level="file"><did><physloc> Online </physloc><unittitle>Prius Phase III video, <unitdate type="inclusive">June 2003</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116145" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c05>
-<c05 level="file"><did><physloc> Online </physloc><unittitle>Prius wrap-up video, <unitdate type="inclusive">January 2004</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116132" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Solid Hydrogen ICE <unitdate type="inclusive">circa 2003</unitdate></unittitle><note><p>(Internal Combustion Engine)%ne Vehicle test drive and speeches</p></note></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Storage, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Electrovonic Data Processor, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(Contains photograph)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Electrovonic Reader, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Film, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Film-192, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Flat Panel Display, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Graphic Arts Film-902, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Medical, <unitdate type="inclusive">1973</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Memory, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Microfiche system, <unitdate type="inclusive">1974</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Microvonic, <unitdate type="inclusive">1979</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>MicrOvonic File (MOF), <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Microvonic Ovonic series <unitdate type="inclusive">7000</unitdate> image processors, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>MicrOvonic Terminal (MOT), <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(Contains photographs)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Optical memory -- video disc, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Ovonic <unitdate type="inclusive">8000</unitdate> image processor, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Ovonic imaging, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">51</container><unittitle>Ovonic Imaging Systems, Inc, <unitdate type="inclusive">1987-1989</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Optical phase change memory, <unitdate type="inclusive">2000</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Photosensitive film, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Thin Film Transistor (TFT), <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Threshold switch, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Video tape recording, <unitdate type="inclusive">1970</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">52</container><unittitle>Internal Combustion Engine (ICE), <unitdate type="inclusive">October 2001</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">52</container><unittitle>Miscellaneous, <unitdate type="inclusive">1963-1997</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">52</container><unittitle>Optical memory disk, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Ovonyx</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Cognitive computer, <unitdate type="inclusive">2003-2004</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Cognitive computer and encryption technology, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Cognitive Computer -- memory, <unitdate type="inclusive">2005</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Unified memory chip, <unitdate type="inclusive">2001-2002</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>X-ray optics, <unitdate type="inclusive">1985</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>X-ray reflecting multilayers, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">52</container><unittitle>Photoelectrochemical cells, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Photovoltaic</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Binder, <unitdate type="inclusive">2005</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Machine development, <unitdate type="inclusive">2005</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Ovonic cell technology, <unitdate type="inclusive">1986</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Ovonic Solar panels, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Photographs, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Photovoltaic manufacturing technology (PvMaT), <unitdate type="inclusive">1994</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Solar -- the promise realized, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Solar cell, <unitdate type="inclusive">1982-2003</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Sovonics Solar Systems, <unitdate type="inclusive">1984-1988</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Sunpal, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Uni-Solar --shingles, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">52</container><unittitle>Quartet Ovonics, <unitdate type="inclusive">1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Solar energy</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Absorber, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Applications, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Comparisons, 1980(?)</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Efficiencies, <unitdate type="inclusive">1983-1984</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Financial, <unitdate type="inclusive">1980-1981</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Miscellaneous, <unitdate type="inclusive">1981</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Modification, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Output, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Projections, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><unittitle>Switches</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Limit and threshold, <unitdate type="inclusive">1958-1966</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Ovonic squib, <unitdate type="inclusive">1968</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Read-Mostly Memory, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><unittitle>Thermoelectric</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>1981(?) </unittitle></did> <note><p>(Contains photographs of thermoelectric cell)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Devices and materials, <unitdate type="inclusive">1983</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Generators, 1986(?)</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">52</container><unittitle>Thermal hydride products group, <unitdate type="inclusive">November 1977</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">52</container><unittitle>Thin film transistor, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">52</container><unittitle>Unique ovonic technologies, <unitdate type="inclusive">1986</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">53</container><unittitle>Promotional literature, <unitdate type="inclusive">1986-1989</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">97</container><unittitle>Promotional videos and media, <unitdate type="inclusive">1993-2002</unitdate></unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">97</container><unittitle>ECD/Bekaert videos, <unitdate type="inclusive">2001-2002</unitdate> </unittitle> <physdesc><physfacet>10 Betacam SP videocassettes, 2 DVCam videotapes</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">89</container><unittitle>ECD employee interviews, <unitdate type="inclusive">1996</unitdate> (Dhar, Guha, Hudgens, and Stempel) </unittitle> <physdesc><physfacet>3 Betacam SP videocassettes</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">96</container><unittitle>ECD employee interview transcripts, <unitdate type="inclusive">1996</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">96</container><unittitle>ECD employee interview transcripts and publicity video production materials, <unitdate type="inclusive">1996</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">96</container><unittitle>ECD employee interview transcripts, <unitdate type="inclusive">2002</unitdate></unittitle></did></c04>
-<c04 level="file"><did><physloc> Online </physloc><unittitle>"ECD Energy Solutions," <unitdate type="inclusive">February 11, 2003</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116165" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c04>
-<c04 level="file"><did><container type="box" label="Box">89</container><unittitle>ECD footage miscellaneous, dated <unitdate type="inclusive">April 4, 1996</unitdate> </unittitle> <physdesc><physfacet>Betacam SP videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">89</container><unittitle>ECD footage, miscellaneous (archival pictures), dated <unitdate type="inclusive">April 9, 1996</unitdate> </unittitle> <physdesc><physfacet>Betacam SP videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">89</container><unittitle>ECD footage, miscellaneous, dated <unitdate type="inclusive">June 4, 1996</unitdate> </unittitle> <physdesc><physfacet>Betacam SP videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">97</container><unittitle>ECD General Interviews, <unitdate type="inclusive">1993-2000</unitdate> </unittitle> <physdesc><physfacet>23 Betacam SP videocassettes</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">94</container><unittitle>ECD Headquarters, SRO (Stanford R. Ovshinsky) at Work, OBC (Ovonic Battery Company) Lab/EV Battery </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">95</container><unittitle>ECD/HKO Media promotional video scripts, <unitdate type="inclusive">1994-2009</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">95</container><unittitle>ECD Mexico Video/Stan Ovshinsky Video, <unitdate type="inclusive">April 15, 2002</unitdate> </unittitle> <physdesc><physfacet>2 Betacam SP videocassettes</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">95</container><unittitle>ECD/HKO Media miscellaneous B-roll footage notes</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">97 </container><unittitle>"ECD Photovoltaics" raw footage, <unitdate type="inclusive">ca. 2002</unitdate> </unittitle> <physdesc><physfacet>10 Betacam SP videocassettes</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">97 </container><unittitle>ECD product display footage, dated <unitdate type="inclusive">March 5, 1996</unitdate> </unittitle> <physdesc><physfacet>2 Betacam SP videocassettes</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">97 </container><unittitle>"ECD Rolls 8-10 Photographers Commercial"</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">89</container><unittitle>ECD tour footage, dated <unitdate type="inclusive">January 16, 1997</unitdate> </unittitle> <physdesc><physfacet>3 Betacam SP videocassettes</physfacet></physdesc></did></c04>
-<c04 level="file"><did><physloc> Online </physloc><unittitle>"ECD: Transforming the Future," <unitdate type="inclusive">April 25, 2002</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116157" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c04>
-<c04 level="file"><did><container type="box" label="Box">90 </container><unittitle>"ECD: Transforming the Future" field master tapes </unittitle> <physdesc><physfacet>18 Betacam SP videocassettes</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">93</container><unittitle> "ECD: Transforming the Future" raw footage </unittitle> <physdesc><physfacet>30 Betacam SP videocassettes and miniature digital cassettes</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">89 </container><unittitle>"ECD's Ovonic Battery: The Future is Now," dated <unitdate type="inclusive">September 12, 1993</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><physloc> Online </physloc><unittitle>"ECD's Ovonic Battery: The Future is Now (Scooter Version)," <unitdate type="inclusive">April 4, 1995</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116156" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c04>
-<c04 level="file"><did><container type="box" label="Box">89 </container><unittitle>"ECD Ovonics: Excerpt from the Leadership Challenge," WDIV TV, <unitdate type="inclusive">July 29, 2002</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">89 </container><unittitle> "ECD Ovonics Solutions" miscellaneous footage, <unitdate type="inclusive">August 13, 2002</unitdate> </unittitle> <physdesc><physfacet>3 Betacam SP videocassettes</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">106</container><unittitle>ECD/Uni-Solar general footage, <unitdate type="inclusive">ca. 2002</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">97</container><unittitle>ECD/Uni-Solar general footage, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>8 Betacam SP videocassettes</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">106 </container><unittitle>"ECD Video," <unitdate type="inclusive">August 19, 1996</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">95</container><unittitle> "ECD Web Segments: Corporate History, Ovonic Battery, Hydrogen Technology, United Solar, and Information Storage," <unitdate type="inclusive">August 4, 2000</unitdate> </unittitle> <physdesc><physfacet>Betacam SP videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">106 </container><unittitle>"Energy Conversion Devices Video," <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">89</container><unittitle>General Motors Corporation ATV miscellaneous footage, dated <unitdate type="inclusive">January 6, 1998</unitdate> </unittitle> <physdesc><physfacet>Betacam SP videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">91</container><unittitle>Mexico promotional material and media, <unitdate type="inclusive">ca. 1994-2001</unitdate> </unittitle> <physdesc><physfacet>21 Betacamp SP videocassettes and miniature digital cassettes</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">92 </container><unittitle>"Ovonic Battery," miscellaneous videos (1990-1998) </unittitle> <physdesc><physfacet>19 Betacam SP videocassettes</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">89</container><unittitle>Ovonic Battery Compilation Reel, <unitdate type="inclusive">July 10, 1998</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><physloc> Online </physloc><unittitle>"Ovonic Battery Video News Release," <unitdate type="inclusive">May 18, 1992</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116159" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c04>
-<c04 level="file"><did><physloc> Online </physloc><unittitle>Ovonic Battery Company video (Selectra version), <unitdate type="inclusive">July 9, 1996</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116161" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c04>
-<c04 level="file"><did><container type="box" label="Box">89 </container><unittitle>"Ovonic Battery/EV1 Cross-Country Shoot" miscellaneous footage, <unitdate type="inclusive">October 12, 2000</unitdate> </unittitle> <physdesc><physfacet>3 Betacam SP videocassettes</physfacet></physdesc></did></c04>
-<c04 level="file"><did><physloc> Online </physloc><unittitle>Ovonics@Work video, <unitdate type="inclusive">May 9, 2002</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116134" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c04>
-<c04 level="file"><did><container type="box" label="Box">94 </container><unittitle>"Ovonic Hydrogen Solutions: A Video News Release," <unitdate type="inclusive">February 6, 2003</unitdate> </unittitle> <physdesc><physfacet>Betacam SP videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">106</container><unittitle>Ovshinsky, interview with HKO Media, <unitdate type="inclusive">December 21, 1993</unitdate> </unittitle> <physdesc><physfacet>3 Betacam SP videocassettes</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">106</container><unittitle>Ovshinsky, interview with HKO Media, <unitdate type="inclusive">March 4, 1996</unitdate> </unittitle> <physdesc><physfacet>Betacam SP videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">106</container><unittitle>Ovshinsky/Stempel interview, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><physloc> Online </physloc><unittitle>"The Road to the Sun: Alternative Energy for the Americas," <unitdate type="inclusive">2009</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116163" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c04>
-<c04 level="file"><did><container type="box" label="Box">96</container><unittitle> "The Road to the Sun: Alternative Energy for the Americas" production binder, University of California Berkeley/HKO Media, <unitdate type="inclusive">February 13, 2009</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">103 </container><unittitle>"Sunlaw Cogeneration Partners 1," Sunlaw/Bosustow Video, <unitdate type="inclusive">June 7, 1990</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">104</container><unittitle>Publicity and media coverage</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">104</container><unittitle>"Alaska Report,"  <unitdate type="inclusive">September 25, 1996</unitdate></unittitle><physdesc><physfacet>VHS videocassette) </physfacet> </physdesc><note><p>(includes electric car and interview Robert Stempel)</p></note></did></c04>
-<c04 level="file"><did><container type="box" label="Box">104</container><unittitle>Blieden  <unitdate type="inclusive">February 7, 1983</unitdate> </unittitle> <physdesc><physfacet>U-matic videocassette</physfacet></physdesc> <note><p>(H. Richard Blieden)%ne interview, Channel 7</p></note> </did></c04>
-<c04 level="file"><did><container type="box" label="Box">104</container><unittitle>"The Bloomberg Forum," Robert C. Stempel, Chairman/CEO, Interview <unitdate type="inclusive">September 15, 1998</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">105</container><unittitle>Bloomfield Community Television, "Michigan on Wall Street" with Stan Ovshinsky and Robert Stempel, <unitdate type="inclusive">January 1997</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">103</container><unittitle>Bush, George H.W. and electric car reports: News 7, WJLA TV,  October 25, 1991/Cable News Network (CNN)<title render="italic"> Weekend News</title>, <unitdate type="inclusive">October 26, 1991</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">103</container><unittitle>Cable News Network (CNN) footage, <unitdate type="inclusive">October 19, 1987</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">94</container><unittitle>Channel 56 video </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">95 </container><unittitle>"ECD Analysts Video," <unitdate type="inclusive">April 20, 1998</unitdate> </unittitle> <physdesc><physfacet>Betacam SP videocassettes</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">95 </container><unittitle>ECD News Program Channel 7, Channel 55 </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">95 </container><unittitle>ECD/USSC (United Solar Systems Corporation) press conference, <unitdate type="inclusive">February 14, 1996</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">95 </container><unittitle>ECD/USSC (United Solar Systems Corporation) 5 Mega-Watt Opening, <unitdate type="inclusive">February 15, 1996</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">95 </container><unittitle>"Edge--CNBC Cable, Energy Conversion Devices," <unitdate type="inclusive">February 22, 2000</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">95 </container><unittitle>"Electric Vehicles,"<title render="italic"> Cutting Edge Technology Report</title>, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">95 </container><unittitle>"Energy Efficient House," Headline News Network, <unitdate type="inclusive">October 23, 1996</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><physloc> Online </physloc><unittitle>GM Advanced Technology Vehicles Press Conference at North American International Auto Show, highlights, <unitdate type="inclusive">January 4, 1998</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116154" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c04>
-<c04 level="file"><did><container type="box" label="Box">88</container><unittitle>GM Battery, Energy Conversion Devices, <unitdate type="inclusive">March 18, 1994</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><physloc> Online </physloc><unittitle>GM EV1 Global Motors and ECD Press Conference and Tour Highlights with Lee Iacocca, dated <unitdate type="inclusive">April 16, 1998</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116164" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c04>
-<c04 level="file"><did><container type="box" label="Box">89</container><unittitle>GM EV1 Global Motors and ECD Press Conference additional footage, dated <unitdate type="inclusive">February 10, 1998</unitdate> </unittitle> <physdesc><physfacet>2 Betacam SP videocassettes</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">89</container><unittitle>GM Ovonic Auto Show Display, dated <unitdate type="inclusive">January 13, 1998</unitdate> </unittitle> <physdesc><physfacet> (2 Betacam SP videocassettes</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">103</container><unittitle>GM Ovonic, TV 2 News, <unitdate type="inclusive">December 1, 1994</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">103</container><unittitle>"Hidden Tech," Target 7 News, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">97 </container><unittitle>"La Luz de La Esperanza," Documental Oaxaca, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>Betacam SP videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">104 </container><unittitle>"Market Call,"  CNN/FN Cable <unitdate type="inclusive">May 21, 2002</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc><note><p>(featuring Robert Stempel) </p></note></did></c04>
-<c04 level="file"><did><container type="box" label="Box">94 </container><unittitle>"Ovonic Energy Solutions," <unitdate type="inclusive">November 19, 2008</unitdate> </unittitle> <physdesc><physfacet>Sony DVCAM videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">95 </container><unittitle>"Ovonic Hydrogen Solutions Demonstration," White House Television, <unitdate type="inclusive">February 6, 2003</unitdate> </unittitle> <physdesc><physfacet>Betacam SP videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">95 </container><unittitle>"Ovonic Hydrogen Solutions in the News, <unitdate type="inclusive">February 6-11, 2003</unitdate>" <unitdate type="inclusive">February 24, 2003</unitdate> </unittitle> <physdesc><physfacet>Betacam SP videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><physloc> Online </physloc><unittitle>"Ovonic Information Technology Solutions," <unitdate type="inclusive">February 13, 2003</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116166" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c04>
-<c04 level="file"><did><physloc> Online </physloc><unittitle>"Ovonic Solar Solutions" in Mexico, <unitdate type="inclusive">July 3, 2002</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116158" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c04>
-<c04 level="file"><did><physloc> Online </physloc><unittitle>Ovonics/Robert Stempel, CEO, WDIV First News at 6, <unitdate type="inclusive">August 22, 2003</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">94</container><unittitle>PV Shingles from United Solar on WDIV, <unitdate type="inclusive">February 1996</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">103</container><unittitle>Rural Electrification Program, Oaxaca, Mexico, <unitdate type="inclusive">2000</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">103</container><unittitle>Saraboo Production/ECD, <unitdate type="inclusive">June 18, 1986</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">106</container><unittitle>United States Department of Energy/Energy Conversion Devices press conference, <unitdate type="inclusive">January 18, 1994</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">89</container><unittitle>US Advanced Battery Consortium (USABC)/Energy Conversion Devices (ECD)/Ovonic Battery press conference, <unitdate type="inclusive">May 19, 1992</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">89</container><unittitle> "What's Up in Technology?" Thirteen/WNET, <unitdate type="inclusive">October 23, 1998</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">103</container><unittitle>White House Conference on Global Climate Change, <unitdate type="inclusive">October 6, 1997</unitdate> excerpt of Secretary Pena's holding and discussion, USSC Solar Shingle </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">53</container><unittitle>Research</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">53</container><unittitle>Active material fabrication basic process, <unitdate type="inclusive">June 1973</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">53</container><unittitle>Affidavits -- missing sample 644, <unitdate type="inclusive">August 1978</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">53</container><unittitle>Amorphous Silicon, <unitdate type="inclusive">1994-1995</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">53</container><unittitle>Cosmology collaboration with Fritzsche, <unitdate type="inclusive">1992-2003</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did> <note><p>(Includes research for papers: <title render="italic"> The Origin of Dark Matter in the Universe</title> and<title render="italic"> Vacuum Energy, Gravity, and an Approach to Combing General Relativity with Quantum Mechanics</title>)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">53</container><unittitle>Memory materials-Ge:Sb:Te, <unitdate type="inclusive">1992-2005</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">53</container><unittitle>Optical recording, <unitdate type="inclusive">1999-2000</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">53</container><unittitle>Posters, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">53</container><unittitle>Properties of amorphous semiconductors at high temperatures, <unitdate type="inclusive">October 1969</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">53</container><unittitle>Resumes, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">53</container><unittitle>Schedules, <unitdate type="inclusive">1968-1969</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Shareholders</unittitle></did>
-<c04 level="file"><did><unittitle>Annual reports</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">53</container><unittitle><unitdate type="inclusive">1968-1976</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">53</container><unittitle><unitdate type="inclusive">1993</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">53</container><unittitle>Financial reports, <unitdate type="inclusive">1962-1985</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">53</container><unittitle>Interim reports, <unitdate type="inclusive">1970</unitdate> and <unitdate type="inclusive">1985</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Letter to shareholders</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">53</container><unittitle><unitdate type="inclusive">1979</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">53</container><unittitle><unitdate type="inclusive">1994</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">53</container><unittitle><unitdate type="inclusive">1995</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">53</container><unittitle><unitdate type="inclusive">1996</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">53</container><unittitle><unitdate type="inclusive">1997</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">53</container><unittitle><unitdate type="inclusive">1999</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">53</container><unittitle><unitdate type="inclusive">2000</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">53</container><unittitle>Meetings, <unitdate type="inclusive">1985</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">53</container><unittitle>Miscellaneous, <unitdate type="inclusive">1981-1983</unitdate> </unittitle></did> <note><p>(Includes an organizational hierarchy)</p></note></c04>
-<c04 level="file"><did><physloc> Online </physloc><unittitle>Presentation to shareholders' meeting, <unitdate type="inclusive">2005</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116149" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c04>
-<c04 level="file"><did><container type="box" label="Box">53</container><unittitle>President's letter</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">53</container><unittitle><unitdate type="inclusive">1981</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">53</container><unittitle><unitdate type="inclusive">1983</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">53</container><unittitle><unitdate type="inclusive">1983</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">53</container><unittitle><unitdate type="inclusive">1985</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">53</container><unittitle><unitdate type="inclusive">1987</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">53</container><unittitle><unitdate type="inclusive">1988</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">53</container><unittitle><unitdate type="inclusive">1990</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">53</container><unittitle><unitdate type="inclusive">1992</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">53</container><unittitle><unitdate type="inclusive">1993</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">53</container><unittitle>Special reports, <unitdate type="inclusive">1972-1996</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">54</container><unittitle>Speeches and interviews, <unitdate type="inclusive">1969-1982</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>SRO employment agreement and termination, <unitdate type="inclusive">1993-2007</unitdate></unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">54</container><unittitle>Stock options, <unitdate type="inclusive">1996-2006</unitdate> </unittitle></did> <note><p>(Contains Iris Ovshinsky's employment agreement)</p></note></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">54</container><unittitle>Stock share prices, <unitdate type="inclusive">2007-2011</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Subsidiaries</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">54</container><unittitle>Grupo Ovonics Latinoamerica, <unitdate type="inclusive">2003-2004</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">54</container><unittitle>Micorovonics -- Notes, <unitdate type="inclusive">1979-1980</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Ovonic Battery Company</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">54</container><unittitle>Advanced development, <unitdate type="inclusive">2002-2005</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">54</container><unittitle>Advance MH alloys,  October 2001(?)</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">54</container><unittitle>American Natural Resources Company annual reports, <unitdate type="inclusive">1983-1984</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">54</container><unittitle>Chevy Volt meeting, <unitdate type="inclusive">April 2007</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">54</container><unittitle>Cobasys-Information binder, <unitdate type="inclusive">2006</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">54</container><unittitle>Correspondence-Unhappy corporate partners, <unitdate type="inclusive">December 1996</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">54</container><unittitle>Development and meeting PowerPoints, <unitdate type="inclusive">2007</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">54</container><unittitle>Development and strategy, 1990-2000(?)</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">54</container><unittitle>Foreign storage and material cost, <unitdate type="inclusive">1994-1998</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">54</container><unittitle>Fritzsche, Hellmut, <unitdate type="inclusive">July 1998</unitdate></unittitle></did></c05>
-<c05 level="file"><did><unittitle>GM Ovonic</unittitle></did>
-<c06 level="file"><did><container type="box" label="Box">54</container><unittitle><unitdate type="inclusive">April 1994</unitdate></unittitle></did></c06>
-<c06 level="file"><did><container type="box" label="Box">54</container><unittitle><unitdate type="inclusive">1997</unitdate></unittitle></did></c06></c05>
-<c05 level="file"><did><container type="box" label="Box">54</container><unittitle>License agreement, <unitdate type="inclusive">April 1995</unitdate> </unittitle></did> <note><p>(Walsin Tech. Corp.)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">54</container><unittitle>Matsushita hydrogen storage alloy patent, <unitdate type="inclusive">June 1989</unitdate> </unittitle></did> <note><p>(Effect on ECD)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">54</container><unittitle>Meeting with ECD, <unitdate type="inclusive">February 21-22, 1996</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">54</container><unittitle>Memos, <unitdate type="inclusive">1997</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">54</container><unittitle>Miscellaneous, <unitdate type="inclusive">1990</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">54</container><unittitle>Presentation slides, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">54</container><unittitle>Review meeting-NIST --AMAPP, <unitdate type="inclusive">July 15, 1999</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">54</container><unittitle>Ovonic Display Systems -- presentation slides, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">54</container><unittitle>Ovonic Hydrogen Technology, <unitdate type="inclusive">1997-2002</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">55</container><unittitle>Ovonic Hydrogen Technology, <unitdate type="inclusive">2000-2003</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c04>
-<c04 level="file"><did><unittitle>Ovonic Hydrogen Systems</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">55</container><unittitle>Texaco Ovonic Hydrogen Systems, LLC, <unitdate type="inclusive">2003</unitdate> </unittitle> <physdesc><physfacet>photographs</physfacet></physdesc></did></c05>
-<c05 level="file"><did><physloc> Online </physloc><unittitle>Ovonic Solid Hydrogen Storage System <unitdate type="inclusive">2003</unitdate> Challenge Bibendum ( September 23-25) photographs </unittitle><dao href="http://hdl.handle.net/2027.42/116204" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c05>
-<c05 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Texaco Ovonic Hydrogen Systems manufacturing facility design, <unitdate type="inclusive">2003</unitdate></unittitle></did></c05>
-<c05 level="file"><did><physloc> Online </physloc><unittitle>Highlights: Texaco, Inc., and Energy Conversion Devices, Inc., press conference, <unitdate type="inclusive">May 2, 2000</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116167" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c05>
-<c05 level="file"><did><container type="box" label="Box">89</container><unittitle>Texaco and Energy Conversion Devices, Inc., press conference additional footage (display materials and reporter reactions), <unitdate type="inclusive">May 2, 2000</unitdate> </unittitle> <physdesc><physfacet>2 Betacam SP videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">106</container><unittitle>Texaco/ECD presentation with Stanford Ovshinsky, <unitdate type="inclusive">June 7, 2000</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">106</container><unittitle>Texaco Hydrogen Economy Corporate Center meeting, <unitdate type="inclusive">June 22, 2000</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">55</container><unittitle>Akron, <unitdate type="inclusive">2006</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">55</container><unittitle>Akron groundbreaking, <unitdate type="inclusive">April 27, 2006</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">55</container><unittitle>Akron meeting, <unitdate type="inclusive">June 13, 2006</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">55</container><unittitle>Acquisition, <unitdate type="inclusive">2007-2008</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">55</container><unittitle>Business model and proposal to purchase, <unitdate type="inclusive">2007</unitdate></unittitle></did></c05>
-<c05 level="file"><did><physloc> Online </physloc><unittitle>ECD Ovonics Press Conference in Akron, <unitdate type="inclusive">April 27, 2006</unitdate> (two videos) </unittitle> <physdesc><physfacet>.ZIP file</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116171" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">55</container><unittitle>Ovonic Imaging Systems, Inc.</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">55</container><unittitle>Report -- New concepts and applications in nonsilver photographic and electrographic recording, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><unittitle>Shareholders</unittitle></did>
-<c06 level="file"><did><container type="box" label="Box">55</container><unittitle>Annual reports, <unitdate type="inclusive">1987</unitdate></unittitle></did></c06>
-<c06 level="file"><did><container type="box" label="Box">55</container><unittitle>President's letter, <unitdate type="inclusive">1989</unitdate></unittitle></did></c06></c05>
-<c05 level="file"><did><container type="box" label="Box">55</container><unittitle>X-ray -- Perspectives on Medical Imaging internal memo, <unitdate type="inclusive">1973-1974</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><unittitle>Ovonic Media, LLC</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">55</container><unittitle><unitdate type="inclusive">1990-2001</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">55</container><unittitle><unitdate type="inclusive">2000</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">55</container><unittitle>Ovonic Memories, Inc. -- Switch memory, <unitdate type="inclusive">1970-1973</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">55</container><unittitle>Ovonic Solar -- marketing strategy slides, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Ovonyx</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">55</container><unittitle><unitdate type="inclusive">2006</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">55</container><unittitle><unitdate type="inclusive">2007</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">55</container><unittitle><unitdate type="inclusive">2008-2009</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">56</container><unittitle><unitdate type="inclusive">2010-2011</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">56</container><unittitle><unitdate type="inclusive">2012</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">56</container><unittitle>Acquisition, <unitdate type="inclusive">2007</unitdate> </unittitle></did> <note><p>(by Ovshinsky Innovation)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">56</container><unittitle>Correspondence and Cognitive computer patents, <unitdate type="inclusive">2000-2002</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">56</container><unittitle>Fritzsche problem solving, <unitdate type="inclusive">August 2000</unitdate> </unittitle></did> <note><p>(Contains research photographs)</p></note></c05>
-<c05 level="file"><did><unittitle>Ovonic Cognitive Computer</unittitle></did>
-<c06 level="file"><did><container type="box" label="Box">56</container><unittitle><unitdate type="inclusive">1992-2000</unitdate></unittitle></did></c06>
-<c06 level="file"><did><container type="box" label="Box">56</container><unittitle><unitdate type="inclusive">2000-2005</unitdate></unittitle></did></c06>
-<c06 level="file"><did><container type="box" label="Box">56</container><unittitle>Abstracts and revisions, <unitdate type="inclusive">2003</unitdate></unittitle></did></c06>
-<c06 level="file"><did><container type="box" label="Box">56</container><unittitle>Board meeting posters, <unitdate type="inclusive">May 8, 2003</unitdate></unittitle></did></c06>
-<c06 level="file"><did><container type="box" label="Box">56</container><unittitle>Cognitive device principles of operation, <unitdate type="inclusive">July 2003</unitdate> </unittitle></did> <note><p>(B. Pashmakov, superseded by Intel pkg. Aug 26, 2003)</p></note></c06>
-<c06 level="file"><did><container type="box" label="Box">56</container><unittitle>Cognitive quantum computing, <unitdate type="inclusive">1992-2000</unitdate></unittitle></did></c06>
-<c06 level="file"><did><container type="box" label="Box">56</container><unittitle>Encryption, <unitdate type="inclusive">1998-2000</unitdate></unittitle></did></c06>
-<c06 level="file"><did><container type="box" label="Box">56</container><unittitle>History, <unitdate type="inclusive">undated</unitdate></unittitle></did></c06>
-<c06 level="file"><did><unittitle>Information binders</unittitle></did>
-<c07 level="file"><did><container type="box" label="Box">56</container><unittitle>Confidential, 1999(?)</unittitle></did></c07>
-<c07 level="file"><did><container type="box" label="Box">56</container><unittitle>Ovonic Cognitive Computer (OCC), <unitdate type="inclusive">2003</unitdate></unittitle></did></c07></c06>
-<c06 level="file"><did><unittitle>Meetings</unittitle></did>
-<c07 level="file"><did><container type="box" label="Box">56</container><unittitle>Logic devices -- 3-terminal devices, <unitdate type="inclusive">January 5, 2004</unitdate></unittitle></did></c07>
-<c07 level="file"><did><container type="box" label="Box">56</container><unittitle>M. Cohen, <unitdate type="inclusive">February 17, 2004</unitdate></unittitle></did></c07></c06>
-<c06 level="file"><did><container type="box" label="Box">56</container><unittitle>Miscellaneous, <unitdate type="inclusive">2004-2006</unitdate></unittitle></did></c06>
-<c06 level="file"><did><container type="box" label="Box">56</container><unittitle>Number of constant amplitude pulses </unittitle></did> <note><p>(added cog comp file, Sept 2003)</p></note></c06>
-<c06 level="file"><did><container type="box" label="Box">56</container><unittitle>Overheads, <unitdate type="inclusive">2002-2005</unitdate></unittitle></did></c06>
-<c06 level="file"><did><container type="box" label="Box">56</container><unittitle>Package to Intel, <unitdate type="inclusive">August 2003</unitdate></unittitle></did></c06>
-<c06 level="file"><did><container type="box" label="Box">56</container><unittitle>Presentations, <unitdate type="inclusive">2004-2007</unitdate></unittitle></did></c06>
-<c06 level="file"><did><unittitle>Proposals</unittitle></did>
-<c07 level="file"><did><container type="box" label="Box">56</container><unittitle>Business version, <unitdate type="inclusive">April 2005</unitdate></unittitle></did></c07>
-<c07 level="file"><did><container type="box" label="Box">56</container><unittitle>Conceptual plan, <unitdate type="inclusive">January 2006</unitdate></unittitle></did></c07>
-<c07 level="file"><did><container type="box" label="Box">56</container><unittitle>Revisions, <unitdate type="inclusive">February 2005</unitdate></unittitle></did></c07>
-<c07 level="file"><did><container type="box" label="Box">56</container><unittitle>Short, long, and Intel versions,  February and <unitdate type="inclusive">April 2005</unitdate></unittitle></did></c07></c06>
-<c06 level="file"><did><container type="box" label="Box">56</container><unittitle>SRO paper drafts, <unitdate type="inclusive">2003-2006</unitdate></unittitle></did></c06></c05>
-<c05 level="file"><did><container type="box" label="Box">56</container><unittitle>Press releases, <unitdate type="inclusive">2003-2008</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">94</container><unittitle>Sovonics</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">94</container><unittitle>Plant 11 opening video, <unitdate type="inclusive">May 31, 1984</unitdate> </unittitle> <physdesc><physfacet>U-matic videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">56</container><unittitle>Photovoltaic plant dedication ceremony, <unitdate type="inclusive">May 31, 1984</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">56</container><unittitle>Presentation slides, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">56</container><unittitle>Press release and patents, <unitdate type="inclusive">1985</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">88 </container><unittitle>"Power Where You Need It," <unitdate type="inclusive">March 29, 1986</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">56</container><unittitle>Recent application photographs, <unitdate type="inclusive">1988</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">56</container><unittitle>Report on solar technology, 1986(?)</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">56</container><unittitle>Status of Amorphous Silicon Alloy solar technology at ECD, <unitdate type="inclusive">1986</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">97</container><unittitle>Uni-Solar</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">97</container><unittitle>ASR Metal Roofing on HGTV, <unitdate type="inclusive">May 14, 1998</unitdate> </unittitle> <physdesc><physfacet>Betacam SP videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">56</container><unittitle>Business plan review, <unitdate type="inclusive">2005</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">56</container><unittitle>Inauguration forum schedule, <unitdate type="inclusive">June 24, 2002</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">56</container><unittitle>Information packet, <unitdate type="inclusive">2004</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">107</container><unittitle>Correspondence, <unitdate type="inclusive">November 1997</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">103</container><unittitle>Distribution and installation of Uni-Solar Unikits in Chiapas, Mexico, <unitdate type="inclusive">October 1994</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">95</container><unittitle>Installation of solar panels on the Mir space station, <unitdate type="inclusive">November 1998</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">56</container><unittitle>Management report, <unitdate type="inclusive">2007</unitdate> </unittitle> <physdesc><physfacet>includes Research and Development department</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">56</container><unittitle>Opening and groundbreaking, <unitdate type="inclusive">June 2002</unitdate> and <unitdate type="inclusive">July 14, 2005</unitdate></unittitle></did></c05>
-<c05 level="file"><did><physloc> Online </physloc><unittitle>Opening photographs, <unitdate type="inclusive">June 2002</unitdate> </unittitle> <physdesc><physfacet>.ZIP file</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116173" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c05>
-<c05 level="file"><did><container type="box" label="Box">88</container><unittitle>ECD/Uni-Solar Groundbreaking Ceremony and Plant Tour, produced <unitdate type="inclusive">August 16, 2005</unitdate> (video is also labeled  August 15, 2005) </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">88</container><unittitle>Samuel Bodman ECD/Uni-Solar speech, <unitdate type="inclusive">August 29, 2005</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><physloc> Online </physloc><unittitle>ECD Uni-Solar Groundbreaking film, <unitdate type="inclusive">July 14, 2005</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116137" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c05>
-<c05 level="file"><did><physloc> Online </physloc><unittitle>ECD Uni-Solar (Greenville, Michigan) press video and visit of President Bush, <unitdate type="inclusive">March 21, 2006</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116160" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c05>
-<c05 level="file"><did><physloc> Online </physloc><unittitle>ECD Uni-Solar Tour and History, <unitdate type="inclusive">July 5, 2010</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116146" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c05>
-<c05 level="file"><did><container type="box" label="Box">89</container><unittitle>ECD Mexico/Uni-Solar PVL training installation, dated <unitdate type="inclusive">June 3, 2002</unitdate> </unittitle> <physdesc><physfacet>Betacam SP videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">57</container><unittitle>Origin, <unitdate type="inclusive">1990-2001</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">57</container><unittitle>Reports, <unitdate type="inclusive">2010-2011</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">57</container><unittitle>Research and correspondence, <unitdate type="inclusive">1992-1995</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">57</container><unittitle>Research and development, <unitdate type="inclusive">2007-2008</unitdate> </unittitle> <physdesc><physfacet>and drift reduction results</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">57</container><unittitle>Shingle roofing products, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">57</container><unittitle>United Solar Sytems: "The Power to Change the World," <unitdate type="inclusive">February 11, 1998</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">95</container><unittitle>United Solar Systems, Inc., compilation reel, <unitdate type="inclusive">May 28, 1998</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05></c04></c03>
-<c03 level="item"><did><container type="box" label="Box">57</container><unittitle>Technical reports, <unitdate type="inclusive">1965-1966</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">57</container><unittitle>Technical reports, <unitdate type="inclusive">1970-1973</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">57</container><unittitle>Working files, <unitdate type="inclusive">1973-1984</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">57</container><unittitle>Working files and notes -- SRO, <unitdate type="inclusive">1971-1985</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">105</container><unittitle>Visit of Stan and Iris Ovshinsky, and "entourage" to Soviet Union, <unitdate type="inclusive">circa 1985-1986</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">104</container><unittitle>Visit of Russian delegation to ECD, <unitdate type="inclusive">January 1991</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">103</container><unittitle>Visit to Russia, <unitdate type="inclusive">July 1990</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03></c02>
-
-
-<c02 level="subseries"><did><unittitle>Institute for Amorphous Studies (IAS)</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">57</container><unittitle>Advisory Committee</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">57</container><unittitle>Committee member list, 1983(?)</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">57</container><unittitle>Committee member list and Institute history, <unitdate type="inclusive">September 1985</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">57</container><unittitle>Photographs of committee members, <unitdate type="inclusive">March 1984</unitdate> </unittitle></did> <note><p>(Contains negatives)</p></note></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">57</container><unittitle>APS satellite meeting, <unitdate type="inclusive">March 1984</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Board of Directors</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">57</container><unittitle>Board member list, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Meetings</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">58</container><unittitle><unitdate type="inclusive">January 4, 1984</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">58</container><unittitle><unitdate type="inclusive">January 3, 1986</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><unittitle>Minutes</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">58</container><unittitle><unitdate type="inclusive">January 1983</unitdate> and <unitdate type="inclusive">March 1984</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">58</container><unittitle><unitdate type="inclusive">January 1983-April 1984</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">58</container><unittitle><unitdate type="inclusive">August 1984-February 1985</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">58</container><unittitle><unitdate type="inclusive">January 1985</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">58</container><unittitle><unitdate type="inclusive">December 1986</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Photographs of board members, <unitdate type="inclusive">1984</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><unittitle>Brochures</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle><unitdate type="inclusive">1982-1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Photographs, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(Contains photographs, negatives, and slides)</p></note></c04></c03>
-<c03 level="file"><did><unittitle>Conferences</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>General information, <unitdate type="inclusive">1983</unitdate> and <unitdate type="inclusive">1985</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>International conference on the Theory of the Structures of Non-Crystalline Solids, <unitdate type="inclusive">1985</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><unittitle>Correspondence</unittitle></did>
-<c04 level="file"><did><unittitle>International topical conference on Transport and Defects in Amorphous Semiconductors (TODIAS)</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">58</container><unittitle>Journal of Non-Crystalline Solids, <unitdate type="inclusive">July 1984</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">58</container><unittitle>Lecture transcripts, <unitdate type="inclusive">March 1984</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">58</container><unittitle>Photographs, <unitdate type="inclusive">March 1984</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Advisory Committee, <unitdate type="inclusive">1984-1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Board of Directors, <unitdate type="inclusive">January 1983-November 1985</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Bogden, Al, <unitdate type="inclusive">August-September 1984</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Corporate communications,  November -- December 1984</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Events at the Institute, <unitdate type="inclusive">May 1982-November 1985</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Ito, Rik, <unitdate type="inclusive">January-September 1985</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Miscellaneous, <unitdate type="inclusive">March 1982-August 1984</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Ovonic Battery Company, <unitdate type="inclusive">March 1985</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Ovshinsky, Stanford,  January 1985-November1986 </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Schwartz, Brian, <unitdate type="inclusive">August 1984-May 1987</unitdate> </unittitle></did> <note><p>(Director)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Steele, Martin, <unitdate type="inclusive">October 1982-June 1984</unitdate> </unittitle></did> <note><p>(Director)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Requests for information, <unitdate type="inclusive">October 1984-September 1985</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><unittitle>Energy Conversion Devices (ECD)</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Corporate Values and Operating Principles, <unitdate type="inclusive">September 1985</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Miscellaneous typing done for ECD personnel, <unitdate type="inclusive">1984</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Project listings, <unitdate type="inclusive">January 1985-May 1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Rosenfield and Clevey</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">58</container><unittitle>Miscellaneous correspondence, <unitdate type="inclusive">November 1984-August 1985</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">58</container><unittitle>National Science Foundation science week, <unitdate type="inclusive">October 1984-March 1985</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">58</container><unittitle>Science and technology exhibit, <unitdate type="inclusive">November 1984-December 1985</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Small business innovation research proposals, <unitdate type="inclusive">October 1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Summer intern program, <unitdate type="inclusive">April-September 1985</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">58</container><unittitle>Events, <unitdate type="inclusive">January 1985-June 1986</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">58</container><unittitle>Financing, <unitdate type="inclusive">September 1984-February 1987</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">58</container><unittitle>Future programs, <unitdate type="inclusive">July-August 1985</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Inauguration, <unitdate type="inclusive">April 1982</unitdate></unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Attendance and Mott dinner party</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Photographs</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Press release</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Transcript of opening remarks</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">58</container><unittitle>Write-ups</unittitle></did></c04></c03>
-<c03 level="file"><did><unittitle>Institute for Amorphous Studies series</unittitle></did>
-<c04 level="file"><did><unittitle>Volume 1</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle>Correspondence with authors, <unitdate type="inclusive">July-November 1984</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle>Correspondence with board of directors, <unitdate type="inclusive">September 1984</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle>Correspondence with publisher and contract, <unitdate type="inclusive">June 1984-February 1985</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle>Dust jacket and cover, <unitdate type="inclusive">January-February 1985</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle>Index, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle>Proofs and permission for publication, <unitdate type="inclusive">June 1984-January 1985</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><unittitle>Volumes 2 &amp; 3</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle>Correspondence with publisher and contracts, <unitdate type="inclusive">November 1984-August 1985</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle>Mott, Nevill Festschrift, <unitdate type="inclusive">October 1985</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle>Schedule sheet, <unitdate type="inclusive">September 1984</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle>SRO paper, <unitdate type="inclusive">November 1984</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">59</container><unittitle>Future Volumes, <unitdate type="inclusive">January 1984-July 1985</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">59</container><unittitle>Institute photographs, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><extent>3 folders</extent></physdesc></did> <note><p>(Contains photographs and negatives)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">59</container><unittitle>Jordan College Energy Institute, <unitdate type="inclusive">1985</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Lecture series</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">59</container><unittitle>Abstracts, <unitdate type="inclusive">1982-1983</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Oversize">111   </container><unittitle>Announcement posters, <unitdate type="inclusive">1982-1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Oversize">112  </container><unittitle>Announcement posters, <unitdate type="inclusive">1989-2010</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Oversize">112</container><unittitle>Attendance lists, <unitdate type="inclusive">1982-1984</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Oversize">112 </container><unittitle>Correspondence miscellaneous, <unitdate type="inclusive">1984-1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Recorded lectures</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle> September 29, 1982--Adler, David, "Physics of Amorphous Semiconductors" </unittitle> <physdesc><physfacet>2 VHS videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle> October 14, 1982--Kastner, Mark </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle> December 8, 1982--Fritzsche, Hellmut, "Determination of the Density of States in Amorphous Semiconductors" </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle> December 20, 1982--Lucovsky, Gerald, "Vibrational Properties of Amorphous Solids--a) Elements and Compounds b) a-Si alloys" </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle> April 6, 1983--Pankove, Jacques </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle> September 28, 1983--Boolchand, Punit, "Massbauer Spectroscopy in Amorphous Semiconductors" </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle> October 24, 1983--Boolchand, Punit </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle> November 6, 1983--Zallen, Richard, "Percolation Theory: A Model for All Seasons" (tape has duplicate label reading Prof. Beinenstock) </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle>1984--Moustakas (likely Theodore) </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle> June 14, 1984--Goldstein, Bernard </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle> June 1984--Conrad, Michael </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle> July 11, 1984--Magar, Roger </unittitle> <physdesc><physfacet>U-matic videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle> July 26, 1984--Chakraverty, B.K. </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle>Cohen, Morrel, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle>Crandall, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle>Desmarteau, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle>Guha, Subhendu, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle>Henisch, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle>Taylor, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle>Thorpe, Michael, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">98</container><unittitle>Pankove, Jacques, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">99</container><unittitle> October 25, 1984--Cooper, Leon </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">99</container><unittitle> November 29, 1984--Twarog, Betty "Oxygen Deficiency Can Control the Form and Function of the Lung Circulation" </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">99</container><unittitle> December 6, 1984--Williamson, Samuel J., "Neuromagnetism Lecture" </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">99</container><unittitle> January 3, 1985--Moss, Si </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">99</container><unittitle> January 17, 1985--Loferski </unittitle> <physdesc><physfacet>U-matic videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">99</container><unittitle> February 28, 1985--Pohl </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">99</container><unittitle> March 6, 1985--"Atomic Comics" </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">99</container><unittitle> March 21, 1985--Tsu, Raphael </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">100</container><unittitle> April 11, 1985--Grieg </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">100</container><unittitle> April 19, 1985--Jean Bennett </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">100</container><unittitle> May 15, 1985--Greenler, Robert </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">100</container><unittitle> May 22, 1985--Schuller, Ivan </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">100</container><unittitle> June 13, 1985--Levanthal, Marvin, "Matter and Anti-Matter at the Center of the Milky Way Galaxy" </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">100</container><unittitle> September 20, 1985--Wilson, Robert Rathbun, "Art, Intuition, and Science" </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">100</container><unittitle> November 1, 1985--Pellier </unittitle> <physdesc><physfacet>U-matic videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">100</container><unittitle> November 22, 1985--Hoffmann, Roald, "Moving from Discrete Molecules to Extended Structures: A chemical and Theoretical Approach to Solid State" </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">101</container><unittitle> December 9, 1985--Hartman, Hy, "Spin Glasses, Clays, and the Origins of Life" </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">101</container><unittitle> January 6, 1986--Davis, Edward A., "21st Birthday of Amorphous Materials" </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">101</container><unittitle> January 17, 1986--Cronin, James, "Do the Macroscopic and Microscopic Assymetries [sic] Have the Same Origin?" </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">101</container><unittitle> February 21, 1986--Frankel, Richard, "Magnetic Navigation in Bacteria and Algae" </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">101</container><unittitle> March 4, 1986--Fitzpatrick, Nigel, "The Aluminum Air Battery" </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">101</container><unittitle> March 14, 1986--Schumaker, Bryan P., "Through History With Comet Halley" </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">101</container><unittitle> April 21, 1986--Pauling, Linus </unittitle> <physdesc><physfacet>U-matic videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">101</container><unittitle> April 28, 1986--Mott, Nevill, "The Mobility Edge Since 1969" </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">101</container><unittitle> June 10, 1986--Edgerton, Harold, "Strobe Lights and Their Use" </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">101</container><unittitle> June 20, 1986--Bell, James W., "Fuzzy Messages, Real Stuff, and the Denial of the Importance of Science and Technology at the Dawn of the Information Age" </unittitle> <physdesc><physfacet>U-matic videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">101</container><unittitle> August 1, 1986--Henke, Burton L. </unittitle> <physdesc><physfacet>U-matic videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">101</container><unittitle> September 3, 1986--Turnbull, David, "Phase Transitions and Metastability in Condensed Ge and Si" </unittitle> <physdesc><physfacet>U-matic videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">101</container><unittitle> October 8, 1986--Sze, Simon M., "Fundamental Limits of VSLI Devices" </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">101</container><unittitle> October 29, 1986--Henisch, Heinz K., "Photographic Pleasures" </unittitle> <physdesc><physfacet>U-matic videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">101</container><unittitle> November 19, 1986--Axelrod, Daniel, "Star Wars: Offense or Defense?" </unittitle> <physdesc><physfacet>U-matic videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">101</container><unittitle> December 3, 1986--Carroll, Robert G., "Cancer Detection and Treatment with Monoclonal Antibodies" </unittitle> <physdesc><physfacet>U-matic videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">102</container><unittitle> March 17, 1989--Adcock, Willis, "The Manufacturing Challenge" </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">102</container><unittitle> November 19, 1990--Weisskopf, Victor, "The Origin of the Universe" </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">102</container><unittitle> March 12, 1991--Hussain, Abid, "India and Its Energy Needs in the 1990s" </unittitle> <physdesc><physfacet>U-matic videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">102</container><unittitle> February 28, 1992--Fritzsche, Hellmut, "Science and Technology of Glasses" </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">102</container><unittitle> April 1, 1992--McNeill, William H., "Population and Modern History" </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">102</container><unittitle> January 19, 1996--Stempel, Robert C., "Personal Automotive Transportation: What is Ahead?" </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><physloc> Online </physloc><unittitle> April 17, 1998--Stanford Ovshinsky: David Adler Memorial Lecture </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116153" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c05>
-<c05 level="file"><did><container type="box" label="Box">102</container><unittitle> March 22, 2002--Kastner, Marc A., "The Single Electron Transistor and What It Can Tell Us About Molecular Electronics" </unittitle> <physdesc><physfacet>Betacam SP videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">102</container><unittitle> June 14, 2002--Kirchheim, Reiner, "The Next Generation Materials by Microstructural Design" </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">102</container><unittitle>Boolchand, Punit, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">102</container><unittitle>Lucovsky, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">102</container><unittitle>Revez,Akos,  <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">102</container><unittitle>Shiff, E., <unitdate type="inclusive">undated</unitdate> (videocassettes also labeled Dr. E Suatux) </unittitle> <physdesc><physfacet>2 U-matic videocassettes</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">102</container><unittitle>Silver, Marvin, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">102</container><unittitle>Tauc, Jan, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">59</container><unittitle>Schedules, <unitdate type="inclusive">1982-1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Speakers</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> October 25, 1984--Cooper, Leon</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> November 29, 1984--Twarog, Betty</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> December 6, 1984--Williamson, Samuel</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> January 3, 1985--Moss, Simon</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> January 17, 1985--Loferski, Joseph</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> February 20, 1985--Pankove, Jacques</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> February 28, 1985--Pohl, Herbert</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> March 6, 1985--Peave, Fran and Charlie Varon</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> March 21, 1985--Tsu, Raphael</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> April 9, 1985--Barna, P.B. </unittitle></did> <note><p>(Lecture at Maple)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> April 11, 1985--Greig, Dennis</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> April 19, 1985--Bennet, Jean</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> May 1, 1985--Schiff, Eric</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> May 15, 1985--Greenler, Robert</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> May 22, 1985--Schuler, Ivan</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> June 13, 1985--Leventhal, Marv</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> August 6, 1985--Spaepen, Frans</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> September 23, 1985--Wilson, Robert R. </unittitle></did> <note><p>(Contains photographs and negatives)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> October 10, 1985--Bachmann, Klaus</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> November 22, 1985--Hoffman, Roald </unittitle></did> <note><p>(Contains photographs and negatives)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> December 9, 1985--Hartman, Hy</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> January 6, 1986--Davis, Ted</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> January 17, 1986--Cronin, James </unittitle></did> <note><p>(Contains negatives)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> February 21, 1986--Frankel, Richard</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> March 6, 1986--Fitzpatrick, Nigel</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> March 7, 1986--Solomon, Peter R.</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> March 21, 1986--Schumaker, Bryan</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> April 21, 1986--Pauling, Linus</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> April 28, 1986--Mott, Sir Nevill </unittitle></did> <note><p>(Contains photographs)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> June 10, 1986--Edgerton, Harold "Doc"</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">59</container><unittitle> June 20, 1986--Bell, James</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">60</container><unittitle> July 7, 1986--Chidichimo, G.</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">60</container><unittitle> August 1, 1986--Henke, Burton L.</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">60</container><unittitle> September 3, 1986--Turnbull, David</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">60</container><unittitle> October 8, 1986--Sze, Simon M.</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">60</container><unittitle> October 29, 1986--Henisch, Heinz</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">60</container><unittitle> November 19, 1986--Axelrod, Daniel</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">60</container><unittitle> December 3, 1986--Carroll, Bob M.D</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">60</container><unittitle> March 17, 1989--Adcock, Willis</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">60</container><unittitle> November 19, 1990--Weisskopf, Victor </unittitle></did> <note><p>(Contains a photograph)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">60</container><unittitle> March 12, 1991--Hussein, Abid</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">60</container><unittitle> November 15, 1991--Salpeter, Edwin E.</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">60</container><unittitle> February 28, 1992--Fritzsche, Hellmut</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">60</container><unittitle> April 11, 1992--McNeill, William H.</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">60</container><unittitle> January 19, 1996--Stempel, Robert C. </unittitle></did> <note><p>(Contains photographs)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">60</container><unittitle> April 17, 1998--Ovshinsky, Stanford O. </unittitle></did> <note><p>(David Adler Memorial lecture)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">60</container><unittitle> March 22, 2002--Kastner, Marc</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">60</container><unittitle> June 14, 2002--Kirchheim, Reiner</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">60</container><unittitle> March 16, 2005--Bienenstock, Arthur  </unittitle></did> <note><p>(Contains cd copy of lecture brochure)</p></note></c05></c04></c03>
-<c03 level="item"><did><container type="box" label="Box">60</container><unittitle>Lectures, symposiums, and workshops,  March 1984-Janufary <unitdate type="inclusive">1988</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">60</container><unittitle>Letter of commendation for Martin Steele, <unitdate type="inclusive">May 1985</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">60</container><unittitle>Miscellaneous photograph negatives, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">60</container><unittitle>NATO Advanced Study Institute, <unitdate type="inclusive">August 1985-August 1986</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">60</container><unittitle>Newspaper clippings, <unitdate type="inclusive">August 1982-April 1987</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">60</container><unittitle>OvonicLink newsletter,  June 1983-Fall <unitdate type="inclusive">1986</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">60</container><unittitle>Ovshinsky award nominations, <unitdate type="inclusive">January-May 1986</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">60</container><unittitle>Seminar, Summer <unitdate type="inclusive">1982</unitdate> </unittitle></did> <note><p>(Contains photographs)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">94</container><unittitle>Seminar, <unitdate type="inclusive">March 22, 1984</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">94</container><unittitle>Seminar, <unitdate type="inclusive">March 23, 1984</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">60</container><unittitle>Short course: Physics, chemistry, and applications of amorphous semiconductors, <unitdate type="inclusive">May 1984</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><unittitle>Symposiums and Festschrifts</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">60</container><unittitle>Adler, David memorial symposium fund and obituary, <unitdate type="inclusive">May 1987-May 1989</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">60</container><unittitle>Fritzsche, Hellmut, <unitdate type="inclusive">February 1986-June 1987</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">60</container><unittitle>Henisch, Heinz, <unitdate type="inclusive">March-November 1987</unitdate> </unittitle></did> <note><p>(Contains photographs)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">60</container><unittitle>Mott, Nevill, <unitdate type="inclusive">January-February 1985</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">60</container><unittitle>Visitor register, <unitdate type="inclusive">March 2005-November 2010</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Workshops</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">60</container><unittitle>Localized States in Tetrahedrally Bonded Amorphous Solids, <unitdate type="inclusive">June 18-20, 1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">60</container><unittitle>Photovoltaic, <unitdate type="inclusive">August 24-25, 1985</unitdate> (2 folders of 3)</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">61</container><unittitle>Photovoltaic, <unitdate type="inclusive">August 24-25, 1985</unitdate> (folder 3 of 3)</unittitle></did></c04></c03>
-<c03 level="file"><did><unittitle>Written works</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">61</container><unittitle>Amorphous Semiconductor Handbook planning, <unitdate type="inclusive">1983-1984</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Conferences</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle>1970--IEEE-Palo Alto</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle> November 1984--International Photovoltaic Science and Engineering</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle> December 18, 1984--Nobel Laureate Symposium</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle>1985--Society of Vacuum Coaters</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle> April 1985--San Francisco</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle> May 1985--China</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle>1985-- June </unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle> October 25, 1985--IEEE Photovoltaic Specialists</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle> November 1985--Copenhagen</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle> January 1986--SPIE-Los Angeles</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle> March 1986--Macro-engineering, Washington D.C.</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle> August 1986--AIChE, Boston </unittitle></did> <note><p>(Contains photographs)</p></note></c05>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle><unitdate type="inclusive">September 15-20, 1986</unitdate>--Hungary</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle><unitdate type="inclusive">September 18-19, 1986</unitdate>--SPIE-Cambridge, Massachusetts</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle> October 1986--International New Materials-Osaka</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle> October 1986--European Photovoltaic Solar Energy-Spain</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle>1986--SPIE-New Delhi</unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">61</container><unittitle>Cosmology paper, <unitdate type="inclusive">July 8, 1985</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Oped</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle>"Is There an Evolutionary Brain?  The Physiology of Politics," <unitdate type="inclusive">January 1986</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle>"What is Realism?" <unitdate type="inclusive">August 3, 1986</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">61</container><unittitle> "U.S. and European Companies are Often Victims of Their Own Hubris," <unitdate type="inclusive">November 1985</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">61</container><unittitle>Papers by the ECD group, <unitdate type="inclusive">September 1985-1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">61</container><unittitle>SRO miscellaneous, <unitdate type="inclusive">September 1984-March 1986</unitdate></unittitle></did></c04></c03></c02></c01>
-
-
-
-<c01 level="series"><did><unittitle>Talks and Recognition</unittitle></did><scopecontent><p>The Talks and Recognition series (16.8 linear feet, 2 oversize boxes, and digital files; 1959-2011) includes mostly correspondence, Microsoft PowerPoint presentations, speech notes, and certificates from Stanford Ovshinsky's awards. Ovshinsky served as a keynote or invited speaker at a large number of college graduations and scientific conferences around the world, so this series contains many of these speeches and speech notes.  He did not limit himself to the high-profile stages of higher education and international scientific conferences, however: the series also includes notes documenting his visits to elementary and middle school classrooms. Materials from interviews given to media outlets ranging from local to international also appear, and rounding out this component of the series are presentations to shareholders and potential corporate partners. Included as well are details about awards that Ovshinsky received, ranging from numerous honorary university degrees and professional organization recognition to commendations of the ingenuity of his products and celebrations of his involvement in service groups. </p></scopecontent>
-
-
-<c02 level="subseries"><did><unittitle>Speeches and Talks</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">107</container><unittitle><unitdate type="inclusive">1959-1979</unitdate> (materials with gaps)</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">62</container><unittitle><unitdate type="inclusive">1967-1980</unitdate> </unittitle> <physdesc><extent>83 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">88 </container><unittitle>"Applications of Amorphous Semiconductors for Solar Energy Conversion,"  January 1980/Ovshinsky,  June 12, 1980/Energy Countdown </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">107</container><unittitle>Supplemental lectures and talks, <unitdate type="inclusive">1980</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">63</container><unittitle><unitdate type="inclusive">1981-1985</unitdate> </unittitle> <physdesc><extent>51 folders</extent></physdesc></did> <note><p>( May 26, 1983 -- AAAS Youth Symposium-photographs)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">88</container><unittitle>S.R. Ovshinsky, "New Technology and Peace," Birmingham Unitarian Church, <unitdate type="inclusive">January 13, 1985</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">94</container><unittitle>Ovshinsky at Grosse Pointe South High School Science Assembly, <unitdate type="inclusive">April 25, 1985</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">64</container><unittitle><unitdate type="inclusive">1985-1988</unitdate> </unittitle> <physdesc><extent>46 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">65</container><unittitle><unitdate type="inclusive">1988-1990</unitdate> </unittitle> <physdesc><extent>41 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">103</container><unittitle>Japanese Society of Detroit, <unitdate type="inclusive">June 6, 1988</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">103</container><unittitle>Ovshinsky, "Harnessing the Sun: New Technologies" at Fairfield University, <unitdate type="inclusive">October 11, 1988</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Oversize">112  </container><unittitle>"Harnessing the Sun" talk announcement poster, <unitdate type="inclusive">October 11, 1988</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">66</container><unittitle><unitdate type="inclusive">1990-1997</unitdate> </unittitle> <physdesc><extent>46 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">88</container><unittitle>SRO, Civic Forum, Akron, Ohio, <unitdate type="inclusive">January 21, 1992</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">95</container><unittitle>S.R. Ovshinsky, "How Can the Developing Countries Achieve Equality Through Alternative Energy," U.C. Berkeley, <unitdate type="inclusive">April 16, 1992</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">88</container><unittitle>S.R. Ovshinsky, Lawrence Technological University, <unitdate type="inclusive">May 4, 1992</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">88</container><unittitle>Stanford Ovshinsky, "A Nickel Hydride Battery for Electric Vehicles," MIT-EECS Colloquium, <unitdate type="inclusive">November 22, 1993</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">67</container><unittitle><unitdate type="inclusive">1997-2002</unitdate> </unittitle> <physdesc><extent>35 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">68</container><unittitle><unitdate type="inclusive">2002-2003</unitdate> </unittitle> <physdesc><extent>22 folders</extent></physdesc></did> <note><p>( October 15, 2002-EMCW Conference -- CD of papers from 1979-2002 sessions of the conference; March 6, 2003 -- SRO's Talk Hydrogen Conference -- CD of Proceedings and CD of Ovshinsky's presentation; March 10-11, 2003 -- EPCOS -- photographs and a CD; May 9, 2003 -- SRO seminar at Kettering -- CD Ovshinsky's presentation;  August 22, 2003--Hydrogen Prius event at Uni-Solar--text of Ovshinsky's talk; October 1-3, 2003 -- SRO Keynote at Colorado School of Engineering Conference -- CD presentation; October 27, 2003 -- Newcastle University -- CD presentation; MRS Fall 2003 -- Tutorial -- CD of tutorial slides, Ted Nara Japan, and MRS photos;  November 4, 2003--International Symposium on Optical Memory in  Nara, Japan--text of Ovshinsky's keynote speech)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">88</container><unittitle>Stan  Ovshinsky Japan Presentation Rough Cut, <unitdate type="inclusive">October 23, 2003</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">69</container><unittitle><unitdate type="inclusive">2004-2005</unitdate> </unittitle> <physdesc><extent>23 folders</extent></physdesc></did> <note><p>( April 22, 2004-SRO at Temple University -- CD presentation; June 2, 2004 -- SRO talk at WSU AET Conf -- CD presentation;September 21, 2004 -- Walker Cisler Memorial Lecture -- CD photograph;  October 19, 2004-Solar Power -- 2 CDs proceedings and presentation; November 8-12, 2004 -- Mexico Congress on Renewable Energy; November 8-12, 2004-- Intl. Non-Oxide Glass Symposium -- CD presentation;  January 11, 2005-Colloquium of Michigan Center For Theoretical Physics -- CD presentation; Feb 17,2005 -- Akron Roundtable)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">88</container><unittitle>Science Lecture for Young People at Detroit Country Day School, <unitdate type="inclusive">May 18, 2004</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>Prerecorded EPCOS <unitdate type="inclusive">2004</unitdate> greeting, <unitdate type="inclusive">August 17, 2004</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116133" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>Photographs from Walker Cisler Memorial Lecture,  September 21, 2004</unittitle> <physdesc><physfacet>.ZIP file</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116175" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>Mexico Congress on Renewable Energy presentation, <unitdate type="inclusive">November 2, 2004</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116148" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>"Akron Roundtable" on WKSU 89.7FM with Stanford Ovshinsky, <unitdate type="inclusive">February 17, 2005</unitdate> </unittitle> <physdesc><physfacet>.ZIP file</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116176" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03>
-<c03 level="file"><did><container type="box" label="Box">70</container><unittitle><unitdate type="inclusive">2005</unitdate> </unittitle> <physdesc><extent>16 folders</extent></physdesc></did> <note><p>( February 26, 2005 -- SRO at Quarterly Meeting of California Hydrogen Business Council -- CD PowerPoint presentation; April 3, 2005-- Swarthmore College-CD; April 12, 2005 -- Meeting with ECD board -- CD presentation; April 16, 2005 -- Annual NYU Entrepreneurship Conerence -- 2CDs proceedings and presentation; July 13-15, 2005 -- intl. Hydrogen  Energy Congress &amp; Exhibition -- 2CDs presentation and recording; September 3-6, 2005 -- EPCOS -- Photographs and CD presentation;  September 21, 2005-Renewables Conference -- 2CDs Rwanda Solar and presentation + video;  September 28, 2005-Global Market Trends Conference -- CD presentation;  November 30, 2005-MI COEJL Fall Gathering -- CD presentation)</p></note></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>NASDAQ Closing Bell Ceremony, <unitdate type="inclusive">March 30, 2005</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116130" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>Prerecorded presentation for IHEC Turkey, <unitdate type="inclusive">July 11, 2005</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116136" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03>
-<c03 level="file"><did><container type="box" label="Box">71</container><unittitle><unitdate type="inclusive">2006-2007</unitdate> </unittitle> <physdesc><extent>27 folders</extent></physdesc></did> <note><p>( April 27, 2006 -- SRO at ACCESS -- CD presentation; May 4, 2006 -- Colloquium in Honor of 80th birthday for Prof. Bower-CD;  June 7, 2006-SRO keynote at EMU spring lecture series-CD presentation;  November 17, 2006-panelist at Technology Transfer -- CD;  March 31, 2007-keynote at Illinois Institute of Technology -- CD)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">88 </container><unittitle>"Civic Forum of the Air" talk on alternative energy by Stanford Ovshinsky, <unitdate type="inclusive">April 28, 2006</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>Prerecorded presentation for Boer Symposium in Germany, <unitdate type="inclusive">May 5, 2006</unitdate> </unittitle>  <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116177" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao><note><p>(recorded  April 18, 2006)</p></note></did></c03>
-<c03 level="file"><did><container type="box" label="Box">72</container><unittitle><unitdate type="inclusive">2007-2009</unitdate> </unittitle> <physdesc><extent>16 folders</extent></physdesc></did> <note><p>( February 27-29, 2008 -- 1st International PV Power Generation Expo-DVD of talk;  April 8, 2008-Berkeley -- Photographs and 3 CDs; September 29, 2008 -- U.S. Mexico Workshop-Photograph book; October 2-3, 2008-Keynote at nanoTX USA-CD)</p></note></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>Photographs relating to Berkeley presentation, <unitdate type="inclusive">April 8, 2008</unitdate> </unittitle><dao href="http://hdl.handle.net/2027.42/116170" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03>
-<c03 level="file"><did><container type="box" label="Oversize">112   </container><unittitle>Announcement poster <unitdate type="inclusive">April 8, 2008</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">73</container><unittitle><unitdate type="inclusive">2009-2012</unitdate> </unittitle> <physdesc><extent>19 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>Presentation at the Ecology Center Annual Meeting in Ann Arbor, <unitdate type="inclusive">May 10, 2011</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116142" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>Presentation at the City Club of Cleveland, <unitdate type="inclusive">September 23, 2011</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116141" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03></c02>
-
-
-<c02 level="subseries"><did><unittitle>Interviews</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">74</container><unittitle><unitdate type="inclusive">1973-2011</unitdate> </unittitle> <physdesc><extent>16 folders</extent></physdesc></did> <note><p>(2010-2011-Miscellaneous -- unedited video; November 2010 &amp; May 2011 -- Radio WUPH)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">89</container><unittitle>Iris Ovshinsky, tape #23, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>audiocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">94</container><unittitle>Stan Ovshinsky, <unitdate type="inclusive">June 12, 1980</unitdate> PM Magazine on WJBK TV2 </unittitle> <physdesc><physfacet>U-matic videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">105</container><unittitle>Stan Ovshinsky and Nancy Bacon, Dow Jones Investor Network, <unitdate type="inclusive">June 29, 1995</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">95 </container><unittitle>"Energy Conversion Devices, Inc.," The International Corporate Forum, Dow Jones Investor Network, <unitdate type="inclusive">March 28, 1996</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">89</container><unittitle>Stan Ovshinsky, <unitdate type="inclusive">August 2, 2002</unitdate> </unittitle> <physdesc><physfacet>audiocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">89</container><unittitle>Stan Ovshinsky interview, <unitdate type="inclusive">August 17, 2004</unitdate> (name given on tape as Oshinski) </unittitle> <physdesc><physfacet>audiocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">89</container><unittitle>Stanford Ovshinsky, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>audiocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">89</container><unittitle>Stanford Ovshinsky, <unitdate type="inclusive">undated</unitdate> (name given on tape as Oshinski) </unittitle> <physdesc><physfacet> audiocassettes</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">89</container><unittitle>Stanford Ovshinsky, ECD interview, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>audiocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">89</container><unittitle>Stanford Ovshinsky/Ovonics, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>audiocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>"Nova: Japan's American Genius," PBS, <unitdate type="inclusive">October 27, 1987</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116155" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>Interview and profile on "City for Youth" on WTVS/WXYZ Detroit," <unitdate type="inclusive">January 24, 1994</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116152" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>Interview on "Anything is Possible" with Jack Krasula on WJR-AM 760, <unitdate type="inclusive">July 1, 2007</unitdate> (audio) </unittitle> <physdesc><physfacet>.ZIP file</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116169" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>Interview for "Electric and Hybrid Cars: A Tragic and Unnecessary Loss for the U.S," <unitdate type="inclusive">May 4, 2009</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116147" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03></c02>
-
-
-<c02 level="series"><did><unittitle>Recognition</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">75</container><unittitle>Awards, <unitdate type="inclusive">1968-2004</unitdate> </unittitle> <physdesc><extent>47 folders</extent></physdesc></did> <note><p>(1968-Diesel Gold Medal -- Photograph and German;July 1996 -- Crain's Michigan's Top 10 Superstocks -- Photograph; 2000-Heroes of Chemistry-Photographs)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">103</container><unittitle>Coors American Ingenuity Award, <unitdate type="inclusive">1988</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">105</container><unittitle>Corporate Leadership Awards (Wayne State University), Thursday, <unitdate type="inclusive">June 21, 2001</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">105</container><unittitle>Heroes of Chemistry, <unitdate type="inclusive">August 20, 2000</unitdate> </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">76</container><unittitle>Awards, <unitdate type="inclusive">2005-2011</unitdate> </unittitle> <physdesc><extent>21 folders</extent></physdesc></did> <note><p>( November 14-15, 2005-Economist Innovation Award-Sketch from front cover;  March 17, 2009-Awards receptions at APS-Photographs)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">77</container><unittitle>Awards, <unitdate type="inclusive">2012</unitdate> </unittitle> <physdesc><extent>22 folders</extent></physdesc></did> <note><p>(European Inventor Award -- Nomination folder 1 -- Photographs and CD; European Inventor Award -- Nomination folder 2-Photographs)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">77</container><unittitle>Festschrift for Stan Ovshinsky</unittitle> <physdesc><extent>3 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><unittitle>Honorary Degrees, <unitdate type="inclusive">1980-2010</unitdate> </unittitle></did> <note><p>( May 2010 -- University of Michigan -- Photographs include Ovshinsky with President Obama)</p></note>
-<c04 level="file"><did><physloc> Online </physloc><unittitle>Introduction to Stanford Ovshinsky played at New York Institute of Technology Commencement, <unitdate type="inclusive">May 18, 2008</unitdate> </unittitle> <physdesc><physfacet>video</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116138" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">77</container><unittitle>Miscellaneous diplomas and awards, <unitdate type="inclusive">1984-1990</unitdate></unittitle><physdesc><extent>1 folder</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Oversize">113  </container><unittitle>Oversize awards, <unitdate type="inclusive">1988-1999</unitdate> </unittitle></did> <note><p>(New York Institute of Technology -- Leadership and Sustainable Technology award; Karl Boer Solar Energy Award; photograph accepting an award)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Oversize">113  </container><unittitle>State government commendations, 1988-2006</unittitle></did> <note><p>(Honorary Citation from the State of Colorado; special recognition from Ohio House of Representatives on factory groundbreaking, )</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">102</container><unittitle>Workmen's Circle: Stan and Iris Ovshinsky video tribute </unittitle> <physdesc><physfacet>VHS videocassettes</physfacet></physdesc></did></c03></c02></c01>
-
-
-
-<c01 level="series"><did><unittitle>Visual Materials</unittitle></did><scopecontent><p>The Visual Materials series (10 linear feet and digital files; 1947-2008) consists primarily of printed photographs, and digital images.  The photographs depict ECD buildings, employees, and parties.  There are also pictures of trips Ovshynski took to places like Mexico and Japan, in addition to publicity photographs of Stan and  Iris Ovshinsky, and Robert Stempel.  Other photographs of note are those documenting the visits of prominent individuals to ECD and Ovshinsky's 70th and 80th birthday parties.  Ovshinsky sketched a great deal, and a sample of his drawings and doodles can also be found in this series. A few videos, largely produced by son Harvey's HKO Media, supplement the visual materials in this series. </p></scopecontent>
-<c02 level="file"><did><container type="box" label="Box">78</container><unittitle>Awards, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">78</container><unittitle>Board members annual meeting, <unitdate type="inclusive">December 19, 1995</unitdate></unittitle></did></c02>
-<c02 level="file"><did><unittitle>Companies</unittitle></did>
-<c03 level="file"><did><unittitle>ECD</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Annual report, <unitdate type="inclusive">1973</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Drafting department, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Electrochemistry division, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><physloc> Online </physloc><unittitle>Family summer outing, <unitdate type="inclusive">August 5, 2001</unitdate> </unittitle><dao href="http://hdl.handle.net/2027.42/116174" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>General structures lab, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(with John Tyler)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Historic moments, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Holiday party at DIA, <unitdate type="inclusive">1985-1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Honda signing, <unitdate type="inclusive">1996</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Interior and exterior, <unitdate type="inclusive">September 1965</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Machine shops, 1984(?)</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Open house, <unitdate type="inclusive">August 1981</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Original building, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Patent department, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Plant 1</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">78</container><unittitle>Headquarters and development facilities, <unitdate type="inclusive">1982</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">78</container><unittitle>Photovoltaics lab, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(with Czubatyj)</p></note></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Plant 2 -- Ovonic photovoltaic pilot plant, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Plant 3 -- Advanced materials lab and model shop -- Lake Angelus Observatory Conference and Seminar Center, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Plant 4 -- Hyrdorgen -- Electrochemsitry Development Facility, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(Barrett Street)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Plant 5 -- Wet Chemistry Photovoltaic Etching, <unitdate type="inclusive">1981</unitdate> </unittitle></did> <note><p>(Edwards Street)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Plant 7, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(Heide Street)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Plant 8, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(Premier Street)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Plant 10 -- Ovonic Battery Company production facility, <unitdate type="inclusive">1985-1988</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Plant 11</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">78</container><unittitle>Sovonics,  July 1984(?)</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">78</container><unittitle>Coating Division facility, <unitdate type="inclusive">1984</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">78</container><unittitle>Dedication, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Plant 12 -- Legal, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Plant 14 -- Ovonic Synthetic Materials Company, <unitdate type="inclusive">December 1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Plant Japan -- Thermovonics</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">78</container><unittitle><unitdate type="inclusive">Undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">78</container><unittitle><unitdate type="inclusive">1985</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Plant New Jersey, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">87</container><unittitle>Plant New Jersey open house, <unitdate type="inclusive">1981</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>President's Letter, <unitdate type="inclusive">1995</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">78</container><unittitle>Support facilities, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">78</container><unittitle>Erricson Telephone signing, <unitdate type="inclusive">1963</unitdate> </unittitle></did> <note><p>(Sweden)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">78</container><unittitle>EV Global signing, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">78</container><unittitle>Fuji Film signing, <unitdate type="inclusive">1970s</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">78</container><unittitle>GM Ovonic, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">78</container><unittitle>Hupp Motor Company -- Electric power steering, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">78</container><unittitle>Hupp Motor Company, Stanford Roberts, New Britain, <unitdate type="inclusive">1947-1950</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">79</container><unittitle>Logos, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">79</container><unittitle>Logo animation </unittitle> <physdesc><physfacet>VHS videocassette</physfacet></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">79</container><unittitle>Ovitron, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Ovonic Battery Company</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">79</container><unittitle>GM signing, <unitdate type="inclusive">1994</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">79</container><unittitle>Tour de Sol, <unitdate type="inclusive">1995-1996</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">79</container><unittitle>Ovonic Display Systems -- production facility, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">79</container><unittitle>Ovonic Memories Inc. -- Stan Ovshinsky, Al Adomines, and Jack Evans, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">79</container><unittitle>Ovonic Solar, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">79</container><unittitle>Ovonic Thermoelectric Company, <unitdate type="inclusive">November 1983</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">79</container><unittitle>Personnel with equipment, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Sharp-ECD Solar, Inc.,</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">79</container><unittitle><unitdate type="inclusive">January-February 1983</unitdate> </unittitle></did> <note><p>(Japan)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">79</container><unittitle>Signing original agreement, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">79</container><unittitle>Sovlux Battery, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">79</container><unittitle>Sovlux plant, 1991(?)</unittitle></did></c03>
-<c03 level="file"><did><unittitle>Sovonics</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">79</container><unittitle>Plant, <unitdate type="inclusive">1988</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">79</container><unittitle>Plant dedication</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">79</container><unittitle>n, <unitdate type="inclusive">May 31, 1984</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">79</container><unittitle>Town hall meeting, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">79</container><unittitle>Underhill signing, <unitdate type="inclusive">July 1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">79</container><unittitle>USSC plant, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">79</container><unittitle>Stanford Roberts Manufacturing Co. -- New Britain machine,  <unitdate type="inclusive">1949-1954(?)</unitdate></unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">79</container><unittitle>Suryovoics,  February 1990(?) </unittitle></did> <note><p>(India)</p></note></c03>
-<c03 level="file"><did><unittitle>Texaco-Ovonic Fuel Cell Company</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">79</container><unittitle><unitdate type="inclusive">Undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">79</container><unittitle>Groundbreaking and Cobasys grand opening, <unitdate type="inclusive">2002</unitdate> and <unitdate type="inclusive">2005</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">79</container><unittitle>Tour for Summer employees, <unitdate type="inclusive">1985</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Uni-Solar</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">79</container><unittitle>Greenville, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">79</container><unittitle>Mexico, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">80</container><unittitle>Visitors</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">80</container><unittitle>British House of Commons delegation, <unitdate type="inclusive">1981</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">80</container><unittitle>Carr, Ray, <unitdate type="inclusive">March 6, 1995</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">80</container><unittitle>Department of Energy, <unitdate type="inclusive">January 1985</unitdate> </unittitle></did> <note><p>(ECD and Sovonics Solar)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">80</container><unittitle>Japanese sunshine study group, <unitdate type="inclusive">March 1984</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">80</container><unittitle>Mott, Sir Nevill, <unitdate type="inclusive">March 1978</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">80</container><unittitle>Secretary of Energy -- Spence Abraham, <unitdate type="inclusive">August 2002</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">80</container><unittitle>Secretary of Energy -- Bodman visits solar plant, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">80</container><unittitle>Senator Simon, <unitdate type="inclusive">March 6, 1995</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">80</container><unittitle>Shanghai Ceramics Institute, <unitdate type="inclusive">May 1984</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">80</container><unittitle>Teller, E., <unitdate type="inclusive">October 8, 1984</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">80</container><unittitle>Young, Coleman, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04></c03></c02>
-<c02 level="file"><did><unittitle>Conferences</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">80</container><unittitle>Institute of Amorphous Studies -- opening ceremony, <unitdate type="inclusive">June 1985</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">80</container><unittitle>International conference on the Theory of the Structures of Non-Crystalline solids, <unitdate type="inclusive">June 1985</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">80</container><unittitle>SPIE -- Los Angeles, <unitdate type="inclusive">August 1985</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">80</container><unittitle>United States Advanced Battery Consortium, <unitdate type="inclusive">1992</unitdate></unittitle></did></c03></c02>
-<c02 level="file"><did><container type="box" label="Box">80</container><unittitle>Corporate Leadership Award, <unitdate type="inclusive">2001</unitdate></unittitle></did></c02>
-<c02 level="file"><did><unittitle>Early Stan Ovshinsky</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">80</container><unittitle><unitdate type="inclusive">1967</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">80</container><unittitle>Bump chart, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">80</container><unittitle>Hydrogen, <unitdate type="inclusive">1964</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">80</container><unittitle>Labs, <unitdate type="inclusive">1970-1997</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">80</container><unittitle>Labs -- Ovonic Memory Switch, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">80</container><unittitle>Life magazine, <unitdate type="inclusive">1969</unitdate> </unittitle></did> <note><p>(with Iris Ovshinsky)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">80</container><unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">80</container><unittitle>Ovonic Switching -- pipe cleaner model, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03></c02>
-<c02 level="file"><did><container type="box" label="Box">80</container><unittitle>Electoluminsecent imaging, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">80</container><unittitle>England -- House of Parliament, <unitdate type="inclusive">1977</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">80</container><unittitle>Equipment, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">80</container><unittitle>Equipment -- miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><unittitle>Events</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">80</container><unittitle>Institute for Amorphous Studies, <unitdate type="inclusive">March 1984</unitdate> -- <unitdate type="inclusive">June 1985</unitdate> </unittitle></did> <note><p>(TADIAS conference, Stan and Iris Ovshinsky anniversary)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">80</container><unittitle>Reception for Ray Tsu, <unitdate type="inclusive">April 1985</unitdate></unittitle></did></c03></c02>
-<c02 level="file"><did><container type="box" label="Box">80</container><unittitle>Hydrogen research, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">80</container><unittitle>Institute for Amorphous Studies -- Lectures, <unitdate type="inclusive">1986</unitdate></unittitle></did></c02>
-<c02 level="file"><did><unittitle>Japan</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">80</container><unittitle>Fuji Film visit(?), 1971(?)</unittitle></did></c03>
-<c03 level="file"><did><unittitle>Lectures</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">80</container><unittitle>Sponsored by Nihon Keizai Shinbun, <unitdate type="inclusive">January 31, 1978</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">81</container><unittitle>Nikkei Science, <unitdate type="inclusive">February 3, 1986</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Rightsholder, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03></c02>
-<c02 level="file"><did><container type="box" label="Box">87</container><unittitle>Machines</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">87</container><unittitle>3 Megawatt machine</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Big VEECO, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(tool coating)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Continuous Deposition Plasma Processor, <unitdate type="inclusive">April 1987</unitdate> </unittitle></did> <note><p>(Herb's machine)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Microwave plasma deposition machine, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Molecular beam epitaxy system and ion beam implanter, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(Includes class 60 clean room)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Plant 5A -- Transmission electron microscope, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Plant 11, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>PV stitching machine, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>SESI, <unitdate type="inclusive">1982</unitdate> </unittitle></did> <note><p>(Sharp-ECD, Inc.. Japan)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Tandem II-A, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>PV cell continuous roll-to-roll tandem processor, <unitdate type="inclusive">August 1982</unitdate> </unittitle></did> <note><p>(1st commercial, shipped to Sharp-ECD, Inc.)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>PV continuous roll-to-roll, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(3rd generation, under construction)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>PV cell processor, 2nd generation multi-chamber research scale shipped to Sharp-ECD, Inc., <unitdate type="inclusive">August 1982</unitdate> </unittitle></did> <note><p>(1st generation shipped 1980)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>PV large area PIN processor modules, <unitdate type="inclusive">June 1980</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>PV processor-sequential stationary deposition, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>PV transparent electrode processor, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>PV TRAIN machine, <unitdate type="inclusive">November 1986</unitdate> </unittitle></did> <note><p>(Plant 2)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Vacuum deposition machine, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03></c02>
-<c02 level="file"><did><container type="box" label="Box">81</container><unittitle>Maeda lunch and reception, <unitdate type="inclusive">May 17, 1984</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">81</container><unittitle>Magnet ball controls -- switches, relays, proximity and limit switches, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">81</container><unittitle>Melt spinning, <unitdate type="inclusive">1985-1986</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">81</container><unittitle>Mexico, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">81</container><unittitle>Microelectronics -- memory, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">81</container><unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><extent>4 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">81</container><unittitle>Miscellaneous negatives, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">81</container><unittitle>Miscellaneous -- solar, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><unittitle>Models</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Builders, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Conformational changes without bond breaking, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Threshold switching and memory, <unitdate type="inclusive">September 1984</unitdate></unittitle></did></c03></c02>
-<c02 level="file"><did><container type="box" label="Box">81</container><unittitle>Oxide, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><unittitle>People</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Adler, David, <unitdate type="inclusive">1983</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Acquaintances, friends, and family, 1963-?</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Bacon, Nancy, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Birkenstock, James W., <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Canella, Vin, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Chen, J.T., <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Cohen, Morrel H., <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Consultants, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Conway, Jack, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Cummings, Richard H., <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Czubatyj, Wally, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>De Neufville, John, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>ECD -- Wright, Neal, Nelson, Flemming, Fogen, Sie, Helbers,  <unitdate type="inclusive">March 1969</unitdate></unittitle></did></c03>
-
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>ECD personnel, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Ervin, Christine, <unitdate type="inclusive">January 1994</unitdate> </unittitle></did> <note><p>(Stan Ovshinsky with Christine at US Department of Energy news conference)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Flasck, Dick, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Goldstein, Alex, <unitdate type="inclusive">1988</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Guha, Subhendu, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Hack, Michael, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Hanak, Joe, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Harwood, Julius, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(President of Ovonic Synthetic Material Co.)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Himelfarb, Alan M., <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(President and COO of EV Global Motors)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Hudgens, Stephen, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(Vice-President of Research and Development at ECD)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Iris Ovshinsky, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Iris Ovshinsky, Klose, and Chang, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Ito, Momoko, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Izu, Masa, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Johnson, Robert, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Kvant with Gorbachev, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Keem, John, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Leach, Robert, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Livesay, Alastar, <unitdate type="inclusive">2001</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Mahr, Sam and Brenda Walton, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Marquart, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Metzger, James, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Nadorov, Ovshinsky, Leach, and others -- KVANT, <unitdate type="inclusive">April 26, 1990</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Ohta, Ted, <unitdate type="inclusive">2003</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Mott, Sir Nevill</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">81</container><unittitle>Institute lecture, <unitdate type="inclusive">April 28, 1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">81</container><unittitle>Signing book, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>O'Leary, Hazel, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Powell, Max, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Pryor, Roger, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">81</container><unittitle>Rabi, Isidor, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Oversize">110  </container><unittitle>Rabi, Isidor, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Reischauer, Edwin, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Schaeffer, Isaac, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Oversize">110</container><unittitle>Seder, Art, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Silver, Marvin, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(Co-author of Disordered Materials)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Stan Ovshinsky's parents-Ben and Bertha, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Stempel, Robert, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Synes, Stanley, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Tech and production brochure, <unitdate type="inclusive">1999</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Trebilcott, James, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Vining, Richard A., <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Rosa Ovshinsky, <unitdate type="inclusive">December 2008</unitdate> </unittitle></did> <note><p>(Cambodia)</p></note></c03></c02>
-<c02 level="file"><did><unittitle>Products</unittitle></did>
-<c03 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Auto show and racing, <unitdate type="inclusive">1990-1995</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Battery</unittitle></did>
-<c04 level="file"><did><container type="box" label="Oversize">110</container><unittitle>Batteries, 1989-2000(?)</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Electric scooters, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Electric vehicles, 1993-1995(?)</unittitle></did></c04>
-<c04 level="file"><did><unittitle>GM</unittitle></did>
-<c05 level="file"><did><container type="box" label="Oversize">110</container><unittitle>Impact -- car, <unitdate type="inclusive">1994</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Ovonic II -- cell and family of batteries, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Ovonic module, <unitdate type="inclusive">1998</unitdate> </unittitle></did> <note><p>(used for 1998 Detroit Auto Show)</p></note></c05></c04>
-<c04 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Honda, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Manufacturing process, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>NiMH licensees, <unitdate type="inclusive">1994</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><unittitle>Coatings</unittitle></did>
-<c04 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Coated vs. uncoated, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Oversize">110 </container><unittitle>Drills,  March 1983(?)</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Southwall PECVD production machine, <unitdate type="inclusive">January 2000</unitdate> </unittitle></did> <note><p>(high-speed microwave)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Tool applications, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Transparent plastic, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(glass hard surface)</p></note></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">83</container><unittitle>EAROM (Electronically alterable read-only memory) array, <unitdate type="inclusive">1024</unitdate> bit </unittitle></did> <note><p>(negatives)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">83</container><unittitle>Electronic Info. Processor, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(with Gazaleh)</p></note></c03>
-<c03 level="file"><did><unittitle>Electrophotography</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>1985(?)</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Canon machine, <unitdate type="inclusive">April 1986</unitdate> </unittitle></did> <note><p>(Plant 16)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Test piece -- Canon, <unitdate type="inclusive">May 1986</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><unittitle>Film</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Microfilm, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Non-silver photo duplication, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(TEBAC with Wozie?)</p></note></c04></c03>
-<c03 level="file"><did><unittitle>Hydrogen</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Car,  March 1999(?)</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Corrosion testing, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Energy system process, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Engine, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Engine demo, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Fuel cell, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Heat pump, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">83</container><unittitle>Microvonic File, <unitdate type="inclusive">1981-1985</unitdate> </unittitle></did> <note><p>(with Freya Saito)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">83</container><unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>N-Gen</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Microelectronics cleanroom, <unitdate type="inclusive">1985</unitdate> </unittitle></did> <note><p>(computer project, with Roger Pryor)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Smart card, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">83</container><unittitle>Old ECD, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Optical Memory</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>EEPROM, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Toray phasewriter, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">83</container><unittitle>Ovonic Design Systems -- touch sensitive input, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Ovonic Imaging Systems</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>2D imager, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Data encoding bar, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Factory of the future, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Flat panel display, 1986-1987(?)</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Laptop, <unitdate type="inclusive">1988</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Office automation, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Ovonic imager, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">83</container><unittitle>Oxygen sensors for exhaust system, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">83</container><unittitle>Quartet white copyboard and linear array scanner, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">83</container><unittitle>RMM, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">83</container><unittitle>Scanning Electron Microscope (SEM), <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Solar</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Amorphous vs. crystalline -- bullet, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Calculator, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Car rooftop, 1986(?)</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Cells, 1984(?)</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">83</container><unittitle>Continuous roll, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Crystalline cells, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Crystalline cells-ARCO, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Crystalline cells to Japan, <unitdate type="inclusive">August 1984</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Solar electric module, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Electric vehicle charging station, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Equipment, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Fishing buoy -- Nippon Steel, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Flexible cell with bullet hole and broken glass cell, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Hawaii, 1989-1990(?)</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>India, 1991(?)</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>ITO machine, <unitdate type="inclusive">January 1985</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Lamp posts, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Machines</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">84</container><unittitle>Metalizer, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">84</container><unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><extent>3 folders</extent></physdesc></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Manufacturing plant -- <unitdate type="inclusive">1000</unitdate> sq. ft., <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Marketing, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Mexico, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><extent>3 folders</extent></physdesc></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Modules, 1986(?)</unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Ovation -- car, <unitdate type="inclusive">May-August, 1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Panels, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Panel mounting comparison, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Panels -- PV International, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Panels -- USSC roof shingles being packed go to Olympic village in Atlanta, <unitdate type="inclusive">1996</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>PV canon drum machine, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>PV cell PCU 800, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Photovoltaic plant pilot -- ECD and ARCO joint development, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Photovoltaic processor</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">84</container><unittitle><unitdate type="inclusive">1982-1984</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">84</container><unittitle>In production, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">84</container><unittitle>Under construction-Sovonics, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">84</container><unittitle>Photovoltaic production, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>Pilot plant, <unitdate type="inclusive">1981</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>Roof shingle and fan, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>Sovonics beach bag, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>Spain-irrigation, <unitdate type="inclusive">1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Sunpal</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">85</container><unittitle>Battery, radio, <unitdate type="inclusive">August 1986</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">85</container><unittitle>Boat, RV, car, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">85</container><unittitle>Camping, beach, fishing, mountains, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>Thin substrate, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(with Joe Hanak)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>Transparent electrode material, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Ultralight</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">85</container><unittitle>MA series, <unitdate type="inclusive">1987-1988</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">85</container><unittitle>Stan Ovshinsky, Joe Hanak, and Pat Dahlin, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">85</container><unittitle>United Solar, <unitdate type="inclusive">undated</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>Video camera, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>Vietnam, <unitdate type="inclusive">1995</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>Warning flasher, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Thermoelectric, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Thermoelectric -- OTEG generator, 1981-1986(?)</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Thermoelectric -- TE device with gasoline engine and wood stove, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>X-ray optics</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>Clean room, <unitdate type="inclusive">June 1986</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>Device elements and mirrors, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>Phillips spectrometer, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>Reflector, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04></c03></c02>
-<c02 level="file"><did><container type="box" label="Box">85</container><unittitle>Rapid solidification, <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(with Dick Clayton)</p></note></c02>
-<c02 level="file"><did><unittitle>Russia</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Delegation, <unitdate type="inclusive">April-May 1990</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Embassy -- scooter and Vice President Gore, 1997(?)</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>KVANT -- Moscow, <unitdate type="inclusive">January 1990</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03></c02>
-<c02 level="file"><did><unittitle>Shareholders Meeting</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle><unitdate type="inclusive">1992</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle><unitdate type="inclusive">April 1995</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle><unitdate type="inclusive">1985-1986</unitdate></unittitle></did></c03></c02>
-<c02 level="file"><did><unittitle>Shows</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>AFL-CIO Union Industries, <unitdate type="inclusive">May 1995</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Auto-Chicago, <unitdate type="inclusive">1998</unitdate></unittitle></did></c03>
-<c03 level="file"><did><unittitle>Trade</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>Cobo Hall, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>GM Ovonic battery display, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>IEEE PV conference, <unitdate type="inclusive">1984</unitdate> </unittitle></did> <note><p>(Sovonics)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>National Hardware, <unitdate type="inclusive">1985</unitdate> </unittitle></did> <note><p>(Chicago, Sovonics sunpak)</p></note></c04></c03></c02>
-<c02 level="file"><did><container type="box" label="Box">85</container><unittitle>Smithsonian </unittitle></did> <note><p>(Ovonic Tech Company chart, Ovshinsky's University of Michigan honorary degree)</p></note></c02>
-<c02 level="file"><did><container type="box" label="Box">85</container><unittitle>Solar Corona eclipse, <unitdate type="inclusive">May 28, 1900</unitdate></unittitle></did></c02>
-<c02 level="file"><did><unittitle>Ovshinsky</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>80th Birthday, <unitdate type="inclusive">2002</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">87</container><unittitle>70th Birthday photo album, <unitdate type="inclusive">1992</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Contents of Ovshinsky's photo album, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Drawings, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Drawings -- Ovshinsky's Fans publication, <unitdate type="inclusive">1982</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Fritzsche, Hellmut, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Machine shop, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Products</unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Oakland press, <unitdate type="inclusive">November 1985</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Leach, Ralph F., <unitdate type="inclusive">undated</unitdate> </unittitle></did> <note><p>(Board member)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Madan, Aran, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Oversize">110  </container><unittitle>Nagashima and Ovshinsky, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Products</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>Optical disk, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04>
-<c04 level="file"><did><container type="box" label="Box">85</container><unittitle>Solar panel -- Japan, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04></c03>
-<c03 level="file"><did><container type="box" label="Box">85</container><unittitle>Parks, Rosa Ovshinsky, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">86</container><unittitle>Promotional, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">86</container><unittitle>Publicity photos, <unitdate type="inclusive">1992-2000</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">86</container><unittitle>Recent, <unitdate type="inclusive">2005-2010</unitdate> </unittitle></did> <note><p>(2 CDs)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">86</container><unittitle>Rosa Ovshinsky, Dr. and Mrs. Ohta in Kyoto, <unitdate type="inclusive">July 2008</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">86</container><unittitle>Umene, Mr. and Mrs. --NSC, <unitdate type="inclusive">October 1985</unitdate></unittitle></did></c03></c02>
-<c02 level="file"><did><unittitle>Stan and Iris Ovshinsky</unittitle></did>
-<c03 level="file"><did><container type="box" label="Box">86</container><unittitle>Anniversary party -- surprise, <unitdate type="inclusive">1984</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">86</container><unittitle>Bio photos, <unitdate type="inclusive">2000</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">86</container><unittitle>Christmas and holiday cards, <unitdate type="inclusive">1969-1985</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">86</container><unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><physloc> Online </physloc><unittitle>Miscellaneous photographs for Notre Dame book, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><physfacet>.ZIP file</physfacet></physdesc><dao href="http://hdl.handle.net/2027.42/116140" show="new" actuate="onrequest"><daodesc><p>[download item]</p></daodesc></dao></did></c03>
-<c03 level="file"><did><container type="box" label="Box">86</container><unittitle>Pauling, Linus, <unitdate type="inclusive">undated</unitdate></unittitle></did></c03>
-<c03 level="file"><did><container type="box" label="Box">86</container><unittitle>Powell, Colin, <unitdate type="inclusive">2000</unitdate> </unittitle></did> <note><p>(Troy, MI, Heroes of Chemistry)</p></note></c03>
-<c03 level="file"><did><container type="box" label="Box">86</container><unittitle>Promotional, <unitdate type="inclusive">undated</unitdate> </unittitle> <physdesc><extent>3 folders</extent></physdesc></did></c03>
-<c03 level="file"><did><container type="box" label="Box">86</container><unittitle>Promotional with Stempel, <unitdate type="inclusive">February 3, 1998</unitdate> </unittitle></did> <note><p>(by Eric Smith)</p></note></c03>
-<c03 level="file"><did><unittitle>Trips</unittitle></did>
-<c04 level="file"><did><container type="box" label="Box">86</container><unittitle>Caracas, <unitdate type="inclusive">July 1982</unitdate> </unittitle></did> <note><p>(with R. Calloratti and Paul Gray of MIT)</p></note></c04>
-<c04 level="file"><did><container type="box" label="Box">86</container><unittitle>China, <unitdate type="inclusive">September 1984</unitdate></unittitle></did></c04>
-<c04 level="file"><did><unittitle>Japan</unittitle></did>
-<c05 level="file"><did><container type="box" label="Box">86</container><unittitle> August 1983(?)</unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">86</container><unittitle><unitdate type="inclusive">February 1986</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">86</container><unittitle>Kobe conference, <unitdate type="inclusive">November 1984</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">86</container><unittitle>Kyoto Nobel lecture, <unitdate type="inclusive">June 1986</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">86</container><unittitle>Meeting with NTT, <unitdate type="inclusive">April 1985</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">87</container><unittitle>Samsung, <unitdate type="inclusive">March 1990</unitdate> </unittitle> <physdesc><extent>2 volumes</extent></physdesc></did></c05>
-<c05 level="file"><did><container type="box" label="Box">86</container><unittitle>YKK, <unitdate type="inclusive">January 1986</unitdate></unittitle></did></c05>
-<c05 level="file"><did><container type="box" label="Box">86</container><unittitle>Yoshida Kogyo K.K., <unitdate type="inclusive">January 1986</unitdate></unittitle></did></c05></c04>
-<c04 level="file"><did><container type="box" label="Box">86</container><unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle></did></c04></c03></c02>
-<c02 level="file"><did><container type="box" label="Box">86</container><unittitle>Stan and Rosa Ovshinsky -- UC Berkeley Review photo shoot, <unitdate type="inclusive">2008</unitdate> </unittitle></did> <note><p>( CD of photos)</p></note></c02>
-<c02 level="file"><did><container type="box" label="Box">86</container><unittitle>Superconductivity -- Rosa Ovshinsky with Squid machine, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">86</container><unittitle>Switching, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">86</container><unittitle>Transistors, <unitdate type="inclusive">undated</unitdate></unittitle></did></c02></c01>
-
-
-
-<c01 level="series"><did><unittitle>Lake Angelus Observatory</unittitle></did><scopecontent><p>The Lake Angelus Observatory series (0.4 linear feet; 1938-1980) consists of miscellaneous records from the Hulbert-McMath Observatory in Lake Angelus, Michigan. Included are photographs of the facility, a 1967 newsletter, and guest books containing signatures of visitors from 1938 through 1980.</p></scopecontent>
-<c02 level="file"><did><container type="box" label="Box">108</container><unittitle>Guest books, <unitdate type="inclusive">1938-1980</unitdate> (3 books)</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">108</container><unittitle>Newsletter, <unitdate type="inclusive">1967</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">108</container><unittitle>Photographs, circa <unitdate type="inclusive">1940</unitdate></unittitle></did></c02></c01>
- 
-
-</dsc>
-
-<descgrp type="add"><relatedmaterial><head>Related material</head>
-<p>Researchers interested in Michigan inventors and inventions, in applied physical sciences, and in technological development in the state, especially as it pertains to industry, may wish to consult the following collections held by the Bentley Historical Library: 
-<list type="simple">
-
-<item>	<title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-851144" show="new" actuate="onrequest">Marston Bates papers</title></item>
-
- <item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-2014075" actuate="onrequest" show="new">Clark J. Charnetski papers</title></item>
- 
- <item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-07126" show="new" actuate="onrequest">Thomas M. Donahue papers</title></item>
- 
- <item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-9740" show="new" actuate="onrequest">Industrial Development Division (University of Michigan) records</title></item>
- 
- <item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-9445" show="new" actuate="onrequest">Inventors Council of Michigan records</title></item>
- 
- <item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-85220" show="new" actuate="onrequest">Russell V. Judson papers</title></item>
- 
- <item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-85254" actuate="onrequest" show="new">Eugene H. Leslie papers</title></item>
- 
- <item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-85254" show="new" actuate="onrequest">Michigan Technology Council records</title></item>
- 
-<item>	<title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-851959" show="new" actuate="onrequest">Arthur D. Moore papers</title></item>
-
-<item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-8733" actuate="onrequest" show="replace">	William Charles Parkinson papers</title></item>
-
-<item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-89273" show="new" actuate="onrequest">	Keeve Milton Siegel papers</title></item>
-
- <item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-8674" show="new" actuate="onrequest">George Owen Squier papers</title></item>
- 
- <item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-2012040" show="new" actuate="onrequest">Robert C. Stempel papers</title></item>
- 
- <item><title href="Thomas R. Stockton" actuate="onrequest" show="new">Thomas R. Stockton papers</title></item>
- 
-<item>	<title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-2013118" show="new" actuate="onrequest">Juris Upatnieks papers</title></item>
-
-<item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-0135" show="new" actuate="onrequest">	Wallace C. Williams papers</title></item>
-
-<item>	<title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-9802" show="new" actuate="onrequest">Shien-Ming Wu papers</title></item>
-
-<item>	<title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-97121" show="new" actuate="onrequest">Chia-Shun Yih papers</title></item>
-
-<item>	<title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-86386" show="new" actuate="onrequest">Philip Newell Youtz papers</title></item></list></p> 
-
-<p>Also, papers of Stan Ovshinsky's son, <title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-2015038" show="new" actuate="onrequest">Harvey Ovshinsky</title>, Michigan writer, journalist, news broadcaster, radio host, television producer, creative consultant, teacher, and founder of <title render="italic">The Fifth Estate</title>, Detroit's first underground newspaper.</p></relatedmaterial></descgrp>
-
-</archdesc>
-
-
-
+    </arrangement>
+    <scopecontent encodinganalog="520">
+      <p>The Stanford R. Ovshinsky papers comprise materials documenting his long scientific career.  Though the collection includes some information about his personal life, the files primarily provide insight into Ovshinsky's professional activities and involvement in the field of amorphous materials.  </p>
+    </scopecontent>
+    <controlaccess>
+      <p>
+        <extptr href="accnote" show="embed" actuate="onload"/>
+      </p>
+      <controlaccess>
+        <head>Subjects:</head>
+        <subject source="lcsh" encodinganalog="650">Alternative fuel vehicles.</subject>
+        <subject source="lcsh" encodinganalog="650">Amorphous substances.</subject>
+        <subject source="lcsh" encodinganalog="650">Electric vehicles--Batteries.</subject>
+        <corpname source="lcnaf" encodinganalog="610">Energy Conversion Devices, Inc.</corpname>
+        <subject source="lcsh" encodinganalog="650">EV1 automobile--Research.</subject>
+        <subject source="lcsh" encodinganalog="650">Inventors--Michigan.</subject>
+        <subject source="lcsh" encodinganalog="650">Inventors--United States.</subject>
+        <subject source="lcsh" encodinganalog="650">Nickel-metal hydride batteries--Research.</subject>
+        <persname source="lcnaf" encodinganalog="600">Ovshinsky, Stanford R.</persname>
+        <subject source="lcsh" encodinganalog="650">Phase change memory--Research.</subject>
+        <subject source="lcsh" encodinganalog="650">Prius automobile--Research.</subject>
+        <subject source="lcsh" encodinganalog="650">Scientists--Michigan.</subject>
+        <subject source="lcsh" encodinganalog="650">Scientists--United States.</subject>
+        <subject source="lcsh" encodinganalog="650">Solar energy--Research.</subject>
+      </controlaccess>
+      <controlaccess>
+        <head>Genre Terms:</head>
+        <genreform source="aat" encodinganalog="655">CDs.</genreform>
+        <genreform source="aat" encodinganalog="655">Color negatives.</genreform>
+        <genreform source="aat" encodinganalog="655">Digital file formats.</genreform>
+        <genreform source="aat" encodinganalog="655">Photographs.</genreform>
+        <genreform source="aat" encodinganalog="655">Video recordings.</genreform>
+        <genreform source="aat" encodinganalog="655">Videocassettes.</genreform>
+      </controlaccess>
+    </controlaccess>
+    <dsc type="combined">
+      <c01 level="series">
+        <did>
+          <unittitle>Personal</unittitle>
+        </did>
+        <scopecontent>
+          <p>The Personal series (2.2 linear feet, 1 oversize box, and digital files; 1922-2012) contains information about Stanford Ovshinsky's life outside of work.  This includes a wide variety of documents, beginning with his birth certificate, high school materials, and photographs from his childhood and marriage to his first wife Norma.  A copy of Ovshinsky's FBI file, which he requested through the Freedom of Information and Privacy Act (FOIPA), is also available in this section, along with documents and correspondence demonstrating his political leanings and involvement. Family communication and financial records, a love letter from Iris Ovshinsky and the couple's marriage certificate, a book of remembrances from Ovshinsky's 80th birthday, his early efforts at poetry, selected excerpts from works about Ovshinsky's life, and his autobiographical drafts also appear in this series. </p>
+        </scopecontent>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">95</container>
+            <unittitle>70th birthday </unittitle>
+            <physdesc>
+              <physfacet>VHS videocassette</physfacet>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>80th birthday remembrance book excerpts, <unitdate type="inclusive">2002</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <physloc> Online </physloc>
+            <unittitle>80th birthday reminiscences, appreciations, and photographs, <unitdate type="inclusive">2002</unitdate> </unittitle>
+            <physdesc>
+              <physfacet>.ZIP file</physfacet>
+            </physdesc>
+            <dao href="http://hdl.handle.net/2027.42/116162" show="new" actuate="onrequest">
+              <daodesc>
+                <p>[download item]</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <physloc> Online </physloc>
+            <unittitle>Autobiography and political essays, <unitdate type="inclusive">1990-1992</unitdate> </unittitle>
+            <physdesc>
+              <physfacet>.ZIP file</physfacet>
+            </physdesc>
+            <dao href="http://hdl.handle.net/2027.42/116168" show="new" actuate="onrequest">
+              <daodesc>
+                <p>[download item]</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Autobiography, <unitdate type="inclusive">1992-1997</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Autobiography, <unitdate type="inclusive">undated</unitdate> </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Autobiography notes, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Certificates -- birth and marriage, <unitdate type="inclusive">1922</unitdate> and <unitdate type="inclusive">1962</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Correspondence, <unitdate type="inclusive">1961-1963</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Early poems, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Education</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">1</container>
+              <unittitle>Buchtel High School -- class of '41, <unitdate type="inclusive">1939-2001</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">1</container>
+              <unittitle>University of Akron, <unitdate type="inclusive">1941-1942</unitdate></unittitle>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Family tree, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Favored cartoons and quotes, <unitdate type="inclusive">undated</unitdate> </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Mementos</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">1</container>
+              <unittitle>
+                <unitdate type="inclusive">1970s</unitdate>
+              </unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">1</container>
+              <unittitle>
+                <unitdate type="inclusive">1980s</unitdate>
+              </unittitle>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Finances</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">1</container>
+              <unittitle>Iris Ovshinsky's estate, <unitdate type="inclusive">2009</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">1</container>
+              <unittitle>Real estate appraisal, <unitdate type="inclusive">2007</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Revocable trust</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">1</container>
+                <unittitle>Agreement, <unitdate type="inclusive">2007-2008</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">1</container>
+                <unittitle>Demand notices, <unitdate type="inclusive">2008-2012</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">1</container>
+                <unittitle>Promissory note, <unitdate type="inclusive">2011</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Family correspondence</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">1</container>
+              <unittitle>Dibner, Rob and Lora, <unitdate type="inclusive">2003</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">1</container>
+              <unittitle>Dibner, Steven, <unitdate type="inclusive">1999-2012</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">1</container>
+              <unittitle>Goddard, Angela, <unitdate type="inclusive">2007</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">1</container>
+              <unittitle>Harper, Dani, <unitdate type="inclusive">2011-2012</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">1</container>
+              <unittitle>Murphy, Natasha and Dave, <unitdate type="inclusive">2007-2011</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">2</container>
+              <unittitle>Ovshinsky, Ben</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">2</container>
+                <unittitle>
+                  <unitdate type="inclusive">2010</unitdate>
+                </unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">2</container>
+                <unittitle>
+                  <unitdate type="inclusive">2011-2012</unitdate>
+                </unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">2</container>
+              <unittitle>Ovshinsky, Dale, <unitdate type="inclusive">2007-2012</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">2</container>
+              <unittitle>Ovshinsky, Harvey, <unitdate type="inclusive">2010-2012</unitdate></unittitle>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Iris Ovshinsky</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">2</container>
+              <unittitle>Boston University, <unitdate type="inclusive">2003</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">2</container>
+              <unittitle>Death, <unitdate type="inclusive">August 2006</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">2</container>
+              <unittitle>Identification card-University of Michigan, <unitdate type="inclusive">1947-1948</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>Video memorial tribute, <unitdate type="inclusive">2006</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>video</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116150" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">2</container>
+              <unittitle>Resume and travel list, <unitdate type="inclusive">1960-1978</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">88</container>
+              <unittitle>Vacation in Canada with Stan Ovshinsky, <unitdate type="inclusive">October 7, 1991</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2</container>
+            <unittitle>Miscellaneous, <unitdate type="inclusive">1944-2004</unitdate> </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+          <note>
+            <p>(resumes -- Robin Dibner and SRO, personal letters, neuro research &amp; correspondence, gardening information)</p>
+          </note>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2</container>
+            <unittitle>Miscellaneous, <unitdate type="inclusive">May-July 2009</unitdate> </unittitle>
+          </did>
+          <note>
+            <p>(medical exam, notes, family history -- Lithuania, photo of Stan and Rosa Ovshinsky)</p>
+          </note>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2</container>
+            <unittitle>Photographs of Ovshinsky family, 1937-1955(?)</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Political</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <unittitle>Bergman, Walter</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">2</container>
+                <unittitle>
+                  <unitdate type="inclusive">1962</unitdate>
+                </unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">2</container>
+                <unittitle>
+                  <unitdate type="inclusive">1962-1981</unitdate>
+                </unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">94</container>
+                <unittitle>Ovshinsky speaking at Bergman's memorial service, <unitdate type="inclusive">October 9, 1999</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>Betacam SP videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Oversize">109</container>
+                <unittitle>Bergman memorabilia album </unittitle>
+              </did>
+              <note>
+                <p>(letters from numerous activists and dignitaries, photographs and articles to 1962 dinner programs, 1962, 1963, and 1982 memorial service program, 1999)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">2</container>
+                <unittitle>Testimonial dinner commemorative binder, <unitdate type="inclusive">1962</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">2</container>
+              <unittitle>Congress on Racial Equality (CORE), <unitdate type="inclusive">1959-1961</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">2</container>
+              <unittitle>Correspondence, <unitdate type="inclusive">1962-1966</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">2</container>
+              <unittitle>Dissent, <unitdate type="inclusive">1956-1963</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(correspondence, publications, and a love letter from Iris Ovshinsky)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>FBI file</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">2</container>
+                <unittitle>Central Industrial Personnel Security Board, <unitdate type="inclusive">1953-1970</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">2</container>
+                <unittitle>Michigan State Police complaints, <unitdate type="inclusive">1961-1969</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">2</container>
+                <unittitle>Ovshinsky miscellaneous information, <unitdate type="inclusive">1953-1985</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">2</container>
+                <unittitle>Ovshinsky, Stanford, <unitdate type="inclusive">1982</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">2</container>
+                <unittitle>SRO file released under FOIPA, <unitdate type="inclusive">1969-1983</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">2</container>
+              <unittitle>Involvement, <unitdate type="inclusive">1944-1965</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">2</container>
+              <unittitle>Politics notes and writings, <unitdate type="inclusive">1964-1968</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">2</container>
+              <unittitle>Socialist membership cards, <unitdate type="inclusive">1940-1941</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">2</container>
+              <unittitle>Thoughts on underdeveloped countries, <unitdate type="inclusive">1960-1964</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">2</container>
+              <unittitle>Workmen's Circle -- Detroit, <unitdate type="inclusive">1966</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">94</container>
+              <unittitle>Workmen's Circle </unittitle>
+              <physdesc>
+                <physfacet>4 Sony DVCAM videocassettes</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+        </c02>
+      </c01>
+      <c01 level="series">
+        <did>
+          <unittitle>Correspondence, <unitdate type="inclusive">1954-2012</unitdate></unittitle>
+        </did>
+        <scopecontent>
+          <p>The Correspondence series (22 linear feet and digital files; 1954-2012) is divided into two subseries: Companies and Individuals. The majority of this series contains letters and emails that relate to business dealings or scientific topics.</p>
+        </scopecontent>
+        <c02 level="subseries">
+          <did>
+            <unittitle>Companies, <unitdate type="inclusive">1965-2012</unitdate></unittitle>
+          </did>
+          <scopecontent>
+            <p>The Companies subseries documents Ovshinsky's collaboration and involvement with a variety of corporations, institutions, and community organizations.  </p>
+          </scopecontent>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">3</container>
+              <unittitle>A-B, <unitdate type="inclusive">1988-2012</unitdate> bulk dates <unitdate type="inclusive">2003-2011</unitdate> </unittitle>
+              <physdesc>
+                <extent>30 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>Automation Alley video, <unitdate type="inclusive">2008</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>video</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116143" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">4</container>
+              <unittitle>C-Ch, <unitdate type="inclusive">2003-2011</unitdate> bulk dates <unitdate type="inclusive">2007-2011</unitdate> </unittitle>
+              <physdesc>
+                <extent>20 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>(Photos: Chile-Stan and Iris Ovshinsky)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">5</container>
+              <unittitle>Cix-En. <unitdate type="inclusive">1965-2012</unitdate> bulk dates <unitdate type="inclusive">2005-2007</unitdate> </unittitle>
+              <physdesc>
+                <extent>35 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>(Photos: ECD travel postcards)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>Electric Battery Bicycle Company report, <unitdate type="inclusive">2007</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>PDF</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116139" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">6</container>
+              <unittitle>En-G, <unitdate type="inclusive">1981-2012</unitdate> bulk dates <unitdate type="inclusive">2002-2008</unitdate> </unittitle>
+              <physdesc>
+                <extent>29 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>(Photographs: Euro Med.  CD-R: First Energy Presentation Jan 26, 2007.)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">7</container>
+              <unittitle>H-In, <unitdate type="inclusive">1997-2012</unitdate> bulk dates <unitdate type="inclusive">2006-2010</unitdate> </unittitle>
+              <physdesc>
+                <extent>23 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">8</container>
+              <unittitle>In-Misc., <unitdate type="inclusive">1988-2012</unitdate> bulk dates <unitdate type="inclusive">2005-2008</unitdate> </unittitle>
+              <physdesc>
+                <extent>38 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">9</container>
+              <unittitle>Misc.-Oh, <unitdate type="inclusive">1985-2011</unitdate> bulk dates <unitdate type="inclusive">2005-2008</unitdate> </unittitle>
+              <physdesc>
+                <extent>24 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>(Nasdaq-Stan and Iris Ovshinsky; Oakland University-Stan Ovshinsky)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>"Walter Bergman, Freedom Rider" </unittitle>
+              <physdesc>
+                <physfacet>video</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116144" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">10</container>
+              <unittitle>Ol-Se, <unitdate type="inclusive">1988-2012</unitdate> bulk dates <unitdate type="inclusive">1995-2011</unitdate> </unittitle>
+              <physdesc>
+                <extent>25 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">11</container>
+              <unittitle>Sh-T, <unitdate type="inclusive">1991-2012</unitdate> bulk dates <unitdate type="inclusive">2004-2007</unitdate> </unittitle>
+              <physdesc>
+                <extent>19 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">12</container>
+              <unittitle>U-Wa, <unitdate type="inclusive">1955-2012</unitdate> bulk dates <unitdate type="inclusive">1999-2012</unitdate> </unittitle>
+              <physdesc>
+                <extent>24 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">13</container>
+              <unittitle>Workmen's Circle, <unitdate type="inclusive">2000-2012</unitdate> </unittitle>
+              <physdesc>
+                <extent>8 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="subseries">
+          <did>
+            <unittitle>Individuals, <unitdate type="inclusive">1954-2012</unitdate></unittitle>
+          </did>
+          <scopecontent>
+            <p>The Individuals subseries contains correspondence from professors, scientists, friends, employees, consultants, and admirers.  There are a number of letters from politicians in this subseries as well, such as Amalia Solórzano de Cárdenas, former First Lady of Mexico, Carl Levin, a long-serving United States Senator from Michigan, and Mark Schauer, a former United States Representative from the Detroit area and subsequently a Michigan gubernatorial candidate. The subseries also includes materials Ovshinsky gathered for his biographer Lillian Hoddeson, professor emerita of history at the University of Illinois and historian of Fermilab.</p>
+          </scopecontent>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">13</container>
+              <unittitle>A-Bray, <unitdate type="inclusive">1986-2012</unitdate> bulk dates <unitdate type="inclusive">2000-2012</unitdate> </unittitle>
+              <physdesc>
+                <extent>16 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">14</container>
+              <unittitle>Brockman-C, <unitdate type="inclusive">1960-2011</unitdate> bulk dates <unitdate type="inclusive">2000-2010</unitdate> </unittitle>
+              <physdesc>
+                <extent>22 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p> (Photograph: Cardenas, Lazaro and Amalia -- Lazaro former President of Mexico)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">15</container>
+              <unittitle>D-F, <unitdate type="inclusive">1963-2012</unitdate> bulk dates <unitdate type="inclusive">2005-2012</unitdate> </unittitle>
+              <physdesc>
+                <extent>34 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>(Photographs: Del Bosque, Homero; Dang, Vijay-Ovshinsky's 90th birthday; Dhar, Subhash.  CD: Ellison, Tom)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">16</container>
+              <unittitle>G-Hoddeson </unittitle>
+              <physdesc>
+                <extent>32 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>(Photographs: Garlovsky, David -- Stan and Iris Ovshinsky; Gasiorowski, Paul -- thick film deposits.  CD: Gibson, Peter -- BSO carb zts folder; Heckeroth, Steve-PowerPoint Uni-Solar and sc roofing; Photographs: Hoddeson, Lillian -- biography materials 3.  CD: Hoddeson, Lillian-biography materials 3 -- Ovonic Quantum Control Device media briefing)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">17</container>
+              <unittitle>Hoffer-I, <unitdate type="inclusive">1954-2012</unitdate> bulk dates <unitdate type="inclusive">2002-2012</unitdate> </unittitle>
+              <physdesc>
+                <extent>19 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>(Howard, George -- Book appendix, SRO files)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">18</container>
+              <unittitle>J-K, <unitdate type="inclusive">1972-2012</unitdate> bulk dates <unitdate type="inclusive">2001-2012</unitdate> </unittitle>
+              <physdesc>
+                <extent>26 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>(Photographs: Kane, Gordon-Stan Ovshinsky; Kolobov, Alex --Stan Ovshinsky; Kumar, Arun-Stan Ovshinsky)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">19</container>
+              <unittitle>L-Mi, <unitdate type="inclusive">1955-2012</unitdate> bulk dates <unitdate type="inclusive">2000-2012</unitdate> </unittitle>
+              <physdesc>
+                <extent>30 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>(Photographs: Levin, Carl.)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">20</container>
+              <unittitle>Mi-Ovshinsky, 1960-2012(27 folders) </unittitle>
+            </did>
+            <note>
+              <p>(Photographs: Mitchell, Tom &amp; Roseanne -- Stan Ovshinsky; Mott, Nevill P. -- statue of Mott; Ohta, Takeo-Stan Ovshinsky)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">21</container>
+              <unittitle>Ovshinsky-Pi, <unitdate type="inclusive">1983-2012</unitdate> </unittitle>
+              <physdesc>
+                <extent>17 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">22</container>
+              <unittitle>Popescu-Slangerup, <unitdate type="inclusive">1969-2012</unitdate> bulk dates <unitdate type="inclusive">2003-2010</unitdate> </unittitle>
+              <physdesc>
+                <extent>31 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>(Photographs: Shaiken, Harley 2000-2008, Shi, Luping-Stan Ovshinsky)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">23</container>
+              <unittitle>Smaga-T, <unitdate type="inclusive">1983-2012</unitdate> bulk dates <unitdate type="inclusive">2003-2011</unitdate> </unittitle>
+              <physdesc>
+                <extent>26 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>(Photograph: Stempel, Robert 1 -- Stan Ovshinsky; Thiessen, Klaus-Stan Ovshinsky.  CD: Takagi, Yasuo -- photographs and PowerPoint; Tamaka, Veiji -- photograph with Stan Ovshinsky.)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">107</container>
+              <unittitle>Sm-Za (supplemental), <unitdate type="inclusive">1986-2000</unitdate> bulk dates <unitdate type="inclusive">1996-2000</unitdate> </unittitle>
+              <physdesc>
+                <extent>4 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">24</container>
+              <unittitle>V-Z, <unitdate type="inclusive">1992-2012</unitdate> </unittitle>
+              <physdesc>
+                <extent>27 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>(Photographs: Winkelman, Margaret -- Stan Ovshinsky; Zeisel, Eva)</p>
+            </note>
+          </c03>
+        </c02>
+      </c01>
+      <c01 level="series">
+        <did>
+          <unittitle>Research and Subject Files, <unitdate type="inclusive">1955-2010</unitdate></unittitle>
+        </did>
+        <scopecontent>
+          <p>The Research and Subject Files series (5.2 linear feet; 1955-2010) contains documents from Ovshinsky's research and collaboration with other scientists on a variety of technical subjects.  Research notes, correspondence, and academic papers constitute the majority of the documents found in this series.  These files highlight the wide range of Ovshinsky's interests, with topics ranging from the brain and neurophysiology to optical memory.  While research files exist throughout the collection, this series holds documents that, for the most part, are not directly connected to one of his many businesses. Of the subject areas in the series, files pertaining to cosmology and superconductivity have the largest number of documents and contain substantial amounts of collaborative correspondence between Ovshinsky, Morrel Cohen, and Hellmut Fritzsche.</p>
+        </scopecontent>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">25</container>
+            <unittitle>Filing Index, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">25</container>
+            <unittitle>Aeroviroment, <unitdate type="inclusive">July 1981</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">25</container>
+            <unittitle>Angstrom, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">25</container>
+            <unittitle>Blood, 1955-1963(?) </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">25</container>
+            <unittitle>Brain, <unitdate type="inclusive">1955-1996</unitdate> </unittitle>
+            <physdesc>
+              <extent>4 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">25</container>
+            <unittitle>Catalysts, <unitdate type="inclusive">1979-1980</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">25</container>
+            <unittitle>Cerebellum, <unitdate type="inclusive">ca. 1955</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">25</container>
+            <unittitle>Chemical Bonding, <unitdate type="inclusive">undated</unitdate> </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">25</container>
+            <unittitle>Chemical Modification, <unitdate type="inclusive">1977-1981</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">25</container>
+            <unittitle>Cognitive Computer, <unitdate type="inclusive">1955-2010</unitdate> </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">25</container>
+            <unittitle>Cosmology, <unitdate type="inclusive">1985-2007</unitdate> </unittitle>
+            <physdesc>
+              <extent>11 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">26</container>
+            <unittitle>Cosmology, <unitdate type="inclusive">1985-2007</unitdate> </unittitle>
+            <physdesc>
+              <extent>11 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">26</container>
+            <unittitle>Encryption, <unitdate type="inclusive">1996-2000</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">26</container>
+            <unittitle>Fluorine, <unitdate type="inclusive">1978</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">26</container>
+            <unittitle>Fuel cells, <unitdate type="inclusive">1979</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">26</container>
+            <unittitle>Fusion, <unitdate type="inclusive">1989</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">26</container>
+            <unittitle>Greenhouse Gasses, <unitdate type="inclusive">1989-1997</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">26</container>
+            <unittitle>Hydrogen, <unitdate type="inclusive">1979</unitdate>, <unitdate type="inclusive">1997</unitdate>, <unitdate type="inclusive">2003</unitdate> </unittitle>
+            <physdesc>
+              <extent>3 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">26</container>
+            <unittitle>Imaging, <unitdate type="inclusive">1970</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">26</container>
+            <unittitle>Intelligence, <unitdate type="inclusive">1950-1962</unitdate> </unittitle>
+            <physdesc>
+              <extent>3 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">27</container>
+            <unittitle>Introns</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">27</container>
+            <unittitle>Magnetic particle control</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">27</container>
+            <unittitle>Memristors, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">27</container>
+            <unittitle>Miscellaneous, <unitdate type="inclusive">1971-1979</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">27</container>
+            <unittitle>Neurophysiology, <unitdate type="inclusive">1955-1965</unitdate> </unittitle>
+            <physdesc>
+              <extent>7 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">27</container>
+            <unittitle>Optical Memory, <unitdate type="inclusive">1977-2001</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">27</container>
+            <unittitle>Photovoltaic, <unitdate type="inclusive">1980-2008</unitdate> </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">27</container>
+            <unittitle>Physical Theory, <unitdate type="inclusive">1965-1968</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">27</container>
+            <unittitle>Semiconductors, <unitdate type="inclusive">1955-1968</unitdate> </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">103</container>
+            <unittitle>Sony chairman Morita interview, <unitdate type="inclusive">April 1990</unitdate> </unittitle>
+            <physdesc>
+              <physfacet>VHS videocassette</physfacet>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">28</container>
+            <unittitle>Superconductivity, <unitdate type="inclusive">1975-1994</unitdate> </unittitle>
+            <physdesc>
+              <extent>15 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">29</container>
+            <unittitle>Superconductivity, <unitdate type="inclusive">1965-1995</unitdate> </unittitle>
+            <physdesc>
+              <extent>31 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">29</container>
+            <unittitle>Superconductivity, <unitdate type="inclusive">1977-1990</unitdate> </unittitle>
+            <physdesc>
+              <extent>26 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">29</container>
+            <unittitle>"Superconductors," Channel 2 (name of channel not specified), <unitdate type="inclusive">July 21, 1987</unitdate> </unittitle>
+            <physdesc>
+              <physfacet>VHS videocassette</physfacet>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">61</container>
+            <unittitle>Switching, <unitdate type="inclusive">1959-1970</unitdate> </unittitle>
+            <physdesc>
+              <extent>9 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">61</container>
+            <unittitle>Thermoelectricity, <unitdate type="inclusive">1960s-1970s</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">61</container>
+            <unittitle>Vision, <unitdate type="inclusive">1998</unitdate></unittitle>
+          </did>
+        </c02>
+      </c01>
+      <c01 level="series">
+        <did>
+          <unittitle>Publications</unittitle>
+        </did>
+        <scopecontent>
+          <p>The Publications series (13.4 linear feet and 3 oversize volumes; 1955-2012) includes both scientific and popular printed works. Technical papers written by Ovshinsky and ECD employees or directors comprise a significant portion of the series; these works, which primarily derive from the period between 1968 and 1995, document the research interests of Ovshinsky and other scientists with whom he worked in his heyday. On occasion, original drafts, collaborative correspondence, and handwritten research notes accompany the articles. Materials produced by business magazines, Detroit-area newspapers, and other accessible publishers help to contextualize the technical developments and situate them in the vocabulary of the lay reader.</p>
+        </scopecontent>
+        <c02 level="subseries">
+          <did>
+            <unittitle>Technical Publications -- Ovshinsky and ECD</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">30</container>
+              <unittitle><unitdate type="inclusive">1955</unitdate> -- <unitdate type="inclusive">1970</unitdate> </unittitle>
+              <physdesc>
+                <extent>83 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">31</container>
+              <unittitle><unitdate type="inclusive">1971</unitdate> -- <unitdate type="inclusive">1975</unitdate> </unittitle>
+              <physdesc>
+                <extent>61 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">32</container>
+              <unittitle><unitdate type="inclusive">1976</unitdate> -- <unitdate type="inclusive">1981</unitdate> </unittitle>
+              <physdesc>
+                <extent>70 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">107</container>
+              <unittitle><unitdate type="inclusive">1975-1980</unitdate> supplemental publications </unittitle>
+              <physdesc>
+                <extent>9 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">33</container>
+              <unittitle><unitdate type="inclusive">1982</unitdate> -- <unitdate type="inclusive">1984</unitdate> </unittitle>
+              <physdesc>
+                <extent>81 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">34</container>
+              <unittitle><unitdate type="inclusive">1985</unitdate> -- <unitdate type="inclusive">1986</unitdate> </unittitle>
+              <physdesc>
+                <extent>75 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">35</container>
+              <unittitle><unitdate type="inclusive">1987</unitdate> -- <unitdate type="inclusive">1993</unitdate> </unittitle>
+              <physdesc>
+                <extent>80 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">36</container>
+              <unittitle><unitdate type="inclusive">1994</unitdate> -- <unitdate type="inclusive">2000</unitdate> </unittitle>
+              <physdesc>
+                <extent>68 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">37</container>
+              <unittitle><unitdate type="inclusive">2001</unitdate> -- <unitdate type="inclusive">2012</unitdate> </unittitle>
+              <physdesc>
+                <extent>42 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="subseries">
+          <did>
+            <unittitle>Newspapers, Magazines, and Books, <unitdate type="inclusive">1963-2012</unitdate></unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">37</container>
+              <unittitle>
+                <unitdate type="inclusive">1966-2012</unitdate>
+              </unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">38</container>
+              <unittitle>Akron Beacon Journal, 2005-ECD, <unitdate type="inclusive">1963-1967</unitdate> </unittitle>
+              <physdesc>
+                <extent>50 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">39</container>
+              <unittitle>ECD, <unitdate type="inclusive">1967-1977</unitdate> </unittitle>
+              <physdesc>
+                <extent>23 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">40</container>
+              <unittitle>ECD, 1978-2002-H </unittitle>
+              <physdesc>
+                <extent>30 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">41</container>
+              <unittitle>I-Optical Memory News </unittitle>
+              <physdesc>
+                <extent>48 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">42</container>
+              <unittitle>Ovonic Link -- Z </unittitle>
+              <physdesc>
+                <extent>38 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="volume" label="Oversize"> 1</container>
+              <unittitle>Newspaper clippings scrapbook, <unitdate type="inclusive">1963</unitdate>, <unitdate type="inclusive">1966</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="volume" label="Oversize"> 2</container>
+              <unittitle>Newspaper clippings scrapbook, <unitdate type="inclusive">1963</unitdate>, <unitdate type="inclusive">1968</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="volume" label="Oversize">  3</container>
+              <unittitle>Newspaper clippings scrapbook, <unitdate type="inclusive">1969-1996</unitdate> (with gaps)</unittitle>
+            </did>
+          </c03>
+        </c02>
+      </c01>
+      <c01 level="series">
+        <did>
+          <unittitle>Business Administration, <unitdate type="inclusive">1943-2009</unitdate></unittitle>
+        </did>
+        <scopecontent>
+          <p>The Business Administration series (26.9 linear feet, 4 oversize boxes, and digital files; 1943-2012) contains materials that extensively document Stanford Ovshinsky's commercial ventures. This series is divided into four subseries based on Ovshinsky's early career, his work with Energy Conversion Devices, and activities of the Institute for Amorphous Studies.  Product literature espousing the benefits of new developments, business and technical materials documenting the evolution of these products, and shareholder reports comprise a significant portion of the series. Prominently represented as well are meeting minutes from the Board of Directors of the Institute for Amorphous Studies (IAS), advertisements and information about the IAS lecture series, and materials regarding Ovshinsky's participation in symposia around the world and festschrifts honoring David Adler, Hellmut Fritzsche, Nevill Mott, and Heinz Henisch. Internal correspondence, discussions of employee discontent, and audits also appear in the Business Administration series. </p>
+        </scopecontent>
+        <c02 level="subseries">
+          <did>
+            <unittitle>General, <unitdate type="inclusive">1952-2007</unitdate></unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">43</container>
+              <unittitle>Audit and internal investigations, <unitdate type="inclusive">1993-2005</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">43</container>
+              <unittitle>Automation Alley, <unitdate type="inclusive">2007</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">43</container>
+              <unittitle>Business cards-Stan Ovshinsky, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">43</container>
+              <unittitle>Correspondence and miscellaneous, <unitdate type="inclusive">1952-1962</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Early business</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">43</container>
+                <unittitle>Amgears, Hupp Corp., General Automation, and personal correspondence, <unitdate type="inclusive">1952-1957</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">43</container>
+                <unittitle>Ovitron, Stanford Roberts, New Britain, Hupp-Servo steer, magnet ball controls, switches and relays, <unitdate type="inclusive">1949-1959</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">107</container>
+                <unittitle>Tann Corporation agreements, press releases, promotional literature, proofs of concepts, scientific schematics, Stan and Herbert Ovshinsky patent applications and related correspondence, <unitdate type="inclusive">1955-1959</unitdate> </unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">43</container>
+              <unittitle>Early neuroscience research, <unitdate type="inclusive">1957 (?)</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">43</container>
+              <unittitle>History, <unitdate type="inclusive">1962-1983</unitdate> </unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>(Folder 1 contains photographs)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Hupp Corporation</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">43</container>
+                <unittitle>Amgears -- no back survey report, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">43</container>
+                <unittitle>Power steering and ServO steer, <unitdate type="inclusive">1953 (?)</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">43</container>
+                <unittitle>ServOsteer division, <unitdate type="inclusive">1952-1957</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Itineraries</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">43</container>
+                <unittitle>
+                  <unitdate type="inclusive">2005</unitdate>
+                </unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">43</container>
+                <unittitle>
+                  <unitdate type="inclusive">2006</unitdate>
+                </unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">43</container>
+                <unittitle>
+                  <unitdate type="inclusive">December 1959</unitdate>
+                </unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">43</container>
+                <unittitle>Presented paper from bedroom, <unitdate type="inclusive">2012</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ovitron </unittitle>
+            </did>
+            <note>
+              <p>(formerly General Automation)</p>
+            </note>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">43</container>
+                <unittitle>
+                  <unitdate type="inclusive">1958-1959</unitdate>
+                </unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">43</container>
+                <unittitle>
+                  <unitdate type="inclusive">1959-1969</unitdate>
+                </unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">43</container>
+                <unittitle>Clippings, <unitdate type="inclusive">1959</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">44</container>
+                <unittitle>Correspondence, <unitdate type="inclusive">1959-1962</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">44</container>
+                <unittitle>Correspondence, <unitdate type="inclusive">1960-1967</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">44</container>
+                <unittitle>Financial Statements, <unitdate type="inclusive">1959-1960</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>General Automation, Inc.</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">44</container>
+                  <unittitle>Correspondence, <unitdate type="inclusive">1958-1959</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">44</container>
+                  <unittitle>Option, License Agreement, and Mechanical Products Agreements,  June -- August 1958</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">44</container>
+                  <unittitle>Tann Corporation litigation, <unitdate type="inclusive">1963</unitdate> </unittitle>
+                </did>
+                <note>
+                  <p>(patent issue)</p>
+                </note>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">44</container>
+                <unittitle>History, <unitdate type="inclusive">1958-1967</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">44</container>
+                <unittitle>Legal, <unitdate type="inclusive">1959-1961</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">44</container>
+                <unittitle>Literature, <unitdate type="inclusive">1959</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">44</container>
+                <unittitle>Memos, <unitdate type="inclusive">1959</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">44</container>
+                <unittitle>Miscellaneous, <unitdate type="inclusive">1959-1960</unitdate> </unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">44</container>
+                <unittitle>Nerve cell, <unitdate type="inclusive">1959</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">44</container>
+                <unittitle>Patents, <unitdate type="inclusive">1959-1961</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">44</container>
+                <unittitle>Press, <unitdate type="inclusive">1959</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">44</container>
+                <unittitle>Stockholders reports, <unitdate type="inclusive">1961-1962</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">44</container>
+              <unittitle>Ovshinsky effect, <unitdate type="inclusive">1974-1975</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">44</container>
+              <unittitle>Ovshinsky energy converter (OEC), <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ovshinsky Innovation LLC</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">44</container>
+                <unittitle>Schedule and presentations, <unitdate type="inclusive">2008-2009</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">44</container>
+                <unittitle>Tours and visitors, <unitdate type="inclusive">2008-2010</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Patents</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">44</container>
+                <unittitle>
+                  <unitdate type="inclusive">1966</unitdate>
+                </unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">44</container>
+                <unittitle>Most significant, Ovshinsky's favorites, and certificate of appreciation, <unitdate type="inclusive">1952-2004</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Resume and CV</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">44</container>
+                <unittitle>Early work, <unitdate type="inclusive">1946-1960</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">44</container>
+                <unittitle>Iris Ovshinsky, <unitdate type="inclusive">1981-2001</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Stanford R. Ovshinsky</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">44</container>
+                  <unittitle>Biographical sketch and backgrounders of SRO and Julius Harwood, <unitdate type="inclusive">1984</unitdate> </unittitle>
+                </did>
+                <note>
+                  <p>(Harwood was President of Ovonic Synthetic Materials.  Contains photographs of Ovshinsky and Harwood)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">44</container>
+                  <unittitle>Long and short CV, <unitdate type="inclusive">2000</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">44</container>
+                  <unittitle>Long resume and phase change optical memory history, <unitdate type="inclusive">1998-2001</unitdate> </unittitle>
+                </did>
+                <note>
+                  <p>(Contains a photograph and 2 floppy disks)</p>
+                </note>
+              </c05>
+            </c04>
+          </c03>
+        </c02>
+        <c02 level="subseries">
+          <did>
+            <unittitle>Stanford Roberts Manufacturing Corporation, <unitdate type="inclusive">1943-1960</unitdate></unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">44</container>
+              <unittitle>Benjamin Auto Tract, <unitdate type="inclusive">1952-1953</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">44</container>
+              <unittitle>Benjamin Center Drive-General Electric, <unitdate type="inclusive">1948-1960</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">44</container>
+              <unittitle>Benjamin Center Drive-New Britain, <unitdate type="inclusive">1943-1958</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(Contains photograph)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">44</container>
+              <unittitle>Memorandums and reports, <unitdate type="inclusive">May 1950</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">44</container>
+              <unittitle>New Britain Machine Company, <unitdate type="inclusive">1950s</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">44</container>
+              <unittitle>Reports on Center Drive machines in regard to Cartridge case production-New Britain, <unitdate type="inclusive">November 1954</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(Contains photographs)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">44</container>
+              <unittitle>Stock certificate,  January 5, 1948</unittitle>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="subseries">
+          <did>
+            <unittitle>Energy Conversion Devices, Inc.</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">44</container>
+              <unittitle>Administrative, <unitdate type="inclusive">1961-1982</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(Statement of funds, management, misc. project notes, + personal history SRO)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">44</container>
+              <unittitle>
+ Advertising, <unitdate type="inclusive">May-September 1982</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(Contains a cassette tape)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">45</container>
+              <unittitle>American Physical Society material for panel, <unitdate type="inclusive">1978-1979</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Board of Directors</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">45</container>
+                <unittitle>
+                  <unitdate type="inclusive">September 1982</unitdate>
+                </unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">45</container>
+                <unittitle>Meeting, <unitdate type="inclusive">September 1994</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">106</container>
+                <unittitle>Annual meeting, <unitdate type="inclusive">1996</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">89</container>
+                <unittitle>Annual meeting, <unitdate type="inclusive">1997</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>Betacam SP videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">89</container>
+                <unittitle>Annual meeting, <unitdate type="inclusive">1998</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>Betacam SP videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">96</container>
+                <unittitle>Annual meeting video production materials, <unitdate type="inclusive">1996-1998</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">95</container>
+                <unittitle>Annual meeting, <unitdate type="inclusive">1999</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>2 Betacam SP videocassettes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">45</container>
+              <unittitle>Brochures, <unitdate type="inclusive">1974-2004</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">45</container>
+              <unittitle>Budget review -- Central Analytical Laboratory, <unitdate type="inclusive">August 5, 1997</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Business proposals and reports</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">45</container>
+                <unittitle>
+                  <unitdate type="inclusive">1970</unitdate>
+                </unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Oversize">110 </container>
+                <unittitle>A clean new business for New York City: electric vehicle/battery manufacturing and operation in NYC, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">45</container>
+                <unittitle>Advanced Research Project Agency (ARPA) proposals,1971(?)</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">45</container>
+                <unittitle>Analysis-Energy conversion and superconductivity and their impact on Japan, 1977(?)</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">45</container>
+                <unittitle>Applications of superconductivity to the power industry, <unitdate type="inclusive">September 1977</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">45</container>
+                <unittitle>Automotive Thermoelectric Generator for General Motors Corporation, <unitdate type="inclusive">May 1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">45</container>
+                <unittitle>Biological and medical aspects of Ovonic mechanism, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Business plan</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">45</container>
+                  <unittitle>Lithium battery for ANR Energy Technology Company, <unitdate type="inclusive">November 1983</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">45</container>
+                  <unittitle>Next generation computer systems, optical fiber and ceramics, <unitdate type="inclusive">January 1985</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">45</container>
+                  <unittitle>Ovonic Solid State Heat Pump, <unitdate type="inclusive">October 1985</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">45</container>
+                <unittitle>Business plan and strategy, <unitdate type="inclusive">December 2004</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">45</container>
+                <unittitle>Cost analysis-Ovonic photovoltaic manufacturing, <unitdate type="inclusive">February 1981</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">45</container>
+                <unittitle>Development of an integrated circuit for remote meter reading equipment, <unitdate type="inclusive">1964</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(for Line Materials Industries of McGraw Edis Company)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">45</container>
+                <unittitle>Examination of mechanical problems associated with the initially proposed packages, <unitdate type="inclusive">January 1968</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">45</container>
+                <unittitle>Limited contract -- thin film active devices based on the original quantrol concept, <unitdate type="inclusive">February-March 1984</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Electronic Machine Company Ltd.)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">45</container>
+                <unittitle>Microfilm Development, <unitdate type="inclusive">January-April 1972</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">45</container>
+                <unittitle>Miscellaneous proposals, <unitdate type="inclusive">1971-1978</unitdate> &amp; <unitdate type="inclusive">2001</unitdate> </unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">45</container>
+                <unittitle>Miscellaneous proposals, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>New companies</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">45</container>
+                  <unittitle>Nonsilver Graphic Arts film, <unitdate type="inclusive">April 1980</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">45</container>
+                  <unittitle>Ovonic Hydrogen-Akron, LLC, <unitdate type="inclusive">June 2005-2007</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">45</container>
+                  <unittitle>Ovonic Microelectronic devices, <unitdate type="inclusive">April 1981</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">45</container>
+                  <unittitle>Ovonic photovoltaic devices for consumer applications, <unitdate type="inclusive">May 1981</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">46</container>
+                  <unittitle>Ovonic photovoltaic systems for U.S. commercial market, <unitdate type="inclusive">March 1981</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">46</container>
+                  <unittitle>Photo products, <unitdate type="inclusive">March 1973</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">46</container>
+                <unittitle>New High Temperature Superconductors research and development program, <unitdate type="inclusive">February 1989</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">46</container>
+                <unittitle>Outline on Ovonic solid state heat pump, <unitdate type="inclusive">October 1985</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">46</container>
+                <unittitle>Outline Thermocouple project, <unitdate type="inclusive">May 1960</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">46</container>
+                <unittitle>Ovonic Battery Company-Business plan: Small Rechargeable Sealed Cells, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Ovonic Cognitive Computer</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">46</container>
+                  <unittitle>Capabilities, <unitdate type="inclusive">2000</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">46</container>
+                  <unittitle>Report, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">46</container>
+                <unittitle>Ovonic energy programs, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">46</container>
+                <unittitle>Perspectives on medical imaging, <unitdate type="inclusive">January 1975</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">46</container>
+                <unittitle>Physical analogs of physiological communicative and control systems, <unitdate type="inclusive">November-December 1960</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">46</container>
+                <unittitle>Plan of operations, <unitdate type="inclusive">1967</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">46</container>
+                <unittitle>Plan of work-commercialization of hydrogen bulk materials and systems application, <unitdate type="inclusive">October 1981</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">46</container>
+                <unittitle>Progress reports-energy research projects, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">46</container>
+                <unittitle>Proposed projects, <unitdate type="inclusive">June 1989</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">46</container>
+                <unittitle>Public relations program, <unitdate type="inclusive">May 1984</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Sovonics </unittitle>
+              </did>
+              <note>
+                <p>(Sovonics Solar Energy Company)</p>
+              </note>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">46</container>
+                  <unittitle>Business plan-manufacturing photovoltaics in Michigan, <unitdate type="inclusive">March 1986</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">46</container>
+                  <unittitle>Commercialization plan for SOHIO-ECD photovoltaic program, <unitdate type="inclusive">October 1981</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">46</container>
+                  <unittitle>Marketing activities summary, <unitdate type="inclusive">March 1984</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">46</container>
+                  <unittitle>Status report -- photovoltaic systems for the utility market, <unitdate type="inclusive">January 1986</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">46</container>
+                <unittitle>Thin-film semiconductor devices report to Fairchild Research Center, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Uni-Solar </unittitle>
+              </did>
+              <note>
+                <p>(United Solar Systems Corp.)</p>
+              </note>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">46</container>
+                  <unittitle>Business plan development, <unitdate type="inclusive">1997-1999</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">46</container>
+                  <unittitle>BIPV market driven strategy, <unitdate type="inclusive">December 2000</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+          </c03>
+          <c03 level="item">
+            <did>
+              <container type="box" label="Box">47</container>
+              <unittitle>Consultants</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">47</container>
+                <unittitle>
+                  <unitdate type="inclusive">1984-1987</unitdate>
+                </unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">47</container>
+                <unittitle>Adler, David, <unitdate type="inclusive">1974-1997</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Corporate partners</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">47</container>
+                <unittitle>Fuji agreement and meetings, <unitdate type="inclusive">April 1973</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Joint ventures</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">47</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1971-2004</unitdate>
+                  </unittitle>
+                </did>
+                <note>
+                  <p>(Contains photographs) </p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">47</container>
+                  <unittitle>Inland Steel, <unitdate type="inclusive">1989</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">94</container>
+                  <unittitle>Sovlux Plant Tour, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">47</container>
+                  <unittitle>United Nuclear, <unitdate type="inclusive">1977-1978</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>Includes litigation</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">47</container>
+                <unittitle>Partners and affiliations, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">47</container>
+                <unittitle>Relations with Japan, <unitdate type="inclusive">2001</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Correspondence</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">47</container>
+                <unittitle>Important various letters, <unitdate type="inclusive">1992-2007</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Includes Board of Directors decision to remove Ovshinsky) </p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">47</container>
+                <unittitle>Inter-office memos, <unitdate type="inclusive">1963-1979</unitdate> </unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">47</container>
+                <unittitle>Internal memos, <unitdate type="inclusive">1966-1986</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Includes documents regarding United Nuclear litigation)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">47</container>
+                <unittitle>Kolomiets, B.T., <unitdate type="inclusive">December 1969</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">47</container>
+                <unittitle>Miscellaneous, <unitdate type="inclusive">1967-1977</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(History)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">47</container>
+                <unittitle>Spanenberg, Charles regarding patent, <unitdate type="inclusive">1968</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">47</container>
+                <unittitle>Watanabe, Y, <unitdate type="inclusive">November 1989</unitdate> and <unitdate type="inclusive">January 1990</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Tokyo Institute of Technology)</p>
+              </note>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">47</container>
+              <unittitle>Development and lab incident, <unitdate type="inclusive">1968-1974</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">103</container>
+              <unittitle>ECD Japan 5th Anniversary Celebration, <unitdate type="inclusive">January 28, 1986</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">47</container>
+              <unittitle>Energy Conversion Laboratories, <unitdate type="inclusive">1961</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Fritzsche</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">47</container>
+                <unittitle>80th birthday symposium, <unitdate type="inclusive">February 2007</unitdate> </unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
+                <physdesc>
+                  <physfacet>2 CDs</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">47</container>
+                <unittitle>Correspondence-Physical Review letters, <unitdate type="inclusive">1968</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">47</container>
+                <unittitle>Correspondence, <unitdate type="inclusive">1995-1999</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">47</container>
+                <unittitle>Inventory-technology, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">47</container>
+                <unittitle>Memory patent, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Ovonic Hydrogen Technology</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">47</container>
+                  <unittitle>Fuel cylinder assembly process, <unitdate type="inclusive">1999</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">47</container>
+                  <unittitle>Hydride, <unitdate type="inclusive">1999</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">47</container>
+                <unittitle>Ovonic information images, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Research</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">47</container>
+                  <unittitle>Early <unitdate type="inclusive">1990s</unitdate> optical media, ovonic memory, 1991-1992(?)</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1995</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1995-1996</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1996-1998</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1997-1998</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1999-2000</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>
+                    <unitdate type="inclusive">2001</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>
+                    <unitdate type="inclusive">2004</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>
+                    <unitdate type="inclusive">2004-2005</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>
+                    <unitdate type="inclusive">2005</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Circuit diagrams, <unitdate type="inclusive">1984-1985</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Compensated a-Si:H, <unitdate type="inclusive">1992-2000</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Compensated a-Si:H -- 4S213, <unitdate type="inclusive">1995</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Cooling cathode vespel information, <unitdate type="inclusive">2002-2004</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Dewars, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Frequency difference monitor, <unitdate type="inclusive">1969-1975</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Glow discharge apparatus, <unitdate type="inclusive">2004 (?)</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Hydrogen, <unitdate type="inclusive">1999-2000</unitdate> </unittitle>
+                </did>
+                <note>
+                  <p>(Stan and Rosa Ovshinsky)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Hydrogenated MF139Z alloy, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Indium(III) Oxide (In2O3), <unitdate type="inclusive">1994-1996</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Memory, <unitdate type="inclusive">1995-1996</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Memory switching, <unitdate type="inclusive">2001</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Miscellaneous, <unitdate type="inclusive">1996-2012</unitdate> </unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Passivation, <unitdate type="inclusive">2004-2007</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Patents, <unitdate type="inclusive">1969-1997</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>PDS manual and deposition system, <unitdate type="inclusive">1993-2003</unitdate> </unittitle>
+                </did>
+                <note>
+                  <p>(Photothermal Deflection Spectroscopy)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Photoconductivity, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Published material</unittitle>
+                </did>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">48</container>
+                    <unittitle>Chalcogenides, <unitdate type="inclusive">1978-1985 (?)</unitdate></unittitle>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">48</container>
+                    <unittitle>Light-Induced Structural Changes in Glasses, <unitdate type="inclusive">1999</unitdate> </unittitle>
+                  </did>
+                  <note>
+                    <p>(Ch 10 of<title render="italic"> Insulating and Semiconducting Glasses</title>)</p>
+                  </note>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">48</container>
+                    <unittitle>Physics and Chemistry of Glasses, <unitdate type="inclusive">September 2005</unitdate></unittitle>
+                  </did>
+                </c06>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Standards and constants, <unitdate type="inclusive">1967-1985</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>SWE viewgraphs, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                </did>
+                <note>
+                  <p>(Overheads)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Switching, On-state, <unitdate type="inclusive">2004</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">48</container>
+                  <unittitle>Theory of Photoconductivity, <unitdate type="inclusive">1982-1983</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">49</container>
+                  <unittitle>Transients, <unitdate type="inclusive">1995</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>Sirius workshop, <unitdate type="inclusive">September 20-24, 1999</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>Talk outline, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>Tanaka and Kikuchi research and correspondence, <unitdate type="inclusive">1973-1976</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Uni-Solar </unittitle>
+              </did>
+              <note>
+                <p>(United Solar Systems Corporation)</p>
+              </note>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">49</container>
+                  <unittitle>Back reflector studies, <unitdate type="inclusive">1990-2005</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">49</container>
+                  <unittitle>P-chamber cooling, <unitdate type="inclusive">2003-2004</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">49</container>
+                  <unittitle>Plasma Emission Monitor, <unitdate type="inclusive">2000-2004</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">49</container>
+                  <unittitle>Production problems   <unitdate type="inclusive">1997-2000</unitdate></unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">49</container>
+                  <unittitle>Shunt studies, <unitdate type="inclusive">2004</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+          </c03>
+          <c03 level="item">
+            <did>
+              <unittitle>History</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>Background, <unitdate type="inclusive">1980-1984</unitdate> </unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>Company history, <unitdate type="inclusive">1960-1984</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>Encyclopedia, <unitdate type="inclusive">1969-1971</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>First Ovonic Photocopier Drum(?) and operating Ovonic Live Imager, <unitdate type="inclusive">1985</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(signed by creators)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>First Three-terminal OTS device from new lab, <unitdate type="inclusive">December 2002</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Contains photograph)</p>
+              </note>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">49</container>
+              <unittitle>Hydrogen project potential investors, <unitdate type="inclusive">2006</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">49</container>
+              <unittitle>Identification card-Stan Ovshinsky, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">49</container>
+              <unittitle>Information package, <unitdate type="inclusive">1968</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">49</container>
+              <unittitle>Laboratory notebooks -- Henry Berger, <unitdate type="inclusive">1982-1984</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Magazine articles</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>American Men and Women of Science, <unitdate type="inclusive">1981</unitdate> and <unitdate type="inclusive">1985</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>Corporate Detroit--Stempel's Renewed Energy, <unitdate type="inclusive">October 1996</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>The Detroit Engineer -- Adventures into Amorphous Materials, <unitdate type="inclusive">April 1974</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>Discover -- The Amorphous Man, <unitdate type="inclusive">November 1984</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>EEE -- Thin-film Semis, At Last, <unitdate type="inclusive">May 1966</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>The Fifth Estate -- Letters to My Children, <unitdate type="inclusive">November 1966</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>Marquis Who's Who in America, <unitdate type="inclusive">1972-2003</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Scientific American</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">49</container>
+                  <unittitle>Amorphous-semiconductor Devices, <unitdate type="inclusive">May 1977</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>TIME -- Heroes for the Planet, <unitdate type="inclusive">February 1999</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>Manufacturing Technology and Building Division presentations, dated <unitdate type="inclusive">April 11, 2005</unitdate> (two PowerPoint presentations) </unittitle>
+              <physdesc>
+                <physfacet>.ZIP file</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116172" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">49</container>
+              <unittitle>Materials Research Society (MRS) -- Phase change data storage, <unitdate type="inclusive">December 2003</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">49</container>
+              <unittitle>Memory, <unitdate type="inclusive">1995-2001</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Miscellaneous</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>
+                  <unitdate type="inclusive">1963-2002</unitdate>
+                </unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>
+                  <unitdate type="inclusive">1986-1993</unitdate>
+                </unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">49</container>
+                <unittitle>
+                  <unitdate type="inclusive">1993-1995</unitdate>
+                </unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">50</container>
+                <unittitle>Binder -- Core business, role of disorder, cartoons, quotations, and publications, <unitdate type="inclusive">1985-2007</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">50</container>
+              <unittitle>Model shop closing, <unitdate type="inclusive">2007</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Notes</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">50</container>
+                <unittitle>
+                  <unitdate type="inclusive">1976-1979</unitdate>
+                </unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">50</container>
+                <unittitle>Work and meetings, <unitdate type="inclusive">1976-1979</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">50</container>
+                <unittitle>Ideas and Notes, <unitdate type="inclusive">1979-1981</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">50</container>
+                <unittitle>2002(?)</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">50</container>
+                <unittitle>
+                  <unitdate type="inclusive">2005-2006</unitdate>
+                </unittitle>
+              </did>
+              <note>
+                <p>(Includes an organizational chart)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">50</container>
+                <unittitle>Ovonics application, <unitdate type="inclusive">1964</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">50</container>
+              <unittitle>Nuclear and solar commercialization, 1977(?)</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">50</container>
+              <unittitle>Ovonic Memory, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">50</container>
+              <unittitle>P-project binder, <unitdate type="inclusive">2007</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">50</container>
+              <unittitle>Patent application map, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">50</container>
+              <unittitle>Photovoltaics, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">50</container>
+              <unittitle>Presentations and talks, <unitdate type="inclusive">1969-2009</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Press kits</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">50</container>
+                <unittitle>EV Global Motors Company, <unitdate type="inclusive">1998</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">50</container>
+                <unittitle>House of Commons-London, <unitdate type="inclusive">July 5, 1977</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">107</container>
+                <unittitle>House of Representatives testimony transcript, <unitdate type="inclusive">May 18, 1978</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">50</container>
+                <unittitle>Matsushita press conference, <unitdate type="inclusive">May 11, 1983</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc> Online </physloc>
+                <unittitle>Texaco Ovonic Battery Systems press conference highlights, <unitdate type="inclusive">July 18, 2001</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>video</physfacet>
+                </physdesc>
+                <dao href="http://hdl.handle.net/2027.42/116135" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download item]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">96</container>
+                <unittitle>Transcripts of interviews (SRO and Stempel), GM press conference, and Texaco Ovonic Systems press conference, <unitdate type="inclusive">1998-2002</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">50</container>
+                <unittitle>Ovonic Battery, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">50</container>
+                <unittitle>Ovonic Quantum Control device, <unitdate type="inclusive">June 6, 2006</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Contains CD-ROM)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Press releases</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">50</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1982-1997</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">50</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1993-2007</unitdate>
+                  </unittitle>
+                </did>
+                <note>
+                  <p>(Includes announcement of Stan Ovshinsky leaving ECD)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">50</container>
+                  <unittitle>
+                    <unitdate type="inclusive">2007-2009</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">50</container>
+                  <unittitle>
+                    <unitdate type="inclusive">2010</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">95</container>
+                <unittitle>Freedom Car Press Announcement, <unitdate type="inclusive">January 9, 2002</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>Betacam SP videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">94</container>
+                <unittitle>Sharp-ECD Solar Inc. Ovonic Photovoltatic Processor, <unitdate type="inclusive">August 1982</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>U-matic videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">51</container>
+                <unittitle>Sharp-ECD Solar Inc.-Japan press conference, <unitdate type="inclusive">February 3, 1983</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">94</container>
+                <unittitle>Sharp-ECD Solar Inc. Industrial presentation, <unitdate type="inclusive">May 20, 1983</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>U-matic videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">51</container>
+                <unittitle>Sovonics, <unitdate type="inclusive">February-March, 1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">51</container>
+                <unittitle>Sovonics -- new release solar frontier -- 100 module, <unitdate type="inclusive">March 7, 1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">51</container>
+                <unittitle>Switches, <unitdate type="inclusive">1964-1968</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Contains photographs)</p>
+              </note>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Product literature</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">51</container>
+                <unittitle>Amorphous materials and superconductors, 1978-1981(?)</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Automotive</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Automotive thermoelectric generator-final phase, <unitdate type="inclusive">1986</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Cars, batteries, buses, and trucks, 2002-2005(?)</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Miscellaneous, <unitdate type="inclusive">1985-1986</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Power assist steering, <unitdate type="inclusive">1995</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Power steering, <unitdate type="inclusive">2006</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Batteries</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <unittitle>Nickel-metal hydride</unittitle>
+                </did>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">51</container>
+                    <unittitle>1988(?)</unittitle>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">51</container>
+                    <unittitle>
+                      <unitdate type="inclusive">1998</unitdate>
+                    </unittitle>
+                  </did>
+                </c06>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Ovonic rechargeable batteries, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Texaco Ovonic Battery Systems, 2003(?) </unittitle>
+                </did>
+                <note>
+                  <p>(becomes Cobasys LLC)</p>
+                </note>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">51</container>
+                <unittitle>Charts and graphics, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Coatings</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Diamond Black, <unitdate type="inclusive">1984-1986</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Ovonic Wear coating, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Precision coldalloys, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">51</container>
+                <unittitle>Electrochemistry, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Contains photographs)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">51</container>
+                <unittitle>Electrochemistry and hydrogen energy technology, <unitdate type="inclusive">1979</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">51</container>
+                <unittitle>Electrovonic Print Heads-24x, <unitdate type="inclusive">July 29, 1977</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">51</container>
+                <unittitle>Fuel cell, <unitdate type="inclusive">2004-2005</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Ovonic Fuel Cell Company LLC)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc> Online </physloc>
+                <unittitle>Fuel cell brochures and papers, <unitdate type="inclusive">2004-2005</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>.ZIP file</physfacet>
+                </physdesc>
+                <note>
+                  <p>(Ovonic Fuel Cell Company LLC)</p>
+                </note>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc> Online </physloc>
+                <unittitle/>
+                <dao href="http://hdl.handle.net/2027.42/116151" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download item]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">51</container>
+                <unittitle>High-Low units, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Hydrogen</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Hydrogen, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Binder</unittitle>
+                </did>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">51</container>
+                    <unittitle>
+                      <unitdate type="inclusive">2005</unitdate>
+                    </unittitle>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">51</container>
+                    <unittitle>Hydrogen and photovoltaic, <unitdate type="inclusive">2001-2004</unitdate></unittitle>
+                  </did>
+                </c06>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Car, <unitdate type="inclusive">2006-2011</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Prius -- reports and master video, <unitdate type="inclusive">2003</unitdate> </unittitle>
+                </did>
+                <note>
+                  <p>(Contains photographs)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <physloc> Online </physloc>
+                  <unittitle>Ovonic Solid Hydrogen ICE Vehicle test drive and ECD interviews, <unitdate type="inclusive">August 22, 2003</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>video</physfacet>
+                  </physdesc>
+                  <dao href="http://hdl.handle.net/2027.42/116178" show="new" actuate="onrequest">
+                    <daodesc>
+                      <p>[download item]</p>
+                    </daodesc>
+                  </dao>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">106 </container>
+                  <unittitle>"Ovonic Solid Hydrogen ICE Vehicle: Ready for a Test Drive," <unitdate type="inclusive">October 22, 2003</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <physloc> Online </physloc>
+                  <unittitle>Prius Phase I status report, <unitdate type="inclusive">October 2002</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>video</physfacet>
+                  </physdesc>
+                  <dao href="http://hdl.handle.net/ 2027.42/116131" show="new" actuate="onrequest">
+                    <daodesc>
+                      <p>[download item]</p>
+                    </daodesc>
+                  </dao>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <physloc> Online </physloc>
+                  <unittitle>Prius Phase III video, <unitdate type="inclusive">June 2003</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>video</physfacet>
+                  </physdesc>
+                  <dao href="http://hdl.handle.net/2027.42/116145" show="new" actuate="onrequest">
+                    <daodesc>
+                      <p>[download item]</p>
+                    </daodesc>
+                  </dao>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <physloc> Online </physloc>
+                  <unittitle>Prius wrap-up video, <unitdate type="inclusive">January 2004</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>video</physfacet>
+                  </physdesc>
+                  <dao href="http://hdl.handle.net/2027.42/116132" show="new" actuate="onrequest">
+                    <daodesc>
+                      <p>[download item]</p>
+                    </daodesc>
+                  </dao>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Solid Hydrogen ICE <unitdate type="inclusive">circa 2003</unitdate></unittitle>
+                  <note>
+                    <p>(Internal Combustion Engine)%ne Vehicle test drive and speeches</p>
+                  </note>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Storage, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Electrovonic Data Processor, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                </did>
+                <note>
+                  <p>(Contains photograph)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Electrovonic Reader, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Film, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Film-192, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Flat Panel Display, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Graphic Arts Film-902, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Medical, <unitdate type="inclusive">1973</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Memory, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Microfiche system, <unitdate type="inclusive">1974</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Microvonic, <unitdate type="inclusive">1979</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>MicrOvonic File (MOF), <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Microvonic Ovonic series <unitdate type="inclusive">7000</unitdate> image processors, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>MicrOvonic Terminal (MOT), <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                </did>
+                <note>
+                  <p>(Contains photographs)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Optical memory -- video disc, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Ovonic <unitdate type="inclusive">8000</unitdate> image processor, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Ovonic imaging, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">51</container>
+                  <unittitle>Ovonic Imaging Systems, Inc, <unitdate type="inclusive">1987-1989</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Optical phase change memory, <unitdate type="inclusive">2000</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Photosensitive film, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Thin Film Transistor (TFT), <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Threshold switch, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Video tape recording, <unitdate type="inclusive">1970</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">52</container>
+                <unittitle>Internal Combustion Engine (ICE), <unitdate type="inclusive">October 2001</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">52</container>
+                <unittitle>Miscellaneous, <unitdate type="inclusive">1963-1997</unitdate> </unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">52</container>
+                <unittitle>Optical memory disk, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Ovonyx</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Cognitive computer, <unitdate type="inclusive">2003-2004</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Cognitive computer and encryption technology, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Cognitive Computer -- memory, <unitdate type="inclusive">2005</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Unified memory chip, <unitdate type="inclusive">2001-2002</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>X-ray optics, <unitdate type="inclusive">1985</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>X-ray reflecting multilayers, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">52</container>
+                <unittitle>Photoelectrochemical cells, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Photovoltaic</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Binder, <unitdate type="inclusive">2005</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Machine development, <unitdate type="inclusive">2005</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Ovonic cell technology, <unitdate type="inclusive">1986</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Ovonic Solar panels, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Photographs, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Photovoltaic manufacturing technology (PvMaT), <unitdate type="inclusive">1994</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Solar -- the promise realized, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Solar cell, <unitdate type="inclusive">1982-2003</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Sovonics Solar Systems, <unitdate type="inclusive">1984-1988</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Sunpal, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Uni-Solar --shingles, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">52</container>
+                <unittitle>Quartet Ovonics, <unitdate type="inclusive">1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Solar energy</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Absorber, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Applications, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Comparisons, 1980(?)</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Efficiencies, <unitdate type="inclusive">1983-1984</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Financial, <unitdate type="inclusive">1980-1981</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Miscellaneous, <unitdate type="inclusive">1981</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Modification, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Output, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Projections, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Switches</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Limit and threshold, <unitdate type="inclusive">1958-1966</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Ovonic squib, <unitdate type="inclusive">1968</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Read-Mostly Memory, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Thermoelectric</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>1981(?) </unittitle>
+                </did>
+                <note>
+                  <p>(Contains photographs of thermoelectric cell)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Devices and materials, <unitdate type="inclusive">1983</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Generators, 1986(?)</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">52</container>
+                  <unittitle>Thermal hydride products group, <unitdate type="inclusive">November 1977</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">52</container>
+                <unittitle>Thin film transistor, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">52</container>
+                <unittitle>Unique ovonic technologies, <unitdate type="inclusive">1986</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">53</container>
+              <unittitle>Promotional literature, <unitdate type="inclusive">1986-1989</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">97</container>
+              <unittitle>Promotional videos and media, <unitdate type="inclusive">1993-2002</unitdate></unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">97</container>
+                <unittitle>ECD/Bekaert videos, <unitdate type="inclusive">2001-2002</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>10 Betacam SP videocassettes, 2 DVCam videotapes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">89</container>
+                <unittitle>ECD employee interviews, <unitdate type="inclusive">1996</unitdate> (Dhar, Guha, Hudgens, and Stempel) </unittitle>
+                <physdesc>
+                  <physfacet>3 Betacam SP videocassettes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">96</container>
+                <unittitle>ECD employee interview transcripts, <unitdate type="inclusive">1996</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">96</container>
+                <unittitle>ECD employee interview transcripts and publicity video production materials, <unitdate type="inclusive">1996</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">96</container>
+                <unittitle>ECD employee interview transcripts, <unitdate type="inclusive">2002</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc> Online </physloc>
+                <unittitle>"ECD Energy Solutions," <unitdate type="inclusive">February 11, 2003</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>video</physfacet>
+                </physdesc>
+                <dao href="http://hdl.handle.net/2027.42/116165" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download item]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">89</container>
+                <unittitle>ECD footage miscellaneous, dated <unitdate type="inclusive">April 4, 1996</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>Betacam SP videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">89</container>
+                <unittitle>ECD footage, miscellaneous (archival pictures), dated <unitdate type="inclusive">April 9, 1996</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>Betacam SP videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">89</container>
+                <unittitle>ECD footage, miscellaneous, dated <unitdate type="inclusive">June 4, 1996</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>Betacam SP videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">97</container>
+                <unittitle>ECD General Interviews, <unitdate type="inclusive">1993-2000</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>23 Betacam SP videocassettes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">94</container>
+                <unittitle>ECD Headquarters, SRO (Stanford R. Ovshinsky) at Work, OBC (Ovonic Battery Company) Lab/EV Battery </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">95</container>
+                <unittitle>ECD/HKO Media promotional video scripts, <unitdate type="inclusive">1994-2009</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">95</container>
+                <unittitle>ECD Mexico Video/Stan Ovshinsky Video, <unitdate type="inclusive">April 15, 2002</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>2 Betacam SP videocassettes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">95</container>
+                <unittitle>ECD/HKO Media miscellaneous B-roll footage notes</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">97 </container>
+                <unittitle>"ECD Photovoltaics" raw footage, <unitdate type="inclusive">ca. 2002</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>10 Betacam SP videocassettes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">97 </container>
+                <unittitle>ECD product display footage, dated <unitdate type="inclusive">March 5, 1996</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>2 Betacam SP videocassettes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">97 </container>
+                <unittitle>"ECD Rolls 8-10 Photographers Commercial"</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">89</container>
+                <unittitle>ECD tour footage, dated <unitdate type="inclusive">January 16, 1997</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>3 Betacam SP videocassettes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc> Online </physloc>
+                <unittitle>"ECD: Transforming the Future," <unitdate type="inclusive">April 25, 2002</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>video</physfacet>
+                </physdesc>
+                <dao href="http://hdl.handle.net/2027.42/116157" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download item]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">90 </container>
+                <unittitle>"ECD: Transforming the Future" field master tapes </unittitle>
+                <physdesc>
+                  <physfacet>18 Betacam SP videocassettes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">93</container>
+                <unittitle> "ECD: Transforming the Future" raw footage </unittitle>
+                <physdesc>
+                  <physfacet>30 Betacam SP videocassettes and miniature digital cassettes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">89 </container>
+                <unittitle>"ECD's Ovonic Battery: The Future is Now," dated <unitdate type="inclusive">September 12, 1993</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc> Online </physloc>
+                <unittitle>"ECD's Ovonic Battery: The Future is Now (Scooter Version)," <unitdate type="inclusive">April 4, 1995</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>video</physfacet>
+                </physdesc>
+                <dao href="http://hdl.handle.net/2027.42/116156" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download item]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">89 </container>
+                <unittitle>"ECD Ovonics: Excerpt from the Leadership Challenge," WDIV TV, <unitdate type="inclusive">July 29, 2002</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">89 </container>
+                <unittitle> "ECD Ovonics Solutions" miscellaneous footage, <unitdate type="inclusive">August 13, 2002</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>3 Betacam SP videocassettes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">106</container>
+                <unittitle>ECD/Uni-Solar general footage, <unitdate type="inclusive">ca. 2002</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">97</container>
+                <unittitle>ECD/Uni-Solar general footage, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>8 Betacam SP videocassettes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">106 </container>
+                <unittitle>"ECD Video," <unitdate type="inclusive">August 19, 1996</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">95</container>
+                <unittitle> "ECD Web Segments: Corporate History, Ovonic Battery, Hydrogen Technology, United Solar, and Information Storage," <unitdate type="inclusive">August 4, 2000</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>Betacam SP videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">106 </container>
+                <unittitle>"Energy Conversion Devices Video," <unitdate type="inclusive">undated</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">89</container>
+                <unittitle>General Motors Corporation ATV miscellaneous footage, dated <unitdate type="inclusive">January 6, 1998</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>Betacam SP videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">91</container>
+                <unittitle>Mexico promotional material and media, <unitdate type="inclusive">ca. 1994-2001</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>21 Betacamp SP videocassettes and miniature digital cassettes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">92 </container>
+                <unittitle>"Ovonic Battery," miscellaneous videos (1990-1998) </unittitle>
+                <physdesc>
+                  <physfacet>19 Betacam SP videocassettes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">89</container>
+                <unittitle>Ovonic Battery Compilation Reel, <unitdate type="inclusive">July 10, 1998</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc> Online </physloc>
+                <unittitle>"Ovonic Battery Video News Release," <unitdate type="inclusive">May 18, 1992</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>video</physfacet>
+                </physdesc>
+                <dao href="http://hdl.handle.net/2027.42/116159" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download item]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc> Online </physloc>
+                <unittitle>Ovonic Battery Company video (Selectra version), <unitdate type="inclusive">July 9, 1996</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>video</physfacet>
+                </physdesc>
+                <dao href="http://hdl.handle.net/2027.42/116161" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download item]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">89 </container>
+                <unittitle>"Ovonic Battery/EV1 Cross-Country Shoot" miscellaneous footage, <unitdate type="inclusive">October 12, 2000</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>3 Betacam SP videocassettes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc> Online </physloc>
+                <unittitle>Ovonics@Work video, <unitdate type="inclusive">May 9, 2002</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>video</physfacet>
+                </physdesc>
+                <dao href="http://hdl.handle.net/2027.42/116134" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download item]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">94 </container>
+                <unittitle>"Ovonic Hydrogen Solutions: A Video News Release," <unitdate type="inclusive">February 6, 2003</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>Betacam SP videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">106</container>
+                <unittitle>Ovshinsky, interview with HKO Media, <unitdate type="inclusive">December 21, 1993</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>3 Betacam SP videocassettes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">106</container>
+                <unittitle>Ovshinsky, interview with HKO Media, <unitdate type="inclusive">March 4, 1996</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>Betacam SP videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">106</container>
+                <unittitle>Ovshinsky/Stempel interview, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc> Online </physloc>
+                <unittitle>"The Road to the Sun: Alternative Energy for the Americas," <unitdate type="inclusive">2009</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>video</physfacet>
+                </physdesc>
+                <dao href="http://hdl.handle.net/2027.42/116163" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download item]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">96</container>
+                <unittitle> "The Road to the Sun: Alternative Energy for the Americas" production binder, University of California Berkeley/HKO Media, <unitdate type="inclusive">February 13, 2009</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">103 </container>
+                <unittitle>"Sunlaw Cogeneration Partners 1," Sunlaw/Bosustow Video, <unitdate type="inclusive">June 7, 1990</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">104</container>
+              <unittitle>Publicity and media coverage</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">104</container>
+                <unittitle>"Alaska Report,"  <unitdate type="inclusive">September 25, 1996</unitdate></unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette) </physfacet>
+                </physdesc>
+                <note>
+                  <p>(includes electric car and interview Robert Stempel)</p>
+                </note>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">104</container>
+                <unittitle>Blieden  <unitdate type="inclusive">February 7, 1983</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>U-matic videocassette</physfacet>
+                </physdesc>
+                <note>
+                  <p>(H. Richard Blieden)%ne interview, Channel 7</p>
+                </note>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">104</container>
+                <unittitle>"The Bloomberg Forum," Robert C. Stempel, Chairman/CEO, Interview <unitdate type="inclusive">September 15, 1998</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">105</container>
+                <unittitle>Bloomfield Community Television, "Michigan on Wall Street" with Stan Ovshinsky and Robert Stempel, <unitdate type="inclusive">January 1997</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">103</container>
+                <unittitle>Bush, George H.W. and electric car reports: News 7, WJLA TV,  October 25, 1991/Cable News Network (CNN)<title render="italic"> Weekend News</title>, <unitdate type="inclusive">October 26, 1991</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">103</container>
+                <unittitle>Cable News Network (CNN) footage, <unitdate type="inclusive">October 19, 1987</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">94</container>
+                <unittitle>Channel 56 video </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">95 </container>
+                <unittitle>"ECD Analysts Video," <unitdate type="inclusive">April 20, 1998</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>Betacam SP videocassettes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">95 </container>
+                <unittitle>ECD News Program Channel 7, Channel 55 </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">95 </container>
+                <unittitle>ECD/USSC (United Solar Systems Corporation) press conference, <unitdate type="inclusive">February 14, 1996</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">95 </container>
+                <unittitle>ECD/USSC (United Solar Systems Corporation) 5 Mega-Watt Opening, <unitdate type="inclusive">February 15, 1996</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">95 </container>
+                <unittitle>"Edge--CNBC Cable, Energy Conversion Devices," <unitdate type="inclusive">February 22, 2000</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">95 </container>
+                <unittitle>"Electric Vehicles,"<title render="italic"> Cutting Edge Technology Report</title>, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">95 </container>
+                <unittitle>"Energy Efficient House," Headline News Network, <unitdate type="inclusive">October 23, 1996</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc> Online </physloc>
+                <unittitle>GM Advanced Technology Vehicles Press Conference at North American International Auto Show, highlights, <unitdate type="inclusive">January 4, 1998</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>video</physfacet>
+                </physdesc>
+                <dao href="http://hdl.handle.net/2027.42/116154" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download item]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">88</container>
+                <unittitle>GM Battery, Energy Conversion Devices, <unitdate type="inclusive">March 18, 1994</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc> Online </physloc>
+                <unittitle>GM EV1 Global Motors and ECD Press Conference and Tour Highlights with Lee Iacocca, dated <unitdate type="inclusive">April 16, 1998</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>video</physfacet>
+                </physdesc>
+                <dao href="http://hdl.handle.net/2027.42/116164" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download item]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">89</container>
+                <unittitle>GM EV1 Global Motors and ECD Press Conference additional footage, dated <unitdate type="inclusive">February 10, 1998</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>2 Betacam SP videocassettes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">89</container>
+                <unittitle>GM Ovonic Auto Show Display, dated <unitdate type="inclusive">January 13, 1998</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet> (2 Betacam SP videocassettes</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">103</container>
+                <unittitle>GM Ovonic, TV 2 News, <unitdate type="inclusive">December 1, 1994</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">103</container>
+                <unittitle>"Hidden Tech," Target 7 News, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">97 </container>
+                <unittitle>"La Luz de La Esperanza," Documental Oaxaca, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>Betacam SP videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">104 </container>
+                <unittitle>"Market Call,"  CNN/FN Cable <unitdate type="inclusive">May 21, 2002</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+                <note>
+                  <p>(featuring Robert Stempel) </p>
+                </note>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">94 </container>
+                <unittitle>"Ovonic Energy Solutions," <unitdate type="inclusive">November 19, 2008</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>Sony DVCAM videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">95 </container>
+                <unittitle>"Ovonic Hydrogen Solutions Demonstration," White House Television, <unitdate type="inclusive">February 6, 2003</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>Betacam SP videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">95 </container>
+                <unittitle>"Ovonic Hydrogen Solutions in the News, <unitdate type="inclusive">February 6-11, 2003</unitdate>" <unitdate type="inclusive">February 24, 2003</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>Betacam SP videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc> Online </physloc>
+                <unittitle>"Ovonic Information Technology Solutions," <unitdate type="inclusive">February 13, 2003</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>video</physfacet>
+                </physdesc>
+                <dao href="http://hdl.handle.net/2027.42/116166" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download item]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc> Online </physloc>
+                <unittitle>"Ovonic Solar Solutions" in Mexico, <unitdate type="inclusive">July 3, 2002</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>video</physfacet>
+                </physdesc>
+                <dao href="http://hdl.handle.net/2027.42/116158" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download item]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc> Online </physloc>
+                <unittitle>Ovonics/Robert Stempel, CEO, WDIV First News at 6, <unitdate type="inclusive">August 22, 2003</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">94</container>
+                <unittitle>PV Shingles from United Solar on WDIV, <unitdate type="inclusive">February 1996</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">103</container>
+                <unittitle>Rural Electrification Program, Oaxaca, Mexico, <unitdate type="inclusive">2000</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">103</container>
+                <unittitle>Saraboo Production/ECD, <unitdate type="inclusive">June 18, 1986</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">106</container>
+                <unittitle>United States Department of Energy/Energy Conversion Devices press conference, <unitdate type="inclusive">January 18, 1994</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">89</container>
+                <unittitle>US Advanced Battery Consortium (USABC)/Energy Conversion Devices (ECD)/Ovonic Battery press conference, <unitdate type="inclusive">May 19, 1992</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">89</container>
+                <unittitle> "What's Up in Technology?" Thirteen/WNET, <unitdate type="inclusive">October 23, 1998</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">103</container>
+                <unittitle>White House Conference on Global Climate Change, <unitdate type="inclusive">October 6, 1997</unitdate> excerpt of Secretary Pena's holding and discussion, USSC Solar Shingle </unittitle>
+                <physdesc>
+                  <physfacet>VHS videocassette</physfacet>
+                </physdesc>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">53</container>
+              <unittitle>Research</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">53</container>
+                <unittitle>Active material fabrication basic process, <unitdate type="inclusive">June 1973</unitdate> </unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">53</container>
+                <unittitle>Affidavits -- missing sample 644, <unitdate type="inclusive">August 1978</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">53</container>
+                <unittitle>Amorphous Silicon, <unitdate type="inclusive">1994-1995</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">53</container>
+                <unittitle>Cosmology collaboration with Fritzsche, <unitdate type="inclusive">1992-2003</unitdate> </unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
+              </did>
+              <note>
+                <p>(Includes research for papers: <title render="italic"> The Origin of Dark Matter in the Universe</title> and<title render="italic"> Vacuum Energy, Gravity, and an Approach to Combing General Relativity with Quantum Mechanics</title>)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">53</container>
+                <unittitle>Memory materials-Ge:Sb:Te, <unitdate type="inclusive">1992-2005</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">53</container>
+                <unittitle>Optical recording, <unitdate type="inclusive">1999-2000</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">53</container>
+                <unittitle>Posters, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">53</container>
+                <unittitle>Properties of amorphous semiconductors at high temperatures, <unitdate type="inclusive">October 1969</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">53</container>
+              <unittitle>Resumes, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">53</container>
+              <unittitle>Schedules, <unitdate type="inclusive">1968-1969</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Shareholders</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Annual reports</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">53</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1968-1976</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">53</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1993</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">53</container>
+                <unittitle>Financial reports, <unitdate type="inclusive">1962-1985</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">53</container>
+                <unittitle>Interim reports, <unitdate type="inclusive">1970</unitdate> and <unitdate type="inclusive">1985</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Letter to shareholders</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">53</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1979</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">53</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1994</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">53</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1995</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">53</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1996</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">53</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1997</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">53</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1999</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">53</container>
+                  <unittitle>
+                    <unitdate type="inclusive">2000</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">53</container>
+                <unittitle>Meetings, <unitdate type="inclusive">1985</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">53</container>
+                <unittitle>Miscellaneous, <unitdate type="inclusive">1981-1983</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Includes an organizational hierarchy)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc> Online </physloc>
+                <unittitle>Presentation to shareholders' meeting, <unitdate type="inclusive">2005</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>video</physfacet>
+                </physdesc>
+                <dao href="http://hdl.handle.net/2027.42/116149" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download item]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">53</container>
+                <unittitle>President's letter</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">53</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1981</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">53</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1983</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">53</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1983</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">53</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1985</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">53</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1987</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">53</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1988</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">53</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1990</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">53</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1992</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">53</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1993</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">53</container>
+                <unittitle>Special reports, <unitdate type="inclusive">1972-1996</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">54</container>
+              <unittitle>Speeches and interviews, <unitdate type="inclusive">1969-1982</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>SRO employment agreement and termination, <unitdate type="inclusive">1993-2007</unitdate></unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">54</container>
+                <unittitle>Stock options, <unitdate type="inclusive">1996-2006</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Contains Iris Ovshinsky's employment agreement)</p>
+              </note>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">54</container>
+              <unittitle>Stock share prices, <unitdate type="inclusive">2007-2011</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Subsidiaries</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">54</container>
+                <unittitle>Grupo Ovonics Latinoamerica, <unitdate type="inclusive">2003-2004</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">54</container>
+                <unittitle>Micorovonics -- Notes, <unitdate type="inclusive">1979-1980</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Ovonic Battery Company</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">54</container>
+                  <unittitle>Advanced development, <unitdate type="inclusive">2002-2005</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">54</container>
+                  <unittitle>Advance MH alloys,  October 2001(?)</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">54</container>
+                  <unittitle>American Natural Resources Company annual reports, <unitdate type="inclusive">1983-1984</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">54</container>
+                  <unittitle>Chevy Volt meeting, <unitdate type="inclusive">April 2007</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">54</container>
+                  <unittitle>Cobasys-Information binder, <unitdate type="inclusive">2006</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">54</container>
+                  <unittitle>Correspondence-Unhappy corporate partners, <unitdate type="inclusive">December 1996</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">54</container>
+                  <unittitle>Development and meeting PowerPoints, <unitdate type="inclusive">2007</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">54</container>
+                  <unittitle>Development and strategy, 1990-2000(?)</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">54</container>
+                  <unittitle>Foreign storage and material cost, <unitdate type="inclusive">1994-1998</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">54</container>
+                  <unittitle>Fritzsche, Hellmut, <unitdate type="inclusive">July 1998</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>GM Ovonic</unittitle>
+                </did>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">54</container>
+                    <unittitle>
+                      <unitdate type="inclusive">April 1994</unitdate>
+                    </unittitle>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">54</container>
+                    <unittitle>
+                      <unitdate type="inclusive">1997</unitdate>
+                    </unittitle>
+                  </did>
+                </c06>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">54</container>
+                  <unittitle>License agreement, <unitdate type="inclusive">April 1995</unitdate> </unittitle>
+                </did>
+                <note>
+                  <p>(Walsin Tech. Corp.)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">54</container>
+                  <unittitle>Matsushita hydrogen storage alloy patent, <unitdate type="inclusive">June 1989</unitdate> </unittitle>
+                </did>
+                <note>
+                  <p>(Effect on ECD)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">54</container>
+                  <unittitle>Meeting with ECD, <unitdate type="inclusive">February 21-22, 1996</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">54</container>
+                  <unittitle>Memos, <unitdate type="inclusive">1997</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">54</container>
+                  <unittitle>Miscellaneous, <unitdate type="inclusive">1990</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">54</container>
+                  <unittitle>Presentation slides, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">54</container>
+                  <unittitle>Review meeting-NIST --AMAPP, <unitdate type="inclusive">July 15, 1999</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">54</container>
+                <unittitle>Ovonic Display Systems -- presentation slides, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">54</container>
+                <unittitle>Ovonic Hydrogen Technology, <unitdate type="inclusive">1997-2002</unitdate> </unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">55</container>
+                <unittitle>Ovonic Hydrogen Technology, <unitdate type="inclusive">2000-2003</unitdate> </unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Ovonic Hydrogen Systems</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">55</container>
+                  <unittitle>Texaco Ovonic Hydrogen Systems, LLC, <unitdate type="inclusive">2003</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>photographs</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <physloc> Online </physloc>
+                  <unittitle>Ovonic Solid Hydrogen Storage System <unitdate type="inclusive">2003</unitdate> Challenge Bibendum ( September 23-25) photographs </unittitle>
+                  <dao href="http://hdl.handle.net/2027.42/116204" show="new" actuate="onrequest">
+                    <daodesc>
+                      <p>[download item]</p>
+                    </daodesc>
+                  </dao>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Oversize">110 </container>
+                  <unittitle>Texaco Ovonic Hydrogen Systems manufacturing facility design, <unitdate type="inclusive">2003</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <physloc> Online </physloc>
+                  <unittitle>Highlights: Texaco, Inc., and Energy Conversion Devices, Inc., press conference, <unitdate type="inclusive">May 2, 2000</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>video</physfacet>
+                  </physdesc>
+                  <dao href="http://hdl.handle.net/2027.42/116167" show="new" actuate="onrequest">
+                    <daodesc>
+                      <p>[download item]</p>
+                    </daodesc>
+                  </dao>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">89</container>
+                  <unittitle>Texaco and Energy Conversion Devices, Inc., press conference additional footage (display materials and reporter reactions), <unitdate type="inclusive">May 2, 2000</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>2 Betacam SP videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">106</container>
+                  <unittitle>Texaco/ECD presentation with Stanford Ovshinsky, <unitdate type="inclusive">June 7, 2000</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">106</container>
+                  <unittitle>Texaco Hydrogen Economy Corporate Center meeting, <unitdate type="inclusive">June 22, 2000</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">55</container>
+                  <unittitle>Akron, <unitdate type="inclusive">2006</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">55</container>
+                  <unittitle>Akron groundbreaking, <unitdate type="inclusive">April 27, 2006</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">55</container>
+                  <unittitle>Akron meeting, <unitdate type="inclusive">June 13, 2006</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">55</container>
+                  <unittitle>Acquisition, <unitdate type="inclusive">2007-2008</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">55</container>
+                  <unittitle>Business model and proposal to purchase, <unitdate type="inclusive">2007</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <physloc> Online </physloc>
+                  <unittitle>ECD Ovonics Press Conference in Akron, <unitdate type="inclusive">April 27, 2006</unitdate> (two videos) </unittitle>
+                  <physdesc>
+                    <physfacet>.ZIP file</physfacet>
+                  </physdesc>
+                  <dao href="http://hdl.handle.net/2027.42/116171" show="new" actuate="onrequest">
+                    <daodesc>
+                      <p>[download item]</p>
+                    </daodesc>
+                  </dao>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">55</container>
+                <unittitle>Ovonic Imaging Systems, Inc.</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">55</container>
+                  <unittitle>Report -- New concepts and applications in nonsilver photographic and electrographic recording, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Shareholders</unittitle>
+                </did>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">55</container>
+                    <unittitle>Annual reports, <unitdate type="inclusive">1987</unitdate></unittitle>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">55</container>
+                    <unittitle>President's letter, <unitdate type="inclusive">1989</unitdate></unittitle>
+                  </did>
+                </c06>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">55</container>
+                  <unittitle>X-ray -- Perspectives on Medical Imaging internal memo, <unitdate type="inclusive">1973-1974</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Ovonic Media, LLC</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">55</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1990-2001</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">55</container>
+                  <unittitle>
+                    <unitdate type="inclusive">2000</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">55</container>
+                <unittitle>Ovonic Memories, Inc. -- Switch memory, <unitdate type="inclusive">1970-1973</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">55</container>
+                <unittitle>Ovonic Solar -- marketing strategy slides, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Ovonyx</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">55</container>
+                  <unittitle>
+                    <unitdate type="inclusive">2006</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">55</container>
+                  <unittitle>
+                    <unitdate type="inclusive">2007</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">55</container>
+                  <unittitle>
+                    <unitdate type="inclusive">2008-2009</unitdate>
+                  </unittitle>
+                  <physdesc>
+                    <extent>2 folders</extent>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">56</container>
+                  <unittitle>
+                    <unitdate type="inclusive">2010-2011</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">56</container>
+                  <unittitle>
+                    <unitdate type="inclusive">2012</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">56</container>
+                  <unittitle>Acquisition, <unitdate type="inclusive">2007</unitdate> </unittitle>
+                </did>
+                <note>
+                  <p>(by Ovshinsky Innovation)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">56</container>
+                  <unittitle>Correspondence and Cognitive computer patents, <unitdate type="inclusive">2000-2002</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">56</container>
+                  <unittitle>Fritzsche problem solving, <unitdate type="inclusive">August 2000</unitdate> </unittitle>
+                </did>
+                <note>
+                  <p>(Contains research photographs)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <unittitle>Ovonic Cognitive Computer</unittitle>
+                </did>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">56</container>
+                    <unittitle>
+                      <unitdate type="inclusive">1992-2000</unitdate>
+                    </unittitle>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">56</container>
+                    <unittitle>
+                      <unitdate type="inclusive">2000-2005</unitdate>
+                    </unittitle>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">56</container>
+                    <unittitle>Abstracts and revisions, <unitdate type="inclusive">2003</unitdate></unittitle>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">56</container>
+                    <unittitle>Board meeting posters, <unitdate type="inclusive">May 8, 2003</unitdate></unittitle>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">56</container>
+                    <unittitle>Cognitive device principles of operation, <unitdate type="inclusive">July 2003</unitdate> </unittitle>
+                  </did>
+                  <note>
+                    <p>(B. Pashmakov, superseded by Intel pkg. Aug 26, 2003)</p>
+                  </note>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">56</container>
+                    <unittitle>Cognitive quantum computing, <unitdate type="inclusive">1992-2000</unitdate></unittitle>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">56</container>
+                    <unittitle>Encryption, <unitdate type="inclusive">1998-2000</unitdate></unittitle>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">56</container>
+                    <unittitle>History, <unitdate type="inclusive">undated</unitdate></unittitle>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Information binders</unittitle>
+                  </did>
+                  <c07 level="file">
+                    <did>
+                      <container type="box" label="Box">56</container>
+                      <unittitle>Confidential, 1999(?)</unittitle>
+                    </did>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <container type="box" label="Box">56</container>
+                      <unittitle>Ovonic Cognitive Computer (OCC), <unitdate type="inclusive">2003</unitdate></unittitle>
+                    </did>
+                  </c07>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Meetings</unittitle>
+                  </did>
+                  <c07 level="file">
+                    <did>
+                      <container type="box" label="Box">56</container>
+                      <unittitle>Logic devices -- 3-terminal devices, <unitdate type="inclusive">January 5, 2004</unitdate></unittitle>
+                    </did>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <container type="box" label="Box">56</container>
+                      <unittitle>M. Cohen, <unitdate type="inclusive">February 17, 2004</unitdate></unittitle>
+                    </did>
+                  </c07>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">56</container>
+                    <unittitle>Miscellaneous, <unitdate type="inclusive">2004-2006</unitdate></unittitle>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">56</container>
+                    <unittitle>Number of constant amplitude pulses </unittitle>
+                  </did>
+                  <note>
+                    <p>(added cog comp file, Sept 2003)</p>
+                  </note>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">56</container>
+                    <unittitle>Overheads, <unitdate type="inclusive">2002-2005</unitdate></unittitle>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">56</container>
+                    <unittitle>Package to Intel, <unitdate type="inclusive">August 2003</unitdate></unittitle>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">56</container>
+                    <unittitle>Presentations, <unitdate type="inclusive">2004-2007</unitdate></unittitle>
+                  </did>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <unittitle>Proposals</unittitle>
+                  </did>
+                  <c07 level="file">
+                    <did>
+                      <container type="box" label="Box">56</container>
+                      <unittitle>Business version, <unitdate type="inclusive">April 2005</unitdate></unittitle>
+                    </did>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <container type="box" label="Box">56</container>
+                      <unittitle>Conceptual plan, <unitdate type="inclusive">January 2006</unitdate></unittitle>
+                    </did>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <container type="box" label="Box">56</container>
+                      <unittitle>Revisions, <unitdate type="inclusive">February 2005</unitdate></unittitle>
+                    </did>
+                  </c07>
+                  <c07 level="file">
+                    <did>
+                      <container type="box" label="Box">56</container>
+                      <unittitle>Short, long, and Intel versions,  February and <unitdate type="inclusive">April 2005</unitdate></unittitle>
+                    </did>
+                  </c07>
+                </c06>
+                <c06 level="file">
+                  <did>
+                    <container type="box" label="Box">56</container>
+                    <unittitle>SRO paper drafts, <unitdate type="inclusive">2003-2006</unitdate></unittitle>
+                  </did>
+                </c06>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">56</container>
+                  <unittitle>Press releases, <unitdate type="inclusive">2003-2008</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">94</container>
+                <unittitle>Sovonics</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">94</container>
+                  <unittitle>Plant 11 opening video, <unitdate type="inclusive">May 31, 1984</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>U-matic videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">56</container>
+                  <unittitle>Photovoltaic plant dedication ceremony, <unitdate type="inclusive">May 31, 1984</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">56</container>
+                  <unittitle>Presentation slides, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">56</container>
+                  <unittitle>Press release and patents, <unitdate type="inclusive">1985</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">88 </container>
+                  <unittitle>"Power Where You Need It," <unitdate type="inclusive">March 29, 1986</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">56</container>
+                  <unittitle>Recent application photographs, <unitdate type="inclusive">1988</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">56</container>
+                  <unittitle>Report on solar technology, 1986(?)</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">56</container>
+                  <unittitle>Status of Amorphous Silicon Alloy solar technology at ECD, <unitdate type="inclusive">1986</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">97</container>
+                <unittitle>Uni-Solar</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">97</container>
+                  <unittitle>ASR Metal Roofing on HGTV, <unitdate type="inclusive">May 14, 1998</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>Betacam SP videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">56</container>
+                  <unittitle>Business plan review, <unitdate type="inclusive">2005</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">56</container>
+                  <unittitle>Inauguration forum schedule, <unitdate type="inclusive">June 24, 2002</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">56</container>
+                  <unittitle>Information packet, <unitdate type="inclusive">2004</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">107</container>
+                  <unittitle>Correspondence, <unitdate type="inclusive">November 1997</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">103</container>
+                  <unittitle>Distribution and installation of Uni-Solar Unikits in Chiapas, Mexico, <unitdate type="inclusive">October 1994</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">95</container>
+                  <unittitle>Installation of solar panels on the Mir space station, <unitdate type="inclusive">November 1998</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">56</container>
+                  <unittitle>Management report, <unitdate type="inclusive">2007</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>includes Research and Development department</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">56</container>
+                  <unittitle>Opening and groundbreaking, <unitdate type="inclusive">June 2002</unitdate> and <unitdate type="inclusive">July 14, 2005</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <physloc> Online </physloc>
+                  <unittitle>Opening photographs, <unitdate type="inclusive">June 2002</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>.ZIP file</physfacet>
+                  </physdesc>
+                  <dao href="http://hdl.handle.net/2027.42/116173" show="new" actuate="onrequest">
+                    <daodesc>
+                      <p>[download item]</p>
+                    </daodesc>
+                  </dao>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">88</container>
+                  <unittitle>ECD/Uni-Solar Groundbreaking Ceremony and Plant Tour, produced <unitdate type="inclusive">August 16, 2005</unitdate> (video is also labeled  August 15, 2005) </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">88</container>
+                  <unittitle>Samuel Bodman ECD/Uni-Solar speech, <unitdate type="inclusive">August 29, 2005</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <physloc> Online </physloc>
+                  <unittitle>ECD Uni-Solar Groundbreaking film, <unitdate type="inclusive">July 14, 2005</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>video</physfacet>
+                  </physdesc>
+                  <dao href="http://hdl.handle.net/2027.42/116137" show="new" actuate="onrequest">
+                    <daodesc>
+                      <p>[download item]</p>
+                    </daodesc>
+                  </dao>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <physloc> Online </physloc>
+                  <unittitle>ECD Uni-Solar (Greenville, Michigan) press video and visit of President Bush, <unitdate type="inclusive">March 21, 2006</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>video</physfacet>
+                  </physdesc>
+                  <dao href="http://hdl.handle.net/2027.42/116160" show="new" actuate="onrequest">
+                    <daodesc>
+                      <p>[download item]</p>
+                    </daodesc>
+                  </dao>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <physloc> Online </physloc>
+                  <unittitle>ECD Uni-Solar Tour and History, <unitdate type="inclusive">July 5, 2010</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>video</physfacet>
+                  </physdesc>
+                  <dao href="http://hdl.handle.net/2027.42/116146" show="new" actuate="onrequest">
+                    <daodesc>
+                      <p>[download item]</p>
+                    </daodesc>
+                  </dao>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">89</container>
+                  <unittitle>ECD Mexico/Uni-Solar PVL training installation, dated <unitdate type="inclusive">June 3, 2002</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>Betacam SP videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">57</container>
+                  <unittitle>Origin, <unitdate type="inclusive">1990-2001</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">57</container>
+                  <unittitle>Reports, <unitdate type="inclusive">2010-2011</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">57</container>
+                  <unittitle>Research and correspondence, <unitdate type="inclusive">1992-1995</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">57</container>
+                  <unittitle>Research and development, <unitdate type="inclusive">2007-2008</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>and drift reduction results</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">57</container>
+                  <unittitle>Shingle roofing products, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">57</container>
+                  <unittitle>United Solar Sytems: "The Power to Change the World," <unitdate type="inclusive">February 11, 1998</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">95</container>
+                  <unittitle>United Solar Systems, Inc., compilation reel, <unitdate type="inclusive">May 28, 1998</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+            </c04>
+          </c03>
+          <c03 level="item">
+            <did>
+              <container type="box" label="Box">57</container>
+              <unittitle>Technical reports, <unitdate type="inclusive">1965-1966</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">57</container>
+              <unittitle>Technical reports, <unitdate type="inclusive">1970-1973</unitdate> </unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">57</container>
+              <unittitle>Working files, <unitdate type="inclusive">1973-1984</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">57</container>
+              <unittitle>Working files and notes -- SRO, <unitdate type="inclusive">1971-1985</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">105</container>
+              <unittitle>Visit of Stan and Iris Ovshinsky, and "entourage" to Soviet Union, <unitdate type="inclusive">circa 1985-1986</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">104</container>
+              <unittitle>Visit of Russian delegation to ECD, <unitdate type="inclusive">January 1991</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">103</container>
+              <unittitle>Visit to Russia, <unitdate type="inclusive">July 1990</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="subseries">
+          <did>
+            <unittitle>Institute for Amorphous Studies (IAS)</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">57</container>
+              <unittitle>Advisory Committee</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">57</container>
+                <unittitle>Committee member list, 1983(?)</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">57</container>
+                <unittitle>Committee member list and Institute history, <unitdate type="inclusive">September 1985</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">57</container>
+                <unittitle>Photographs of committee members, <unitdate type="inclusive">March 1984</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Contains negatives)</p>
+              </note>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">57</container>
+              <unittitle>APS satellite meeting, <unitdate type="inclusive">March 1984</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Board of Directors</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">57</container>
+                <unittitle>Board member list, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Meetings</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">58</container>
+                  <unittitle>
+                    <unitdate type="inclusive">January 4, 1984</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">58</container>
+                  <unittitle>
+                    <unitdate type="inclusive">January 3, 1986</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Minutes</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">58</container>
+                  <unittitle><unitdate type="inclusive">January 1983</unitdate> and <unitdate type="inclusive">March 1984</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">58</container>
+                  <unittitle>
+                    <unitdate type="inclusive">January 1983-April 1984</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">58</container>
+                  <unittitle>
+                    <unitdate type="inclusive">August 1984-February 1985</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">58</container>
+                  <unittitle>
+                    <unitdate type="inclusive">January 1985</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">58</container>
+                  <unittitle>
+                    <unitdate type="inclusive">December 1986</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Photographs of board members, <unitdate type="inclusive">1984</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Brochures</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>
+                  <unitdate type="inclusive">1982-1986</unitdate>
+                </unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Photographs, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Contains photographs, negatives, and slides)</p>
+              </note>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Conferences</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>General information, <unitdate type="inclusive">1983</unitdate> and <unitdate type="inclusive">1985</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>International conference on the Theory of the Structures of Non-Crystalline Solids, <unitdate type="inclusive">1985</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Correspondence</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <unittitle>International topical conference on Transport and Defects in Amorphous Semiconductors (TODIAS)</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">58</container>
+                  <unittitle>Journal of Non-Crystalline Solids, <unitdate type="inclusive">July 1984</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">58</container>
+                  <unittitle>Lecture transcripts, <unitdate type="inclusive">March 1984</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">58</container>
+                  <unittitle>Photographs, <unitdate type="inclusive">March 1984</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Advisory Committee, <unitdate type="inclusive">1984-1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Board of Directors, <unitdate type="inclusive">January 1983-November 1985</unitdate> </unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Bogden, Al, <unitdate type="inclusive">August-September 1984</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Corporate communications,  November -- December 1984</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Events at the Institute, <unitdate type="inclusive">May 1982-November 1985</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Ito, Rik, <unitdate type="inclusive">January-September 1985</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Miscellaneous, <unitdate type="inclusive">March 1982-August 1984</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Ovonic Battery Company, <unitdate type="inclusive">March 1985</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Ovshinsky, Stanford,  January 1985-November1986 </unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Schwartz, Brian, <unitdate type="inclusive">August 1984-May 1987</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Director)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Steele, Martin, <unitdate type="inclusive">October 1982-June 1984</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Director)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Requests for information, <unitdate type="inclusive">October 1984-September 1985</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Energy Conversion Devices (ECD)</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Corporate Values and Operating Principles, <unitdate type="inclusive">September 1985</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Miscellaneous typing done for ECD personnel, <unitdate type="inclusive">1984</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Project listings, <unitdate type="inclusive">January 1985-May 1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Rosenfield and Clevey</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">58</container>
+                  <unittitle>Miscellaneous correspondence, <unitdate type="inclusive">November 1984-August 1985</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">58</container>
+                  <unittitle>National Science Foundation science week, <unitdate type="inclusive">October 1984-March 1985</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">58</container>
+                  <unittitle>Science and technology exhibit, <unitdate type="inclusive">November 1984-December 1985</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Small business innovation research proposals, <unitdate type="inclusive">October 1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Summer intern program, <unitdate type="inclusive">April-September 1985</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">58</container>
+              <unittitle>Events, <unitdate type="inclusive">January 1985-June 1986</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">58</container>
+              <unittitle>Financing, <unitdate type="inclusive">September 1984-February 1987</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">58</container>
+              <unittitle>Future programs, <unitdate type="inclusive">July-August 1985</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Inauguration, <unitdate type="inclusive">April 1982</unitdate></unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Attendance and Mott dinner party</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Photographs</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Press release</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Transcript of opening remarks</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">58</container>
+                <unittitle>Write-ups</unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Institute for Amorphous Studies series</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <unittitle>Volume 1</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle>Correspondence with authors, <unitdate type="inclusive">July-November 1984</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle>Correspondence with board of directors, <unitdate type="inclusive">September 1984</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle>Correspondence with publisher and contract, <unitdate type="inclusive">June 1984-February 1985</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle>Dust jacket and cover, <unitdate type="inclusive">January-February 1985</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle>Index, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle>Proofs and permission for publication, <unitdate type="inclusive">June 1984-January 1985</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Volumes 2 &amp; 3</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle>Correspondence with publisher and contracts, <unitdate type="inclusive">November 1984-August 1985</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle>Mott, Nevill Festschrift, <unitdate type="inclusive">October 1985</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle>Schedule sheet, <unitdate type="inclusive">September 1984</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle>SRO paper, <unitdate type="inclusive">November 1984</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">59</container>
+                <unittitle>Future Volumes, <unitdate type="inclusive">January 1984-July 1985</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">59</container>
+              <unittitle>Institute photographs, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              <physdesc>
+                <extent>3 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>(Contains photographs and negatives)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">59</container>
+              <unittitle>Jordan College Energy Institute, <unitdate type="inclusive">1985</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Lecture series</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">59</container>
+                <unittitle>Abstracts, <unitdate type="inclusive">1982-1983</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Oversize">111   </container>
+                <unittitle>Announcement posters, <unitdate type="inclusive">1982-1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Oversize">112  </container>
+                <unittitle>Announcement posters, <unitdate type="inclusive">1989-2010</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Oversize">112</container>
+                <unittitle>Attendance lists, <unitdate type="inclusive">1982-1984</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Oversize">112 </container>
+                <unittitle>Correspondence miscellaneous, <unitdate type="inclusive">1984-1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Recorded lectures</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle> September 29, 1982--Adler, David, "Physics of Amorphous Semiconductors" </unittitle>
+                  <physdesc>
+                    <physfacet>2 VHS videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle> October 14, 1982--Kastner, Mark </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle> December 8, 1982--Fritzsche, Hellmut, "Determination of the Density of States in Amorphous Semiconductors" </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle> December 20, 1982--Lucovsky, Gerald, "Vibrational Properties of Amorphous Solids--a) Elements and Compounds b) a-Si alloys" </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle> April 6, 1983--Pankove, Jacques </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle> September 28, 1983--Boolchand, Punit, "Massbauer Spectroscopy in Amorphous Semiconductors" </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle> October 24, 1983--Boolchand, Punit </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle> November 6, 1983--Zallen, Richard, "Percolation Theory: A Model for All Seasons" (tape has duplicate label reading Prof. Beinenstock) </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle>1984--Moustakas (likely Theodore) </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle> June 14, 1984--Goldstein, Bernard </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle> June 1984--Conrad, Michael </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle> July 11, 1984--Magar, Roger </unittitle>
+                  <physdesc>
+                    <physfacet>U-matic videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle> July 26, 1984--Chakraverty, B.K. </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle>Cohen, Morrel, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle>Crandall, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle>Desmarteau, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle>Guha, Subhendu, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle>Henisch, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle>Taylor, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle>Thorpe, Michael, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">98</container>
+                  <unittitle>Pankove, Jacques, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">99</container>
+                  <unittitle> October 25, 1984--Cooper, Leon </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">99</container>
+                  <unittitle> November 29, 1984--Twarog, Betty "Oxygen Deficiency Can Control the Form and Function of the Lung Circulation" </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">99</container>
+                  <unittitle> December 6, 1984--Williamson, Samuel J., "Neuromagnetism Lecture" </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">99</container>
+                  <unittitle> January 3, 1985--Moss, Si </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">99</container>
+                  <unittitle> January 17, 1985--Loferski </unittitle>
+                  <physdesc>
+                    <physfacet>U-matic videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">99</container>
+                  <unittitle> February 28, 1985--Pohl </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">99</container>
+                  <unittitle> March 6, 1985--"Atomic Comics" </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">99</container>
+                  <unittitle> March 21, 1985--Tsu, Raphael </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">100</container>
+                  <unittitle> April 11, 1985--Grieg </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">100</container>
+                  <unittitle> April 19, 1985--Jean Bennett </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">100</container>
+                  <unittitle> May 15, 1985--Greenler, Robert </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">100</container>
+                  <unittitle> May 22, 1985--Schuller, Ivan </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">100</container>
+                  <unittitle> June 13, 1985--Levanthal, Marvin, "Matter and Anti-Matter at the Center of the Milky Way Galaxy" </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">100</container>
+                  <unittitle> September 20, 1985--Wilson, Robert Rathbun, "Art, Intuition, and Science" </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">100</container>
+                  <unittitle> November 1, 1985--Pellier </unittitle>
+                  <physdesc>
+                    <physfacet>U-matic videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">100</container>
+                  <unittitle> November 22, 1985--Hoffmann, Roald, "Moving from Discrete Molecules to Extended Structures: A chemical and Theoretical Approach to Solid State" </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">101</container>
+                  <unittitle> December 9, 1985--Hartman, Hy, "Spin Glasses, Clays, and the Origins of Life" </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">101</container>
+                  <unittitle> January 6, 1986--Davis, Edward A., "21st Birthday of Amorphous Materials" </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">101</container>
+                  <unittitle> January 17, 1986--Cronin, James, "Do the Macroscopic and Microscopic Assymetries [sic] Have the Same Origin?" </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">101</container>
+                  <unittitle> February 21, 1986--Frankel, Richard, "Magnetic Navigation in Bacteria and Algae" </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">101</container>
+                  <unittitle> March 4, 1986--Fitzpatrick, Nigel, "The Aluminum Air Battery" </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">101</container>
+                  <unittitle> March 14, 1986--Schumaker, Bryan P., "Through History With Comet Halley" </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">101</container>
+                  <unittitle> April 21, 1986--Pauling, Linus </unittitle>
+                  <physdesc>
+                    <physfacet>U-matic videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">101</container>
+                  <unittitle> April 28, 1986--Mott, Nevill, "The Mobility Edge Since 1969" </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">101</container>
+                  <unittitle> June 10, 1986--Edgerton, Harold, "Strobe Lights and Their Use" </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">101</container>
+                  <unittitle> June 20, 1986--Bell, James W., "Fuzzy Messages, Real Stuff, and the Denial of the Importance of Science and Technology at the Dawn of the Information Age" </unittitle>
+                  <physdesc>
+                    <physfacet>U-matic videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">101</container>
+                  <unittitle> August 1, 1986--Henke, Burton L. </unittitle>
+                  <physdesc>
+                    <physfacet>U-matic videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">101</container>
+                  <unittitle> September 3, 1986--Turnbull, David, "Phase Transitions and Metastability in Condensed Ge and Si" </unittitle>
+                  <physdesc>
+                    <physfacet>U-matic videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">101</container>
+                  <unittitle> October 8, 1986--Sze, Simon M., "Fundamental Limits of VSLI Devices" </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">101</container>
+                  <unittitle> October 29, 1986--Henisch, Heinz K., "Photographic Pleasures" </unittitle>
+                  <physdesc>
+                    <physfacet>U-matic videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">101</container>
+                  <unittitle> November 19, 1986--Axelrod, Daniel, "Star Wars: Offense or Defense?" </unittitle>
+                  <physdesc>
+                    <physfacet>U-matic videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">101</container>
+                  <unittitle> December 3, 1986--Carroll, Robert G., "Cancer Detection and Treatment with Monoclonal Antibodies" </unittitle>
+                  <physdesc>
+                    <physfacet>U-matic videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">102</container>
+                  <unittitle> March 17, 1989--Adcock, Willis, "The Manufacturing Challenge" </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">102</container>
+                  <unittitle> November 19, 1990--Weisskopf, Victor, "The Origin of the Universe" </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">102</container>
+                  <unittitle> March 12, 1991--Hussain, Abid, "India and Its Energy Needs in the 1990s" </unittitle>
+                  <physdesc>
+                    <physfacet>U-matic videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">102</container>
+                  <unittitle> February 28, 1992--Fritzsche, Hellmut, "Science and Technology of Glasses" </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">102</container>
+                  <unittitle> April 1, 1992--McNeill, William H., "Population and Modern History" </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">102</container>
+                  <unittitle> January 19, 1996--Stempel, Robert C., "Personal Automotive Transportation: What is Ahead?" </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <physloc> Online </physloc>
+                  <unittitle> April 17, 1998--Stanford Ovshinsky: David Adler Memorial Lecture </unittitle>
+                  <physdesc>
+                    <physfacet>video</physfacet>
+                  </physdesc>
+                  <dao href="http://hdl.handle.net/2027.42/116153" show="new" actuate="onrequest">
+                    <daodesc>
+                      <p>[download item]</p>
+                    </daodesc>
+                  </dao>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">102</container>
+                  <unittitle> March 22, 2002--Kastner, Marc A., "The Single Electron Transistor and What It Can Tell Us About Molecular Electronics" </unittitle>
+                  <physdesc>
+                    <physfacet>Betacam SP videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">102</container>
+                  <unittitle> June 14, 2002--Kirchheim, Reiner, "The Next Generation Materials by Microstructural Design" </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">102</container>
+                  <unittitle>Boolchand, Punit, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">102</container>
+                  <unittitle>Lucovsky, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">102</container>
+                  <unittitle>Revez,Akos,  <unitdate type="inclusive">undated</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">102</container>
+                  <unittitle>Shiff, E., <unitdate type="inclusive">undated</unitdate> (videocassettes also labeled Dr. E Suatux) </unittitle>
+                  <physdesc>
+                    <physfacet>2 U-matic videocassettes</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">102</container>
+                  <unittitle>Silver, Marvin, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">102</container>
+                  <unittitle>Tauc, Jan, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                  <physdesc>
+                    <physfacet>VHS videocassette</physfacet>
+                  </physdesc>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">59</container>
+                <unittitle>Schedules, <unitdate type="inclusive">1982-1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Speakers</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> October 25, 1984--Cooper, Leon</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> November 29, 1984--Twarog, Betty</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> December 6, 1984--Williamson, Samuel</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> January 3, 1985--Moss, Simon</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> January 17, 1985--Loferski, Joseph</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> February 20, 1985--Pankove, Jacques</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> February 28, 1985--Pohl, Herbert</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> March 6, 1985--Peave, Fran and Charlie Varon</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> March 21, 1985--Tsu, Raphael</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> April 9, 1985--Barna, P.B. </unittitle>
+                </did>
+                <note>
+                  <p>(Lecture at Maple)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> April 11, 1985--Greig, Dennis</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> April 19, 1985--Bennet, Jean</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> May 1, 1985--Schiff, Eric</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> May 15, 1985--Greenler, Robert</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> May 22, 1985--Schuler, Ivan</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> June 13, 1985--Leventhal, Marv</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> August 6, 1985--Spaepen, Frans</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> September 23, 1985--Wilson, Robert R. </unittitle>
+                </did>
+                <note>
+                  <p>(Contains photographs and negatives)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> October 10, 1985--Bachmann, Klaus</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> November 22, 1985--Hoffman, Roald </unittitle>
+                </did>
+                <note>
+                  <p>(Contains photographs and negatives)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> December 9, 1985--Hartman, Hy</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> January 6, 1986--Davis, Ted</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> January 17, 1986--Cronin, James </unittitle>
+                </did>
+                <note>
+                  <p>(Contains negatives)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> February 21, 1986--Frankel, Richard</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> March 6, 1986--Fitzpatrick, Nigel</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> March 7, 1986--Solomon, Peter R.</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> March 21, 1986--Schumaker, Bryan</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> April 21, 1986--Pauling, Linus</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> April 28, 1986--Mott, Sir Nevill </unittitle>
+                </did>
+                <note>
+                  <p>(Contains photographs)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> June 10, 1986--Edgerton, Harold "Doc"</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">59</container>
+                  <unittitle> June 20, 1986--Bell, James</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">60</container>
+                  <unittitle> July 7, 1986--Chidichimo, G.</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">60</container>
+                  <unittitle> August 1, 1986--Henke, Burton L.</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">60</container>
+                  <unittitle> September 3, 1986--Turnbull, David</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">60</container>
+                  <unittitle> October 8, 1986--Sze, Simon M.</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">60</container>
+                  <unittitle> October 29, 1986--Henisch, Heinz</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">60</container>
+                  <unittitle> November 19, 1986--Axelrod, Daniel</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">60</container>
+                  <unittitle> December 3, 1986--Carroll, Bob M.D</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">60</container>
+                  <unittitle> March 17, 1989--Adcock, Willis</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">60</container>
+                  <unittitle> November 19, 1990--Weisskopf, Victor </unittitle>
+                </did>
+                <note>
+                  <p>(Contains a photograph)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">60</container>
+                  <unittitle> March 12, 1991--Hussein, Abid</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">60</container>
+                  <unittitle> November 15, 1991--Salpeter, Edwin E.</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">60</container>
+                  <unittitle> February 28, 1992--Fritzsche, Hellmut</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">60</container>
+                  <unittitle> April 11, 1992--McNeill, William H.</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">60</container>
+                  <unittitle> January 19, 1996--Stempel, Robert C. </unittitle>
+                </did>
+                <note>
+                  <p>(Contains photographs)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">60</container>
+                  <unittitle> April 17, 1998--Ovshinsky, Stanford O. </unittitle>
+                </did>
+                <note>
+                  <p>(David Adler Memorial lecture)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">60</container>
+                  <unittitle> March 22, 2002--Kastner, Marc</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">60</container>
+                  <unittitle> June 14, 2002--Kirchheim, Reiner</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">60</container>
+                  <unittitle> March 16, 2005--Bienenstock, Arthur  </unittitle>
+                </did>
+                <note>
+                  <p>(Contains cd copy of lecture brochure)</p>
+                </note>
+              </c05>
+            </c04>
+          </c03>
+          <c03 level="item">
+            <did>
+              <container type="box" label="Box">60</container>
+              <unittitle>Lectures, symposiums, and workshops,  March 1984-Janufary <unitdate type="inclusive">1988</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">60</container>
+              <unittitle>Letter of commendation for Martin Steele, <unitdate type="inclusive">May 1985</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">60</container>
+              <unittitle>Miscellaneous photograph negatives, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">60</container>
+              <unittitle>NATO Advanced Study Institute, <unitdate type="inclusive">August 1985-August 1986</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">60</container>
+              <unittitle>Newspaper clippings, <unitdate type="inclusive">August 1982-April 1987</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">60</container>
+              <unittitle>OvonicLink newsletter,  June 1983-Fall <unitdate type="inclusive">1986</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">60</container>
+              <unittitle>Ovshinsky award nominations, <unitdate type="inclusive">January-May 1986</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">60</container>
+              <unittitle>Seminar, Summer <unitdate type="inclusive">1982</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(Contains photographs)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">94</container>
+              <unittitle>Seminar, <unitdate type="inclusive">March 22, 1984</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">94</container>
+              <unittitle>Seminar, <unitdate type="inclusive">March 23, 1984</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">60</container>
+              <unittitle>Short course: Physics, chemistry, and applications of amorphous semiconductors, <unitdate type="inclusive">May 1984</unitdate> </unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Symposiums and Festschrifts</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">60</container>
+                <unittitle>Adler, David memorial symposium fund and obituary, <unitdate type="inclusive">May 1987-May 1989</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">60</container>
+                <unittitle>Fritzsche, Hellmut, <unitdate type="inclusive">February 1986-June 1987</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">60</container>
+                <unittitle>Henisch, Heinz, <unitdate type="inclusive">March-November 1987</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Contains photographs)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">60</container>
+                <unittitle>Mott, Nevill, <unitdate type="inclusive">January-February 1985</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">60</container>
+              <unittitle>Visitor register, <unitdate type="inclusive">March 2005-November 2010</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Workshops</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">60</container>
+                <unittitle>Localized States in Tetrahedrally Bonded Amorphous Solids, <unitdate type="inclusive">June 18-20, 1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">60</container>
+                <unittitle>Photovoltaic, <unitdate type="inclusive">August 24-25, 1985</unitdate> (2 folders of 3)</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">61</container>
+                <unittitle>Photovoltaic, <unitdate type="inclusive">August 24-25, 1985</unitdate> (folder 3 of 3)</unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Written works</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">61</container>
+                <unittitle>Amorphous Semiconductor Handbook planning, <unitdate type="inclusive">1983-1984</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Conferences</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle>1970--IEEE-Palo Alto</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle> November 1984--International Photovoltaic Science and Engineering</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle> December 18, 1984--Nobel Laureate Symposium</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle>1985--Society of Vacuum Coaters</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle> April 1985--San Francisco</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle> May 1985--China</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle>1985-- June </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle> October 25, 1985--IEEE Photovoltaic Specialists</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle> November 1985--Copenhagen</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle> January 1986--SPIE-Los Angeles</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle> March 1986--Macro-engineering, Washington D.C.</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle> August 1986--AIChE, Boston </unittitle>
+                </did>
+                <note>
+                  <p>(Contains photographs)</p>
+                </note>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle><unitdate type="inclusive">September 15-20, 1986</unitdate>--Hungary</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle><unitdate type="inclusive">September 18-19, 1986</unitdate>--SPIE-Cambridge, Massachusetts</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle> October 1986--International New Materials-Osaka</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle> October 1986--European Photovoltaic Solar Energy-Spain</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle>1986--SPIE-New Delhi</unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">61</container>
+                <unittitle>Cosmology paper, <unitdate type="inclusive">July 8, 1985</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Oped</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle>"Is There an Evolutionary Brain?  The Physiology of Politics," <unitdate type="inclusive">January 1986</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle>"What is Realism?" <unitdate type="inclusive">August 3, 1986</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">61</container>
+                  <unittitle> "U.S. and European Companies are Often Victims of Their Own Hubris," <unitdate type="inclusive">November 1985</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">61</container>
+                <unittitle>Papers by the ECD group, <unitdate type="inclusive">September 1985-1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">61</container>
+                <unittitle>SRO miscellaneous, <unitdate type="inclusive">September 1984-March 1986</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+        </c02>
+      </c01>
+      <c01 level="series">
+        <did>
+          <unittitle>Talks and Recognition</unittitle>
+        </did>
+        <scopecontent>
+          <p>The Talks and Recognition series (16.8 linear feet, 2 oversize boxes, and digital files; 1959-2011) includes mostly correspondence, Microsoft PowerPoint presentations, speech notes, and certificates from Stanford Ovshinsky's awards. Ovshinsky served as a keynote or invited speaker at a large number of college graduations and scientific conferences around the world, so this series contains many of these speeches and speech notes.  He did not limit himself to the high-profile stages of higher education and international scientific conferences, however: the series also includes notes documenting his visits to elementary and middle school classrooms. Materials from interviews given to media outlets ranging from local to international also appear, and rounding out this component of the series are presentations to shareholders and potential corporate partners. Included as well are details about awards that Ovshinsky received, ranging from numerous honorary university degrees and professional organization recognition to commendations of the ingenuity of his products and celebrations of his involvement in service groups. </p>
+        </scopecontent>
+        <c02 level="subseries">
+          <did>
+            <unittitle>Speeches and Talks</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">107</container>
+              <unittitle><unitdate type="inclusive">1959-1979</unitdate> (materials with gaps)</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">62</container>
+              <unittitle>
+                <unitdate type="inclusive">1967-1980</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>83 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">88 </container>
+              <unittitle>"Applications of Amorphous Semiconductors for Solar Energy Conversion,"  January 1980/Ovshinsky,  June 12, 1980/Energy Countdown </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">107</container>
+              <unittitle>Supplemental lectures and talks, <unitdate type="inclusive">1980</unitdate> </unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">63</container>
+              <unittitle>
+                <unitdate type="inclusive">1981-1985</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>51 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>( May 26, 1983 -- AAAS Youth Symposium-photographs)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">88</container>
+              <unittitle>S.R. Ovshinsky, "New Technology and Peace," Birmingham Unitarian Church, <unitdate type="inclusive">January 13, 1985</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">94</container>
+              <unittitle>Ovshinsky at Grosse Pointe South High School Science Assembly, <unitdate type="inclusive">April 25, 1985</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">64</container>
+              <unittitle>
+                <unitdate type="inclusive">1985-1988</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>46 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">65</container>
+              <unittitle>
+                <unitdate type="inclusive">1988-1990</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>41 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">103</container>
+              <unittitle>Japanese Society of Detroit, <unitdate type="inclusive">June 6, 1988</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">103</container>
+              <unittitle>Ovshinsky, "Harnessing the Sun: New Technologies" at Fairfield University, <unitdate type="inclusive">October 11, 1988</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Oversize">112  </container>
+              <unittitle>"Harnessing the Sun" talk announcement poster, <unitdate type="inclusive">October 11, 1988</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">66</container>
+              <unittitle>
+                <unitdate type="inclusive">1990-1997</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>46 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">88</container>
+              <unittitle>SRO, Civic Forum, Akron, Ohio, <unitdate type="inclusive">January 21, 1992</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">95</container>
+              <unittitle>S.R. Ovshinsky, "How Can the Developing Countries Achieve Equality Through Alternative Energy," U.C. Berkeley, <unitdate type="inclusive">April 16, 1992</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">88</container>
+              <unittitle>S.R. Ovshinsky, Lawrence Technological University, <unitdate type="inclusive">May 4, 1992</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">88</container>
+              <unittitle>Stanford Ovshinsky, "A Nickel Hydride Battery for Electric Vehicles," MIT-EECS Colloquium, <unitdate type="inclusive">November 22, 1993</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">67</container>
+              <unittitle>
+                <unitdate type="inclusive">1997-2002</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>35 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">68</container>
+              <unittitle>
+                <unitdate type="inclusive">2002-2003</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>22 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>( October 15, 2002-EMCW Conference -- CD of papers from 1979-2002 sessions of the conference; March 6, 2003 -- SRO's Talk Hydrogen Conference -- CD of Proceedings and CD of Ovshinsky's presentation; March 10-11, 2003 -- EPCOS -- photographs and a CD; May 9, 2003 -- SRO seminar at Kettering -- CD Ovshinsky's presentation;  August 22, 2003--Hydrogen Prius event at Uni-Solar--text of Ovshinsky's talk; October 1-3, 2003 -- SRO Keynote at Colorado School of Engineering Conference -- CD presentation; October 27, 2003 -- Newcastle University -- CD presentation; MRS Fall 2003 -- Tutorial -- CD of tutorial slides, Ted Nara Japan, and MRS photos;  November 4, 2003--International Symposium on Optical Memory in  Nara, Japan--text of Ovshinsky's keynote speech)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">88</container>
+              <unittitle>Stan  Ovshinsky Japan Presentation Rough Cut, <unitdate type="inclusive">October 23, 2003</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">69</container>
+              <unittitle>
+                <unitdate type="inclusive">2004-2005</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>23 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>( April 22, 2004-SRO at Temple University -- CD presentation; June 2, 2004 -- SRO talk at WSU AET Conf -- CD presentation;September 21, 2004 -- Walker Cisler Memorial Lecture -- CD photograph;  October 19, 2004-Solar Power -- 2 CDs proceedings and presentation; November 8-12, 2004 -- Mexico Congress on Renewable Energy; November 8-12, 2004-- Intl. Non-Oxide Glass Symposium -- CD presentation;  January 11, 2005-Colloquium of Michigan Center For Theoretical Physics -- CD presentation; Feb 17,2005 -- Akron Roundtable)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">88</container>
+              <unittitle>Science Lecture for Young People at Detroit Country Day School, <unitdate type="inclusive">May 18, 2004</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>Prerecorded EPCOS <unitdate type="inclusive">2004</unitdate> greeting, <unitdate type="inclusive">August 17, 2004</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>video</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116133" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>Photographs from Walker Cisler Memorial Lecture,  September 21, 2004</unittitle>
+              <physdesc>
+                <physfacet>.ZIP file</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116175" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>Mexico Congress on Renewable Energy presentation, <unitdate type="inclusive">November 2, 2004</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>video</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116148" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>"Akron Roundtable" on WKSU 89.7FM with Stanford Ovshinsky, <unitdate type="inclusive">February 17, 2005</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>.ZIP file</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116176" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">70</container>
+              <unittitle>
+                <unitdate type="inclusive">2005</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>16 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>( February 26, 2005 -- SRO at Quarterly Meeting of California Hydrogen Business Council -- CD PowerPoint presentation; April 3, 2005-- Swarthmore College-CD; April 12, 2005 -- Meeting with ECD board -- CD presentation; April 16, 2005 -- Annual NYU Entrepreneurship Conerence -- 2CDs proceedings and presentation; July 13-15, 2005 -- intl. Hydrogen  Energy Congress &amp; Exhibition -- 2CDs presentation and recording; September 3-6, 2005 -- EPCOS -- Photographs and CD presentation;  September 21, 2005-Renewables Conference -- 2CDs Rwanda Solar and presentation + video;  September 28, 2005-Global Market Trends Conference -- CD presentation;  November 30, 2005-MI COEJL Fall Gathering -- CD presentation)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>NASDAQ Closing Bell Ceremony, <unitdate type="inclusive">March 30, 2005</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>video</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116130" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>Prerecorded presentation for IHEC Turkey, <unitdate type="inclusive">July 11, 2005</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>video</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116136" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">71</container>
+              <unittitle>
+                <unitdate type="inclusive">2006-2007</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>27 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>( April 27, 2006 -- SRO at ACCESS -- CD presentation; May 4, 2006 -- Colloquium in Honor of 80th birthday for Prof. Bower-CD;  June 7, 2006-SRO keynote at EMU spring lecture series-CD presentation;  November 17, 2006-panelist at Technology Transfer -- CD;  March 31, 2007-keynote at Illinois Institute of Technology -- CD)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">88 </container>
+              <unittitle>"Civic Forum of the Air" talk on alternative energy by Stanford Ovshinsky, <unitdate type="inclusive">April 28, 2006</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>Prerecorded presentation for Boer Symposium in Germany, <unitdate type="inclusive">May 5, 2006</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>video</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116177" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+              <note>
+                <p>(recorded  April 18, 2006)</p>
+              </note>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">72</container>
+              <unittitle>
+                <unitdate type="inclusive">2007-2009</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>16 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>( February 27-29, 2008 -- 1st International PV Power Generation Expo-DVD of talk;  April 8, 2008-Berkeley -- Photographs and 3 CDs; September 29, 2008 -- U.S. Mexico Workshop-Photograph book; October 2-3, 2008-Keynote at nanoTX USA-CD)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>Photographs relating to Berkeley presentation, <unitdate type="inclusive">April 8, 2008</unitdate> </unittitle>
+              <dao href="http://hdl.handle.net/2027.42/116170" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Oversize">112   </container>
+              <unittitle>Announcement poster <unitdate type="inclusive">April 8, 2008</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">73</container>
+              <unittitle>
+                <unitdate type="inclusive">2009-2012</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>19 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>Presentation at the Ecology Center Annual Meeting in Ann Arbor, <unitdate type="inclusive">May 10, 2011</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>video</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116142" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>Presentation at the City Club of Cleveland, <unitdate type="inclusive">September 23, 2011</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>video</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116141" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="subseries">
+          <did>
+            <unittitle>Interviews</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">74</container>
+              <unittitle>
+                <unitdate type="inclusive">1973-2011</unitdate>
+              </unittitle>
+              <physdesc>
+                <extent>16 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>(2010-2011-Miscellaneous -- unedited video; November 2010 &amp; May 2011 -- Radio WUPH)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">89</container>
+              <unittitle>Iris Ovshinsky, tape #23, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>audiocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">94</container>
+              <unittitle>Stan Ovshinsky, <unitdate type="inclusive">June 12, 1980</unitdate> PM Magazine on WJBK TV2 </unittitle>
+              <physdesc>
+                <physfacet>U-matic videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">105</container>
+              <unittitle>Stan Ovshinsky and Nancy Bacon, Dow Jones Investor Network, <unitdate type="inclusive">June 29, 1995</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">95 </container>
+              <unittitle>"Energy Conversion Devices, Inc.," The International Corporate Forum, Dow Jones Investor Network, <unitdate type="inclusive">March 28, 1996</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">89</container>
+              <unittitle>Stan Ovshinsky, <unitdate type="inclusive">August 2, 2002</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>audiocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">89</container>
+              <unittitle>Stan Ovshinsky interview, <unitdate type="inclusive">August 17, 2004</unitdate> (name given on tape as Oshinski) </unittitle>
+              <physdesc>
+                <physfacet>audiocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">89</container>
+              <unittitle>Stanford Ovshinsky, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>audiocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">89</container>
+              <unittitle>Stanford Ovshinsky, <unitdate type="inclusive">undated</unitdate> (name given on tape as Oshinski) </unittitle>
+              <physdesc>
+                <physfacet> audiocassettes</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">89</container>
+              <unittitle>Stanford Ovshinsky, ECD interview, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>audiocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">89</container>
+              <unittitle>Stanford Ovshinsky/Ovonics, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>audiocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>"Nova: Japan's American Genius," PBS, <unitdate type="inclusive">October 27, 1987</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>video</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116155" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>Interview and profile on "City for Youth" on WTVS/WXYZ Detroit," <unitdate type="inclusive">January 24, 1994</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>video</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116152" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>Interview on "Anything is Possible" with Jack Krasula on WJR-AM 760, <unitdate type="inclusive">July 1, 2007</unitdate> (audio) </unittitle>
+              <physdesc>
+                <physfacet>.ZIP file</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116169" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>Interview for "Electric and Hybrid Cars: A Tragic and Unnecessary Loss for the U.S," <unitdate type="inclusive">May 4, 2009</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>video</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116147" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="series">
+          <did>
+            <unittitle>Recognition</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">75</container>
+              <unittitle>Awards, <unitdate type="inclusive">1968-2004</unitdate> </unittitle>
+              <physdesc>
+                <extent>47 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>(1968-Diesel Gold Medal -- Photograph and German;July 1996 -- Crain's Michigan's Top 10 Superstocks -- Photograph; 2000-Heroes of Chemistry-Photographs)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">103</container>
+              <unittitle>Coors American Ingenuity Award, <unitdate type="inclusive">1988</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">105</container>
+              <unittitle>Corporate Leadership Awards (Wayne State University), Thursday, <unitdate type="inclusive">June 21, 2001</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">105</container>
+              <unittitle>Heroes of Chemistry, <unitdate type="inclusive">August 20, 2000</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">76</container>
+              <unittitle>Awards, <unitdate type="inclusive">2005-2011</unitdate> </unittitle>
+              <physdesc>
+                <extent>21 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>( November 14-15, 2005-Economist Innovation Award-Sketch from front cover;  March 17, 2009-Awards receptions at APS-Photographs)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">77</container>
+              <unittitle>Awards, <unitdate type="inclusive">2012</unitdate> </unittitle>
+              <physdesc>
+                <extent>22 folders</extent>
+              </physdesc>
+            </did>
+            <note>
+              <p>(European Inventor Award -- Nomination folder 1 -- Photographs and CD; European Inventor Award -- Nomination folder 2-Photographs)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">77</container>
+              <unittitle>Festschrift for Stan Ovshinsky</unittitle>
+              <physdesc>
+                <extent>3 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Honorary Degrees, <unitdate type="inclusive">1980-2010</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>( May 2010 -- University of Michigan -- Photographs include Ovshinsky with President Obama)</p>
+            </note>
+            <c04 level="file">
+              <did>
+                <physloc> Online </physloc>
+                <unittitle>Introduction to Stanford Ovshinsky played at New York Institute of Technology Commencement, <unitdate type="inclusive">May 18, 2008</unitdate> </unittitle>
+                <physdesc>
+                  <physfacet>video</physfacet>
+                </physdesc>
+                <dao href="http://hdl.handle.net/2027.42/116138" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download item]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">77</container>
+              <unittitle>Miscellaneous diplomas and awards, <unitdate type="inclusive">1984-1990</unitdate></unittitle>
+              <physdesc>
+                <extent>1 folder</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Oversize">113  </container>
+              <unittitle>Oversize awards, <unitdate type="inclusive">1988-1999</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(New York Institute of Technology -- Leadership and Sustainable Technology award; Karl Boer Solar Energy Award; photograph accepting an award)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Oversize">113  </container>
+              <unittitle>State government commendations, 1988-2006</unittitle>
+            </did>
+            <note>
+              <p>(Honorary Citation from the State of Colorado; special recognition from Ohio House of Representatives on factory groundbreaking, )</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">102</container>
+              <unittitle>Workmen's Circle: Stan and Iris Ovshinsky video tribute </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassettes</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+        </c02>
+      </c01>
+      <c01 level="series">
+        <did>
+          <unittitle>Visual Materials</unittitle>
+        </did>
+        <scopecontent>
+          <p>The Visual Materials series (10 linear feet and digital files; 1947-2008) consists primarily of printed photographs, and digital images.  The photographs depict ECD buildings, employees, and parties.  There are also pictures of trips Ovshynski took to places like Mexico and Japan, in addition to publicity photographs of Stan and  Iris Ovshinsky, and Robert Stempel.  Other photographs of note are those documenting the visits of prominent individuals to ECD and Ovshinsky's 70th and 80th birthday parties.  Ovshinsky sketched a great deal, and a sample of his drawings and doodles can also be found in this series. A few videos, largely produced by son Harvey's HKO Media, supplement the visual materials in this series. </p>
+        </scopecontent>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">78</container>
+            <unittitle>Awards, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">78</container>
+            <unittitle>Board members annual meeting, <unitdate type="inclusive">December 19, 1995</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Companies</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <unittitle>ECD</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Annual report, <unitdate type="inclusive">1973</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Drafting department, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Electrochemistry division, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <physloc> Online </physloc>
+                <unittitle>Family summer outing, <unitdate type="inclusive">August 5, 2001</unitdate> </unittitle>
+                <dao href="http://hdl.handle.net/2027.42/116174" show="new" actuate="onrequest">
+                  <daodesc>
+                    <p>[download item]</p>
+                  </daodesc>
+                </dao>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>General structures lab, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(with John Tyler)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Historic moments, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Holiday party at DIA, <unitdate type="inclusive">1985-1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Honda signing, <unitdate type="inclusive">1996</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Interior and exterior, <unitdate type="inclusive">September 1965</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Machine shops, 1984(?)</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Open house, <unitdate type="inclusive">August 1981</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Original building, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Patent department, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Plant 1</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">78</container>
+                  <unittitle>Headquarters and development facilities, <unitdate type="inclusive">1982</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">78</container>
+                  <unittitle>Photovoltaics lab, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                </did>
+                <note>
+                  <p>(with Czubatyj)</p>
+                </note>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Plant 2 -- Ovonic photovoltaic pilot plant, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Plant 3 -- Advanced materials lab and model shop -- Lake Angelus Observatory Conference and Seminar Center, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Plant 4 -- Hyrdorgen -- Electrochemsitry Development Facility, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Barrett Street)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Plant 5 -- Wet Chemistry Photovoltaic Etching, <unitdate type="inclusive">1981</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Edwards Street)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Plant 7, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Heide Street)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Plant 8, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Premier Street)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Plant 10 -- Ovonic Battery Company production facility, <unitdate type="inclusive">1985-1988</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Plant 11</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">78</container>
+                  <unittitle>Sovonics,  July 1984(?)</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">78</container>
+                  <unittitle>Coating Division facility, <unitdate type="inclusive">1984</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">78</container>
+                  <unittitle>Dedication, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Plant 12 -- Legal, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Plant 14 -- Ovonic Synthetic Materials Company, <unitdate type="inclusive">December 1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Plant Japan -- Thermovonics</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">78</container>
+                  <unittitle>
+                    <unitdate type="inclusive">Undated</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">78</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1985</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Plant New Jersey, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">87</container>
+                <unittitle>Plant New Jersey open house, <unitdate type="inclusive">1981</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>President's Letter, <unitdate type="inclusive">1995</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">78</container>
+                <unittitle>Support facilities, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">78</container>
+              <unittitle>Erricson Telephone signing, <unitdate type="inclusive">1963</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(Sweden)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">78</container>
+              <unittitle>EV Global signing, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">78</container>
+              <unittitle>Fuji Film signing, <unitdate type="inclusive">1970s</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">78</container>
+              <unittitle>GM Ovonic, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">78</container>
+              <unittitle>Hupp Motor Company -- Electric power steering, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">78</container>
+              <unittitle>Hupp Motor Company, Stanford Roberts, New Britain, <unitdate type="inclusive">1947-1950</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">79</container>
+              <unittitle>Logos, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">79</container>
+              <unittitle>Logo animation </unittitle>
+              <physdesc>
+                <physfacet>VHS videocassette</physfacet>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">79</container>
+              <unittitle>Ovitron, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ovonic Battery Company</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">79</container>
+                <unittitle>GM signing, <unitdate type="inclusive">1994</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">79</container>
+                <unittitle>Tour de Sol, <unitdate type="inclusive">1995-1996</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">79</container>
+              <unittitle>Ovonic Display Systems -- production facility, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">79</container>
+              <unittitle>Ovonic Memories Inc. -- Stan Ovshinsky, Al Adomines, and Jack Evans, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">79</container>
+              <unittitle>Ovonic Solar, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">79</container>
+              <unittitle>Ovonic Thermoelectric Company, <unitdate type="inclusive">November 1983</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">79</container>
+              <unittitle>Personnel with equipment, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Sharp-ECD Solar, Inc.,</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">79</container>
+                <unittitle>
+                  <unitdate type="inclusive">January-February 1983</unitdate>
+                </unittitle>
+              </did>
+              <note>
+                <p>(Japan)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">79</container>
+                <unittitle>Signing original agreement, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">79</container>
+              <unittitle>Sovlux Battery, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">79</container>
+              <unittitle>Sovlux plant, 1991(?)</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Sovonics</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">79</container>
+                <unittitle>Plant, <unitdate type="inclusive">1988</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">79</container>
+                <unittitle>Plant dedication</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">79</container>
+                <unittitle>n, <unitdate type="inclusive">May 31, 1984</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">79</container>
+                <unittitle>Town hall meeting, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">79</container>
+                <unittitle>Underhill signing, <unitdate type="inclusive">July 1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">79</container>
+                <unittitle>USSC plant, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">79</container>
+              <unittitle>Stanford Roberts Manufacturing Co. -- New Britain machine,  <unitdate type="inclusive">1949-1954(?)</unitdate></unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">79</container>
+              <unittitle>Suryovoics,  February 1990(?) </unittitle>
+            </did>
+            <note>
+              <p>(India)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Texaco-Ovonic Fuel Cell Company</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">79</container>
+                <unittitle>
+                  <unitdate type="inclusive">Undated</unitdate>
+                </unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">79</container>
+                <unittitle>Groundbreaking and Cobasys grand opening, <unitdate type="inclusive">2002</unitdate> and <unitdate type="inclusive">2005</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">79</container>
+              <unittitle>Tour for Summer employees, <unitdate type="inclusive">1985</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Uni-Solar</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">79</container>
+                <unittitle>Greenville, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">79</container>
+                <unittitle>Mexico, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">80</container>
+              <unittitle>Visitors</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">80</container>
+                <unittitle>British House of Commons delegation, <unitdate type="inclusive">1981</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">80</container>
+                <unittitle>Carr, Ray, <unitdate type="inclusive">March 6, 1995</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">80</container>
+                <unittitle>Department of Energy, <unitdate type="inclusive">January 1985</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(ECD and Sovonics Solar)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">80</container>
+                <unittitle>Japanese sunshine study group, <unitdate type="inclusive">March 1984</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">80</container>
+                <unittitle>Mott, Sir Nevill, <unitdate type="inclusive">March 1978</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">80</container>
+                <unittitle>Secretary of Energy -- Spence Abraham, <unitdate type="inclusive">August 2002</unitdate> </unittitle>
+                <physdesc>
+                  <extent>2 folders</extent>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">80</container>
+                <unittitle>Secretary of Energy -- Bodman visits solar plant, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">80</container>
+                <unittitle>Senator Simon, <unitdate type="inclusive">March 6, 1995</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">80</container>
+                <unittitle>Shanghai Ceramics Institute, <unitdate type="inclusive">May 1984</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">80</container>
+                <unittitle>Teller, E., <unitdate type="inclusive">October 8, 1984</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">80</container>
+                <unittitle>Young, Coleman, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Conferences</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">80</container>
+              <unittitle>Institute of Amorphous Studies -- opening ceremony, <unitdate type="inclusive">June 1985</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">80</container>
+              <unittitle>International conference on the Theory of the Structures of Non-Crystalline solids, <unitdate type="inclusive">June 1985</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">80</container>
+              <unittitle>SPIE -- Los Angeles, <unitdate type="inclusive">August 1985</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">80</container>
+              <unittitle>United States Advanced Battery Consortium, <unitdate type="inclusive">1992</unitdate></unittitle>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">80</container>
+            <unittitle>Corporate Leadership Award, <unitdate type="inclusive">2001</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Early Stan Ovshinsky</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">80</container>
+              <unittitle>
+                <unitdate type="inclusive">1967</unitdate>
+              </unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">80</container>
+              <unittitle>Bump chart, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">80</container>
+              <unittitle>Hydrogen, <unitdate type="inclusive">1964</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">80</container>
+              <unittitle>Labs, <unitdate type="inclusive">1970-1997</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">80</container>
+              <unittitle>Labs -- Ovonic Memory Switch, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">80</container>
+              <unittitle>Life magazine, <unitdate type="inclusive">1969</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(with Iris Ovshinsky)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">80</container>
+              <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">80</container>
+              <unittitle>Ovonic Switching -- pipe cleaner model, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">80</container>
+            <unittitle>Electoluminsecent imaging, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">80</container>
+            <unittitle>England -- House of Parliament, <unitdate type="inclusive">1977</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">80</container>
+            <unittitle>Equipment, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">80</container>
+            <unittitle>Equipment -- miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Events</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">80</container>
+              <unittitle>Institute for Amorphous Studies, <unitdate type="inclusive">March 1984</unitdate> -- <unitdate type="inclusive">June 1985</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(TADIAS conference, Stan and Iris Ovshinsky anniversary)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">80</container>
+              <unittitle>Reception for Ray Tsu, <unitdate type="inclusive">April 1985</unitdate></unittitle>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">80</container>
+            <unittitle>Hydrogen research, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">80</container>
+            <unittitle>Institute for Amorphous Studies -- Lectures, <unitdate type="inclusive">1986</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Japan</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">80</container>
+              <unittitle>Fuji Film visit(?), 1971(?)</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Lectures</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">80</container>
+                <unittitle>Sponsored by Nihon Keizai Shinbun, <unitdate type="inclusive">January 31, 1978</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">81</container>
+                <unittitle>Nikkei Science, <unitdate type="inclusive">February 3, 1986</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Rightsholder, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">87</container>
+            <unittitle>Machines</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">87</container>
+              <unittitle>3 Megawatt machine</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Big VEECO, <unitdate type="inclusive">undated</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(tool coating)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Continuous Deposition Plasma Processor, <unitdate type="inclusive">April 1987</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(Herb's machine)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Microwave plasma deposition machine, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Molecular beam epitaxy system and ion beam implanter, <unitdate type="inclusive">undated</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(Includes class 60 clean room)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Plant 5A -- Transmission electron microscope, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Plant 11, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>PV stitching machine, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>SESI, <unitdate type="inclusive">1982</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(Sharp-ECD, Inc.. Japan)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Tandem II-A, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>PV cell continuous roll-to-roll tandem processor, <unitdate type="inclusive">August 1982</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(1st commercial, shipped to Sharp-ECD, Inc.)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>PV continuous roll-to-roll, <unitdate type="inclusive">undated</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(3rd generation, under construction)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>PV cell processor, 2nd generation multi-chamber research scale shipped to Sharp-ECD, Inc., <unitdate type="inclusive">August 1982</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(1st generation shipped 1980)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>PV large area PIN processor modules, <unitdate type="inclusive">June 1980</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>PV processor-sequential stationary deposition, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>PV transparent electrode processor, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>PV TRAIN machine, <unitdate type="inclusive">November 1986</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(Plant 2)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Vacuum deposition machine, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">81</container>
+            <unittitle>Maeda lunch and reception, <unitdate type="inclusive">May 17, 1984</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">81</container>
+            <unittitle>Magnet ball controls -- switches, relays, proximity and limit switches, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">81</container>
+            <unittitle>Melt spinning, <unitdate type="inclusive">1985-1986</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">81</container>
+            <unittitle>Mexico, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">81</container>
+            <unittitle>Microelectronics -- memory, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">81</container>
+            <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate> </unittitle>
+            <physdesc>
+              <extent>4 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">81</container>
+            <unittitle>Miscellaneous negatives, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">81</container>
+            <unittitle>Miscellaneous -- solar, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Models</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Builders, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Conformational changes without bond breaking, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Threshold switching and memory, <unitdate type="inclusive">September 1984</unitdate></unittitle>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">81</container>
+            <unittitle>Oxide, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>People</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Adler, David, <unitdate type="inclusive">1983</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Acquaintances, friends, and family, 1963-?</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Bacon, Nancy, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Birkenstock, James W., <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Canella, Vin, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Chen, J.T., <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Cohen, Morrel H., <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Consultants, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Conway, Jack, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Cummings, Richard H., <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Czubatyj, Wally, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>De Neufville, John, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>ECD -- Wright, Neal, Nelson, Flemming, Fogen, Sie, Helbers,  <unitdate type="inclusive">March 1969</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>ECD personnel, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Ervin, Christine, <unitdate type="inclusive">January 1994</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(Stan Ovshinsky with Christine at US Department of Energy news conference)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Flasck, Dick, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Goldstein, Alex, <unitdate type="inclusive">1988</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Guha, Subhendu, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Hack, Michael, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Hanak, Joe, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Harwood, Julius, <unitdate type="inclusive">undated</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(President of Ovonic Synthetic Material Co.)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Himelfarb, Alan M., <unitdate type="inclusive">undated</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(President and COO of EV Global Motors)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Hudgens, Stephen, <unitdate type="inclusive">undated</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(Vice-President of Research and Development at ECD)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Iris Ovshinsky, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Iris Ovshinsky, Klose, and Chang, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Ito, Momoko, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Izu, Masa, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Johnson, Robert, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Kvant with Gorbachev, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Keem, John, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Leach, Robert, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Livesay, Alastar, <unitdate type="inclusive">2001</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Mahr, Sam and Brenda Walton, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Marquart, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Metzger, James, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Nadorov, Ovshinsky, Leach, and others -- KVANT, <unitdate type="inclusive">April 26, 1990</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Ohta, Ted, <unitdate type="inclusive">2003</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Mott, Sir Nevill</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">81</container>
+                <unittitle>Institute lecture, <unitdate type="inclusive">April 28, 1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">81</container>
+                <unittitle>Signing book, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>O'Leary, Hazel, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Powell, Max, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Pryor, Roger, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">81</container>
+              <unittitle>Rabi, Isidor, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Oversize">110  </container>
+              <unittitle>Rabi, Isidor, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Oversize">110 </container>
+              <unittitle>Reischauer, Edwin, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Oversize">110 </container>
+              <unittitle>Schaeffer, Isaac, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Oversize">110</container>
+              <unittitle>Seder, Art, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Oversize">110 </container>
+              <unittitle>Silver, Marvin, <unitdate type="inclusive">undated</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(Co-author of Disordered Materials)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Oversize">110 </container>
+              <unittitle>Stan Ovshinsky's parents-Ben and Bertha, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Oversize">110 </container>
+              <unittitle>Stempel, Robert, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Oversize">110 </container>
+              <unittitle>Synes, Stanley, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Oversize">110 </container>
+              <unittitle>Tech and production brochure, <unitdate type="inclusive">1999</unitdate> </unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Oversize">110 </container>
+              <unittitle>Trebilcott, James, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Oversize">110 </container>
+              <unittitle>Vining, Richard A., <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Oversize">110 </container>
+              <unittitle>Rosa Ovshinsky, <unitdate type="inclusive">December 2008</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(Cambodia)</p>
+            </note>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Products</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Oversize">110 </container>
+              <unittitle>Auto show and racing, <unitdate type="inclusive">1990-1995</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Battery</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Oversize">110</container>
+                <unittitle>Batteries, 1989-2000(?)</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Oversize">110 </container>
+                <unittitle>Electric scooters, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Oversize">110 </container>
+                <unittitle>Electric vehicles, 1993-1995(?)</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>GM</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Oversize">110</container>
+                  <unittitle>Impact -- car, <unitdate type="inclusive">1994</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Oversize">110 </container>
+                  <unittitle>Ovonic II -- cell and family of batteries, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Oversize">110 </container>
+                  <unittitle>Ovonic module, <unitdate type="inclusive">1998</unitdate> </unittitle>
+                </did>
+                <note>
+                  <p>(used for 1998 Detroit Auto Show)</p>
+                </note>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Oversize">110 </container>
+                <unittitle>Honda, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Oversize">110 </container>
+                <unittitle>Manufacturing process, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Oversize">110 </container>
+                <unittitle>NiMH licensees, <unitdate type="inclusive">1994</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Coatings</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Oversize">110 </container>
+                <unittitle>Coated vs. uncoated, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Oversize">110 </container>
+                <unittitle>Drills,  March 1983(?)</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Southwall PECVD production machine, <unitdate type="inclusive">January 2000</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(high-speed microwave)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Tool applications, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Transparent plastic, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(glass hard surface)</p>
+              </note>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">83</container>
+              <unittitle>EAROM (Electronically alterable read-only memory) array, <unitdate type="inclusive">1024</unitdate> bit </unittitle>
+            </did>
+            <note>
+              <p>(negatives)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">83</container>
+              <unittitle>Electronic Info. Processor, <unitdate type="inclusive">undated</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(with Gazaleh)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Electrophotography</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>1985(?)</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Canon machine, <unitdate type="inclusive">April 1986</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Plant 16)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Test piece -- Canon, <unitdate type="inclusive">May 1986</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Film</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Microfilm, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Non-silver photo duplication, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(TEBAC with Wozie?)</p>
+              </note>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Hydrogen</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Car,  March 1999(?)</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Corrosion testing, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Energy system process, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Engine, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Engine demo, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Fuel cell, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Heat pump, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">83</container>
+              <unittitle>Microvonic File, <unitdate type="inclusive">1981-1985</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(with Freya Saito)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">83</container>
+              <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>N-Gen</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Microelectronics cleanroom, <unitdate type="inclusive">1985</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(computer project, with Roger Pryor)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Smart card, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">83</container>
+              <unittitle>Old ECD, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Optical Memory</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>EEPROM, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Toray phasewriter, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">83</container>
+              <unittitle>Ovonic Design Systems -- touch sensitive input, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Ovonic Imaging Systems</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>2D imager, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Data encoding bar, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Factory of the future, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Flat panel display, 1986-1987(?)</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Laptop, <unitdate type="inclusive">1988</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Office automation, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Ovonic imager, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">83</container>
+              <unittitle>Oxygen sensors for exhaust system, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">83</container>
+              <unittitle>Quartet white copyboard and linear array scanner, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">83</container>
+              <unittitle>RMM, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">83</container>
+              <unittitle>Scanning Electron Microscope (SEM), <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Solar</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Amorphous vs. crystalline -- bullet, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Calculator, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Car rooftop, 1986(?)</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Cells, 1984(?)</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">83</container>
+                <unittitle>Continuous roll, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Crystalline cells, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Crystalline cells-ARCO, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Crystalline cells to Japan, <unitdate type="inclusive">August 1984</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Solar electric module, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Electric vehicle charging station, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Equipment, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Fishing buoy -- Nippon Steel, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Flexible cell with bullet hole and broken glass cell, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Hawaii, 1989-1990(?)</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>India, 1991(?)</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>ITO machine, <unitdate type="inclusive">January 1985</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Lamp posts, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Machines</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">84</container>
+                  <unittitle>Metalizer, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">84</container>
+                  <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                  <physdesc>
+                    <extent>3 folders</extent>
+                  </physdesc>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Manufacturing plant -- <unitdate type="inclusive">1000</unitdate> sq. ft., <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Marketing, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Mexico, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate> </unittitle>
+                <physdesc>
+                  <extent>3 folders</extent>
+                </physdesc>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Modules, 1986(?)</unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Ovation -- car, <unitdate type="inclusive">May-August, 1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Panels, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Panel mounting comparison, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Panels -- PV International, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Panels -- USSC roof shingles being packed go to Olympic village in Atlanta, <unitdate type="inclusive">1996</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>PV canon drum machine, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>PV cell PCU 800, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Photovoltaic plant pilot -- ECD and ARCO joint development, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Photovoltaic processor</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">84</container>
+                  <unittitle>
+                    <unitdate type="inclusive">1982-1984</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">84</container>
+                  <unittitle>In production, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">84</container>
+                  <unittitle>Under construction-Sovonics, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">84</container>
+                <unittitle>Photovoltaic production, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>Pilot plant, <unitdate type="inclusive">1981</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>Roof shingle and fan, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>Sovonics beach bag, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>Spain-irrigation, <unitdate type="inclusive">1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Sunpal</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">85</container>
+                  <unittitle>Battery, radio, <unitdate type="inclusive">August 1986</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">85</container>
+                  <unittitle>Boat, RV, car, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">85</container>
+                  <unittitle>Camping, beach, fishing, mountains, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>Thin substrate, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(with Joe Hanak)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>Transparent electrode material, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Ultralight</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">85</container>
+                  <unittitle>MA series, <unitdate type="inclusive">1987-1988</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">85</container>
+                  <unittitle>Stan Ovshinsky, Joe Hanak, and Pat Dahlin, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">85</container>
+                  <unittitle>United Solar, <unitdate type="inclusive">undated</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>Video camera, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>Vietnam, <unitdate type="inclusive">1995</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>Warning flasher, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Thermoelectric, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Thermoelectric -- OTEG generator, 1981-1986(?)</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Thermoelectric -- TE device with gasoline engine and wood stove, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>X-ray optics</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>Clean room, <unitdate type="inclusive">June 1986</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>Device elements and mirrors, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>Phillips spectrometer, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>Reflector, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">85</container>
+            <unittitle>Rapid solidification, <unitdate type="inclusive">undated</unitdate> </unittitle>
+          </did>
+          <note>
+            <p>(with Dick Clayton)</p>
+          </note>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Russia</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Delegation, <unitdate type="inclusive">April-May 1990</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Embassy -- scooter and Vice President Gore, 1997(?)</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>KVANT -- Moscow, <unitdate type="inclusive">January 1990</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Shareholders Meeting</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>
+                <unitdate type="inclusive">1992</unitdate>
+              </unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>
+                <unitdate type="inclusive">April 1995</unitdate>
+              </unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>
+                <unitdate type="inclusive">1985-1986</unitdate>
+              </unittitle>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Shows</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>AFL-CIO Union Industries, <unitdate type="inclusive">May 1995</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Auto-Chicago, <unitdate type="inclusive">1998</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Trade</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>Cobo Hall, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>GM Ovonic battery display, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>IEEE PV conference, <unitdate type="inclusive">1984</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Sovonics)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>National Hardware, <unitdate type="inclusive">1985</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(Chicago, Sovonics sunpak)</p>
+              </note>
+            </c04>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">85</container>
+            <unittitle>Smithsonian </unittitle>
+          </did>
+          <note>
+            <p>(Ovonic Tech Company chart, Ovshinsky's University of Michigan honorary degree)</p>
+          </note>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">85</container>
+            <unittitle>Solar Corona eclipse, <unitdate type="inclusive">May 28, 1900</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Ovshinsky</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>80th Birthday, <unitdate type="inclusive">2002</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">87</container>
+              <unittitle>70th Birthday photo album, <unitdate type="inclusive">1992</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Contents of Ovshinsky's photo album, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Drawings, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Drawings -- Ovshinsky's Fans publication, <unitdate type="inclusive">1982</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Fritzsche, Hellmut, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Machine shop, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Products</unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Oakland press, <unitdate type="inclusive">November 1985</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Leach, Ralph F., <unitdate type="inclusive">undated</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(Board member)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Madan, Aran, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Oversize">110  </container>
+              <unittitle>Nagashima and Ovshinsky, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Products</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>Optical disk, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">85</container>
+                <unittitle>Solar panel -- Japan, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">85</container>
+              <unittitle>Parks, Rosa Ovshinsky, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">86</container>
+              <unittitle>Promotional, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              <physdesc>
+                <extent>2 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">86</container>
+              <unittitle>Publicity photos, <unitdate type="inclusive">1992-2000</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">86</container>
+              <unittitle>Recent, <unitdate type="inclusive">2005-2010</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(2 CDs)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">86</container>
+              <unittitle>Rosa Ovshinsky, Dr. and Mrs. Ohta in Kyoto, <unitdate type="inclusive">July 2008</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">86</container>
+              <unittitle>Umene, Mr. and Mrs. --NSC, <unitdate type="inclusive">October 1985</unitdate></unittitle>
+            </did>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <unittitle>Stan and Iris Ovshinsky</unittitle>
+          </did>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">86</container>
+              <unittitle>Anniversary party -- surprise, <unitdate type="inclusive">1984</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">86</container>
+              <unittitle>Bio photos, <unitdate type="inclusive">2000</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">86</container>
+              <unittitle>Christmas and holiday cards, <unitdate type="inclusive">1969-1985</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">86</container>
+              <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <physloc> Online </physloc>
+              <unittitle>Miscellaneous photographs for Notre Dame book, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              <physdesc>
+                <physfacet>.ZIP file</physfacet>
+              </physdesc>
+              <dao href="http://hdl.handle.net/2027.42/116140" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">86</container>
+              <unittitle>Pauling, Linus, <unitdate type="inclusive">undated</unitdate></unittitle>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">86</container>
+              <unittitle>Powell, Colin, <unitdate type="inclusive">2000</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(Troy, MI, Heroes of Chemistry)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">86</container>
+              <unittitle>Promotional, <unitdate type="inclusive">undated</unitdate> </unittitle>
+              <physdesc>
+                <extent>3 folders</extent>
+              </physdesc>
+            </did>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">86</container>
+              <unittitle>Promotional with Stempel, <unitdate type="inclusive">February 3, 1998</unitdate> </unittitle>
+            </did>
+            <note>
+              <p>(by Eric Smith)</p>
+            </note>
+          </c03>
+          <c03 level="file">
+            <did>
+              <unittitle>Trips</unittitle>
+            </did>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">86</container>
+                <unittitle>Caracas, <unitdate type="inclusive">July 1982</unitdate> </unittitle>
+              </did>
+              <note>
+                <p>(with R. Calloratti and Paul Gray of MIT)</p>
+              </note>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">86</container>
+                <unittitle>China, <unitdate type="inclusive">September 1984</unitdate></unittitle>
+              </did>
+            </c04>
+            <c04 level="file">
+              <did>
+                <unittitle>Japan</unittitle>
+              </did>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">86</container>
+                  <unittitle> August 1983(?)</unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">86</container>
+                  <unittitle>
+                    <unitdate type="inclusive">February 1986</unitdate>
+                  </unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">86</container>
+                  <unittitle>Kobe conference, <unitdate type="inclusive">November 1984</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">86</container>
+                  <unittitle>Kyoto Nobel lecture, <unitdate type="inclusive">June 1986</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">86</container>
+                  <unittitle>Meeting with NTT, <unitdate type="inclusive">April 1985</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">87</container>
+                  <unittitle>Samsung, <unitdate type="inclusive">March 1990</unitdate> </unittitle>
+                  <physdesc>
+                    <extent>2 volumes</extent>
+                  </physdesc>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">86</container>
+                  <unittitle>YKK, <unitdate type="inclusive">January 1986</unitdate></unittitle>
+                </did>
+              </c05>
+              <c05 level="file">
+                <did>
+                  <container type="box" label="Box">86</container>
+                  <unittitle>Yoshida Kogyo K.K., <unitdate type="inclusive">January 1986</unitdate></unittitle>
+                </did>
+              </c05>
+            </c04>
+            <c04 level="file">
+              <did>
+                <container type="box" label="Box">86</container>
+                <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle>
+              </did>
+            </c04>
+          </c03>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">86</container>
+            <unittitle>Stan and Rosa Ovshinsky -- UC Berkeley Review photo shoot, <unitdate type="inclusive">2008</unitdate> </unittitle>
+          </did>
+          <note>
+            <p>( CD of photos)</p>
+          </note>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">86</container>
+            <unittitle>Superconductivity -- Rosa Ovshinsky with Squid machine, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">86</container>
+            <unittitle>Switching, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">86</container>
+            <unittitle>Transistors, <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+      </c01>
+      <c01 level="series">
+        <did>
+          <unittitle>Lake Angelus Observatory</unittitle>
+        </did>
+        <scopecontent>
+          <p>The Lake Angelus Observatory series (0.4 linear feet; 1938-1980) consists of miscellaneous records from the Hulbert-McMath Observatory in Lake Angelus, Michigan. Included are photographs of the facility, a 1967 newsletter, and guest books containing signatures of visitors from 1938 through 1980.</p>
+        </scopecontent>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">108</container>
+            <unittitle>Guest books, <unitdate type="inclusive">1938-1980</unitdate> (3 books)</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">108</container>
+            <unittitle>Newsletter, <unitdate type="inclusive">1967</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">108</container>
+            <unittitle>Photographs, circa <unitdate type="inclusive">1940</unitdate></unittitle>
+          </did>
+        </c02>
+      </c01>
+    </dsc>
+    <descgrp type="add">
+      <relatedmaterial>
+        <head>Related material</head>
+        <p>Researchers interested in Michigan inventors and inventions, in applied physical sciences, and in technological development in the state, especially as it pertains to industry, may wish to consult the following collections held by the Bentley Historical Library: 
+<list type="simple"><item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-851144" show="new" actuate="onrequest">Marston Bates papers</title></item><item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-2014075" actuate="onrequest" show="new">Clark J. Charnetski papers</title></item><item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-07126" show="new" actuate="onrequest">Thomas M. Donahue papers</title></item><item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-9740" show="new" actuate="onrequest">Industrial Development Division (University of Michigan) records</title></item><item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-9445" show="new" actuate="onrequest">Inventors Council of Michigan records</title></item><item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-85220" show="new" actuate="onrequest">Russell V. Judson papers</title></item><item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-85254" actuate="onrequest" show="new">Eugene H. Leslie papers</title></item><item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-85254" show="new" actuate="onrequest">Michigan Technology Council records</title></item><item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-851959" show="new" actuate="onrequest">Arthur D. Moore papers</title></item><item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-8733" actuate="onrequest" show="replace">	William Charles Parkinson papers</title></item><item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-89273" show="new" actuate="onrequest">	Keeve Milton Siegel papers</title></item><item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-8674" show="new" actuate="onrequest">George Owen Squier papers</title></item><item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-2012040" show="new" actuate="onrequest">Robert C. Stempel papers</title></item><item><title href="Thomas R. Stockton" actuate="onrequest" show="new">Thomas R. Stockton papers</title></item><item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-2013118" show="new" actuate="onrequest">Juris Upatnieks papers</title></item><item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-0135" show="new" actuate="onrequest">	Wallace C. Williams papers</title></item><item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-9802" show="new" actuate="onrequest">Shien-Ming Wu papers</title></item><item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-97121" show="new" actuate="onrequest">Chia-Shun Yih papers</title></item><item><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-86386" show="new" actuate="onrequest">Philip Newell Youtz papers</title></item></list></p>
+        <p>Also, papers of Stan Ovshinsky's son, <title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-2015038" show="new" actuate="onrequest">Harvey Ovshinsky</title>, Michigan writer, journalist, news broadcaster, radio host, television producer, creative consultant, teacher, and founder of <title render="italic">The Fifth Estate</title>, Detroit's first underground newspaper.</p>
+      </relatedmaterial>
+    </descgrp>
+  </archdesc>
 </ead>

--- a/Real_Masters_all/ovshinskysr.xml
+++ b/Real_Masters_all/ovshinskysr.xml
@@ -61,10 +61,9 @@ Stanford R. Ovshinsky papers
 1950-2012
 </unitdate>
 </unittitle>
-      <physdesc>
-        <extent encodinganalog="300">
-97.4 linear feet (in 108 boxes), 6 oversize boxes, 3 oversize volumes, and 41.7 GB (online)
-</extent>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">97.4 linear feet</extent>
+        <extent altrender="carrier">(in 108 boxes)</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2014092 Aa 2
@@ -214,8 +213,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Autobiography, <unitdate type="inclusive">undated</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -270,8 +269,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Favored cartoons and quotes, <unitdate type="inclusive">undated</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -461,8 +460,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Miscellaneous, <unitdate type="inclusive">1944-2004</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
           <note>
@@ -648,8 +647,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>A-B, <unitdate type="inclusive">1988-2012</unitdate> bulk dates <unitdate type="inclusive">2003-2011</unitdate> </unittitle>
-              <physdesc>
-                <extent>30 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">30 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -671,8 +670,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>C-Ch, <unitdate type="inclusive">2003-2011</unitdate> bulk dates <unitdate type="inclusive">2007-2011</unitdate> </unittitle>
-              <physdesc>
-                <extent>20 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">20 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -683,8 +682,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Cix-En. <unitdate type="inclusive">1965-2012</unitdate> bulk dates <unitdate type="inclusive">2005-2007</unitdate> </unittitle>
-              <physdesc>
-                <extent>35 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">35 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -709,8 +708,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>En-G, <unitdate type="inclusive">1981-2012</unitdate> bulk dates <unitdate type="inclusive">2002-2008</unitdate> </unittitle>
-              <physdesc>
-                <extent>29 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">29 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -721,8 +720,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>H-In, <unitdate type="inclusive">1997-2012</unitdate> bulk dates <unitdate type="inclusive">2006-2010</unitdate> </unittitle>
-              <physdesc>
-                <extent>23 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">23 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -730,8 +729,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">8</container>
               <unittitle>In-Misc., <unitdate type="inclusive">1988-2012</unitdate> bulk dates <unitdate type="inclusive">2005-2008</unitdate> </unittitle>
-              <physdesc>
-                <extent>38 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">38 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -739,8 +738,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>Misc.-Oh, <unitdate type="inclusive">1985-2011</unitdate> bulk dates <unitdate type="inclusive">2005-2008</unitdate> </unittitle>
-              <physdesc>
-                <extent>24 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">24 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -765,8 +764,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">10</container>
               <unittitle>Ol-Se, <unitdate type="inclusive">1988-2012</unitdate> bulk dates <unitdate type="inclusive">1995-2011</unitdate> </unittitle>
-              <physdesc>
-                <extent>25 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">25 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -774,8 +773,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>Sh-T, <unitdate type="inclusive">1991-2012</unitdate> bulk dates <unitdate type="inclusive">2004-2007</unitdate> </unittitle>
-              <physdesc>
-                <extent>19 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">19 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -783,8 +782,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>U-Wa, <unitdate type="inclusive">1955-2012</unitdate> bulk dates <unitdate type="inclusive">1999-2012</unitdate> </unittitle>
-              <physdesc>
-                <extent>24 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">24 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -792,8 +791,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">13</container>
               <unittitle>Workmen's Circle, <unitdate type="inclusive">2000-2012</unitdate> </unittitle>
-              <physdesc>
-                <extent>8 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">8 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -809,8 +808,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">13</container>
               <unittitle>A-Bray, <unitdate type="inclusive">1986-2012</unitdate> bulk dates <unitdate type="inclusive">2000-2012</unitdate> </unittitle>
-              <physdesc>
-                <extent>16 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">16 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -818,8 +817,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">14</container>
               <unittitle>Brockman-C, <unitdate type="inclusive">1960-2011</unitdate> bulk dates <unitdate type="inclusive">2000-2010</unitdate> </unittitle>
-              <physdesc>
-                <extent>22 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">22 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -830,8 +829,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">15</container>
               <unittitle>D-F, <unitdate type="inclusive">1963-2012</unitdate> bulk dates <unitdate type="inclusive">2005-2012</unitdate> </unittitle>
-              <physdesc>
-                <extent>34 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">34 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -842,8 +841,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">16</container>
               <unittitle>G-Hoddeson </unittitle>
-              <physdesc>
-                <extent>32 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">32 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -854,8 +853,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">17</container>
               <unittitle>Hoffer-I, <unitdate type="inclusive">1954-2012</unitdate> bulk dates <unitdate type="inclusive">2002-2012</unitdate> </unittitle>
-              <physdesc>
-                <extent>19 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">19 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -866,8 +865,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">18</container>
               <unittitle>J-K, <unitdate type="inclusive">1972-2012</unitdate> bulk dates <unitdate type="inclusive">2001-2012</unitdate> </unittitle>
-              <physdesc>
-                <extent>26 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">26 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -878,8 +877,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">19</container>
               <unittitle>L-Mi, <unitdate type="inclusive">1955-2012</unitdate> bulk dates <unitdate type="inclusive">2000-2012</unitdate> </unittitle>
-              <physdesc>
-                <extent>30 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">30 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -899,8 +898,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">21</container>
               <unittitle>Ovshinsky-Pi, <unitdate type="inclusive">1983-2012</unitdate> </unittitle>
-              <physdesc>
-                <extent>17 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">17 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -908,8 +907,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">22</container>
               <unittitle>Popescu-Slangerup, <unitdate type="inclusive">1969-2012</unitdate> bulk dates <unitdate type="inclusive">2003-2010</unitdate> </unittitle>
-              <physdesc>
-                <extent>31 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">31 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -920,8 +919,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">23</container>
               <unittitle>Smaga-T, <unitdate type="inclusive">1983-2012</unitdate> bulk dates <unitdate type="inclusive">2003-2011</unitdate> </unittitle>
-              <physdesc>
-                <extent>26 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">26 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -932,8 +931,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">107</container>
               <unittitle>Sm-Za (supplemental), <unitdate type="inclusive">1986-2000</unitdate> bulk dates <unitdate type="inclusive">1996-2000</unitdate> </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -941,8 +940,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">24</container>
               <unittitle>V-Z, <unitdate type="inclusive">1992-2012</unitdate> </unittitle>
-              <physdesc>
-                <extent>27 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">27 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -980,8 +979,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">25</container>
             <unittitle>Blood, 1955-1963(?) </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -989,8 +988,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">25</container>
             <unittitle>Brain, <unitdate type="inclusive">1955-1996</unitdate> </unittitle>
-            <physdesc>
-              <extent>4 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1010,8 +1009,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">25</container>
             <unittitle>Chemical Bonding, <unitdate type="inclusive">undated</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1025,8 +1024,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">25</container>
             <unittitle>Cognitive Computer, <unitdate type="inclusive">1955-2010</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1034,8 +1033,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">25</container>
             <unittitle>Cosmology, <unitdate type="inclusive">1985-2007</unitdate> </unittitle>
-            <physdesc>
-              <extent>11 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">11 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1043,8 +1042,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">26</container>
             <unittitle>Cosmology, <unitdate type="inclusive">1985-2007</unitdate> </unittitle>
-            <physdesc>
-              <extent>11 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">11 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1082,8 +1081,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">26</container>
             <unittitle>Hydrogen, <unitdate type="inclusive">1979</unitdate>, <unitdate type="inclusive">1997</unitdate>, <unitdate type="inclusive">2003</unitdate> </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1097,8 +1096,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">26</container>
             <unittitle>Intelligence, <unitdate type="inclusive">1950-1962</unitdate> </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1130,8 +1129,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">27</container>
             <unittitle>Neurophysiology, <unitdate type="inclusive">1955-1965</unitdate> </unittitle>
-            <physdesc>
-              <extent>7 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">7 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1145,8 +1144,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">27</container>
             <unittitle>Photovoltaic, <unitdate type="inclusive">1980-2008</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1160,8 +1159,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">27</container>
             <unittitle>Semiconductors, <unitdate type="inclusive">1955-1968</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1178,8 +1177,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">28</container>
             <unittitle>Superconductivity, <unitdate type="inclusive">1975-1994</unitdate> </unittitle>
-            <physdesc>
-              <extent>15 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">15 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1187,8 +1186,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">29</container>
             <unittitle>Superconductivity, <unitdate type="inclusive">1965-1995</unitdate> </unittitle>
-            <physdesc>
-              <extent>31 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">31 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1196,8 +1195,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">29</container>
             <unittitle>Superconductivity, <unitdate type="inclusive">1977-1990</unitdate> </unittitle>
-            <physdesc>
-              <extent>26 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">26 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1214,8 +1213,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">61</container>
             <unittitle>Switching, <unitdate type="inclusive">1959-1970</unitdate> </unittitle>
-            <physdesc>
-              <extent>9 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">9 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -1247,8 +1246,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">30</container>
               <unittitle><unitdate type="inclusive">1955</unitdate> -- <unitdate type="inclusive">1970</unitdate> </unittitle>
-              <physdesc>
-                <extent>83 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">83 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1256,8 +1255,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">31</container>
               <unittitle><unitdate type="inclusive">1971</unitdate> -- <unitdate type="inclusive">1975</unitdate> </unittitle>
-              <physdesc>
-                <extent>61 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">61 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1265,8 +1264,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">32</container>
               <unittitle><unitdate type="inclusive">1976</unitdate> -- <unitdate type="inclusive">1981</unitdate> </unittitle>
-              <physdesc>
-                <extent>70 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">70 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1274,8 +1273,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">107</container>
               <unittitle><unitdate type="inclusive">1975-1980</unitdate> supplemental publications </unittitle>
-              <physdesc>
-                <extent>9 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">9 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1283,8 +1282,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">33</container>
               <unittitle><unitdate type="inclusive">1982</unitdate> -- <unitdate type="inclusive">1984</unitdate> </unittitle>
-              <physdesc>
-                <extent>81 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">81 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1292,8 +1291,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">34</container>
               <unittitle><unitdate type="inclusive">1985</unitdate> -- <unitdate type="inclusive">1986</unitdate> </unittitle>
-              <physdesc>
-                <extent>75 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">75 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1301,8 +1300,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">35</container>
               <unittitle><unitdate type="inclusive">1987</unitdate> -- <unitdate type="inclusive">1993</unitdate> </unittitle>
-              <physdesc>
-                <extent>80 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">80 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1310,8 +1309,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">36</container>
               <unittitle><unitdate type="inclusive">1994</unitdate> -- <unitdate type="inclusive">2000</unitdate> </unittitle>
-              <physdesc>
-                <extent>68 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">68 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1319,8 +1318,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">37</container>
               <unittitle><unitdate type="inclusive">2001</unitdate> -- <unitdate type="inclusive">2012</unitdate> </unittitle>
-              <physdesc>
-                <extent>42 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">42 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1341,8 +1340,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">38</container>
               <unittitle>Akron Beacon Journal, 2005-ECD, <unitdate type="inclusive">1963-1967</unitdate> </unittitle>
-              <physdesc>
-                <extent>50 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">50 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1350,8 +1349,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">39</container>
               <unittitle>ECD, <unitdate type="inclusive">1967-1977</unitdate> </unittitle>
-              <physdesc>
-                <extent>23 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">23 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1359,8 +1358,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">40</container>
               <unittitle>ECD, 1978-2002-H </unittitle>
-              <physdesc>
-                <extent>30 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">30 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1368,8 +1367,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">41</container>
               <unittitle>I-Optical Memory News </unittitle>
-              <physdesc>
-                <extent>48 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">48 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1377,8 +1376,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">42</container>
               <unittitle>Ovonic Link -- Z </unittitle>
-              <physdesc>
-                <extent>38 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">38 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1457,8 +1456,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <did>
                 <container type="box" label="Box">107</container>
                 <unittitle>Tann Corporation agreements, press releases, promotional literature, proofs of concepts, scientific schematics, Stan and Herbert Ovshinsky patent applications and related correspondence, <unitdate type="inclusive">1955-1959</unitdate> </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1473,8 +1472,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">43</container>
               <unittitle>History, <unitdate type="inclusive">1962-1983</unitdate> </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -1645,8 +1644,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <did>
                 <container type="box" label="Box">44</container>
                 <unittitle>Miscellaneous, <unitdate type="inclusive">1959-1960</unitdate> </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -2042,8 +2041,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <did>
                 <container type="box" label="Box">45</container>
                 <unittitle>Miscellaneous proposals, <unitdate type="inclusive">1971-1978</unitdate> &amp; <unitdate type="inclusive">2001</unitdate> </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -2342,8 +2341,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <did>
                 <container type="box" label="Box">47</container>
                 <unittitle>Inter-office memos, <unitdate type="inclusive">1963-1979</unitdate> </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -2417,10 +2416,10 @@ This collection is divided into eight series: Personal; Correspondence; Research
                 <container type="box" label="Box">47</container>
                 <unittitle>80th birthday symposium, <unitdate type="inclusive">February 2007</unitdate> </unittitle>
                 <physdesc>
-                  <extent>2 folders</extent>
-                </physdesc>
-                <physdesc>
                   <physfacet>2 CDs</physfacet>
+                </physdesc>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -2632,8 +2631,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
                 <did>
                   <container type="box" label="Box">48</container>
                   <unittitle>Miscellaneous, <unitdate type="inclusive">1996-2012</unitdate> </unittitle>
-                  <physdesc>
-                    <extent>2 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -2771,8 +2770,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
                 <did>
                   <container type="box" label="Box">49</container>
                   <unittitle>Production problems   <unitdate type="inclusive">1997-2000</unitdate></unittitle>
-                  <physdesc>
-                    <extent>2 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -2792,8 +2791,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <did>
                 <container type="box" label="Box">49</container>
                 <unittitle>Background, <unitdate type="inclusive">1980-1984</unitdate> </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -2968,8 +2967,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
                 <unittitle>
                   <unitdate type="inclusive">1993-1995</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3679,8 +3678,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <did>
                 <container type="box" label="Box">52</container>
                 <unittitle>Miscellaneous, <unitdate type="inclusive">1963-1997</unitdate> </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4737,8 +4736,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <did>
                 <container type="box" label="Box">53</container>
                 <unittitle>Active material fabrication basic process, <unitdate type="inclusive">June 1973</unitdate> </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4758,8 +4757,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <did>
                 <container type="box" label="Box">53</container>
                 <unittitle>Cosmology collaboration with Fritzsche, <unitdate type="inclusive">1992-2003</unitdate> </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
               <note>
@@ -5201,8 +5200,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <did>
                 <container type="box" label="Box">54</container>
                 <unittitle>Ovonic Hydrogen Technology, <unitdate type="inclusive">1997-2002</unitdate> </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -5210,8 +5209,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <did>
                 <container type="box" label="Box">55</container>
                 <unittitle>Ovonic Hydrogen Technology, <unitdate type="inclusive">2000-2003</unitdate> </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -5409,8 +5408,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
                   <unittitle>
                     <unitdate type="inclusive">2006</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>2 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -5420,8 +5419,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
                   <unittitle>
                     <unitdate type="inclusive">2007</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>2 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -5431,8 +5430,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
                   <unittitle>
                     <unitdate type="inclusive">2008-2009</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>2 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -5922,8 +5921,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">57</container>
               <unittitle>Technical reports, <unitdate type="inclusive">1970-1973</unitdate> </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -6162,8 +6161,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>Board of Directors, <unitdate type="inclusive">January 1983-November 1985</unitdate> </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -6207,8 +6206,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>Ovshinsky, Stanford,  January 1985-November1986 </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -6433,8 +6432,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">59</container>
               <unittitle>Institute photographs, <unitdate type="inclusive">undated</unitdate> </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -7509,8 +7508,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">60</container>
               <unittitle>Short course: Physics, chemistry, and applications of amorphous semiconductors, <unitdate type="inclusive">May 1984</unitdate> </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -7762,8 +7761,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <unittitle>
                 <unitdate type="inclusive">1967-1980</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>83 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">83 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -7780,8 +7779,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">107</container>
               <unittitle>Supplemental lectures and talks, <unitdate type="inclusive">1980</unitdate> </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -7791,8 +7790,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <unittitle>
                 <unitdate type="inclusive">1981-1985</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>51 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">51 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -7823,8 +7822,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <unittitle>
                 <unitdate type="inclusive">1985-1988</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>46 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">46 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -7834,8 +7833,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <unittitle>
                 <unitdate type="inclusive">1988-1990</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>41 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">41 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -7869,8 +7868,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <unittitle>
                 <unitdate type="inclusive">1990-1997</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>46 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">46 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -7916,8 +7915,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <unittitle>
                 <unitdate type="inclusive">1997-2002</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>35 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">35 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -7927,8 +7926,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <unittitle>
                 <unitdate type="inclusive">2002-2003</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>22 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">22 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -7950,8 +7949,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <unittitle>
                 <unitdate type="inclusive">2004-2005</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>23 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">23 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -8029,8 +8028,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <unittitle>
                 <unitdate type="inclusive">2005</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>16 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">16 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -8071,8 +8070,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <unittitle>
                 <unitdate type="inclusive">2006-2007</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>27 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">27 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -8111,8 +8110,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <unittitle>
                 <unitdate type="inclusive">2007-2009</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>16 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">16 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -8142,8 +8141,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <unittitle>
                 <unitdate type="inclusive">2009-2012</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>19 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">19 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -8186,8 +8185,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <unittitle>
                 <unitdate type="inclusive">1973-2011</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>16 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">16 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -8349,8 +8348,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">75</container>
               <unittitle>Awards, <unitdate type="inclusive">1968-2004</unitdate> </unittitle>
-              <physdesc>
-                <extent>47 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">47 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -8388,8 +8387,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">76</container>
               <unittitle>Awards, <unitdate type="inclusive">2005-2011</unitdate> </unittitle>
-              <physdesc>
-                <extent>21 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">21 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -8400,8 +8399,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">77</container>
               <unittitle>Awards, <unitdate type="inclusive">2012</unitdate> </unittitle>
-              <physdesc>
-                <extent>22 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">22 folders</extent>
               </physdesc>
             </did>
             <note>
@@ -8412,8 +8411,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">77</container>
               <unittitle>Festschrift for Stan Ovshinsky</unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -8443,8 +8442,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">77</container>
               <unittitle>Miscellaneous diplomas and awards, <unitdate type="inclusive">1984-1990</unitdate></unittitle>
-              <physdesc>
-                <extent>1 folder</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -8931,8 +8930,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">79</container>
               <unittitle>Stanford Roberts Manufacturing Co. -- New Britain machine,  <unitdate type="inclusive">1949-1954(?)</unitdate></unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -9029,8 +9028,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <did>
                 <container type="box" label="Box">80</container>
                 <unittitle>Secretary of Energy -- Spence Abraham, <unitdate type="inclusive">August 2002</unitdate> </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -9421,8 +9420,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
           <did>
             <container type="box" label="Box">81</container>
             <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate> </unittitle>
-            <physdesc>
-              <extent>4 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -9553,8 +9552,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">81</container>
               <unittitle>ECD personnel, <unitdate type="inclusive">undated</unitdate> </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -9700,8 +9699,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">81</container>
               <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate> </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -9813,8 +9812,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Oversize">110 </container>
               <unittitle>Tech and production brochure, <unitdate type="inclusive">1999</unitdate> </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -10342,8 +10341,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
                 <did>
                   <container type="box" label="Box">84</container>
                   <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                  <physdesc>
-                    <extent>3 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">3 folders</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -10370,8 +10369,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
               <did>
                 <container type="box" label="Box">84</container>
                 <unittitle>Miscellaneous, <unitdate type="inclusive">undated</unitdate> </unittitle>
-                <physdesc>
-                  <extent>3 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -10865,8 +10864,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">86</container>
               <unittitle>Promotional, <unitdate type="inclusive">undated</unitdate> </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -10959,8 +10958,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
             <did>
               <container type="box" label="Box">86</container>
               <unittitle>Promotional, <unitdate type="inclusive">undated</unitdate> </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -11032,8 +11031,8 @@ This collection is divided into eight series: Personal; Correspondence; Research
                 <did>
                   <container type="box" label="Box">87</container>
                   <unittitle>Samsung, <unitdate type="inclusive">March 1990</unitdate> </unittitle>
-                  <physdesc>
-                    <extent>2 volumes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 volumes</extent>
                   </physdesc>
                 </did>
               </c05>

--- a/Real_Masters_all/pacoszch.xml
+++ b/Real_Masters_all/pacoszch.xml
@@ -906,8 +906,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>This is not a Place to Sing <unitdate type="inclusive" normal="1987">1987</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -916,8 +916,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>The Abundance of Mary, Songs and Poems in Honor of The Divine Feminine</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -926,8 +926,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Montserrat Poetry Festival<unitdate type="inclusive" normal="2010">2010</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVDs</physfacet>
               </physdesc>
             </did>
@@ -936,8 +936,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>New Works Review <unitdate type="inclusive" normal="2005">2005</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -946,8 +946,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>The Night of The Arts, North Carolina Community College, Visiting Artists, Live at the Kennedy Center <unitdate type="inclusive" normal="1989">1989</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -956,8 +956,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>"Writer as Spider" Telling Tales taped at Shelby, NC, Cleveland Community College, and other tapes <unitdate type="inclusive" normal="1988/1990" certainty="approximate">1988-1990</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/palmerfa.xml
+++ b/Real_Masters_all/palmerfa.xml
@@ -160,8 +160,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Business Correspondence, <unitdate type="inclusive" normal="1862/1877">1862-1877</unitdate></unittitle>
-              <physdesc>
-                <extent>5 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">5 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -240,8 +240,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Correspondence, <unitdate type="inclusive" normal="1867/1895">1867-1895</unitdate></unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -327,8 +327,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Correspondence and Miscellaneous, <unitdate type="inclusive">undated</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/patterlb.xml
+++ b/Real_Masters_all/patterlb.xml
@@ -3551,8 +3551,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>New Underage Drinking Law <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3561,8 +3561,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Patterson for Co. Executive <unitdate type="inclusive" normal="1992-10-15">October 15, 1992</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3571,8 +3571,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Guest Editorial Telecast <unitdate type="inclusive" normal="1993-04-04/1993-04-05">April 4-5 1993</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3581,8 +3581,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Oakland County Veteran's Memorial Dedication <unitdate type="inclusive" normal="1994-05-28">May 28, 1994</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>Betacam (TM)</physfacet>
               </physdesc>
             </did>
@@ -3591,8 +3591,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Comcast Newsmakers <unitdate type="inclusive" normal="2003-12-16">December 16, 2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3601,8 +3601,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Oakland County Prescription Plan <unitdate type="inclusive" normal="2005-04-14">April 14, 2005</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3611,8 +3611,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Oakland Prescription Plan, <unitdate type="inclusive" normal="2005">Summer 2005</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -3622,8 +3622,8 @@
           <did>
             <container label="CD Box" type="box">1</container>
             <unittitle>Oakland County Executive website CD, captured <unitdate type="inclusive" normal="2007-06-13">June 13, 2007</unitdate></unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-R</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/pcma.xml
+++ b/Real_Masters_all/pcma.xml
@@ -927,8 +927,8 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Two <unitdate type="inclusive">Undated</unitdate> STP Sessions</unittitle>
-              <physdesc>
-                <extent>2 floppy disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 floppy disks</extent>
                 <physfacet>5.25"</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/peacewrk.xml
+++ b/Real_Masters_all/peacewrk.xml
@@ -1068,8 +1068,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Arlington Midwest <unitdate type="inclusive" normal="2004">2004</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1078,8 +1078,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Chicago Media <unitdate type="inclusive" normal="2007-10-27">October 27, 2007</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1088,8 +1088,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Cindy Sheehan Support Rally Photographs <unitdate type="inclusive" normal="2005">2005</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1104,8 +1104,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Michigan Peaceworks July 4th <unitdate type="inclusive" normal="2006-03">March, 2006</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1114,8 +1114,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>MPW photographs <unitdate type="inclusive" normal="2004/2010">2004-2010</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1134,8 +1134,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Peace Rally photographs <unitdate type="inclusive" normal="2004">2004</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1144,8 +1144,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Peace Vigil Photographs <unitdate type="inclusive" normal="2007">2007</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -1154,8 +1154,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Stop the War March photographs and "Turn Yourself In" mugshots <unitdate type="inclusive" normal="2006">2006</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/perazza.xml
+++ b/Real_Masters_all/perazza.xml
@@ -443,8 +443,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>Miscellaneous, <unitdate type="inclusive" normal="1978/1999">1978-1999</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -499,8 +499,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Miscellaneous, <unitdate type="inclusive" normal="1971/1986">1971-1986</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -526,8 +526,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Puerto Rico, <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -630,8 +630,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Unidentified images, <unitdate type="inclusive">1985 undated</unitdate></unittitle>
-            <physdesc>
-              <extent>2 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
               <physfacet>CDs</physfacet>
             </physdesc>
           </did>
@@ -707,8 +707,8 @@
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>Interviews, Concert, Drives and Walks around Detroit, <unitdate type="inclusive" normal="1985">1985</unitdate></unittitle>
-            <physdesc>
-              <extent>3 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 optical disks</extent>
               <physfacet>DVDs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/physics.xml
+++ b/Real_Masters_all/physics.xml
@@ -58,10 +58,10 @@
       </origination>
       <unittitle encodinganalog="245">Dept. of Physics (University of Michigan) records <unitdate type="inclusive" encodinganalog="245$f" normal="1873/9999">1873-[ongoing]</unitdate></unittitle>
       <physdesc altrender="part">
-        <extent encodinganalog="300">14.5 linear feet</extent>
+        <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>
       </physdesc>
       <physdesc altrender="part">
-        <extent encodinganalog="300">1 oversize folders</extent>
+        <extent altrender="materialtype spaceoccupied">14.5 linear feet</extent>
       </physdesc>
       <abstract>Correspondence and other papers dealing with departmental plans, reviews and organization, buildings and laboratories, staff recruitment, research, impact of World War I and personal affairs of various staff members especially when they were studying in Europe. Correspondence includes letters of John W. Langley, Robert A. Millikan, Harrison Randall, James M. Cork, Ernest Lawrence, Walter Stevens, John O. Reed, Henry Carhart, Karl Guthe, Fred Hodges, Horace R. Crane, and others. Also includes correspondence of chairmen Daniel Sinclair, Richard H. Sands, and Lawrence W. Jones. Efforts to locate a superconducting super collider in Michigan in the 1980s are well documented in these records.</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">87145 Bimu C26 2 UBImul C26</unitid>
@@ -319,8 +319,8 @@
                 <did>
                   <container type="box" label="Box">1</container>
                   <unittitle>College of LS&amp;A <unitdate type="inclusive" normal="1984-01/1986-05">January 1984-May 1986</unitdate></unittitle>
-                  <physdesc>
-                    <extent>2 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -711,12 +711,12 @@
               </did>
               <c05 level="file">
                 <did>
-                  <physdesc>
-                    <extent>3 folders</extent>
-                  </physdesc>
                   <unittitle>
                     <unitdate type="inclusive" normal="1954-10/1966-07">October 1954-July 1966</unitdate>
                   </unittitle>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">3 folders</extent>
+                  </physdesc>
                 </did>
               </c05>
               <c05 level="file">
@@ -1408,8 +1408,8 @@
               <did>
                 <container type="box" label="Box">14</container>
                 <unittitle>Budget Files <unitdate type="inclusive" normal="1920/1945" certainty="approximate">circa 1920-1945</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 microfilms</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 microfilms</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1799,8 +1799,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Class and Section Enrollment Reports, Fall 1956-Spring <unitdate type="inclusive" normal="1973">1973</unitdate></unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2226,8 +2226,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>Review <unitdate type="inclusive" normal="1986">1986</unitdate></unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2601,8 +2601,8 @@
                 <unittitle>
                   <unitdate>undated</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -2639,8 +2639,8 @@
               <did>
                 <container type="box" label="Box">9</container>
                 <unittitle>1985-87</unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -2661,8 +2661,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>Engineering Drawings, 1985-87</unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2676,8 +2676,8 @@
             <did>
               <container type="box" label="Box">9</container>
               <unittitle>Instrumentation, 1983-88</unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2719,8 +2719,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1987">1987</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -2730,8 +2730,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1988">1988</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -2776,8 +2776,8 @@
               <did>
                 <container type="box" label="Box">10</container>
                 <unittitle>Hadron Calorimeter</unittitle>
-                <physdesc>
-                  <extent>3 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -2866,8 +2866,8 @@
             <did>
               <container type="box" label="Box">16</container>
               <unittitle>Martin Luther King Day <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>2 tapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 tapes</extent>
               </physdesc>
             </did>
           </c03>
@@ -2875,8 +2875,8 @@
             <did>
               <container type="box" label="Box">16</container>
               <unittitle>M. Perl <unitdate type="inclusive" normal="1991-04-11">April 11, 1991</unitdate></unittitle>
-              <physdesc>
-                <extent>2 tapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 tapes</extent>
               </physdesc>
             </did>
           </c03>
@@ -2884,8 +2884,8 @@
             <did>
               <container type="box" label="Box">16</container>
               <unittitle>Lynn Rivers <unitdate type="inclusive" normal="1996-02-09">February 9, 1996</unitdate></unittitle>
-              <physdesc>
-                <extent>2 tapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 tapes</extent>
               </physdesc>
             </did>
           </c03>
@@ -2934,8 +2934,8 @@
             <did>
               <container type="box" label="Box">16</container>
               <unittitle>Unidentified</unittitle>
-              <physdesc>
-                <extent>1 tape</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 tapes</extent>
               </physdesc>
             </did>
           </c03>
@@ -2960,8 +2960,8 @@
             <did>
               <container type="box" label="Box">16</container>
               <unittitle>Stockbridge on Target <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>2 tapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 tapes</extent>
               </physdesc>
             </did>
           </c03>
@@ -2975,8 +2975,8 @@
             <did>
               <container type="box" label="Box">16</container>
               <unittitle>Ta-You Wu Symposium I <unitdate type="inclusive" normal="1991-05-03">May 3, 1991</unitdate></unittitle>
-              <physdesc>
-                <extent>2 tapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 tapes</extent>
               </physdesc>
             </did>
           </c03>
@@ -2984,8 +2984,8 @@
             <did>
               <container type="box" label="Box">16</container>
               <unittitle>Unidentified</unittitle>
-              <physdesc>
-                <extent>17 tapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">17 tapes</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/plecharyan.xml
+++ b/Real_Masters_all/plecharyan.xml
@@ -1,143 +1,144 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE ead PUBLIC "+//ISBN 1-931666-00-8//DTD ead.dtd (Encoded Archival Description (EAD) Version 2002)//EN" "ead.dtd">
 <ead>
-
-<eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
-
-<eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::plecharyan.xml//EN" encodinganalog="Identifier">
+  <eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
+    <eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::plecharyan.xml//EN" encodinganalog="Identifier">
 umich-bhl-2016018</eadid>
-
-<filedesc><titlestmt><titleproper encodinganalog="Title">Finding Aid for 
+    <filedesc>
+      <titlestmt>
+        <titleproper encodinganalog="Title">Finding Aid for 
 Ryan C. Plecha papers
 
 </titleproper>
-<author encodinganalog="Creator">Collection processed and finding aid created by 
-Olga Virakhovskaya </author></titlestmt>
-
-<publicationstmt><publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
-<date encodinganalog="Date" normal="2016">
-2016</date></publicationstmt></filedesc>
-
-<profiledesc>
-<creation>Encoded finding aid created by 
+        <author encodinganalog="Creator">Collection processed and finding aid created by 
+Olga Virakhovskaya </author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
+        <date encodinganalog="Date" normal="2016">
+2016</date>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>Encoded finding aid created by 
 Olga Virakhovskaya 
 <date>2016</date></creation>
-
-<langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage><descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules></profiledesc>
-
-<revisiondesc><change><date>2016-02-11</date><item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item></change></revisiondesc></eadheader>
-
-<frontmatter><titlepage>
-
-<publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
-
-<titleproper>Finding aid for<lb/>
+      <langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage>
+      <descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules>
+    </profiledesc>
+    <revisiondesc>
+      <change>
+        <date>2016-02-11</date>
+        <item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item>
+      </change>
+    </revisiondesc>
+  </eadheader>
+  <frontmatter>
+    <titlepage>
+      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <titleproper>Finding aid for<lb/>
 Ryan C. Plecha papers
 </titleproper>
-
-<author>Finding aid created by<lb/> 
+      <author>Finding aid created by<lb/> 
 Olga Virakhovskaya, in February 2016
 </author>
-
-</titlepage>
-</frontmatter>
-
-<archdesc level="collection" audience="external" type="inventory" relatedencoding="MARC21"><did>
-
-<origination>
-<persname source="lcnaf" encodinganalog="100">
+    </titlepage>
+  </frontmatter>
+  <archdesc level="collection" audience="external" type="inventory" relatedencoding="MARC21">
+    <did>
+      <origination>
+        <persname source="lcnaf" encodinganalog="100">
 Plecha, Ryan C.
-</persname></origination>
-
-<unittitle encodinganalog="245">
+</persname>
+      </origination>
+      <unittitle encodinganalog="245">
 Ryan C. Plecha papers
 <unitdate type="inclusive" encodinganalog="245$f">
 2013-2014
 </unitdate>
  
 </unittitle>
-
-<physdesc><extent encodinganalog="300">
+      <physdesc>
+        <extent encodinganalog="300">
 0.2 linear feet
-</extent></physdesc>
-
-<unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
+</extent>
+      </physdesc>
+      <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2016018 Aa 2
 </unitid>
-
-<langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
-
-<abstract>
+      <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
+      <abstract>
 Documentation and photogrphs related to the Detroit Retired City Employees Association and the Detroit's Chapter 9 bankruptcy.
 </abstract>
-
-
-<repository><corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
-<extptr href="bhladd" show="embed" actuate="onload"/></repository></did>
-
-<descgrp type="admin">
-<acqinfo encodinganalog="541"><p>
+      <repository>
+        <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
+        <extptr href="bhladd" show="embed" actuate="onload"/>
+      </repository>
+    </did>
+    <descgrp type="admin">
+      <acqinfo encodinganalog="541">
+        <p>
 Donated by Ryan C. Plecha (donor no. 
 <num type="donor" encodinganalog="541$e">11438</num>) in February 2016.
  
-</p></acqinfo>
+</p>
+      </acqinfo>
+      <accruals encodinganalog="584">
+        <p>Periodic additions to the records expected.</p>
+      </accruals>
+      <accessrestrict encodinganalog="506">
+        <p>The collection is open for research.  
 
-<accruals encodinganalog="584"><p>Periodic additions to the records expected.</p></accruals>
-
-<accessrestrict encodinganalog="506">
-<p>The collection is open for research.  
-
- </p></accessrestrict>
-
-
-<userestrict encodinganalog="540"><p>
+ </p>
+      </accessrestrict>
+      <userestrict encodinganalog="540">
+        <p>
 Copyright is held by the Regents of the University of Michigan. 
-</p></userestrict>
-
-
-<prefercite encodinganalog="524"><p>[item], folder, box,
-Ryan C. Plecha papers, Bentley Historical Library, University of Michigan</p></prefercite>
- </descgrp>
-
-<bioghist encodinganalog="545">
-
-<p>
-Ryan C. Plecha is a Partner and debt relief attorney at Lippitt O'Keefe Gornbein law firm in Birmingham, Mich. Plecha focuses his practice on civil litigation, complex commercial litigation, estate planning and bankruptcy.  </p><p>
- 
+</p>
+      </userestrict>
+      <prefercite encodinganalog="524">
+        <p>[item], folder, box,
+Ryan C. Plecha papers, Bentley Historical Library, University of Michigan</p>
+      </prefercite>
+    </descgrp>
+    <bioghist encodinganalog="545">
+      <p>
+Ryan C. Plecha is a Partner and debt relief attorney at Lippitt O'Keefe Gornbein law firm in Birmingham, Mich. Plecha focuses his practice on civil litigation, complex commercial litigation, estate planning and bankruptcy.  </p>
+      <p>
 Plecha graduated cum laude with a Bachelor of Arts from Kalamazoo College and earned his Law Degree from Western Michigan University Thomas M. Cooley Law School. While working on his law degree, Plecha received several prestigious honors, including the Sol Siegal Award and the Shane Joseph Memorial Scholarship. Prior to joining Lippitt O'Keefe Gornbein in 2011, he served as a judicial intern to the Honorable Gerald E. Rosen, Chief Judge, U.S. District Court for the Eastern Distrit of Michigan. In 2008, Plecha established Plecha Legal, a general practice firm engaged in cases concerning civil litigation, family law, estate planning, and corporate formations.  Between 2009 and 2011 Plecha worked for Hyman Lyppitt, PC as a Contract Attorney and an Associate Attorney. During this time he also served as a research and writing clerk on the Michigan Law Revision Commission.  </p>
-<p>
+      <p>
 Plecha's notable successes include providing representation representation of a Michigan corporation in a multimillion dollar federal antitrust class action suit; representation of a big three automotive company in supplier disputes; representation of two hedge funds in a class action shareholder oppression case; represented Ford Motor Company in various matters; and participated in prosecution of the Fair Labor Standards Act (FLSA) class action on behalf of employees (prison guards) of Michigan Department of Corrections. Plecha was counsel to two Detroit Retiree Associations (the Retired Detroit Police and Fire Fighters Association (RDPFFA), and the Detroit Retired City Employees Association (DRCEA)) in the historic City of Detroit Chapter 9 bankruptcy.  The RDPFFA, whose 6,500 members at the time  included more than 80 percent of police and fire pensioners, was a Lippitt O'Keefe Gornbein  client, and the DRCEA specifically retained the firm for the bankruptcy. The police-fire association reached an agreement to support Detroit's plan of adjustment out of mediation in <unitdate type="inclusive">April 2014</unitdate> -- one that avoided benefit cuts but reduced cost-of-living increases for pensioners going forward. Other employees and later the boards of Detroit's two employee pension funds later got on board with the city's plan as well. </p>
-<p>
+      <p>
 Plecha is a member of the Oakland County Bar Association, the American Bankruptcy Institute, the American Bar Association, the Federal Bar Association and The Oakland County Bar Association American Inn of Court. In 2013 Plecha was appointed to the executive council of the State Bar of Michigan's Young Lawyers Section. He is admitted to practice law in the state of Michigan as well as before the United States District Court for the Eastern District of Michigan and the United States Court of Appeals for the 6th Circuit.     
 </p>
-
-</bioghist>
-   
-
-<scopecontent encodinganalog="520"><p>
-DRCEA and RDPFFA communications and press releases; U.S. Bankruptcy Court Eastersn District of Michigan notices; statements by Shirley V. Lightsey, President of the DRCEA, and Don Taylor, President of RDPFFA; photographs.</p> </scopecontent>
-
-<controlaccess><p><extptr href="accnote" show="embed" actuate="onload"/></p><controlaccess><head>Subjects:</head>
-
-<geogname source="lcsh" encodinganalog="651">Detroit (Mich.)</geogname>
-<corpname source="lcnaf" encodinganalog="610">Detroit Retired City Employees Association.</corpname>
-<subject source="lcsh" encodinganalog="650">Municipal bankruptcy--Michigan--Detroit.</subject>
-<persname source="lcnaf" encodinganalog="600">Plecha, Ryan C.</persname>
-<corpname source="lcnaf" encodinganalog="610">Retired Detroit Police and Fire Fighters Association.</corpname>
-<subject source="lcsh" encodinganalog="650">Retirees--Michigan--Detroit.</subject>
-
-</controlaccess>
-<controlaccess><head>Genre Terms:</head>
-<genreform source="aat" encodinganalog="655">Photographs.</genreform></controlaccess>
-
-</controlaccess>
-
-<dsc type="combined"> <c01 level="series">
-
-  <did>
+    </bioghist>
+    <scopecontent encodinganalog="520">
+      <p>
+DRCEA and RDPFFA communications and press releases; U.S. Bankruptcy Court Eastersn District of Michigan notices; statements by Shirley V. Lightsey, President of the DRCEA, and Don Taylor, President of RDPFFA; photographs.</p>
+    </scopecontent>
+    <controlaccess>
+      <p>
+        <extptr href="accnote" show="embed" actuate="onload"/>
+      </p>
+      <controlaccess>
+        <head>Subjects:</head>
+        <geogname source="lcsh" encodinganalog="651">Detroit (Mich.)</geogname>
+        <corpname source="lcnaf" encodinganalog="610">Detroit Retired City Employees Association.</corpname>
+        <subject source="lcsh" encodinganalog="650">Municipal bankruptcy--Michigan--Detroit.</subject>
+        <persname source="lcnaf" encodinganalog="600">Plecha, Ryan C.</persname>
+        <corpname source="lcnaf" encodinganalog="610">Retired Detroit Police and Fire Fighters Association.</corpname>
+        <subject source="lcsh" encodinganalog="650">Retirees--Michigan--Detroit.</subject>
+      </controlaccess>
+      <controlaccess>
+        <head>Genre Terms:</head>
+        <genreform source="aat" encodinganalog="655">Photographs.</genreform>
+      </controlaccess>
+    </controlaccess>
+    <dsc type="combined">
+      <c01 level="series">
+        <did>
           <unittitle>Ryan C. Plecha papers</unittitle>
         </did>
-         
         <c02 level="file">
           <did>
             <container type="box" label="Box">1</container>
@@ -148,17 +149,15 @@ DRCEA and RDPFFA communications and press releases; U.S. Bankruptcy Court Easter
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Retired Detroit Police and Fire Fighters Association</unittitle>
-             
           </did>
-        </c02><c02 level="file">
+        </c02>
+        <c02 level="file">
           <did>
             <container type="box" label="Box">1</container>
-            <unittitle>Photographs</unittitle></did>
-        </c02></c01>
-</dsc>
-
-</archdesc>
-
-
-
+            <unittitle>Photographs</unittitle>
+          </did>
+        </c02>
+      </c01>
+    </dsc>
+  </archdesc>
 </ead>

--- a/Real_Masters_all/plecharyan.xml
+++ b/Real_Masters_all/plecharyan.xml
@@ -58,10 +58,8 @@ Ryan C. Plecha papers
 </unitdate>
  
 </unittitle>
-      <physdesc>
-        <extent encodinganalog="300">
-0.2 linear feet
-</extent>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">0.2 linear feet</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2016018 Aa 2

--- a/Real_Masters_all/polisci.xml
+++ b/Real_Masters_all/polisci.xml
@@ -1402,8 +1402,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>Walker Conference: Politics (or unpolitics) of Unemployed and Underclass (Undergraduate Political Science Association) <unitdate type="inclusive" normal="1992">1992</unitdate></unittitle>
-              <physdesc>
-                <extent>2 tapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 tapes</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/pollockj.xml
+++ b/Real_Masters_all/pollockj.xml
@@ -21,7 +21,8 @@
       <change>
         <date>20160609</date>
         <item>Added digitized audio</item>
-      </change><change>
+      </change>
+      <change>
         <date>20141212</date>
         <item>Card index to correspondence is added to collection.</item>
       </change>
@@ -70,7 +71,8 @@
       </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">16.3 GB</extent>
-      </physdesc><repository>
+      </physdesc>
+      <repository>
         <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea> University of Michigan</corpname>
         <extptr href="bhladd" show="embed" actuate="onload"/>
       </repository>
@@ -81,23 +83,26 @@
       </acqinfo>
       <accessrestrict encodinganalog="506">
         <p>The collection is open for research.</p>
-      <p>The collection contains audio tapes from which digital copies have been made. Source tapes are for staff use only. Audio files are only available in the Bentley Historical Library reading room on designated Bentley Library computers.
+        <p>The collection contains audio tapes from which digital copies have been made. Source tapes are for staff use only. Audio files are only available in the Bentley Historical Library reading room on designated Bentley Library computers.
 </p>
-</accessrestrict>
+      </accessrestrict>
       <userestrict encodinganalog="540">
         <p>Robert Pollock has transferred copyright of his father's papers to the University of Michigan, effective March 30, 1991.</p>
       </userestrict>
       <prefercite encodinganalog="524">
         <p>item, folder title, box no., James K. Pollock Papers, Bentley Historical Library, University of Michigan</p>
       </prefercite>
-      
-      
-    <altformavail>
-  <p><emph>Microfilm: </emph>A microfilm negative of the entire subseries Office of the Military Government for Germany (U.S.), 1945-1946 and later official observatory and fact-finding missions to Germany, 1947, 1948, 1950 of the series Germany: Research and Official Responsibilities is available.</p><p><emph render="bold">Digitization:</emph> The Library has undertaken the digitization of a number of sound recordings within this collection. The resulting audio files are available for playback only in the Bentley Library Reading Room. Links to item images and additional information are available within this finding aid.  Original sound recordings are only available for staff use.</p>
-</altformavail>
-
-<processinfo><p>Box 57 was eliminated during reprocessing.</p><p><extptr href="digitalproc" show="embed" actuate="onload"/></p>
-</processinfo></descgrp>
+      <altformavail>
+        <p><emph>Microfilm: </emph>A microfilm negative of the entire subseries Office of the Military Government for Germany (U.S.), 1945-1946 and later official observatory and fact-finding missions to Germany, 1947, 1948, 1950 of the series Germany: Research and Official Responsibilities is available.</p>
+        <p><emph render="bold">Digitization:</emph> The Library has undertaken the digitization of a number of sound recordings within this collection. The resulting audio files are available for playback only in the Bentley Library Reading Room. Links to item images and additional information are available within this finding aid.  Original sound recordings are only available for staff use.</p>
+      </altformavail>
+      <processinfo>
+        <p>Box 57 was eliminated during reprocessing.</p>
+        <p>
+          <extptr href="digitalproc" show="embed" actuate="onload"/>
+        </p>
+      </processinfo>
+    </descgrp>
     <bioghist encodinganalog="545">
       <p>James K. Pollock was born in New Castle, Pennsylvania, on May 25, 1898. He began his academic association with the University of Michigan as a student from 1916 to 1921. He received his A.B. degree in 1920 followed by the M.A. in 1921. While working on his Ph.D. degree at Harvard University, 1921-1925, he taught at Geneva College in Pennsylvania and at Ohio State University. In 1925 he accepted an instructorship in political science at the University of Michigan. He was promoted to full professor in 1934, served as departmental chairman, 1947-61, and occupied the Murfin chair from 1948 until his retirement in 1968. Although involved in many non-academic activities as well, Professor Pollock always considered himself primarily a teacher. Upon his retirement as departmental chairman, he insisted upon spending his remaining years on the faculty teaching undergraduates. In recognition of his achievements, the University of Michigan gave him its Distinguished Faculty Award in 1959.</p>
       <p>Professor Pollock's work at the University of Michigan was only one facet of a varied career, however. His interest in political parties, campaigns, and elections, both in America and in Europe, was not just academic. Over the years, his expertise in these subjects led both the state of Michigan and the U.S. government to request his advice on various occasions.</p>
@@ -115,43 +120,22 @@
         <list type="simple">
           <head>Summary Contents List</head>
           <item>Correspondence, 1912-1968
-            <list type="simple">
-              <item>1912-1938 -- Boxes 1-3</item>
-              <item>1926-1939 -- Boxes 3-7</item>
-              <item>1938-1945 -- Boxes 7-11</item>
-              <item>1945-1961 -- Boxes 11-16</item>
-              <item>1946-1966 -- Boxes 20-28</item>
-              <item>1946-1968 -- Boxes 28-30</item>
-            </list>
+            <list type="simple"><item>1912-1938 -- Boxes 1-3</item><item>1926-1939 -- Boxes 3-7</item><item>1938-1945 -- Boxes 7-11</item><item>1945-1961 -- Boxes 11-16</item><item>1946-1966 -- Boxes 20-28</item><item>1946-1968 -- Boxes 28-30</item></list>
           </item>
           <item>Organizational Affiliations and Professional Interests, 1935-1968 -- Boxes 16-20, 31-33</item>
           <item>Research Files -- Boxes 33-37</item>
           <item>Government Public Service
-            <list type="simple">
-              <item>Hoover Commission, 1948-1949 -- Boxes 38-44</item>
-              <item>Advisory Commission Intergovernmental Relations, 1959-1961 -- Boxes 45-48</item>
-              <item>Michigan Constitutional Convention, 1962-1963 -- Boxes 48-55</item>
-            </list>
+            <list type="simple"><item>Hoover Commission, 1948-1949 -- Boxes 38-44</item><item>Advisory Commission Intergovernmental Relations, 1959-1961 -- Boxes 45-48</item><item>Michigan Constitutional Convention, 1962-1963 -- Boxes 48-55</item></list>
           </item>
           <item>Germany: Research and Official Responsibilities
-            <list type="simple">
-              <item>Saar, 1935, 1955 -- Box 56, 58</item>
-              <item>Office of the Military Government of Germany, 1945-1946, 1947-1950 -- Boxes 58-64</item>
-              <item>University of Michigan Civil Affairs Training School -- Boxes 64-65</item>
-              <item>Later German Activities and Interests -- Boxes 65-69</item>
-              <item>German Election Studies --Boxes 69-70</item>
-              <item>Franz Lieber Foundation -- Boxes 71-72</item>
-            </list>
+            <list type="simple"><item>Saar, 1935, 1955 -- Box 56, 58</item><item>Office of the Military Government of Germany, 1945-1946, 1947-1950 -- Boxes 58-64</item><item>University of Michigan Civil Affairs Training School -- Boxes 64-65</item><item>Later German Activities and Interests -- Boxes 65-69</item><item>German Election Studies --Boxes 69-70</item><item>Franz Lieber Foundation -- Boxes 71-72</item></list>
           </item>
           <item>European Election Studies -- Boxes 72-73</item>
           <item>University of Michigan -- Boxes 74-77</item>
           <item>Speeches and Writings, 1920s-1968 -- Boxes 78-82</item>
           <item>Clippings, 1924-1968 -- Box 83</item>
           <item>Visual Materials
-            <list type="simple">
-              <item>Photographs -- Box 84 and outsize folders</item>
-              <item>Motion Pictures -- Box 85 and outsize</item>
-            </list>
+            <list type="simple"><item>Photographs -- Box 84 and outsize folders</item><item>Motion Pictures -- Box 85 and outsize</item></list>
           </item>
           <item>Personal/Miscellaneous -- Boxes 87-88</item>
         </list>

--- a/Real_Masters_all/posthumu.xml
+++ b/Real_Masters_all/posthumu.xml
@@ -670,8 +670,8 @@
           <c03 level="file">
             <did>
               <unittitle>Staff Files</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -679,8 +679,8 @@
               <did>
                 <container type="box" label="Box">6</container>
                 <unittitle>Kristyn Files</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -689,8 +689,8 @@
               <did>
                 <container type="box" label="Box">6</container>
                 <unittitle>Matt Press Releases, Photos and Speeches</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -722,8 +722,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>Granholm Compilation #1 (with notes in separate folder)</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -732,8 +732,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>Granholm: "Tweak to Capture Resources"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -742,8 +742,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>"Fox and Friends: Lt. Governor" <unitdate type="inclusive" normal="2001-06-01">June 1, 2001</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -752,8 +752,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>"Posthumus <unitdate type="inclusive" normal="2002">2002</unitdate> Compilation"</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -762,8 +762,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>"Posthumus for Governor"</unittitle>
-              <physdesc>
-                <extent>2 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/psycdept.xml
+++ b/Real_Masters_all/psycdept.xml
@@ -204,8 +204,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>Photographs, Psychology Laboratory <unitdate type="inclusive" normal="1903/1910" certainty="approximate">circa 1903-1910</unitdate></unittitle>
-              <physdesc>
-                <extent>2 photographs</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 photographs</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/rackhamg.xml
+++ b/Real_Masters_all/rackhamg.xml
@@ -3538,8 +3538,8 @@
             <did>
               <container type="box" label="Box">113</container>
               <unittitle>Bentley Historical Library <unitdate type="inclusive" normal="1979/1991">1979-1991</unitdate></unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/ranville.xml
+++ b/Real_Masters_all/ranville.xml
@@ -1205,8 +1205,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>"The Jack Lessenberry Show"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/rescoll.xml
+++ b/Real_Masters_all/rescoll.xml
@@ -50,19 +50,19 @@
         <corpname source="lcnaf" encodinganalog="110">University of Michigan. Residential College.</corpname>
       </origination>
       <unittitle encodinganalog="245">Residential College (University of Michigan) records <unitdate type="inclusive" encodinganalog="245$f" normal="1957/2011">1957-2011</unitdate></unittitle>
-      <physdesc>
-        <extent encodinganalog="300">30 linear feet</extent>
-        <extent altrender="carrier">in 31 boxes</extent>
-      </physdesc>
-      <physdesc>
-        <extent encodinganalog="300">1 oversize folders</extent>
-      </physdesc>
-      <physdesc>
-        <extent encodinganalog="300">2 sound discs</extent>
-      </physdesc>
-      <physdesc>
-        <extent encodinganalog="300">73.7 GB</extent>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">73.7 GB</extent>
         <physfacet>online</physfacet>
+      </physdesc>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">2 phonograph records</extent>
+      </physdesc>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">1 oversize folders</extent>
+      </physdesc>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">30 linear feet</extent>
+        <extent altrender="carrier">in 31 boxes</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">87319 Bimu 2 UAI</unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
@@ -2423,8 +2423,8 @@
           <did>
             <container type="box" label="Box">20</container>
             <unittitle>Admissions, <unitdate type="inclusive" normal="1967/1974">1967-1974</unitdate>, <unitdate type="inclusive" normal="2003/2009">2003-2009</unitdate> </unittitle>
-            <physdesc>
-              <extent>8 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">8 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2454,8 +2454,8 @@
             <did>
               <container type="box" label="Box">20</container>
               <unittitle>20th, <unitdate type="inclusive" normal="1987/1988">1987-1988</unitdate> </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -2526,8 +2526,8 @@
           <did>
             <container type="box" label="Box">25</container>
             <unittitle>Arts and Ideas Concentration in the Humanities, <unitdate type="inclusive" normal="1977/1996">1977-1996</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2535,8 +2535,8 @@
           <did>
             <container type="box" label="Box">5</container>
             <unittitle>Arts and Ideas Concentration in the Humanities, <unitdate type="inclusive" normal="1980/1998">1980-1998</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2604,8 +2604,8 @@
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>Carl Cohen Correspondence, <unitdate type="inclusive" normal="1971/1999">1971-1999</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2613,8 +2613,8 @@
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>Carl Cohen Reading Room, <unitdate type="inclusive" normal="1998">1998</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2700,8 +2700,8 @@
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>Constitution, <unitdate type="inclusive" normal="1970/1971">1970-1971</unitdate> </unittitle>
-            <physdesc>
-              <extent>5 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">5 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2709,8 +2709,8 @@
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>Counseling, Admissions, and Recruitment, <unitdate type="inclusive" normal="1977/1981">1977-1981</unitdate>, <unitdate type="inclusive">undated</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2760,8 +2760,8 @@
           <did>
             <container type="box" label="Box">21</container>
             <unittitle>Course Proposals, <unitdate type="inclusive" normal="1969/1974">1969-1974</unitdate>, <unitdate type="inclusive">undated</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2831,8 +2831,8 @@
               <did>
                 <container type="box" label="Box">21</container>
                 <unittitle>Section B, <unitdate type="inclusive" normal="1968">1968</unitdate> </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -2874,8 +2874,8 @@
               <did>
                 <container type="box" label="Box">21</container>
                 <unittitle>290-Arts and Ideas in the Twentieth Century: The Post-Modern Era, <unitdate type="inclusive" normal="1950/1970">1950-1970</unitdate>, <unitdate type="inclusive" normal="1978/1984">1978-1984</unitdate> </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -2932,8 +2932,8 @@
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>Curriculum Planning Committee, <unitdate type="inclusive" normal="2001/2002">2001-2002</unitdate> </unittitle>
-            <physdesc>
-              <extent>4 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2977,8 +2977,8 @@
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>Diversity Seminars, <unitdate type="inclusive" normal="1998">1998</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -2986,8 +2986,8 @@
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>Drama Concentration Program, <unitdate type="inclusive" normal="1969/1979">1969-1979</unitdate> </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3016,8 +3016,8 @@
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>Educational Policies Committee </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3053,8 +3053,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1970/1979" certainty="approximate">1970s</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>8 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">8 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3080,8 +3080,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1989/1993">1989-1993</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3164,8 +3164,8 @@
             <did>
               <container type="box" label="Box">23</container>
               <unittitle><unitdate type="inclusive" normal="1968/1977">1968-1977</unitdate>, <unitdate type="inclusive" normal="1982/1987">1982-1987</unitdate></unittitle>
-              <physdesc>
-                <extent>11 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">11 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -3185,8 +3185,8 @@
           <did>
             <container type="box" label="Box">8</container>
             <unittitle>External Relations, <unitdate type="inclusive" normal="1999/2000">1999-2000</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3200,8 +3200,8 @@
           <did>
             <container type="box" label="Box">8</container>
             <unittitle>External Reviews, <unitdate type="inclusive" normal="1984/2004">1984-2004</unitdate> </unittitle>
-            <physdesc>
-              <extent>4 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3221,8 +3221,8 @@
           <did>
             <container type="box" label="Box">8</container>
             <unittitle>Faculty Appointments and Institutional Review, <unitdate type="inclusive" normal="2001/2002">2001-2002</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3257,8 +3257,8 @@
           <did>
             <container type="box" label="Box">8</container>
             <unittitle>Faculty Plans (Teaching), <unitdate type="inclusive" normal="1973/2002">1973-2002</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3266,8 +3266,8 @@
           <did>
             <container type="box" label="Box">23</container>
             <unittitle>Faculty Policy, <unitdate type="inclusive" normal="1964/1974">1964-1974</unitdate> </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3293,8 +3293,8 @@
           <did>
             <container type="box" label="Box">8</container>
             <unittitle>Field Studies, <unitdate type="inclusive" normal="1976/1980">1976-1980</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3336,8 +3336,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1970/1989">1970-1989</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -3360,8 +3360,8 @@
           <did>
             <container type="box" label="Box">8</container>
             <unittitle>Fundraising, <unitdate type="inclusive" normal="1985/1986">1985-1986</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3381,8 +3381,8 @@
           <did>
             <container type="box" label="Box">8</container>
             <unittitle>German Program, <unitdate type="inclusive" normal="1992/1999">1992-1999</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3402,8 +3402,8 @@
           <did>
             <container type="box" label="Box">8</container>
             <unittitle>Grade Issues, <unitdate type="inclusive" normal="1999/2002">1999-2002</unitdate> </unittitle>
-            <physdesc>
-              <extent>6 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">6 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3441,8 +3441,8 @@
           <did>
             <container type="box" label="Box">9</container>
             <unittitle>Handbook for Counselors, <unitdate type="inclusive" normal="1967/1970">1967-1970</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3456,8 +3456,8 @@
           <did>
             <container type="box" label="Box">24</container>
             <unittitle>Historical Documents, <unitdate type="inclusive" normal="1966/1987">1966-1987</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3537,8 +3537,8 @@
           <did>
             <container type="box" label="Box">24</container>
             <unittitle>Joint Board, <unitdate type="inclusive" normal="1971/1985">1971-1985</unitdate> </unittitle>
-            <physdesc>
-              <extent>4 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">4 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3546,8 +3546,8 @@
           <did>
             <container type="box" label="Box">9</container>
             <unittitle>Joint Board, <unitdate type="inclusive" normal="1973/1983">1973-1983</unitdate> </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3603,8 +3603,8 @@
           <did>
             <container type="box" label="Box">9</container>
             <unittitle>Liaison Committee, <unitdate type="inclusive" normal="1993/2000">1993-2000</unitdate> </unittitle>
-            <physdesc>
-              <extent>9 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">9 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3642,8 +3642,8 @@
           <did>
             <container type="box" label="Box">9</container>
             <unittitle>Long Range Plan, <unitdate type="inclusive" normal="1967/2002">1967-2002</unitdate> </unittitle>
-            <physdesc>
-              <extent>9 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">9 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3657,8 +3657,8 @@
           <did>
             <container type="box" label="Box">10</container>
             <unittitle>LSA/RC Review, <unitdate type="inclusive" normal="1992/1993">1992-1993</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3895,8 +3895,8 @@
           <did>
             <container type="box" label="Box">11</container>
             <unittitle>Residential College 30th Anniversary Advisory Committee (RC 30 AC), <unitdate type="inclusive" normal="1997">1997</unitdate> </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3916,8 +3916,8 @@
           <did>
             <container type="box" label="Box">11</container>
             <unittitle>Residential College Social Science Program (RCSSP), <unitdate type="inclusive" normal="1997">1997</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -3929,8 +3929,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>Collation, <unitdate type="inclusive" normal="1966/1987">1966-1987</unitdate> </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -3956,8 +3956,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>RC Reports, <unitdate type="inclusive" normal="1969/1970">1969-1970</unitdate> </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -3965,8 +3965,8 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>Residential College Report, <unitdate type="inclusive" normal="1977/1981">1977-1981</unitdate> </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -3981,8 +3981,8 @@
           <did>
             <container type="box" label="Box">12</container>
             <unittitle>Residential Colleges in North America, <unitdate type="inclusive" normal="1977">1977</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -4019,8 +4019,8 @@
             <did>
               <container type="box" label="Box">12</container>
               <unittitle>RC Review, <unitdate type="inclusive" normal="1972/1977">1972-1977</unitdate> </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -4190,8 +4190,8 @@
           <did>
             <container type="box" label="Box">25</container>
             <unittitle>Strategic Planning, <unitdate type="inclusive" normal="1998/2000">1998-2000</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -4247,8 +4247,8 @@
           <did>
             <container type="box" label="Box">25</container>
             <unittitle>Time Schedules/Course Descriptions, <unitdate type="inclusive" normal="1968/2001">1968-2001</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -4293,8 +4293,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1972/1984">1972-1984</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>9 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">9 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -4321,8 +4321,8 @@
           <did>
             <container type="box" label="Box">13</container>
             <unittitle>Written Evaluations, <unitdate type="inclusive" normal="1999">1999</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -4342,8 +4342,8 @@
             <did>
               <container type="box" label="Box">28</container>
               <unittitle>30th Anniversary Events <unitdate type="inclusive" normal="1997">1997</unitdate></unittitle>
-              <physdesc>
-                <extent>12 tapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">12 tapes</extent>
               </physdesc>
             </did>
           </c03>
@@ -4351,8 +4351,8 @@
             <did>
               <container type="box" label="Box">28</container>
               <unittitle>Graduation <unitdate type="inclusive" normal="1990/1993">1990-1993</unitdate></unittitle>
-              <physdesc>
-                <extent>8 tapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">8 tapes</extent>
               </physdesc>
             </did>
           </c03>
@@ -4360,8 +4360,8 @@
             <did>
               <container type="box" label="Box">28</container>
               <unittitle>Miscellaneous <unitdate type="inclusive" normal="1990/1994">1990-1994</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>24 tapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">24 tapes</extent>
               </physdesc>
             </did>
           </c03>
@@ -4370,8 +4370,8 @@
           <did>
             <container type="box" label="Box">29</container>
             <unittitle>EIAJ-1 Videotape <unitdate type="inclusive" normal="1973/1976">1973-1976</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
-            <physdesc>
-              <extent>13 reels</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">13 reels</extent>
             </physdesc>
           </did>
         </c02>
@@ -4379,8 +4379,8 @@
           <did>
             <container type="box" label="Box">29</container>
             <unittitle>Mini DVs <unitdate type="inclusive" normal="2006/2007">2006-2007</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
-            <physdesc>
-              <extent>32 cassettes</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">32 audiocassettes</extent>
             </physdesc>
           </did>
         </c02>
@@ -4392,8 +4392,8 @@
             <did>
               <container type="box" label="Box">29</container>
               <unittitle>Miscellaneous <unitdate type="inclusive" normal="2004/2005">2004-2005</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>17 tapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">17 tapes</extent>
               </physdesc>
             </did>
           </c03>
@@ -4401,8 +4401,8 @@
             <did>
               <container type="box" label="Box">29</container>
               <unittitle>Student-Faculty Research Community Research Design Training Tapes <unitdate type="inclusive" normal="1979">1979</unitdate></unittitle>
-              <physdesc>
-                <extent>19 tapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">19 tapes</extent>
               </physdesc>
             </did>
           </c03>
@@ -4415,8 +4415,8 @@
             <did>
               <container type="box" label="Box">30</container>
               <unittitle>7 inch <unitdate type="inclusive" normal="1976/1978">1976-1978</unitdate></unittitle>
-              <physdesc>
-                <extent>3 reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 reels</extent>
               </physdesc>
             </did>
           </c03>
@@ -4424,8 +4424,8 @@
             <did>
               <container type="box" label="Box">30</container>
               <unittitle>10.5 inch <unitdate type="inclusive" normal="1968/1971">1968-1971</unitdate>, <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>7 reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">7 reels</extent>
               </physdesc>
             </did>
           </c03>
@@ -4433,8 +4433,8 @@
         <c02 level="file">
           <did>
             <unittitle>12 inch Phonograph Records</unittitle>
-            <physdesc>
-              <extent>2 12-inch Phonograph Records</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 12-inch Phonograph Records</extent>
             </physdesc>
           </did>
           <c03 level="file">

--- a/Real_Masters_all/rescoll.xml
+++ b/Real_Masters_all/rescoll.xml
@@ -4504,16 +4504,16 @@
               <physdesc>
                 <physfacet>.MP4 and .avi files</physfacet>
               </physdesc>
-            <dao href="http://hdl.handle.net/2027.42/110254" show="new" actuate="onrequest">
-              <daodesc>
-                <p>[download item]</p>
-              </daodesc>
-            </dao>
-          </did>
+              <dao href="http://hdl.handle.net/2027.42/110254" show="new" actuate="onrequest">
+                <daodesc>
+                  <p>[download item]</p>
+                </daodesc>
+              </dao>
+            </did>
             <odd>
               <p>(Includes materials from courses on "Nonviolence in Action" and Afro-Cuban drumming.)</p>
             </odd>
-            </c03>
+          </c03>
           <c03 level="file">
             <did>
               <unittitle>Introductions to Residential College</unittitle>

--- a/Real_Masters_all/rfwms.xml
+++ b/Real_Masters_all/rfwms.xml
@@ -2012,12 +2012,12 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle>November 1964, Hanoi, Vietnam Conference-- Speeches of Anna Louise Strong and RFW <unitdate type="inclusive">Undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
-                  <physfacet>CD-Rs</physfacet>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+                  <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
             </c04>
@@ -2025,12 +2025,12 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle><unitdate type="inclusive" normal="1964-12-11">December 11, 1964</unitdate> Sidney Brecht (Blues); Max Roach -- Ray Charles -- Gravy Train Waltz</unittitle>
-                <physdesc>
-                  <extent>2 optical disks</extent>
-                  <physfacet>CD-Rs</physfacet>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
+                  <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
             </c04>
@@ -2038,12 +2038,12 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle><unitdate type="inclusive">Undated</unitdate> Ordeal of Change reading</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
-                  <physfacet>CD-Rs</physfacet>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+                  <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
             </c04>
@@ -2051,8 +2051,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle><unitdate type="inclusive" normal="1965-04-23">April 23, 1965</unitdate> Speech of Malcolm X</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -2061,8 +2061,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle><unitdate type="inclusive" normal="1965-05-28">May 28, 1965</unitdate> Blues in Mississippi</unittitle>
-                <physdesc>
-                  <extent>2 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -2073,8 +2073,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1965-07-30">July 30, 1965</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -2085,8 +2085,8 @@
                 <unittitle>
                   <unitdate type="inclusive">Undated</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -2098,8 +2098,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle><unitdate type="inclusive" normal="1965-01-22">January 22, 1965</unitdate> Protests songs</unittitle>
-                <physdesc>
-                  <extent>2 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -2108,8 +2108,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle><unitdate type="inclusive">Undated</unitdate> Hanoi, Vietnam conference; speeches of Strong P. Williams</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -2118,8 +2118,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle><unitdate type="inclusive" normal="1965-08-20">August 20, 1965</unitdate> Premier Chou En-lai</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -2128,8 +2128,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle><unitdate type="inclusive">Undated</unitdate> Blues in Mississippi Night</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -2138,8 +2138,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle><unitdate type="inclusive" normal="1966-01-21">January 21, 1966</unitdate> Rock &amp; Roll Protest</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -2152,12 +2152,12 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle>Undated-Malcolm X Speaks to the Grass Roots</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
-                  <physfacet>CD-Rs</physfacet>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
+                  <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
             </c04>
@@ -2165,8 +2165,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle><unitdate type="inclusive" normal="1965-10-06">October 6, 1965</unitdate> Night Call</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -2175,8 +2175,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle><unitdate type="inclusive" normal="1966">1966</unitdate> Rally, Peking</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -2185,8 +2185,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle><unitdate type="inclusive" normal="1966-08-08">August 8, 1966</unitdate> Speech, Great Hall of the People</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -2195,8 +2195,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle><unitdate type="inclusive" normal="1966">1966</unitdate> Peking Rally</unittitle>
-                <physdesc>
-                  <extent>2 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -2205,8 +2205,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle><unitdate type="inclusive">Undated</unitdate> Children's Palace &amp; Worker's Palace, Shanghai: songs and conversation</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CD-Rs</physfacet>
                 </physdesc>
               </did>
@@ -2255,7 +2255,7 @@
               <container type="box" label="Box">15</container>
               <unittitle>Master tape digitization CDs</unittitle>
               <physdesc altrender="whole">
-                <extent>22 optical disks</extent>
+                <extent altrender="materialtype spaceoccupied">22 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/riegled.xml
+++ b/Real_Masters_all/riegled.xml
@@ -6986,8 +6986,8 @@
             <c04 level="file">
               <did>
                 <unittitle>Biomedical Research Act (S.773)</unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
               <c05 level="file">
@@ -7281,8 +7281,8 @@
             <c04 level="file">
               <did>
                 <unittitle>Miscellaneous</unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
               <c05 level="file">
@@ -8456,8 +8456,8 @@
                 <did>
                   <container type="box" label="Box">41</container>
                   <unittitle>Tax Reform Act</unittitle>
-                  <physdesc>
-                    <extent>2 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
               </c05>

--- a/Real_Masters_all/rossdoug.xml
+++ b/Real_Masters_all/rossdoug.xml
@@ -1055,8 +1055,8 @@
             <physdesc altrender="whole">
               <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
-            <physdesc>
-              <extent>1 floppy disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
               <physfacet>3.5"</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/russellk.xml
+++ b/Real_Masters_all/russellk.xml
@@ -297,8 +297,8 @@
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>LGBTRC <genreform normal="Web sites">Web Site</genreform>, <unitdate type="inclusive" normal="2004-04-27">April 27, 2004</unitdate></unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-ROMs</physfacet>
             </physdesc>
           </did>
@@ -337,8 +337,8 @@
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Ruth Ellis Center power-point presentation <unitdate type="inclusive" normal="2003">2003</unitdate></unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-Rs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/russlect.xml
+++ b/Real_Masters_all/russlect.xml
@@ -754,8 +754,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Rowena Matthews <unitdate type="inclusive" normal="2003">2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-ROMs</physfacet>
               </physdesc>
             </did>
@@ -764,8 +764,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Maris Vinovskis <unitdate type="inclusive" normal="2004">2004</unitdate></unittitle>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
               </physdesc>
             </did>
           </c03>
@@ -773,8 +773,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>William Fulton <unitdate type="inclusive" normal="2005">2005</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-ROMs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/saastudent.xml
+++ b/Real_Masters_all/saastudent.xml
@@ -39,11 +39,11 @@
       </origination>
       <unittitle encodinganalog="245"> Society of American Archivists Student Chapter (University of Michigan) records. <unitdate type="inclusive" encodinganalog="245$f"> 1993-1996 </unitdate></unittitle>
       <physdesc altrender="part">
-        <extent encodinganalog="300">0.2 linear feet</extent>
+        <extent altrender="materialtype spaceoccupied">1.13 MB</extent>
+        <physfacet>online</physfacet>
       </physdesc>
       <physdesc altrender="part">
-        <extent encodinganalog="300">1.13 MB</extent>
-        <physfacet>online</physfacet>
+        <extent altrender="materialtype spaceoccupied">0.2 linear feet</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number"> 9530 Bimu 2 </unitid>
       <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language>. </langmaterial>
@@ -115,8 +115,8 @@
             <unittitle>
               <unitdate type="inclusive" normal="1993/1995">1993-1995</unitdate>
             </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/schmerl.xml
+++ b/Real_Masters_all/schmerl.xml
@@ -1,149 +1,180 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE ead PUBLIC "+//ISBN 1-931666-00-8//DTD ead.dtd (Encoded Archival Description (EAD) Version 2002)//EN" "ead.dtd">
 <ead>
-
-<eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
-
-<eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::schmerl.xml//EN" encodinganalog="Identifier">
+  <eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
+    <eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::schmerl.xml//EN" encodinganalog="Identifier">
 umich-bhl-2016002</eadid>
-
-<filedesc><titlestmt><titleproper encodinganalog="Title">Finding Aid for 
+    <filedesc>
+      <titlestmt>
+        <titleproper encodinganalog="Title">Finding Aid for 
 Rudolf B. Schmerl papers
 
 </titleproper>
-<author encodinganalog="Creator">Collection processed and finding aid created by 
-Sarah Lebovitz  </author></titlestmt>
-
-<publicationstmt><publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
-<date encodinganalog="Date" normal="2016">
-2016</date></publicationstmt></filedesc>
-
-<profiledesc>
-<creation>Encoded finding aid created by 
+        <author encodinganalog="Creator">Collection processed and finding aid created by 
+Sarah Lebovitz  </author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
+        <date encodinganalog="Date" normal="2016">
+2016</date>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>Encoded finding aid created by 
 Olga Virakhovskaya 
 <date>2015</date></creation>
-
-<langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage><descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules></profiledesc>
-
-<revisiondesc><change><date>2016-01-19</date><item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item></change></revisiondesc></eadheader>
-
-<frontmatter><titlepage>
-
-<publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
-
-<titleproper>Finding aid for<lb/>
+      <langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage>
+      <descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules>
+    </profiledesc>
+    <revisiondesc>
+      <change>
+        <date>2016-01-19</date>
+        <item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item>
+      </change>
+    </revisiondesc>
+  </eadheader>
+  <frontmatter>
+    <titlepage>
+      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <titleproper>Finding aid for<lb/>
 Rudolf B. Schmerl papers
 </titleproper>
-
-<author>Finding aid created by<lb/> 
+      <author>Finding aid created by<lb/> 
 Sarah Lebovitz, in January 2016.
 </author>
-
-</titlepage>
-</frontmatter>
-
-<archdesc level="recordgrp" audience="external" type="inventory" relatedencoding="MARC21"><did>
-
-<origination>
-<corpname source="lcnaf" encodinganalog="110">
+    </titlepage>
+  </frontmatter>
+  <archdesc level="recordgrp" audience="external" type="inventory" relatedencoding="MARC21">
+    <did>
+      <origination>
+        <corpname source="lcnaf" encodinganalog="110">
 Schmerl, Rudolf B.
-</corpname></origination>
-
-<unittitle encodinganalog="245">
+</corpname>
+      </origination>
+      <unittitle encodinganalog="245">
 Rudolf B. Schmerl papers
 <unitdate type="inclusive" encodinganalog="245$f">
 1960-2004
 </unitdate>
  
 </unittitle>
-
-<physdesc><extent encodinganalog="300">
+      <physdesc>
+        <extent encodinganalog="300">
 0.4 linear feet 
-</extent></physdesc>
-
-<unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
+</extent>
+      </physdesc>
+      <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2016002 Aa 2
 </unitid>
-
-<langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
-
-<abstract>
+      <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
+      <abstract>
 Rudolf B. Schmerl was a professor at the University of Michigan from 1957-1988 and worked as both a visiting professor and a consultant in program development at the Tuskegee Institute from 1966-1967. The collection includes materials related to his personal and professional activities at the Tuskegee Institute in Alabama (now the Tuskegee University) such as correspondence, news clippings, speaker programs, a grant manuscript, and historical material relating to the Tuskegee Institute. 
 </abstract>
-
-
-<repository><corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
-<extptr href="bhladd" show="embed" actuate="onload"/></repository></did>
-
-<descgrp type="admin">
-<acqinfo encodinganalog="541"><p>
+      <repository>
+        <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
+        <extptr href="bhladd" show="embed" actuate="onload"/>
+      </repository>
+    </did>
+    <descgrp type="admin">
+      <acqinfo encodinganalog="541">
+        <p>
 Donated by Rudolf B. Schmerl (donor no. 
 <num type="donor" encodinganalog="541$e">4554</num>), in May 2014.
  
-</p></acqinfo>
-
- 
-<accruals encodinganalog="584"><p>
+</p>
+      </acqinfo>
+      <accruals encodinganalog="584">
+        <p>
 No further additions to the records are expected.
-</p></accruals><accessrestrict encodinganalog="506">
-<p>The collection is open without restriction</p>
- </accessrestrict>
-
-
-<userestrict encodinganalog="540"><p>
-Copyright is held by the Regents of the University of Michigan.</p></userestrict>
-
-
-<prefercite encodinganalog="524"><p>[item], folder, box,
-Rudolf B. Schmerl papers, Bentley Historical Library, University of Michigan</p></prefercite>
-</descgrp>
-
-<bioghist encodinganalog="545">
-
-<p>Between 1966-1967, Rudolf participated in the University of Michigan's inter-institutional program with the Tuskegee Institute in Alabama, a historically black university, and functioned both as a visiting professor of English and as a consultant in program development where he held the title of President of the Michigan Educational Consultants. This was part of the University of Michigan's efforts to confront the issue of diversity in higher education. Between 1969-1970, he functioned as the planning director for Wayne County Community College. </p>
-
-<p>After returning to the University of Michigan, he served as the Assistant Dean of Research in the School of Education between the years of 1970-1979, and was promoted to associate professor of education. He retired from his teaching position in 1988. Over the course of his life, he has published monographs, articles, essays, and literary criticisms covering material ranging from race and ethnicity issues in American life to the teaching of English.  </p>
-
-
-</bioghist>
- 
-
-<scopecontent encodinganalog="520">
-<p>This collection documents the business and personal activities of Rudolf B. Schmerl in relation to the Tuskegee Institute. The materials include programs for two separate conferences in which Schmerl spoke on the topic of communication, newspaper clippings related to the exchange program written either by Schmerl or by other authors, and a manuscript copy of a 1967 grant application for the Model Cities Demonstration Program submitted by C.M. Keener (the mayor of Tuskegee at the time) to the Secretary of the Department of Housing and Urban Development. Schmerl's correspondence highlights his continued interest and involvement in the ongoing development of Tuskegee University after his official tenure as a professor and a consultant. </p>
-
-<p>The bulk of materials date from the mid-1960s to the early 1980s, as well as correspondence to and from Schmerl up to 2004.</p>
-</scopecontent>
-
-<controlaccess><p><extptr href="accnote" show="embed" actuate="onload"/></p><controlaccess><head>Subjects:</head>
-
- 
-<subject source="lcsh" encodinganalog="650">African American universities and colleges--Alabama--Tuskegee.</subject>
-<persname source="lcnaf" encodinganalog="600">Schmerl, Rudolf B.</persname>
-<corpname source="lcnaf" encodinganalog="610">Tuskegee Institute--Faculty.</corpname>
-<corpname source="lcnaf" encodinganalog="610">Tuskegee Institute--History.</corpname>
-<corpname source="lcnaf" encodinganalog="610">University of Michigan--Faculty.</corpname>
- 
-
-</controlaccess>
- 
-</controlaccess>
-
-
-<dsc type="combined">
-<c01 level="series"><did><unittitle>Rudolf B. Schmerl papers</unittitle></did>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Annual Report of the President -- Tuskegee, <unitdate type="inclusive">1963-1984</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Bulletins, <unitdate type="inclusive">1965-1987</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Carver Research Foundation publications, <unitdate type="inclusive">1960-1966</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Correspondence, <unitdate type="inclusive">1967-2004</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Miscellaneous/Manuscript</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Newspaper Clippings</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Speaker Programs, <unitdate type="inclusive">1967</unitdate>, <unitdate type="inclusive">1981</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Tuskegee Institute Centennial Celebration, <unitdate type="inclusive">1981</unitdate></unittitle></did></c02></c01>
-
-</dsc>
-
-</archdesc>
-
-
-
+</p>
+      </accruals>
+      <accessrestrict encodinganalog="506">
+        <p>The collection is open without restriction</p>
+      </accessrestrict>
+      <userestrict encodinganalog="540">
+        <p>
+Copyright is held by the Regents of the University of Michigan.</p>
+      </userestrict>
+      <prefercite encodinganalog="524">
+        <p>[item], folder, box,
+Rudolf B. Schmerl papers, Bentley Historical Library, University of Michigan</p>
+      </prefercite>
+    </descgrp>
+    <bioghist encodinganalog="545">
+      <p>Between 1966-1967, Rudolf participated in the University of Michigan's inter-institutional program with the Tuskegee Institute in Alabama, a historically black university, and functioned both as a visiting professor of English and as a consultant in program development where he held the title of President of the Michigan Educational Consultants. This was part of the University of Michigan's efforts to confront the issue of diversity in higher education. Between 1969-1970, he functioned as the planning director for Wayne County Community College. </p>
+      <p>After returning to the University of Michigan, he served as the Assistant Dean of Research in the School of Education between the years of 1970-1979, and was promoted to associate professor of education. He retired from his teaching position in 1988. Over the course of his life, he has published monographs, articles, essays, and literary criticisms covering material ranging from race and ethnicity issues in American life to the teaching of English.  </p>
+    </bioghist>
+    <scopecontent encodinganalog="520">
+      <p>This collection documents the business and personal activities of Rudolf B. Schmerl in relation to the Tuskegee Institute. The materials include programs for two separate conferences in which Schmerl spoke on the topic of communication, newspaper clippings related to the exchange program written either by Schmerl or by other authors, and a manuscript copy of a 1967 grant application for the Model Cities Demonstration Program submitted by C.M. Keener (the mayor of Tuskegee at the time) to the Secretary of the Department of Housing and Urban Development. Schmerl's correspondence highlights his continued interest and involvement in the ongoing development of Tuskegee University after his official tenure as a professor and a consultant. </p>
+      <p>The bulk of materials date from the mid-1960s to the early 1980s, as well as correspondence to and from Schmerl up to 2004.</p>
+    </scopecontent>
+    <controlaccess>
+      <p>
+        <extptr href="accnote" show="embed" actuate="onload"/>
+      </p>
+      <controlaccess>
+        <head>Subjects:</head>
+        <subject source="lcsh" encodinganalog="650">African American universities and colleges--Alabama--Tuskegee.</subject>
+        <persname source="lcnaf" encodinganalog="600">Schmerl, Rudolf B.</persname>
+        <corpname source="lcnaf" encodinganalog="610">Tuskegee Institute--Faculty.</corpname>
+        <corpname source="lcnaf" encodinganalog="610">Tuskegee Institute--History.</corpname>
+        <corpname source="lcnaf" encodinganalog="610">University of Michigan--Faculty.</corpname>
+      </controlaccess>
+    </controlaccess>
+    <dsc type="combined">
+      <c01 level="series">
+        <did>
+          <unittitle>Rudolf B. Schmerl papers</unittitle>
+        </did>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Annual Report of the President -- Tuskegee, <unitdate type="inclusive">1963-1984</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Bulletins, <unitdate type="inclusive">1965-1987</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Carver Research Foundation publications, <unitdate type="inclusive">1960-1966</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Correspondence, <unitdate type="inclusive">1967-2004</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Miscellaneous/Manuscript</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Newspaper Clippings</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Speaker Programs, <unitdate type="inclusive">1967</unitdate>, <unitdate type="inclusive">1981</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Tuskegee Institute Centennial Celebration, <unitdate type="inclusive">1981</unitdate></unittitle>
+          </did>
+        </c02>
+      </c01>
+    </dsc>
+  </archdesc>
 </ead>

--- a/Real_Masters_all/schmerl.xml
+++ b/Real_Masters_all/schmerl.xml
@@ -58,10 +58,8 @@ Rudolf B. Schmerl papers
 </unitdate>
  
 </unittitle>
-      <physdesc>
-        <extent encodinganalog="300">
-0.4 linear feet 
-</extent>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">0.4 linear feet</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2016002 Aa 2

--- a/Real_Masters_all/schofed.xml
+++ b/Real_Masters_all/schofed.xml
@@ -677,8 +677,8 @@
               <unittitle>
                 <unitdate type="inclusive">September 1988</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -691,8 +691,8 @@
               <unittitle>
                 <unitdate type="inclusive">October 1988</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -716,8 +716,8 @@
               <unittitle>
                 <unitdate type="inclusive">December 1988</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -730,8 +730,8 @@
               <unittitle>
                 <unitdate type="inclusive">January 1989</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -744,8 +744,8 @@
               <unittitle>
                 <unitdate type="inclusive">February 1989</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -758,8 +758,8 @@
               <unittitle>
                 <unitdate type="inclusive">March 1989</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -772,8 +772,8 @@
               <unittitle>
                 <unitdate type="inclusive">April 1989</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -786,8 +786,8 @@
               <unittitle>
                 <unitdate type="inclusive">May 1989</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -800,8 +800,8 @@
               <unittitle>
                 <unitdate type="inclusive">June 1989</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -814,8 +814,8 @@
               <unittitle>
                 <unitdate type="inclusive">July 1989</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -828,8 +828,8 @@
               <unittitle>
                 <unitdate type="inclusive">September 1989</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -842,8 +842,8 @@
               <unittitle>
                 <unitdate type="inclusive">October 1989</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -856,8 +856,8 @@
               <unittitle>
                 <unitdate type="inclusive">November 1989</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -881,8 +881,8 @@
               <unittitle>
                 <unitdate type="inclusive">January 1990</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -895,8 +895,8 @@
               <unittitle>
                 <unitdate type="inclusive">February 1990</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -909,8 +909,8 @@
               <unittitle>
                 <unitdate type="inclusive">March 1990</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -923,8 +923,8 @@
               <unittitle>
                 <unitdate type="inclusive">April 1990</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -937,8 +937,8 @@
               <unittitle>
                 <unitdate type="inclusive">May 1990</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -951,8 +951,8 @@
               <unittitle>
                 <unitdate type="inclusive">June 1990</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -965,8 +965,8 @@
               <unittitle>
                 <unitdate type="inclusive">September 1990</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1012,8 +1012,8 @@
               <unittitle>
                 <unitdate type="inclusive">January 1991</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1026,8 +1026,8 @@
               <unittitle>
                 <unitdate type="inclusive">February 1991</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1040,8 +1040,8 @@
               <unittitle>
                 <unitdate type="inclusive">March 1991</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1186,8 +1186,8 @@
               <unittitle>
                 <unitdate type="inclusive">September 1992</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1200,8 +1200,8 @@
               <unittitle>
                 <unitdate type="inclusive">October 1992</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1214,8 +1214,8 @@
               <unittitle>
                 <unitdate type="inclusive">November 1992</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1259,8 +1259,8 @@
               <unittitle>
                 <unitdate type="inclusive">February 1993</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1273,8 +1273,8 @@
               <unittitle>
                 <unitdate type="inclusive">March 1993</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1287,8 +1287,8 @@
               <unittitle>
                 <unitdate type="inclusive">April 1993</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1301,8 +1301,8 @@
               <unittitle>
                 <unitdate type="inclusive">May 1993</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1348,8 +1348,8 @@
               <unittitle>
                 <unitdate type="inclusive">October 1993</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1362,8 +1362,8 @@
               <unittitle>
                 <unitdate type="inclusive">November 1993</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1376,8 +1376,8 @@
               <unittitle>
                 <unitdate type="inclusive">December 1993</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1401,8 +1401,8 @@
               <unittitle>
                 <unitdate type="inclusive">February 1994</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1415,8 +1415,8 @@
               <unittitle>
                 <unitdate type="inclusive">March 1994</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1440,8 +1440,8 @@
               <unittitle>
                 <unitdate type="inclusive">May 1994</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1454,8 +1454,8 @@
               <unittitle>
                 <unitdate type="inclusive">June 1994</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1468,8 +1468,8 @@
               <unittitle>
                 <unitdate type="inclusive">September 1994</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1493,8 +1493,8 @@
               <unittitle>
                 <unitdate type="inclusive">November 1994</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1518,8 +1518,8 @@
               <unittitle>
                 <unitdate type="inclusive">January 1995</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1543,8 +1543,8 @@
               <unittitle>
                 <unitdate type="inclusive">March 1995</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>3 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1557,8 +1557,8 @@
               <unittitle>
                 <unitdate type="inclusive">April 1995</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1571,8 +1571,8 @@
               <unittitle>
                 <unitdate type="inclusive">May 1995</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1585,8 +1585,8 @@
               <unittitle>
                 <unitdate type="inclusive">June 1995</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1610,8 +1610,8 @@
               <unittitle>
                 <unitdate type="inclusive">September 1995</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1635,8 +1635,8 @@
               <unittitle>
                 <unitdate type="inclusive">November 1995</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1660,8 +1660,8 @@
               <unittitle>
                 <unitdate type="inclusive">January 1996</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1674,8 +1674,8 @@
               <unittitle>
                 <unitdate type="inclusive">February 1996</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1688,8 +1688,8 @@
               <unittitle>
                 <unitdate type="inclusive">March 1996</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1713,8 +1713,8 @@
               <unittitle>
                 <unitdate type="inclusive">October 1996</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1727,8 +1727,8 @@
               <unittitle>
                 <unitdate type="inclusive">November 1996</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1741,8 +1741,8 @@
               <unittitle>
                 <unitdate type="inclusive">December 1996</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1755,8 +1755,8 @@
               <unittitle>
                 <unitdate type="inclusive">January 1997</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1769,8 +1769,8 @@
               <unittitle>
                 <unitdate type="inclusive">February 1997</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1783,8 +1783,8 @@
               <unittitle>
                 <unitdate type="inclusive">March 1997</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1797,8 +1797,8 @@
               <unittitle>
                 <unitdate type="inclusive">April 1997</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -1811,8 +1811,8 @@
               <unittitle>
                 <unitdate type="inclusive">May 1997</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -11580,8 +11580,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1989/1990">1989-1990</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>2 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -11644,8 +11644,8 @@
                   <unittitle>
                     <unitdate type="inclusive">7/19/1989</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>2 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -11983,8 +11983,8 @@
             <did>
               <container type="box" label="Box">58</container>
               <unittitle>America 2000 The President's Education Strategy, <unitdate type="inclusive" normal="1991/1992">1991-1992</unitdate> </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -12306,8 +12306,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1990/1991">1990-1991</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>4 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">4 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -12320,8 +12320,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1991/1992">1991-1992</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>3 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">3 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -12360,8 +12360,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1992/1993">1992-1993</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
               <accessrestrict>
@@ -12544,8 +12544,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1990/1991">1990-1991</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>2 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -12558,8 +12558,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1991/1992">1991-1992</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>2 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -12572,8 +12572,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1992/1993">1992-1993</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>2 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -12892,8 +12892,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1988/1989">1988-1989</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>2 Folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
               <accessrestrict>
@@ -13339,8 +13339,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1996">1996</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>2 Folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
               <accessrestrict>
@@ -15069,8 +15069,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1988">1988</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>4 Folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">4 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -15083,8 +15083,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1989">1989</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>3 Folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">3 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -15097,8 +15097,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1990">1990</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>4 Folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">4 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -15111,8 +15111,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1991">1991</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>3 Folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">3 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -15125,8 +15125,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1992">1992</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>6 Folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">6 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -15139,8 +15139,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1993">1993</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>6 Folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">6 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -15153,8 +15153,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1994">1994</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>4 Folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">4 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -15167,8 +15167,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1995">1995</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>5 Folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">5 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -15181,8 +15181,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1996">1996</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>4 Folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">4 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -15195,8 +15195,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1997">1997</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>4 Folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">4 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -15209,8 +15209,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1998">1998</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>6 Folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">6 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -15223,8 +15223,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1999">1999</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>5 Folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">5 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -15511,8 +15511,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1997/1998">1997-1998</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>2 Folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -15740,8 +15740,8 @@
               <did>
                 <container type="box" label="Box">81</container>
                 <unittitle>Agenda Items and Meeting Minutes (1985-1992) </unittitle>
-                <physdesc>
-                  <extent>51 Folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">51 folders</extent>
                 </physdesc>
               </did>
               <accessrestrict>
@@ -15809,8 +15809,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1988">1988</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>2 Folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -15860,8 +15860,8 @@
               <did>
                 <container type="box" label="Box">68</container>
                 <unittitle>Core Courses, <unitdate type="inclusive" normal="1987">1987</unitdate> </unittitle>
-                <physdesc>
-                  <extent>3 Folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 folders</extent>
                 </physdesc>
               </did>
               <accessrestrict>
@@ -16025,8 +16025,8 @@
               <did>
                 <container type="box" label="Box">69</container>
                 <unittitle>Implementation of Report on Improving Dissertation Quality, <unitdate type="inclusive" normal="1990/1999" certainty="approximate">1990s</unitdate></unittitle>
-                <physdesc>
-                  <extent>4 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">4 folders</extent>
                 </physdesc>
               </did>
               <accessrestrict>
@@ -16154,8 +16154,8 @@
               <did>
                 <container type="box" label="Box">81</container>
                 <unittitle>Predoctoral Fellowships (1993) </unittitle>
-                <physdesc>
-                  <extent>4 Folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">4 folders</extent>
                 </physdesc>
               </did>
               <accessrestrict>
@@ -16613,8 +16613,8 @@
             <did>
               <container type="box" label="Box">70</container>
               <unittitle>Interactive Communication Simulation, <unitdate type="inclusive" normal="1989/1992">1989-1992</unitdate> </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -16975,8 +16975,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1991/1992">1991-1992</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>2 Folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>
@@ -18086,8 +18086,8 @@
               <did>
                 <container type="box" label="Box">75</container>
                 <unittitle>Detroit Edison (1991-1992) </unittitle>
-                <physdesc>
-                  <extent>2 Folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
               <accessrestrict>
@@ -18175,8 +18175,8 @@
               <did>
                 <container type="box" label="Box">75</container>
                 <unittitle>EdD/PhD Information, <unitdate type="inclusive" normal="1980/1999" certainty="approximate">1980s-1990s</unitdate> </unittitle>
-                <physdesc>
-                  <extent>3 Folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 folders</extent>
                 </physdesc>
               </did>
               <accessrestrict>
@@ -19182,8 +19182,8 @@
               <did>
                 <container type="box" label="Box">78</container>
                 <unittitle>Special Education Commission, <unitdate type="inclusive" normal="1980/1999" certainty="approximate">1980s-1990s</unitdate> </unittitle>
-                <physdesc>
-                  <extent>5 Folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">5 folders</extent>
                 </physdesc>
               </did>
               <accessrestrict>
@@ -19407,8 +19407,8 @@
             <did>
               <container type="box" label="Box">79</container>
               <unittitle>Teacher Competency Testing, <unitdate type="inclusive" normal="1992/1993">1992-1993</unitdate> </unittitle>
-              <physdesc>
-                <extent>2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
             <accessrestrict>
@@ -19450,8 +19450,8 @@
               <did>
                 <container type="box" label="Box">79</container>
                 <unittitle>Testimony, <unitdate type="inclusive" normal="1991">1991</unitdate> </unittitle>
-                <physdesc>
-                  <extent>2 Folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
               <accessrestrict>

--- a/Real_Masters_all/seagrpub.xml
+++ b/Real_Masters_all/seagrpub.xml
@@ -1546,8 +1546,8 @@
           <did>
             <container type="box" label="Box">6</container>
             <unittitle><title render="italic">Hurricane Mitch Reconstruction: Nicaragua Assistance Program</title> (CD-ROM), <unitdate type="inclusive" normal="2002">2002</unitdate></unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-ROMs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/sectryvp.xml
+++ b/Real_Masters_all/sectryvp.xml
@@ -7480,8 +7480,8 @@
             <did>
               <container type="box" label="Box">36</container>
               <unittitle>School of Nursing, <unitdate type="inclusive" normal="2002/2005">2002-2005</unitdate> (includes CD-ROM)</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-ROMs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/sincljl.xml
+++ b/Real_Masters_all/sincljl.xml
@@ -350,8 +350,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>Clippings, resumes, press releases(4 folders)</unittitle>
-              <physdesc>
-                <extent>4 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -4571,8 +4571,8 @@
               <did>
                 <container type="box" label="Box">23</container>
                 <unittitle>Artists Workshop notebooks, desk calendars, address books</unittitle>
-                <physdesc>
-                  <extent>2 expandable folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -7839,8 +7839,8 @@
               <did>
                 <container type="box" label="Box">56</container>
                 <unittitle>In this Corner</unittitle>
-                <physdesc>
-                  <extent>2 issues</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 issues</extent>
                 </physdesc>
               </did>
             </c04>
@@ -7866,8 +7866,8 @@
               <did>
                 <container type="box" label="Box">56</container>
                 <unittitle>Meat City</unittitle>
-                <physdesc>
-                  <extent>3 issues</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 issues</extent>
                 </physdesc>
               </did>
             </c04>
@@ -7881,8 +7881,8 @@
               <did>
                 <container type="box" label="Box">56</container>
                 <unittitle>Notas</unittitle>
-                <physdesc>
-                  <extent>3 issues</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 issues</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8024,8 +8024,8 @@
               <did>
                 <container type="box" label="Box">28a</container>
                 <unittitle>Ann Arbor Free City Council," concerning street peoples' conflicts with police, <unitdate type="inclusive" normal="1969">Spring 1969</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8036,8 +8036,8 @@
               <did>
                 <container type="box" label="Box">28a</container>
                 <unittitle>White Panther Central Committee <unitdate type="inclusive" normal="1969-06">June, 1969</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8048,8 +8048,8 @@
               <did>
                 <container type="box" label="Box">28a</container>
                 <unittitle>White Panther Central Committee <unitdate type="inclusive" normal="1970-04-08">April 8, 1970</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8063,8 +8063,8 @@
               <did>
                 <container type="box" label="Box">28a</container>
                 <unittitle>Rainbow People's Party Reorganizational Meeting, December 17, [1971]</unittitle>
-                <physdesc>
-                  <extent>2 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8075,8 +8075,8 @@
               <did>
                 <container type="box" label="Box">28a</container>
                 <unittitle>Rainbow People's Party Reorganizational Meeting <unitdate type="inclusive" normal="1972-01-01">January 1, 1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8087,8 +8087,8 @@
               <did>
                 <container type="box" label="Box">28a</container>
                 <unittitle>Rainbow People's Party Reorganizational Meeting <unitdate type="inclusive" normal="1972-01-03">January 3, 1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8099,8 +8099,8 @@
               <did>
                 <container type="box" label="Box">28a</container>
                 <unittitle>Radio Meeting: discussion of need to establish community radio in Ann Arbor <unitdate type="inclusive" normal="1972-01-04">January 4, 1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8111,8 +8111,8 @@
               <did>
                 <container type="box" label="Box">28a</container>
                 <unittitle>Radio Meeting: discussion of WNRZ "boycott" <unitdate type="inclusive" normal="1973-06-30">June 30, 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8131,8 +8131,8 @@
               <did>
                 <container type="box" label="Box">28a</container>
                 <unittitle>Letter to the Underground Press / John and Leni Sinclair; [Telephone] interview with John Sinclair on WABX; Miscellaneous newscasts regarding banning of Sun by Oakland Community College <unitdate type="inclusive" normal="1969">1969</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8143,8 +8143,8 @@
               <did>
                 <container type="box" label="Box">28a</container>
                 <unittitle>Translations from the Danish press : interviews with Genie Plamondon and Richard [Coleman] regarding the White Panther Party <unitdate type="inclusive" normal="1970-04-03">April 3, 1970</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8155,8 +8155,8 @@
               <did>
                 <container type="box" label="Box">28a</container>
                 <unittitle>[Dan Carlisle?] interview with Bob [Rudnick?] on WKNR--FM, Dearborn ; Interview with Genie Plamondon and Ken [Kelley] (side A is blank) <unitdate type="inclusive" normal="1970-06">June 1970</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8167,8 +8167,8 @@
               <did>
                 <container type="box" label="Box">28a</container>
                 <unittitle>Dan Carlisle interview with the UP (rock band) on WKNR-FM, Dearborn, 7 <unitdate type="inclusive" normal="1970">1970</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8179,8 +8179,8 @@
               <did>
                 <container type="box" label="Box">28a</container>
                 <unittitle>Interview with Dan [Carlisle] and Jerry [Lubin] regarding the WRIF firings and current state of "free form" radio <unitdate type="inclusive" normal="1971-11">November 1971</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8191,8 +8191,8 @@
               <did>
                 <container type="box" label="Box">28b</container>
                 <unittitle>"Spotlight" (WXYZ radio program): Bill Bonds interview with John and Leni Sinclair <unitdate type="inclusive" normal="1971-12-17">December 17, 1971</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8206,8 +8206,8 @@
               <did>
                 <container type="box" label="Box">28b</container>
                 <unittitle>Lou Gordon interview with John Sinclair <unitdate type="inclusive" normal="1971-12-17">December 17, 1971</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8218,8 +8218,8 @@
               <did>
                 <container type="box" label="Box">28b</container>
                 <unittitle>Larry Monroe interview with John and Leni Sinclair <unitdate type="inclusive" normal="1971-12-18">December 18, 1971</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8230,8 +8230,8 @@
               <did>
                 <container type="box" label="Box">28b</container>
                 <unittitle>Excerpt of radio call-in program (WRIF; Peter Wiebe, host) featuring John and Leni Sinclair <unitdate type="inclusive" normal="1971-12-26">December 26, 1971</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8242,8 +8242,8 @@
               <did>
                 <container type="box" label="Box">28b</container>
                 <unittitle>Community Reporter interview with John and Leni Sinclair <unitdate type="inclusive" normal="1971-12-28">December 28, 1971</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8254,8 +8254,8 @@
               <did>
                 <container type="box" label="Box">28b</container>
                 <unittitle>John Sinclair on the Peter Werbe show (WRIF) <unitdate type="inclusive" normal="1971-12-26">December 26, 1971</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8266,8 +8266,8 @@
               <did>
                 <container type="box" label="Box">28b</container>
                 <unittitle>John Erlich interview with John and Leni Sinclair <unitdate type="inclusive" normal="1971-12-31">December 31, 1971</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8278,8 +8278,8 @@
               <did>
                 <container type="box" label="Box">28b</container>
                 <unittitle>"Rap with John Sinclair," December, 1971-B side John Lennon/Yoko Ono "Attica State," "Luck of the Irish," "Sisters O Sisters," "John Sinclair,"</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8290,8 +8290,8 @@
               <did>
                 <container type="box" label="Box">28b</container>
                 <unittitle>Kalamazoo Patriot interview with John and Leni Sinclair regarding community involvement <unitdate type="inclusive" normal="1972-01-09">January 9, 1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8302,8 +8302,8 @@
               <did>
                 <container type="box" label="Box">28b</container>
                 <unittitle>Conversation with Howard Kohn, David Sinclair, John Sinclair, Leni Sinclair, Bob Rudnick <unitdate type="inclusive" normal="1972-02-02">February 2, 1972</unitdate> (Unit II, no. 13-b)</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8311,8 +8311,8 @@
               <did>
                 <container type="box" label="Box">28b</container>
                 <unittitle>Unidentified classroom discussion featuring John Sinclair <unitdate type="inclusive" normal="1972-03-01">March 1, 1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8326,8 +8326,8 @@
               <did>
                 <container type="box" label="Box">28b</container>
                 <unittitle>John Askein interview with Sunny and Leni Sinclair, <unitdate type="inclusive" normal="1972">Summer 1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8338,8 +8338,8 @@
               <did>
                 <container type="box" label="Box">28b</container>
                 <unittitle>Side A: Statements from John Sinclair and Pun Plamondon concerning dismissal of conspiracy charges ; Sun benefit concert ; Interview with John Sinclair and Pun Plamondon // Side B: David Fenton interview with Commander Cody <unitdate type="inclusive" normal="1972-07-28/1972-07-29">July 28-29, 1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8350,8 +8350,8 @@
               <did>
                 <container type="box" label="Box">28b</container>
                 <unittitle>"On-the-street" interviews regarding Blues and Jazz Festival ; [Sun ?] interview with the Art Ensemble of Chicago <unitdate type="inclusive" normal="1972-08-05">August 5, 1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8362,8 +8362,8 @@
               <did>
                 <container type="box" label="Box">28b</container>
                 <unittitle>Side A: John Sinclair on Michigan Marijuana Initiative Week // Side B: Telephone interviews with various Ann Arbor citizens and officials regarding judge's ruling on Ann Arbor marijuana ordinance <unitdate type="inclusive" normal="1972-06-26">June 26, 1972</unitdate> Sep./ October, <unitdate type="inclusive" normal="1972">1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8374,8 +8374,8 @@
               <did>
                 <container type="box" label="Box">28c</container>
                 <unittitle>Interviews with Jeff Sterling regarding mass firings at CJOM-Windsor <unitdate type="inclusive" normal="1972-10">October 1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8386,8 +8386,8 @@
               <did>
                 <container type="box" label="Box">28c</container>
                 <unittitle>[Sun ?] interview with Lightnin' rock band <unitdate type="inclusive" normal="1972-11-07">November 7, 1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8398,8 +8398,8 @@
               <did>
                 <container type="box" label="Box">28c</container>
                 <unittitle>Side 1: Press conference with HRP candidates for Ann Arbor City Council <unitdate type="inclusive" normal="1972-02-15">February 15, 1972</unitdate> // Side II: Interview with [Bob] Rudnick regarding his involvement in progressive radio</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8410,8 +8410,8 @@
               <did>
                 <container type="box" label="Box">28c</container>
                 <unittitle>Telephone interview with Hugh ("Buck") Davis regarding illegal government wiretapping of telephones at 1510 Hill St, <unitdate type="inclusive" normal="1972">1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8422,8 +8422,8 @@
               <did>
                 <container type="box" label="Box">28c</container>
                 <unittitle>[Sun ?] interview with Luther Allison (blues artist) <unitdate type="inclusive" normal="1972">1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8434,8 +8434,8 @@
               <did>
                 <container type="box" label="Box">28c</container>
                 <unittitle>"Visit to the Children's Room 1510 Hill St.," <unitdate type="inclusive" normal="1988-12">December, 1988</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8446,8 +8446,8 @@
               <did>
                 <container type="box" label="Box">28c</container>
                 <unittitle>David Sinclair HRP primary speech at Couzens Hall, Univ. of Mich., et al. (Unit II, no. 24b)</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8455,8 +8455,8 @@
               <did>
                 <container type="box" label="Box">28c</container>
                 <unittitle>Interview with members of Radio King and His Court of Rhythm (rhythm and blues band) <unitdate type="inclusive" normal="1973-02">February 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8467,8 +8467,8 @@
               <did>
                 <container type="box" label="Box">28c</container>
                 <unittitle>Side A: David Sinclair candidacy statement at Lightnin' concert (Markley Hall, Univ. of Mich.) unidentified telephone conversation with high school student regarding banning of Sun at his school // Side B: Interview of 2nd Ward Human Rights Party candidates on WNRZ-FM, Ann Arbor <unitdate type="inclusive" normal="1973-02-11/1973-02-12">February 11-12, 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8479,8 +8479,8 @@
               <did>
                 <container type="box" label="Box">28c</container>
                 <unittitle>Side A: 2nd Ward Human Rights Party candidates on "Talk Back," live radio interview program, WCBN-FM // Side B: Democratic, Republican and Human Rights Party candidates on call-in program [WNRZ-FM, Ann Arbor] <unitdate type="inclusive" normal="1973-02-12">February 12, 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8491,8 +8491,8 @@
               <did>
                 <container type="box" label="Box">28c</container>
                 <unittitle>David Fenton and Ken Kelley interview with members of Elephant's Memory (rock band) <unitdate type="inclusive" normal="1973-02-13">February 13, 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8503,8 +8503,8 @@
               <did>
                 <container type="box" label="Box">28c</container>
                 <unittitle>Debate featuring Human Rights Party primary candidates (Alice Lloyd Hall, Univ. of Mich.) <unitdate type="inclusive" normal="1973-02-13/1973-02-14">February 13-14, 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8515,8 +8515,8 @@
               <did>
                 <container type="box" label="Box">28c</container>
                 <unittitle>Human Rights Party candidates debate (Alice Lloyd Hall) <unitdate type="inclusive" normal="1973-02-14">February 14, 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8527,8 +8527,8 @@
               <did>
                 <container type="box" label="Box">28c</container>
                 <unittitle>Interview with [Buck Davis] regarding Plamondon bond reduction, CIA conspiracy charges ; John Sinclair promotion of benefit for victims of Monroe flood; unidentified statements before Ann Arbor City Council regarding loss of WNRZ and need for community radio; David Fenton dialogue with Monroe mayor <unitdate type="inclusive" normal="1973-05-15">May 15, 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8539,8 +8539,8 @@
               <did>
                 <container type="box" label="Box">28c</container>
                 <unittitle>David Fenton and Shawn McShane interviews with Detroit (band) <unitdate type="inclusive" normal="1973-06-22/1973-06-23">June 22-23, 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8551,8 +8551,8 @@
               <did>
                 <container type="box" label="Box">28c</container>
                 <unittitle>Statements from Sun photographers regarding suit against undercover narcotics agent ; unidentified Ann Arbor City Council meeting <unitdate type="inclusive" normal="1973-07">July 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8563,8 +8563,8 @@
               <did>
                 <container type="box" label="Box">28d</container>
                 <unittitle>[David Fenton?] interview regarding Plamondon drug case <unitdate type="inclusive" normal="1973-07-20">July 20, 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8575,8 +8575,8 @@
               <did>
                 <container type="box" label="Box">28d</container>
                 <unittitle>Interview with John Sinclair regarding Blues and Jazz Festival <unitdate type="inclusive" normal="1973-08-20">August 20, 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8587,8 +8587,8 @@
               <did>
                 <container type="box" label="Box">28d</container>
                 <unittitle>"Righteous Ray" interview with John Sinclair regarding Blues and Jazz Festival (Triad Radio, Chicago) <unitdate type="inclusive" normal="1973-08-29" certainty="approximate">August [29], 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8599,8 +8599,8 @@
               <did>
                 <container type="box" label="Box">28d</container>
                 <unittitle>Ken Kelley interview with John Sinclair (excerpts), Sep. 13 <unitdate type="inclusive" normal="1973">1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>4 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">4 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8611,8 +8611,8 @@
               <did>
                 <container type="box" label="Box">28d</container>
                 <unittitle>Side A: John Sinclair on "Community Dialogue" // Side B: Unidentified conversation between woman and child <unitdate type="inclusive" normal="1973-12-27">December 27, 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8623,8 +8623,8 @@
               <did>
                 <container type="box" label="Box">28d</container>
                 <unittitle>Unidentified interview with members of Radio King and His Court of Rhythm <unitdate type="inclusive" normal="1973">1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8635,8 +8635,8 @@
               <did>
                 <container type="box" label="Box">28d</container>
                 <unittitle>[Sun ?] interview with Yusef Lateef <unitdate type="inclusive" normal="1973">1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8647,8 +8647,8 @@
               <did>
                 <container type="box" label="Box">28d</container>
                 <unittitle>Unidentified interview with Pun Plamondon regarding going underground, aims of cultural revolution, etc <unitdate type="inclusive" normal="1973" certainty="approximate">circa 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8659,8 +8659,8 @@
               <did>
                 <container type="box" label="Box">28d</container>
                 <unittitle>Side I: Frank Bach conversations with Ken Levy regarding Tribal Council attempts to find new building // Side II: Statement by Genie Plamondon regarding Tribal Council efforts to find building; David Sinclair telephone conversation with Councilman Colburn regarding People's Ballroom Project <unitdate type="inclusive" normal="1973-12/1974-01">December 1973-January 1974</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8671,8 +8671,8 @@
               <did>
                 <container type="box" label="Box">28d</container>
                 <unittitle>Side I: Unidentified // Side II: Ken [Kelley] interview with John Sinclair regarding Rainbow Peoples Party conflicts with Human Rights Party leadership, Spr. <unitdate type="inclusive" normal="1974">1974</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8683,8 +8683,8 @@
               <did>
                 <container type="box" label="Box">28d</container>
                 <unittitle>Side I: Ken Kelley and Genie Plamondon informal interview with Jerry Rubin // Side II: Excerpt from Russ Gibb's call-in program on WCAR, [n.d.]</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8695,8 +8695,8 @@
               <did>
                 <container type="box" label="Box">28d</container>
                 <unittitle>Side I: Unidentified interview with Popular Front for the Liberation of Palestine ; Unidentified interview with European radical // Side II: Pre-recorded <unitdate type="inclusive" normal="1970-03" certainty="approximate">March 1970</unitdate> interview with AL-Fateh (c.f. I:3), [n.d.]</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8707,8 +8707,8 @@
               <did>
                 <container type="box" label="Box">28d</container>
                 <unittitle>[Sun ?] interview with Dr. John (blues artist), [n.d.]</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8719,8 +8719,8 @@
               <did>
                 <container type="box" label="Box">28d</container>
                 <unittitle>[J.C. Crawford?] conversation regarding White Panther Party aims, Zenta philosophy, etc., [n.d.]</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8731,8 +8731,8 @@
               <did>
                 <container type="box" label="Box">28d</container>
                 <unittitle>John Sinclair on the David Neuman show, WXYZ radio <unitdate type="inclusive" normal="1978-01-28">January 28, 1978</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8743,8 +8743,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>Clark Coolidge and John Sinclair, "City Arts Review," WDET <unitdate type="inclusive" normal="1984-06-06">June 6, 1984</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8752,8 +8752,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>"Against the Current," John Sinclair and Mike Leiber <unitdate type="inclusive" normal="1985-09">September 1985</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8761,8 +8761,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>John Sinclair on "The Famous Coachmen Show," WDET <unitdate type="inclusive" normal="1986-01">January, 1986</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8770,8 +8770,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>John Sinclair with Bruce Peterson on WNMC, Traverse City <unitdate type="inclusive" normal="1986-08-10">August 10, 1986</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8779,8 +8779,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>"Detroit Underground," Gil Margolis radio report on MC 5, Stooges, Sinclair, etc. <unitdate type="inclusive" normal="1986">1986</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8788,8 +8788,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>John Sinclair with Jon Lockard, WNMC <unitdate type="inclusive" normal="1987-04-05">April 5, 1987</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8797,8 +8797,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>Elsie Sinclair Interview <unitdate type="inclusive" normal="1987-12">December, 1987</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8806,8 +8806,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>John Sinclair on "Focus: Detroit" <unitdate type="inclusive" normal="1988-02-19">February 19, 1988</unitdate></unittitle>
-                <physdesc>
-                  <extent>3 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8815,8 +8815,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>John Sinclair interview WCSX-FM <unitdate type="inclusive" normal="1988-03-31">March 31, 1988</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8824,8 +8824,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>John Sinclair on the Nkenge Zola Program, WDET-FM <unitdate type="inclusive" normal="1988-05-26">May 26, 1988</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8833,8 +8833,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>John Sinclair Interview with Arcadia Letkeman, WFYR-FM <unitdate type="inclusive" normal="1988-08-19">August 19, 1988</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8842,8 +8842,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>John Sinclair on the Nkenge Zola Program, WDET-FM <unitdate type="inclusive" normal="1988-11-28">November 28, 1988</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8851,8 +8851,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>John Sinclair Special with Dan Gunning and Don Surath <unitdate type="inclusive" normal="1988-12-17">December 17, 1988</unitdate></unittitle>
-                <physdesc>
-                  <extent>3 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8860,8 +8860,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>Kalamu Ya Salam interview with John Sinclair <unitdate type="inclusive" normal="1989-02-06">February 6, 1989</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8869,8 +8869,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>John Sinclair with Scott Allman, WMMQ-FM <unitdate type="inclusive" normal="1989-02-26">February 26, 1989</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8878,8 +8878,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>John Sinclair and George Friend, "Radio Free Earth," WDET-FM <unitdate type="inclusive" normal="1991">1991</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8887,8 +8887,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>John Sinclair on "Destination Out," with Kim Heron, WDET-FM <unitdate type="inclusive" normal="1991-05-19">May 19, 1991</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8896,8 +8896,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>"Pow Wow" radio feature with Larry "Pun" Plamondon, White Buffalo thanksgiving special with Goat Larson <unitdate type="inclusive" normal="1996">1996</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8905,8 +8905,8 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>Chuck Carbo-John Sinclair Interview <unitdate type="inclusive" normal="1996-03">March 1996</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -8914,24 +8914,24 @@
               <did>
                 <container type="box" label="Box">58</container>
                 <unittitle>John Sinclair with Dave Dixon, WXYT, Detroit <unitdate type="inclusive" normal="1997-06">June 1997</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <unittitle>Miscellaneous Promotional spots and Broadcasts</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <c05 level="file">
                 <did>
                   <container type="box" label="Box">58</container>
                   <unittitle>Rainbow productions spots <unitdate type="inclusive" normal="1977/1978">1977-1978</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -8939,8 +8939,8 @@
                 <did>
                   <container type="box" label="Box">58</container>
                   <unittitle>Strata Associates spots <unitdate type="inclusive" normal="1979">1979</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -8948,8 +8948,8 @@
                 <did>
                   <container type="box" label="Box">58</container>
                   <unittitle>Detroit Jazz Center Promos <unitdate type="inclusive" normal="1980">1980</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -8957,8 +8957,8 @@
                 <did>
                   <container type="box" label="Box">58</container>
                   <unittitle>Danceteria spots <unitdate type="inclusive" normal="1985">1985</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -8966,8 +8966,8 @@
                 <did>
                   <container type="box" label="Box">58</container>
                   <unittitle>10 for 2 advertisement, no date</unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -8984,8 +8984,8 @@
               <did>
                 <container type="box" label="Box">28e</container>
                 <unittitle>Side A: Poetry reading (very poor sound quality) University of Michigan student dialogue with [Robben Fleming] ; South University demonstration and "celebration" // Side B: June 18 [riot] ; Rally on "Diag," <unitdate type="inclusive" normal="1969-06-17/1969-06-18">June 17-18, 1969</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8996,8 +8996,8 @@
               <did>
                 <container type="box" label="Box">28e</container>
                 <unittitle>Statements before Ann Arbor City Council ; Interview with John Sinclair <unitdate type="inclusive" normal="1969-06-16">June 16, 1969</unitdate>, <unitdate type="inclusive" normal="1969-06-21">June 21, 1969</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9008,8 +9008,8 @@
               <did>
                 <container type="box" label="Box">28e</container>
                 <unittitle>Ann Arbor riot report and interviews ; "Open Letter to the University Community" from Mayor Harris ; Interview with Walter Krasny <unitdate type="inclusive" normal="1969-07-17/1969-07-19">July 17-19, 1969</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9020,8 +9020,8 @@
               <did>
                 <container type="box" label="Box">28e</container>
                 <unittitle>"Ann Arbor Report" concerning murders, <unitdate type="inclusive" normal="1969">Spring 1969</unitdate> Free City Council meetings, police harassment, and South University riot / Pun Plamondon, <unitdate type="inclusive" normal="1969-07">July, 1969</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9032,8 +9032,8 @@
               <did>
                 <container type="box" label="Box">28e</container>
                 <unittitle>Skip [Taube], et. al. in legal council session regarding White Panther Party suit against Washtenaw County Sheriff's Department <unitdate type="inclusive" normal="1969">1969</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9044,8 +9044,8 @@
               <did>
                 <container type="box" label="Box">28e</container>
                 <unittitle>[Rally] and concert to promote counterculture revolution in Denmark / Genie Plamondon, Richard [Coleman], et. al <unitdate type="inclusive" normal="1970-04-04">April 4, 1970</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9056,8 +9056,8 @@
               <did>
                 <container type="box" label="Box">28e</container>
                 <unittitle>Statement concerning John Sinclair, et. al. /Pun Plamondon <unitdate type="inclusive" normal="1970-07-04">July 4, 1970</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9068,8 +9068,8 @@
               <did>
                 <container type="box" label="Box">28e</container>
                 <unittitle>Statement concerning Rock and Roll Conspiracy Benefit / Pun Plamondon <unitdate type="inclusive" normal="1970-07-21">July 21, 1970</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9080,8 +9080,8 @@
               <did>
                 <container type="box" label="Box">28e</container>
                 <unittitle>[Speech?] at Wayne State University Law School / John Sinclair <unitdate type="inclusive" normal="1972-01-24">January 24, 1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9092,8 +9092,8 @@
               <did>
                 <container type="box" label="Box">28e</container>
                 <unittitle>[Speech] for University of Michigan "prison class" [Program for Educational and Social Change?] / John Sinclair ; Rod Miller <unitdate type="inclusive" normal="1972-02-01">February 1, 1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9104,8 +9104,8 @@
               <did>
                 <container type="box" label="Box">28e</container>
                 <unittitle>"On Assignment Meets..." featuring John Sinclair WMSB-TV, East Lansing <unitdate type="inclusive" normal="1972-02-09">February 9, 1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9119,8 +9119,8 @@
               <did>
                 <container type="box" label="Box">28e</container>
                 <unittitle>[Speech] for prison class / John Sinclair <unitdate type="inclusive" normal="1972-02-15">February 15, 1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9131,8 +9131,8 @@
               <did>
                 <container type="box" label="Box">28e</container>
                 <unittitle>[Speech] at Syracuse University concerning prison experience / John Sinclair <unitdate type="inclusive" normal="1972-02-23">February 23, 1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9143,8 +9143,8 @@
               <did>
                 <container type="box" label="Box">28e</container>
                 <unittitle>Side A: Statements by Human Rights Party candidates on police demonstration, abortion laws, public hearings, Ann Arbor mayoralty, etc <unitdate type="inclusive" normal="1973-01-28">January 28, 1973</unitdate> // Side B: Statements before Ann Arbor City Council / David Sinclair, Genie Plamondon; Press conference with David Sinclair, <unitdate type="inclusive" normal="1973-02-04">February 4, 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9155,8 +9155,8 @@
               <did>
                 <container type="box" label="Box">28e</container>
                 <unittitle>David Sinclair speech at East Quadrangle (Univ. of Mich.) concerning City Council candidacy <unitdate type="inclusive" normal="1973-02-09">February 9, 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9167,8 +9167,8 @@
               <did>
                 <container type="box" label="Box">28e</container>
                 <unittitle>Side A: Press conference with David Sinclair ; "War Bulletin" ; Commander Cody statement on Human Rights Party primary and David Sinclair <unitdate type="inclusive" normal="1973-02-08/1973-02-09">February 8-9, 1973</unitdate> // Side B: Statement before City Council concerning People's Ballroom / Genie Plamondon ; Debate featuring 2nd Ward HRP candidates, <unitdate type="inclusive" normal="1973-02-12/1973-02-14">February 12-14, 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9179,8 +9179,8 @@
               <did>
                 <container type="box" label="Box">28e</container>
                 <unittitle>Tribal Council presentation to Ann Arbor City Council / Genie Plamondon, et. al. ; Voter registration promotional spots <unitdate type="inclusive" normal="1973-02-26">February 26, 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9199,8 +9199,8 @@
               <did>
                 <container type="box" label="Box">28f</container>
                 <unittitle>Recorder's Court, Detroit, Mich.: Trial of John Sinclair for possession of marijuana <unitdate type="inclusive" normal="1969-06-24">June 24, 1969</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9214,8 +9214,8 @@
               <did>
                 <container type="box" label="Box">28f</container>
                 <unittitle>Recorder's Court, Detroit, Mich.: Summations and final statements in Sinclair marijuana trial <unitdate type="inclusive" normal="1969-07-05">July 5, 1969</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9226,8 +9226,8 @@
               <did>
                 <container type="box" label="Box">28f</container>
                 <unittitle>Side A: Statements regarding sentencing of John Sinclair, announcement of upcoming "John Sinclair Week" / Pun Plamondon <unitdate type="inclusive" normal="1970-07-21">July 21, 1970</unitdate> // Side B: Taped newscast concerning campus unrest at Yale ; Unidentified broadcast of interview with Vietnamese official, [n.d.]</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9238,8 +9238,8 @@
               <did>
                 <container type="box" label="Box">28f</container>
                 <unittitle>Oral arguments before Michigan Supreme Court concerning "People vs. John Sinclair"...et. al / Justin C. Ravitz, et. al <unitdate type="inclusive" normal="1971-11-02">November 2, 1971</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9250,8 +9250,8 @@
               <did>
                 <container type="box" label="Box">28f</container>
                 <unittitle>Excerpts from "Free John Now!" rally <unitdate type="inclusive" normal="1971-12-10">December 10, 1971</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9262,8 +9262,8 @@
               <did>
                 <container type="box" label="Box">28f</container>
                 <unittitle>[Radio] commentary concerning Sinclair prison release ; Sinclair prison release and welcome home reception ; telephone conversation between John and Leni Sinclair and John Lennon and Yoko Ono <unitdate type="inclusive" normal="1971-12-15">December 15, 1971</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9274,8 +9274,8 @@
               <did>
                 <container type="box" label="Box">28f</container>
                 <unittitle>Motion for continuance, et. al. in Plamondon CIA trial / Hugh M. ("Buck") Davis <unitdate type="inclusive" normal="1973-05-07">May 7, 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9286,8 +9286,8 @@
               <did>
                 <container type="box" label="Box">28f</container>
                 <unittitle>Argument for renewal of motion for delay in "People vs. Craig Blazier and Pun Plamondon" / Buck Davis ; Pun Plamondon; Memorial Day Conference concerning civil suit against John Mitchell, et. al. (conspiracy case), <unitdate type="inclusive" normal="1973-05-31">1973 May 31</unitdate>, <unitdate type="inclusive" normal="1973">May 24 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9301,8 +9301,8 @@
               <did>
                 <container type="box" label="Box">28f</container>
                 <unittitle>Reports on conspiracy trial and decision ; Pre-decision report concerning decision to waive jury. / Buck Davis ; Pun Plamondon <unitdate type="inclusive" normal="1973-07">July 1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <odd>
@@ -9328,8 +9328,8 @@
                 <did>
                   <container type="box" label="Box">59</container>
                   <unittitle>Fattening Frogs for Snakes: A Delta Sound Suite <unitdate type="inclusive" normal="1981">1981</unitdate>, <unitdate type="inclusive" normal="1984">1984</unitdate>, <unitdate type="inclusive" normal="1994">1994</unitdate></unittitle>
-                  <physdesc>
-                    <extent>5 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">5 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9337,8 +9337,8 @@
                 <did>
                   <container type="box" label="Box">59</container>
                   <unittitle>We Just Change the Beat, various versions <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
-                  <physdesc>
-                    <extent>4 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">4 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9346,8 +9346,8 @@
                 <did>
                   <container type="box" label="Box">59</container>
                   <unittitle>Rebel Poets: Words Made Flesh <unitdate type="inclusive" normal="1990">1990</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
                 <odd>
@@ -9358,8 +9358,8 @@
                 <did>
                   <container type="box" label="Box">59</container>
                   <unittitle>Fly Right: A Monk Suite <unitdate type="inclusive" normal="1992">1992</unitdate></unittitle>
-                  <physdesc>
-                    <extent>2 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9368,8 +9368,8 @@
               <did>
                 <container type="box" label="Box">59</container>
                 <unittitle>Readings and Performances <unitdate type="inclusive" normal="1969/1988">1969-1988</unitdate></unittitle>
-                <physdesc>
-                  <extent>47 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">47 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -9377,8 +9377,8 @@
               <did>
                 <container type="box" label="Box">60</container>
                 <unittitle>Readings and Performances <unitdate type="inclusive" normal="1988/1993">1988-1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>59 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">59 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -9386,8 +9386,8 @@
               <did>
                 <container type="box" label="Box">61</container>
                 <unittitle>Readings and Performances <unitdate type="inclusive" normal="1996/1998">1996-1998</unitdate></unittitle>
-                <physdesc>
-                  <extent>15 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">15 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -9407,8 +9407,8 @@
                 <did>
                   <container type="box" label="Box">61</container>
                   <unittitle>Live performances <unitdate type="inclusive" normal="1968/1972">1968-1972</unitdate></unittitle>
-                  <physdesc>
-                    <extent>5 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">5 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9416,8 +9416,8 @@
                 <did>
                   <container type="box" label="Box">61</container>
                   <unittitle>MC 5, John Sinclair, Bob Rudnick on WFMU, East Orange, New Jersey <unitdate type="inclusive" normal="1968">1968</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9426,8 +9426,8 @@
               <did>
                 <container type="box" label="Box">61</container>
                 <unittitle>"Vancouver," <unitdate type="inclusive" normal="1970">1970</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -9435,8 +9435,8 @@
               <did>
                 <container type="box" label="Box">61</container>
                 <unittitle>Infinite Sound/Revolutionary Ensemble at the <unitdate type="inclusive" normal="1973">1973</unitdate> Ann Arbor Blues and Jazz festival.</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -9444,8 +9444,8 @@
               <did>
                 <container type="box" label="Box">61</container>
                 <unittitle>Willie Williams' "Stars of Stars revue" Union Ballroom, Ann Arbor <unitdate type="inclusive" normal="1975">1975</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -9453,8 +9453,8 @@
               <did>
                 <container type="box" label="Box">61</container>
                 <unittitle>Sam Sanders/Oakland University Jazz ensemble <unitdate type="inclusive" normal="1979">1979</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -9462,8 +9462,8 @@
               <did>
                 <container type="box" label="Box">61</container>
                 <unittitle>New Detroit Jazz Ensemble, Paradise Theater <unitdate type="inclusive" normal="1979-06-27">June 27, 1979</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -9471,8 +9471,8 @@
               <did>
                 <container type="box" label="Box">61</container>
                 <unittitle>The Urbations, various live performances and studio recordings <unitdate type="inclusive" normal="1982/1986">1982-1986</unitdate></unittitle>
-                <physdesc>
-                  <extent>16 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">16 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -9480,8 +9480,8 @@
               <did>
                 <container type="box" label="Box">61</container>
                 <unittitle>What If Thinking, Demo tape <unitdate type="inclusive" normal="1984">1984</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -9489,8 +9489,8 @@
               <did>
                 <container type="box" label="Box">61</container>
                 <unittitle>"Guitar Army," WA Benefit from Harpo's Detroit <unitdate type="inclusive" normal="1985-04-04">April 4, 1985</unitdate></unittitle>
-                <physdesc>
-                  <extent>4 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">4 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -9498,8 +9498,8 @@
               <did>
                 <container type="box" label="Box">61</container>
                 <unittitle>Tony Seymour, Union Street, Detroit <unitdate type="inclusive" normal="1985">1985</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -9507,8 +9507,8 @@
               <did>
                 <container type="box" label="Box">61</container>
                 <unittitle>Wayne Kramer, Demo tape? <unitdate type="inclusive" normal="1994">1994</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -9516,8 +9516,8 @@
               <did>
                 <container type="box" label="Box">61</container>
                 <unittitle>Prestige Jazz Vocalists (King Pleasure, Eddie Jefferson, Joe Carrol, Etc)</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -9525,8 +9525,8 @@
               <did>
                 <container type="box" label="Box">61</container>
                 <unittitle>Music of Detroit Compilation <unitdate type="inclusive" normal="1987">1987</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -9534,8 +9534,8 @@
               <did>
                 <container type="box" label="Box">61</container>
                 <unittitle>Christmas in Detroit Compilation <unitdate type="inclusive" normal="1992">1992</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -9543,8 +9543,8 @@
               <did>
                 <container type="box" label="Box">61</container>
                 <unittitle>Ann Arbor Blues and Jazz Festival tape Compilation <unitdate type="inclusive" normal="1975">1975</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -9564,8 +9564,8 @@
                 <did>
                   <container type="box" label="Box">62</container>
                   <unittitle>"Toke Time," show <unitdate type="inclusive" normal="1972-10/1973-04">October 1972-April 1973</unitdate></unittitle>
-                  <physdesc>
-                    <extent>60 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">60 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9573,8 +9573,8 @@
                 <did>
                   <container type="box" label="Box">63</container>
                   <unittitle>"Toke Time," show <unitdate type="inclusive" normal="1972-10/1973-04">October 1972-April 1973</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9582,8 +9582,8 @@
                 <did>
                   <container type="box" label="Box">63</container>
                   <unittitle>KPFT-FM, Houston, Texas "Toke Time in Texas," show <unitdate type="inclusive" normal="1973-11-12">November 12, 1973</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9596,8 +9596,8 @@
                 <did>
                   <container type="box" label="Box">63</container>
                   <unittitle>"Ancestor Worship" WCBN, Ann Arbor <unitdate type="inclusive" normal="1975/1976">1975-1976</unitdate></unittitle>
-                  <physdesc>
-                    <extent>12 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">12 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9605,8 +9605,8 @@
                 <did>
                   <container type="box" label="Box">63</container>
                   <unittitle>"Re:Visions," WCBN, Ann Arbor <unitdate type="inclusive" normal="1977/1978">1977-1978</unitdate></unittitle>
-                  <physdesc>
-                    <extent>25 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">25 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9614,8 +9614,8 @@
                 <did>
                   <container type="box" label="Box">63</container>
                   <unittitle>"First Impressions"</unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9623,8 +9623,8 @@
                 <did>
                   <container type="box" label="Box">63</container>
                   <unittitle>"Risque Blues"</unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9632,8 +9632,8 @@
                 <did>
                   <container type="box" label="Box">63</container>
                   <unittitle>Halloween Special <unitdate type="inclusive" normal="1977">1977</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9641,8 +9641,8 @@
                 <did>
                   <container type="box" label="Box">63</container>
                   <unittitle>Merry Christmas Baby <unitdate type="inclusive" normal="1977">1977</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9650,8 +9650,8 @@
                 <did>
                   <container type="box" label="Box">63</container>
                   <unittitle>A Night at the Paradise <unitdate type="inclusive" normal="1979">1979</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9659,8 +9659,8 @@
                 <did>
                   <container type="box" label="Box">63</container>
                   <unittitle>Charles Mingus Marathon <unitdate type="inclusive" normal="1979">1979</unitdate></unittitle>
-                  <physdesc>
-                    <extent>3 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">3 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9668,8 +9668,8 @@
                 <did>
                   <container type="box" label="Box">63</container>
                   <unittitle>John Sinclair <unitdate type="inclusive" normal="1979">1979</unitdate></unittitle>
-                  <physdesc>
-                    <extent>2 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9677,8 +9677,8 @@
                 <did>
                   <container type="box" label="Box">63</container>
                   <unittitle>Jazz at the Philharmonic '46 <unitdate type="inclusive" normal="1979">1979</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9686,8 +9686,8 @@
                 <did>
                   <container type="box" label="Box">63</container>
                   <unittitle>Blues Marathon <unitdate type="inclusive" normal="1979">1979</unitdate></unittitle>
-                  <physdesc>
-                    <extent>2 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9695,8 +9695,8 @@
                 <did>
                   <container type="box" label="Box">63</container>
                   <unittitle>John Coltrane Memorial Marathon <unitdate type="inclusive" normal="1979">1979</unitdate></unittitle>
-                  <physdesc>
-                    <extent>2 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9704,8 +9704,8 @@
                 <did>
                   <container type="box" label="Box">63</container>
                   <unittitle>Charlie Parker memorial show <unitdate type="inclusive" normal="1980">1980</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9713,8 +9713,8 @@
                 <did>
                   <container type="box" label="Box">63</container>
                   <unittitle>Marathon <unitdate type="inclusive" normal="1981">1981</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9722,8 +9722,8 @@
                 <did>
                   <container type="box" label="Box">63</container>
                   <unittitle>John Sinclair, Martin Gross, Bill Lee <unitdate type="inclusive" normal="1981">1981</unitdate></unittitle>
-                  <physdesc>
-                    <extent>2 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9736,8 +9736,8 @@
                 <did>
                   <container type="box" label="Box">64</container>
                   <unittitle>"The Sound of Detroit," show WDET-FM, Detroit <unitdate type="inclusive" normal="1979/1980">1979-1980</unitdate></unittitle>
-                  <physdesc>
-                    <extent>40 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">40 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9745,8 +9745,8 @@
                 <did>
                   <container type="box" label="Box">64</container>
                   <unittitle>"Blue Sensations," WDET-FM <unitdate type="inclusive" normal="1989/1991">1989-1991</unitdate></unittitle>
-                  <physdesc>
-                    <extent>10 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">10 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9754,8 +9754,8 @@
                 <did>
                   <container type="box" label="Box">64</container>
                   <unittitle>John Sinclair on WDET <unitdate type="inclusive" normal="1975">1975</unitdate></unittitle>
-                  <physdesc>
-                    <extent>4 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">4 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9763,8 +9763,8 @@
                 <did>
                   <container type="box" label="Box">64</container>
                   <unittitle>"Dimensions" with George Tysh <unitdate type="inclusive" normal="1975">1975</unitdate></unittitle>
-                  <physdesc>
-                    <extent>2 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9772,8 +9772,8 @@
                 <did>
                   <container type="box" label="Box">64</container>
                   <unittitle>"Full Circle," <unitdate type="inclusive" normal="1978">1978</unitdate></unittitle>
-                  <physdesc>
-                    <extent>2 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9781,8 +9781,8 @@
                 <did>
                   <container type="box" label="Box">64</container>
                   <unittitle>"Kick Out the Jams," <unitdate type="inclusive" normal="1983">1983</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9790,8 +9790,8 @@
                 <did>
                   <container type="box" label="Box">64</container>
                   <unittitle>"Everywhere the Music Goes," <unitdate type="inclusive" normal="1978">1978</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9799,8 +9799,8 @@
                 <did>
                   <container type="box" label="Box">65</container>
                   <unittitle>"Blues After Hours," <unitdate type="inclusive" normal="1990">1990</unitdate></unittitle>
-                  <physdesc>
-                    <extent>4 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">4 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9813,8 +9813,8 @@
                 <did>
                   <container type="box" label="Box">65</container>
                   <unittitle>Big City Blues Cruise, WEMU, Ypsilanti <unitdate type="inclusive" normal="1983">1983</unitdate>, <unitdate type="inclusive" normal="1986">1986</unitdate></unittitle>
-                  <physdesc>
-                    <extent>2 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9822,8 +9822,8 @@
                 <did>
                   <container type="box" label="Box">65</container>
                   <unittitle>John Sinclair with Michael G. Nastos, WEMU, Ypsilanti <unitdate type="inclusive" normal="1981">1981</unitdate></unittitle>
-                  <physdesc>
-                    <extent>2 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9831,8 +9831,8 @@
                 <did>
                   <container type="box" label="Box">65</container>
                   <unittitle>WEMU fundraiser</unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9840,8 +9840,8 @@
                 <did>
                   <container type="box" label="Box">65</container>
                   <unittitle>Top 60 of the 60's, WLLZ <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9849,16 +9849,16 @@
                 <did>
                   <container type="box" label="Box">65</container>
                   <unittitle>John Sinclair on KPFT-FM, Houston, Texas <unitdate type="inclusive" normal="1974">1974</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
               <c05 level="file">
                 <did>
                   <unittitle>[Bob] Rudnick on CJOM-FM, Windsor</unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
                 <c06 level="file">
@@ -9867,8 +9867,8 @@
                     <unittitle>
                       <unitdate type="inclusive" normal="1972-01-30">January 30, 1972</unitdate>
                     </unittitle>
-                    <physdesc>
-                      <extent>1 audiocassettes</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                     </physdesc>
                   </did>
                   <odd>
@@ -9881,8 +9881,8 @@
                     <unittitle>
                       <unitdate type="inclusive" normal="1972-02-27">February 27, 1972</unitdate>
                     </unittitle>
-                    <physdesc>
-                      <extent>1 audiocassettes</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                     </physdesc>
                   </did>
                   <odd>
@@ -9895,8 +9895,8 @@
                     <unittitle>
                       <unitdate type="inclusive" normal="1972-03-12">March 12, 1972</unitdate>
                     </unittitle>
-                    <physdesc>
-                      <extent>1 audiocassettes</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                     </physdesc>
                   </did>
                   <odd>
@@ -9909,8 +9909,8 @@
                     <unittitle>
                       <unitdate type="inclusive" normal="1972-03-12">March 12, 1972</unitdate>
                     </unittitle>
-                    <physdesc>
-                      <extent>1 audiocassettes</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                     </physdesc>
                   </did>
                   <odd>
@@ -9923,8 +9923,8 @@
                     <unittitle>
                       <unitdate type="inclusive" normal="1972-03-12">March 12, 1972</unitdate>
                     </unittitle>
-                    <physdesc>
-                      <extent>1 audiocassettes</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                     </physdesc>
                   </did>
                   <odd>
@@ -9936,8 +9936,8 @@
                 <did>
                   <container type="box" label="Box">65</container>
                   <unittitle>Jerry Goodwin on WABX-Detroit <unitdate type="inclusive" normal="1972-03-26">March 26, 1972</unitdate></unittitle>
-                  <physdesc>
-                    <extent>2 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9945,8 +9945,8 @@
                 <did>
                   <container type="box" label="Box">65</container>
                   <unittitle>"Michigan Boogie" radio broadcast...[et. al.] <unitdate type="inclusive" normal="1973">Spring 1973</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9954,8 +9954,8 @@
                 <did>
                   <container type="box" label="Box">65</container>
                   <unittitle>Excerpt from "Takin' Over" radio broadcast, WNRZ <unitdate type="inclusive" normal="1972-11-19">November 19, 1972</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -9974,8 +9974,8 @@
                     <unittitle>
                       <unitdate type="inclusive" normal="1992/1996">1992-1996</unitdate>
                     </unittitle>
-                    <physdesc>
-                      <extent>41 audiocassettes</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">41 audiocassettes</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -9985,8 +9985,8 @@
                     <unittitle>
                       <unitdate type="inclusive" normal="1996/1999">1996-1999</unitdate>
                     </unittitle>
-                    <physdesc>
-                      <extent>35 audiocassettes</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">35 audiocassettes</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -9995,8 +9995,8 @@
                 <did>
                   <container type="box" label="Box">66</container>
                   <unittitle>Blues and Roots <unitdate type="inclusive" normal="1992/1995">1992-1995</unitdate></unittitle>
-                  <physdesc>
-                    <extent>27 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">27 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -10004,8 +10004,8 @@
                 <did>
                   <container type="box" label="Box">67</container>
                   <unittitle>Blues and Roots <unitdate type="inclusive" normal="1995/1999">1995-1999</unitdate></unittitle>
-                  <physdesc>
-                    <extent>42 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">42 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -10013,8 +10013,8 @@
                 <did>
                   <container type="box" label="Box">67</container>
                   <unittitle>Miscellaneous jazz, blues, and R&amp;B shows <unitdate type="inclusive" normal="1992">1992</unitdate></unittitle>
-                  <physdesc>
-                    <extent>19 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">19 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -10022,8 +10022,8 @@
                 <did>
                   <container type="box" label="Box">68</container>
                   <unittitle>Miscellaneous jazz, blues, and R&amp;B shows <unitdate type="inclusive" normal="1992/1993">1992-1993</unitdate></unittitle>
-                  <physdesc>
-                    <extent>60 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">60 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -10031,8 +10031,8 @@
                 <did>
                   <container type="box" label="Box">69</container>
                   <unittitle>Miscellaneous jazz, blues, and R&amp;B shows <unitdate type="inclusive" normal="1993/1996">1993-1996</unitdate></unittitle>
-                  <physdesc>
-                    <extent>32 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">32 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -10055,8 +10055,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1989-09/1989-12">September-December 1989</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>25 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">25 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -10066,8 +10066,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1990-01/1990-04">January-April, 1990</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>2 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -10077,8 +10077,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1990-01/1990-04">January-April, 1990</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>24 audiocassettes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">24 audiocassettes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -10087,8 +10087,8 @@
               <did>
                 <container type="box" label="Box">70</container>
                 <unittitle>"The Roots of Rock 'n Roll," <unitdate type="inclusive" normal="1990-05/1990-07">May-July, 1990</unitdate></unittitle>
-                <physdesc>
-                  <extent>15 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">15 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -10096,8 +10096,8 @@
               <did>
                 <container type="box" label="Box">70</container>
                 <unittitle>"Blues History," <unitdate type="inclusive" normal="1990-09/1990-12">September-December, 1990</unitdate></unittitle>
-                <physdesc>
-                  <extent>15 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">15 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -10106,8 +10106,8 @@
             <did>
               <container type="box" label="Box">70</container>
               <unittitle>"Serious Damage," <unitdate type="inclusive" normal="1981/1982">1981-1982</unitdate></unittitle>
-              <physdesc>
-                <extent>4 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 audiocassettes</extent>
               </physdesc>
             </did>
           </c03>
@@ -10130,8 +10130,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Looking at You" ; "Borderline" / MC 5.--Ann Arbor, Mich. : Total Energy Music <unitdate type="inclusive" normal="1969">1969</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10143,8 +10143,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Looking at You"; "Boderline" 30th anniversary edition, Alive/Total Energy Records <unitdate type="inclusive" normal="1968">1968</unitdate>, <unitdate type="inclusive" normal="1998">1998</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10156,8 +10156,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Kick Out the Jams" ; "Motor City Is Burning" / MC 5.--New York, N. Y. : Elektra <unitdate type="inclusive" normal="1969">1969</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10172,8 +10172,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Kick Out the Jams"...</unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10188,8 +10188,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Kick Out the Jams"...</unittitle>
-                <physdesc>
-                  <extent>2 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10204,8 +10204,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Just Like an Aborigine" ; "Hassan I Sabbah" / UP.--Ann Arbor, Mich. : Sundance Records <unitdate type="inclusive" normal="1970">1970</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10220,8 +10220,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Free John Now!" / UP ; "Prayer for John Sinclair" / Allen Ginsberg and Peter Orlovsky : John Sinclair Freedom Rally <unitdate type="inclusive" normal="1971-12-10">December 10, 1971</unitdate>.--Ann Arbor, Mich. : Rainbow Records, <unitdate type="inclusive" normal="1971">1971</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10233,8 +10233,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Hi-jackin' Love" ; "First Time I Saw You Baby" / Lightnin'.--Ann Arbor, Mich. : Rainbow Records <unitdate type="inclusive" normal="1972">1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10249,8 +10249,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"66 Highway, Parts 1, 2, &amp; 3" ; "Too Many Drivers" / Willie &amp; the Bumblebees.--Cushing, Minn. : Sweet Jane, Ltd. <unitdate type="inclusive" normal="1972">1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10262,8 +10262,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Get Away" ; "Go Home with You" / Mojo Boogie Band.--1973</unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10275,8 +10275,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Rape and Plunder" ; "Delighted" / Walrus--1973</unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10288,8 +10288,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"America, Here It Comes" / J. Brooks and L. Moore. [s.l.] : 14th Floor Productions, p c <unitdate type="inclusive" normal="1975">1975</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10301,8 +10301,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Policeman" ; "PAL Bump" ; / Les Cochons Bleus.--p Les Cochons Bleus. <unitdate>undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10314,8 +10314,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"I Need You" / The Early Rationals ; "Get the Picture" / The Old Exciting Scot Richard Case.--Ann Arbor, Mich. : A2 Records <unitdate>undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10327,8 +10327,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"The Iliad" ; "Jimmy Joe, the Hippy, Billy Boy" / Ed Saunders.--undated</unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10340,8 +10340,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Take a Look"; "Soul Mover" / Detroit/Scott Morgan.--Guardian Angel Records <unitdate>undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10353,8 +10353,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Time of the Season" ; "I Found a Love" / The Thyme.--[Ann Arbor, Mich.] : A2 Records <unitdate>undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10366,8 +10366,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Rama Rama" ; "Endless Path" / Muruga Sharma, "formerly Steve Booker".--Detroit, Mich. : Origin Records <unitdate>undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10379,8 +10379,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Guitar Army" ; "Sunset" / Rationals.--undated</unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10392,8 +10392,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"High Time" ; "Often I Wonder," / The Spike Drivers--OM records? <unitdate>undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10405,8 +10405,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"The Whip" ; "Skaffle" / The Urbations--Wild Child Discs <unitdate type="inclusive" normal="1982">1982</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>45 rpm, stereo, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -10430,8 +10430,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Santa Claus is Coming to Town" ; "Winter Wonderland" / The Urbations <unitdate>undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>33 1/3 rpm flexi-disc</physfacet>
                 </physdesc>
               </did>
@@ -10443,8 +10443,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Danae Adrift upon the Sea" / Ed Sanders and Simonides of Ceos ; "Decoration Day" / John Sinclair--Otherwind Press <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>33 1/3 rpm flexi-disc</physfacet>
                 </physdesc>
               </did>
@@ -10456,8 +10456,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Her Night (an Exercept)" ; "The One Taste"/ Ann Waldman ; "12th Street breathes a sigh of death"/ Sadiq Muhhamand, Otherwind Press <unitdate type="inclusive" normal="1989">1989</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>33 1/3 rpm flexi-disc</physfacet>
                 </physdesc>
               </did>
@@ -10469,8 +10469,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Prelenten Gestures" ; "Affinities II" ; "At the Well" / Paul Blackburn, Otherwind Press <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>33 1/3 rpm flexi-disc</physfacet>
                 </physdesc>
               </did>
@@ -10493,8 +10493,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>Kick Out the Jams / MC 5--1969</unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>33 1/3 rpm stereo</physfacet>
                 </physdesc>
               </did>
@@ -10509,8 +10509,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>Kick Out the Jams / MC 5.--New York, N. Y. : Elektra Records <unitdate type="inclusive" normal="1969">1969</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>33 1/3 rpm stereo</physfacet>
                 </physdesc>
               </did>
@@ -10522,8 +10522,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>Malauwi / Malauwi Nurudin...[et. al.].--Detroit, Mich. : Strata Records, Inc. <unitdate type="inclusive" normal="1969">1969</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>33 1/3 rpm stereo</physfacet>
                 </physdesc>
               </did>
@@ -10535,8 +10535,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>Inside Ourselves / Sphere.--Detroit, Mich. : Strata Records, Inc. <unitdate type="inclusive" normal="1970">1970</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>33 1/3 rpm stereo</physfacet>
                 </physdesc>
               </did>
@@ -10551,8 +10551,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>"Just Like an Aborigine" / UP.--1970</unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>10 in., 45 rpm</physfacet>
                 </physdesc>
               </did>
@@ -10564,8 +10564,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>Ann Arbor Blues and Jazz Festival <unitdate type="inclusive" normal="1972">1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 phonograph records</extent>
                   <physfacet>33 1/3 rpm stereo</physfacet>
                 </physdesc>
               </did>
@@ -10580,8 +10580,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>Ann Arbor Blues and Jazz Festival, 1972 : Recorded Live at Otis Spann Memorial Field.--New York, N. Y. : Atlantic Recording Corp. ; Rainbow Multi-Media, p c <unitdate type="inclusive" normal="1973">1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 phonograph records</extent>
                   <physfacet>33 1/3 rpm stereo</physfacet>
                 </physdesc>
               </did>
@@ -10593,8 +10593,8 @@
               <did>
                 <container type="box" label="Box">29a</container>
                 <unittitle>The Dial-a Poem Poets / Allen Ginsberg...[et. al.] New York, N. Y. : Giorno Poetry Systems, c p <unitdate type="inclusive" normal="1972">1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>33 1/3 rpm stereo</physfacet>
                 </physdesc>
               </did>
@@ -10609,8 +10609,8 @@
               <did>
                 <container type="box" label="Box">29b</container>
                 <unittitle>Saturday Night Special</unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>33 1/3 rpm stereo</physfacet>
                 </physdesc>
               </did>
@@ -10637,8 +10637,8 @@
               <did>
                 <container type="box" label="Box">29b</container>
                 <unittitle>Liberation Music : People's Yoga / Peace, Bread &amp; Land Band.--Seattle, Wash. : Natural Liberation Front <unitdate>undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>10 in., mono.</physfacet>
                 </physdesc>
               </did>
@@ -10650,8 +10650,8 @@
               <did>
                 <container type="box" label="Box">29b</container>
                 <unittitle>"Gimme Shelter" / Detroit.--[s.l.]: Paramount Records <unitdate>undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>10 in., 45 rpm</physfacet>
                 </physdesc>
               </did>
@@ -10663,8 +10663,8 @@
               <did>
                 <container type="box" label="Box">29b</container>
                 <unittitle>"Friday the 13th" / John Sinclair and Wayne Kramer.--Burbank, CA. : Alive Records, 1995.</unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>33 1/3 rpm stereo</physfacet>
                 </physdesc>
               </did>
@@ -10676,8 +10676,8 @@
               <did>
                 <container type="box" label="Box">29b</container>
                 <unittitle>"PowerTrip" / MC 5.--Burbank, CA. : Alive Records, c <unitdate type="inclusive" normal="1994">1994</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>33 1/3 rpm stereo</physfacet>
                 </physdesc>
               </did>
@@ -10689,8 +10689,8 @@
               <did>
                 <container type="box" label="Box">29b</container>
                 <unittitle>"Ice Pick Slim" / . MC 5.--Burbank, CA. : Alive Records <unitdate type="inclusive" normal="1995">1995</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>33 1/3 rpm stereo</physfacet>
                 </physdesc>
               </did>
@@ -10702,8 +10702,8 @@
               <did>
                 <container type="box" label="Box">29b</container>
                 <unittitle>"Teenage Lust" / MC 5.--Burbank, CA. : Alive Records/Total Energy Records <unitdate type="inclusive" normal="1996">1996</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>33 1/3 rpm stereo</physfacet>
                 </physdesc>
               </did>
@@ -10715,8 +10715,8 @@
               <did>
                 <container type="box" label="Box">29b</container>
                 <unittitle>"Starship" / MC 5.--Burbank, CA. : Alive Records/Total Energy Records <unitdate type="inclusive" normal="1998">1998</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 phonograph records</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>33 1/3 rpm stereo</physfacet>
                 </physdesc>
               </did>
@@ -10740,8 +10740,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>White Panther Party meeting and criticism; (Unit I, no. 1), <unitdate type="inclusive" normal="1968">1968</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7 1/2 ips</physfacet>
                 </physdesc>
               </did>
@@ -10765,8 +10765,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Discussion and music recorded at the Rainbow People's Party headquarters; (Unit I, no. 2), <unitdate type="inclusive" normal="1971">1971</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7 1/2 ips</physfacet>
                 </physdesc>
               </did>
@@ -10822,8 +10822,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Meeting for John Sinclair; (Unit I, no. 3), <unitdate type="inclusive">1971 October 28</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 1 7/8 ips, double track</physfacet>
                 </physdesc>
               </did>
@@ -10927,8 +10927,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Rainbow People's Party: December Central Committee Meetings, January Plenary Meeting; (Unit I, no. 4), <unitdate type="inclusive">1971 December 28-31, 1972 January 01</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 1 7/8 ips</physfacet>
                 </physdesc>
               </did>
@@ -11144,8 +11144,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>House meetings, probably of Rainbow People's Party; (Unit I, no. 5), <unitdate type="inclusive" normal="1972">1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 1 7/8 ips, 4 track mono.</physfacet>
                 </physdesc>
               </did>
@@ -11217,8 +11217,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Rainbow People's Party plenary meeting; (Unit I, no. 6), <unitdate type="inclusive">1972 January 02</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 1 7/8 ips, double track</physfacet>
                 </physdesc>
               </did>
@@ -11274,8 +11274,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Rainbow People's Party central committee meetings; (Unit I, no. 7), <unitdate type="inclusive">1972 January 25</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 1 7/8 ips, 4 track mono.</physfacet>
                 </physdesc>
               </did>
@@ -11347,8 +11347,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Rainbow People's Party central committee sessions; (Unit I, no. 8), <unitdate type="inclusive">1972 January 26</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 1 7/8 ips, 4 track mono.</physfacet>
                 </physdesc>
               </did>
@@ -11404,8 +11404,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Rainbow People's Party plenary meeting; (Unit I, no. 9), <unitdate type="inclusive">1972 January 29</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 1 7/8 ips, 4 track mono.</physfacet>
                 </physdesc>
               </did>
@@ -11477,8 +11477,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Rainbow People's Party central committee meetings; (Unit I, no. 10), <unitdate type="inclusive">1972 January 31</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 1 7/8 ips, 4 track mono.</physfacet>
                 </physdesc>
               </did>
@@ -11550,8 +11550,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Rainbow People's Party central committee session held at the Michigan Union; (Unit I, no. 11), <unitdate type="inclusive">1972 February 03</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 1 7/8 ips, 4 track mono.</physfacet>
                 </physdesc>
               </did>
@@ -11639,8 +11639,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Rainbow People's Party central committee meeting; (Unit I, no. 12), <unitdate type="inclusive">[1972 February 08], 1972 February 10</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 1 7/8 ips, double track</physfacet>
                 </physdesc>
               </did>
@@ -11712,8 +11712,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Rainbow People's Party central committee sessions and interview with John Sinclair recently out of prison; (Unit I, no. 13), <unitdate type="inclusive">1972 February 11</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 1 7/8 ips, 4 track mono</physfacet>
                 </physdesc>
               </did>
@@ -11801,8 +11801,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Rainbow People's Party plenary meetings; (Unit I, no. 14) , <unitdate type="inclusive">1972 February 14, 1972 February 17, 1972 February 18</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 1 7/8 ips</physfacet>
                 </physdesc>
               </did>
@@ -11874,8 +11874,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Rainbow People's Party plenary meetings; (Unit I, no. 15), <unitdate type="inclusive">1972 March 06-09</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 1 7/8 ips, 4 track mono</physfacet>
                 </physdesc>
               </did>
@@ -11947,8 +11947,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Rainbow People's Party evaluation meetings; (Unit I, no. 16) , <unitdate type="inclusive">1972 September 13-14</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 1 7/8 ips, double track</physfacet>
                 </physdesc>
               </did>
@@ -12009,8 +12009,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Interview with Pun Plamondon conducted by Bernadine Dohrn; (Unit II, no. 17), <unitdate type="inclusive">[Undated]</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 1 7/8 ips</physfacet>
                 </physdesc>
               </did>
@@ -12066,8 +12066,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Speech given at Hill Auditorium concerning drugs and the youth culture; (Unit II, no. 18), <unitdate type="inclusive">[Undated]</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 3 3/4 ips</physfacet>
                 </physdesc>
               </did>
@@ -12107,8 +12107,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Interview with the People's Band, official representatives of the White Panther Party; (Unit II, no. 19), <unitdate type="inclusive">[Undated]</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7 1/2 ips</physfacet>
                 </physdesc>
               </did>
@@ -12132,8 +12132,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Interview with Frank Bach and Jeanie Plamondon on "Talk Back" show, WCBN-FM; (Unit II, no. 20), <unitdate type="inclusive">[Undated]</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7 1/2 ips</physfacet>
                 </physdesc>
               </did>
@@ -12157,8 +12157,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Interview of Avatar staff on WFMU; (Unit II, no. 21), <unitdate type="inclusive">[Undated]</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7 1/2 ips</physfacet>
                 </physdesc>
               </did>
@@ -12182,9 +12182,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>John Sinclair Interview, WWUH, West Hartford, CT; (Unit II, no. 22-23), <unitdate type="inclusive">[Undated]</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 audiotapes</extent>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, reel-to-reel tapes, 7 inch, 7 1/2 ips</physfacet>
                 </physdesc>
               </did>
@@ -12224,8 +12223,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>John Sinclair on the David Newman show (WXYZ AM) (marijuana laws discussion); (Unit II, no. 24), <unitdate type="inclusive">[1976-1977?]</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 3 3/4 ips</physfacet>
                 </physdesc>
               </did>
@@ -12249,8 +12248,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Bobby Seale Interview and press conference; (Unit II, no. 25), <unitdate type="inclusive">[Undated]</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 1 7/8 ips</physfacet>
                 </physdesc>
               </did>
@@ -12290,8 +12289,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Duke Ellington Interview in Sacristy of Fountain Street Church, Grand Rapids MI following Concert; (Unit II, no. 26), <unitdate type="inclusive">1966 April 17</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7 1/2 ips</physfacet>
                 </physdesc>
               </did>
@@ -12315,8 +12314,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Interview with Marshall Rubinoff conducted by John Sinclair in Detroit; (Unit II, no. 27), <unitdate type="inclusive">1967 November 16</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 3 3/4 ips</physfacet>
                 </physdesc>
               </did>
@@ -12340,8 +12339,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Interview with John Sinclair; WCBN; (Unit II, no. 28), <unitdate type="inclusive" normal="1968">1968</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 3 3/4 ips</physfacet>
                 </physdesc>
               </did>
@@ -12365,8 +12364,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>John Sinclair interview with John Askins of Detroit Free Press, Marquette Prison; (Unit II, No. 29), <unitdate type="inclusive">1969 November</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 5 inch, 1 7/8 ips</physfacet>
                 </physdesc>
               </did>
@@ -12438,8 +12437,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Speech made by Robert Williams at Black Panther benefit, undated, and interview in jail with Black Panther member, Bobby Seale; (Unit II, no. 30), <unitdate type="inclusive">1969 December 07</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7 1/2 ips, double track</physfacet>
                 </physdesc>
               </did>
@@ -12463,8 +12462,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>WXYZ-FM show, "Spare Change"; (Unit II, no. 31-32), <unitdate type="inclusive">1969 December 31</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 3 3/4 ips</physfacet>
                 </physdesc>
               </did>
@@ -12504,8 +12503,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>WXYZ-FM show, "Spare Change," with Peter Werbe, Ken Kelley, and Leni Sinclair; (Unit II, no. 33), <unitdate type="inclusive">1970 June 07</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 3 3/4 ips</physfacet>
                 </physdesc>
               </did>
@@ -12529,8 +12528,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Hank Malone show with John and Leni Sinclair; (Unit II, no. 34) , <unitdate type="inclusive">1971 December 20</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 1 7/8 ips</physfacet>
                 </physdesc>
               </did>
@@ -12554,8 +12553,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Hank Malone show with John and Leni Sinclair; (Unit II, no. 35), <unitdate type="inclusive">1971 December 20</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 3 3/4 ips</physfacet>
                 </physdesc>
               </did>
@@ -12595,8 +12594,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Discussion concerning John Sinclair while he was in prison; (Unit II, no. 36), <unitdate type="inclusive" normal="1971">1971</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7 1/2 ips</physfacet>
                 </physdesc>
               </did>
@@ -12620,8 +12619,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Stew Cox interviews with Archie Shepp on WDET; (Unit II, no. 37), <unitdate type="inclusive" normal="1971">1971</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 3 3/4 ips</physfacet>
                 </physdesc>
               </did>
@@ -12645,8 +12644,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Outtakes from John Sinclair radio special; (Unit II, no. 38), <unitdate type="inclusive" normal="1971">1971</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7 1/2 ips</physfacet>
                 </physdesc>
               </did>
@@ -12670,8 +12669,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Interview with Dave and Leni Sinclair and Gary Grimshaw by Jesse Crawford; (Unit II, no. 39), <unitdate type="inclusive">[Undated, circa 1972]</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7 1/2 ips</physfacet>
                 </physdesc>
               </did>
@@ -12695,8 +12694,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Mike Brenner show on WRIF-FM with John Sinclair; (Unit II, no. 40), <unitdate type="inclusive">1972 January 24</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 3 3/4 ips</physfacet>
                 </physdesc>
               </did>
@@ -12720,8 +12719,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Interview with Dave Sinclair concerning political history of Rainbow People's Party and its predecessors; (Unit II, no. 41), <unitdate type="inclusive">1973 July 14</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7 1/2 ips</physfacet>
                 </physdesc>
               </did>
@@ -12777,8 +12776,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Talk show concerning Tribal Funding, Inc., represented by Frank Bach, Jeanie Plamondon and John Sinclair; (Unit II, no. 42), <unitdate type="inclusive">[Undated]</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7 1/2 ips</physfacet>
                 </physdesc>
               </did>
@@ -12802,8 +12801,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Community Comment talk show with John Sinclair concerning Tribal Funding, Inc.; (Unit II, no. 43), <unitdate type="inclusive">1973 December 03</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7 1/2 ips</physfacet>
                 </physdesc>
               </did>
@@ -12827,8 +12826,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Patricia Hearst interview; (Unit II, no. 44), <unitdate type="inclusive">1974 June 07</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 5 inch, 7 1/2 ips</physfacet>
                 </physdesc>
               </did>
@@ -12868,9 +12867,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Joilette Payne/Mary Rosenthal conversation labeled "The Dick Cavett of Oak Park"; (Unit II, no. 45), <unitdate type="inclusive">1983 January 02</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, reel-to-reel tapes, 7 inch, 7 1/2 ips</physfacet>
                 </physdesc>
               </did>
@@ -12900,8 +12898,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>"Full Tilt Benefit" rock concert music <unitdate>undated</unitdate> (Unit III, no. 46)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips; 7 in.; double track</physfacet>
                 </physdesc>
               </did>
@@ -12910,8 +12908,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>Ann Arbor Community Park Program on WNRZ-FM <unitdate type="inclusive" normal="1972-07/1972-08">July-August 1972</unitdate> (Unit III, nos. 47-49)</unittitle>
-                <physdesc>
-                  <extent>3 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 and 3 and 3 3/4 ips. 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -12920,8 +12918,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>Ann Arbor park concert performance of Radio King Band <unitdate type="inclusive" normal="1973-06-12">June 12, 1973</unitdate> (Unit III, no. 50)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips; 7 in.; double track</physfacet>
                 </physdesc>
               </did>
@@ -12930,8 +12928,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>Deliverance, rock group, performance at the free park concert held at the Otis Spann Memorial Field <unitdate type="inclusive" normal="1973-06-24">June 24, 1973</unitdate> (Unit III, no. 51)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 3-3/4 ips; 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -12940,8 +12938,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>Rock group "Truth" at Ann Arbor park concert <unitdate type="inclusive" normal="1973-06-24">June 24, 1973</unitdate> (Unit III, no. 52)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips; 7 in.; double track</physfacet>
                 </physdesc>
               </did>
@@ -12950,8 +12948,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>Rock group Deliverance at a park concert <unitdate type="inclusive" normal="1973-07-08">July 8, 1973</unitdate> (Unit III, no. 53)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips; 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -12965,8 +12963,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>Recording <unitdate type="inclusive" normal="1972-09">September 1972</unitdate> (Unit IV, nos. 54-57)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips; 7 in.; double track</physfacet>
                 </physdesc>
               </did>
@@ -12975,8 +12973,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>Recording of Art Ensemble of Chicago group <unitdate type="inclusive" normal="1972-09">September 1972</unitdate> (Unit IV, no. 58)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips; 7 in.; double track</physfacet>
                 </physdesc>
               </did>
@@ -12985,8 +12983,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>Female vocalist, Cocoa <unitdate>undated</unitdate> (Unit IV, no. 59)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips; 7 in.; double track</physfacet>
                 </physdesc>
               </did>
@@ -12995,8 +12993,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>Various performances <unitdate>undated</unitdate> (Unit IV, nos. 60-64)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips; 7 in.; double track</physfacet>
                 </physdesc>
               </did>
@@ -13005,8 +13003,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>General announcements followed by performance by Robert Junior Lockwood <unitdate type="inclusive" normal="1974">1974</unitdate> (Unit IV, no. 65)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips; 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13015,8 +13013,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>Recording <unitdate type="inclusive" normal="1974">1974</unitdate> (Unit IV, nos. 66-67)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips; 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13025,8 +13023,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>Performances include negro spirituals, such as "Amazing Grace," <unitdate type="inclusive" normal="1974">1974</unitdate> (Unit IV, no. 68)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips; 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13035,8 +13033,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>Various performances <unitdate>undated</unitdate> (Unit IV, nos. 69-73)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13045,8 +13043,8 @@
               <did>
                 <container type="box" label="Box">32</container>
                 <unittitle>"Ann Arbor Boogie" recordings of various performances <unitdate type="inclusive" normal="1973-09">September 1973</unitdate> (Unit IV, nos. 74-77)</unittitle>
-                <physdesc>
-                  <extent>r audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">r audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13055,8 +13053,8 @@
               <did>
                 <container type="box" label="Box">32</container>
                 <unittitle>"Detroit Blues" various artists' performances <unitdate type="inclusive" normal="1973-09">September 1973</unitdate> (Unit IV, nos. 78-79)</unittitle>
-                <physdesc>
-                  <extent>2 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13065,8 +13063,8 @@
               <did>
                 <container type="box" label="Box">32</container>
                 <unittitle>"Chicago Blues" various artist performances, undated (Unit IV, nos. 80-81)</unittitle>
-                <physdesc>
-                  <extent>2 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13075,8 +13073,8 @@
               <did>
                 <container type="box" label="Box">32</container>
                 <unittitle><unitdate type="inclusive" normal="1972">1972</unitdate> Recordings, various performances Unit IV, nos. 82-85)</unittitle>
-                <physdesc>
-                  <extent>4 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">4 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips. 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13085,8 +13083,8 @@
               <did>
                 <container type="box" label="Box">32</container>
                 <unittitle><unitdate type="inclusive" normal="1973">1973</unitdate> Recordings, various performances (Unit IV, nos. 86-90)</unittitle>
-                <physdesc>
-                  <extent>5 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">5 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips. 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13095,8 +13093,8 @@
               <did>
                 <container type="box" label="Box">32</container>
                 <unittitle>Hound Dog Taylor <unitdate type="inclusive" normal="1973-09">September 1973</unitdate> (Unit IV, nos. 91-92)</unittitle>
-                <physdesc>
-                  <extent>2 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13105,8 +13103,8 @@
               <did>
                 <container type="box" label="Box">32</container>
                 <unittitle>Mighty Joe Young, <unitdate type="inclusive" normal="1973">September 1973</unitdate> (Unit IV, no. 93, 94, 94a)</unittitle>
-                <physdesc>
-                  <extent>3 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13115,8 +13113,8 @@
               <did>
                 <container type="box" label="Box">32</container>
                 <unittitle>Sun Ra <unitdate type="inclusive" normal="1973-09">September 1973</unitdate> (Unit IV, no. 95)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13125,8 +13123,8 @@
               <did>
                 <container type="box" label="Box">32</container>
                 <unittitle>Louis Spahn with Mighty Joe Young <unitdate type="inclusive" normal="1973-09">September 1973</unitdate> (Unit IV, no. 96)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13135,8 +13133,8 @@
               <did>
                 <container type="box" label="Box">32</container>
                 <unittitle>John Sinclair and Jim Dulzo discussing and playing cuts from the 1972 Ann Arbor Blues and Jazz Festival LP <unitdate type="inclusive" normal="1973-05">May 1973</unitdate> (Unit IV, no. 97-98)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 1-2 ips, 7 in</physfacet>
                 </physdesc>
               </did>
@@ -13145,8 +13143,8 @@
               <did>
                 <container type="box" label="Box">32</container>
                 <unittitle>WDET Broadcast? of 1973 Ann Arbor Blues and Jazz Festival, <unitdate type="inclusive" normal="1973">1973</unitdate> (Unit IV, no. 99)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 in</physfacet>
                 </physdesc>
               </did>
@@ -13160,8 +13158,8 @@
               <did>
                 <container type="box" label="Box">32</container>
                 <unittitle>10 for 2 soundtrack (from John Sinclair Freedom Rally, Ann Arbor) <unitdate type="inclusive" normal="1971-12-10">December 10, 1971 (Unit V, nos. 100-101)</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13170,8 +13168,8 @@
               <did>
                 <container type="box" label="Box">32</container>
                 <unittitle>10 for 2 soundtrack <unitdate type="inclusive" normal="1971-12-10">December 10, 1971</unitdate> (Unit V, no. 102)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 10 in.</physfacet>
                 </physdesc>
               </did>
@@ -13183,8 +13181,8 @@
               <did>
                 <container type="box" label="Box">32</container>
                 <unittitle>Free John Now rally, 1971 (Unit V, no 103)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7 1/2 ips</physfacet>
                 </physdesc>
               </did>
@@ -13200,8 +13198,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Poetry performances, and recordings: John Sinclair Selected Reading; (Unit VI, no. 104), <unitdate type="inclusive">1964 November 22</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7 1/2 ips</physfacet>
                 </physdesc>
               </did>
@@ -13241,8 +13239,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Poetry performances, and recordings: John Sinclair, Robin Eidele, George Tysh, Poets and Press Theatre Benefit; (Unit VI, no. 105), <unitdate type="inclusive" normal="1965">1965</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7.5 ips</physfacet>
                 </physdesc>
               </did>
@@ -13282,8 +13280,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Poetry performances, and recordings: John and David Sinclair reading; (Unit VI, no. 106), <unitdate type="inclusive" normal="1966">1966</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 3 3/4 ips</physfacet>
                 </physdesc>
               </did>
@@ -13307,8 +13305,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Poetry performances, and recordings; John Sinclair (Unit VI, no. 107), <unitdate type="inclusive">1969 Spring</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 5 inch, 7.5 ips</physfacet>
                 </physdesc>
               </did>
@@ -13332,8 +13330,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Poetry performances, and recordings: Allen Ginsberg, "Prayer for John Sinclair"; (Unit VI, no. 108-109), <unitdate type="inclusive">1971 November</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 5 inch, 7.5 ips</physfacet>
                 </physdesc>
               </did>
@@ -13373,8 +13371,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Poetry performances, and recordings: John Sinclair, Ed Sanders, Ken Mikolowski reading at University of Detroit; (Unit VI, no. 110), <unitdate type="inclusive" normal="1972">1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7.5 ips</physfacet>
                 </physdesc>
               </did>
@@ -13398,8 +13396,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Poetry performances, and recordings: John Sinclair, Jerry Younkins reading at the University of Michigan; (Unit VI, no. 111), <unitdate type="inclusive" normal="1972">1972</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7.5 ips</physfacet>
                 </physdesc>
               </did>
@@ -13423,8 +13421,8 @@
             <c04 level="otherlevel" otherlevel="item-main">
               <did>
                 <unittitle>Poetry performances, and recordings: John Sinclair and his Blues Scholars, at Alvin's; (Unit VI, no. 112-113), <unitdate type="inclusive" normal="1985">1985</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7.5 ips</physfacet>
                 </physdesc>
               </did>
@@ -13473,8 +13471,8 @@
               <did>
                 <container type="box" label="Box">71</container>
                 <unittitle>John Badanjek "Coleman Young" and other songs (Unit VII, no. 114)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 inch, 7.5 ips</physfacet>
                 </physdesc>
               </did>
@@ -13483,8 +13481,8 @@
               <did>
                 <container type="box" label="Box">71</container>
                 <unittitle>Music by Sidney James Blair and Vision <unitdate>undated</unitdate> (Unit VII, no. 115)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips; 7 in.; double track</physfacet>
                 </physdesc>
               </did>
@@ -13493,8 +13491,8 @@
               <did>
                 <container type="box" label="Box">71</container>
                 <unittitle>Buddies in the Saddle, at Pretzel Bell, Ann Arbor <unitdate type="inclusive" normal="1972-08-29">August 29, 1972</unitdate> (Unit VII, no. 116)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 3 3/4 ips. 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13503,8 +13501,8 @@
               <did>
                 <container type="box" label="Box">71</container>
                 <unittitle>Carnal Kitchen at "Trust Busters Ball" Ann Arbor <unitdate type="inclusive" normal="1972/1973" certainty="approximate">circa 1972-1973</unitdate> (Unit VII, no. 117)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 3 3/4 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13513,8 +13511,8 @@
               <did>
                 <container type="box" label="Box">71</container>
                 <unittitle>Ornette Coleman jazz music and PCC (People's Communication Committee) news dubs <unitdate>undated</unitdate> (Unit VII, no. 118)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips; 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13523,8 +13521,8 @@
               <did>
                 <container type="box" label="Box">71</container>
                 <unittitle>Deluxe, 5 songs <unitdate type="inclusive" normal="1974-11-01">November 1, 1974</unitdate> (Unit VII, no. 119)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips, 7in.</physfacet>
                 </physdesc>
               </did>
@@ -13533,8 +13531,8 @@
               <did>
                 <container type="box" label="Box">71</container>
                 <unittitle>Detroit, live and studio recordings (Unit VII, no. 120-124)</unittitle>
-                <physdesc>
-                  <extent>5 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">5 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 and 3 3/4 ips., 7 in</physfacet>
                 </physdesc>
               </did>
@@ -13543,8 +13541,8 @@
               <did>
                 <container type="box" label="Box">71</container>
                 <unittitle>Electric Express, sickle cell anemia benefit, Flint <unitdate type="inclusive" normal="1973-08-31">August 31, 1973</unitdate> (Unit VII, no. 125)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13553,8 +13551,8 @@
               <did>
                 <container type="box" label="Box">71</container>
                 <unittitle>Flying Tigers, demos <unitdate type="inclusive" normal="1983">1983</unitdate> (Unit VII, no. 126)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13563,8 +13561,8 @@
               <did>
                 <container type="box" label="Box">71</container>
                 <unittitle>Guardian Angel live and studio recordings, <unitdate type="bulk" normal="1972">1972</unitdate> (Unit VII, no. 127)</unittitle>
-                <physdesc>
-                  <extent>5 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">5 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13573,8 +13571,8 @@
               <did>
                 <container type="box" label="Box">71</container>
                 <unittitle>Infinite Sound (demo tape) <unitdate type="inclusive" normal="1973">1973</unitdate> (Unit VII, no. 128)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13583,8 +13581,8 @@
               <did>
                 <container type="box" label="Box">71</container>
                 <unittitle>Lightnin, various live demo recordings and live performances <unitdate type="inclusive" normal="1972/1974">1972-1974</unitdate> (Unit VII, nos. 129-133)</unittitle>
-                <physdesc>
-                  <extent>4 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">4 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13593,8 +13591,8 @@
               <did>
                 <container type="box" label="Box">71</container>
                 <unittitle>Lightnin, various live demo recordings and live performances <unitdate type="inclusive" normal="1972/1974">1972-1974</unitdate></unittitle>
-                <physdesc>
-                  <extent>4 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">4 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13603,8 +13601,8 @@
               <did>
                 <container type="box" label="Box">71</container>
                 <unittitle>Juanita McCray and her Motor City Beat, St. Andrews Hall. <unitdate type="inclusive" normal="1983-08">August 1983</unitdate> (Unit VII, no. 134)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13613,8 +13611,8 @@
               <did>
                 <container type="box" label="Box">71</container>
                 <unittitle>Scott Morgan "Soul Mover" and "Take a Look" (Unit VII, no. 135)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13627,8 +13625,8 @@
                 <did>
                   <container type="box" label="Box">71</container>
                   <unittitle>MC 5 live at the Grande Ballroom <unitdate type="inclusive" normal="1968-05-26">May 26, 1968</unitdate> (Unit VII, no. 136)</unittitle>
-                  <physdesc>
-                    <extent>1 audiotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                     <physfacet>reel-to-reel tapes, 15 ips, 7 in.</physfacet>
                   </physdesc>
                 </did>
@@ -13637,8 +13635,8 @@
                 <did>
                   <container type="box" label="Box">71</container>
                   <unittitle>MC 5 live at the Union Ballroom <unitdate type="inclusive" normal="1968-09-23">September 23, 1968</unitdate> (Unit VII, no. 137)</unittitle>
-                  <physdesc>
-                    <extent>1 audiotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                     <physfacet>reel-to-reel tapes, 7-1/2 ips, 7 in.</physfacet>
                   </physdesc>
                 </did>
@@ -13647,8 +13645,8 @@
                 <did>
                   <container type="box" label="Box">71</container>
                   <unittitle>MC 5 live a the Grande Ballroom <unitdate type="inclusive" normal="1968-10-10">October 10, 1968</unitdate> (Unit VII, no. 138)</unittitle>
-                  <physdesc>
-                    <extent>1 audiotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                     <physfacet>reel-to-reel tapes, 7-1/2 ips. 7in.</physfacet>
                   </physdesc>
                 </did>
@@ -13657,8 +13655,8 @@
                 <did>
                   <container type="box" label="Box">71</container>
                   <unittitle>MC 5 and the Rationals live at the Grande Ballroom <unitdate type="inclusive" normal="1968-10-27">October 27, 1968</unitdate> (Unit VII, no. 139)</unittitle>
-                  <physdesc>
-                    <extent>1 audiotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                     <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in.</physfacet>
                   </physdesc>
                 </did>
@@ -13667,8 +13665,8 @@
                 <did>
                   <container type="box" label="Box">71</container>
                   <unittitle>MC 5 Back in the USA sessions <unitdate type="inclusive" normal="1969-07/1969-08">July-August, 1969</unitdate> (Unit VII, no. 140-142)</unittitle>
-                  <physdesc>
-                    <extent>3 audiotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">3 audiotapes</extent>
                     <physfacet>reel-to-reel tapes, 7-1/2 ips. 7 in.</physfacet>
                   </physdesc>
                 </did>
@@ -13677,8 +13675,8 @@
                 <did>
                   <container type="box" label="Box">71</container>
                   <unittitle>MC 5 jam session, labeled "probably November 8, 9 1970" (Unit VII, no. 143)</unittitle>
-                  <physdesc>
-                    <extent>1 audiotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                     <physfacet>reel-to-reel tapes, 7-1/2 ips, 7 in.</physfacet>
                   </physdesc>
                 </did>
@@ -13687,8 +13685,8 @@
                 <did>
                   <container type="box" label="Box">72</container>
                   <unittitle>MC 5 jam at Headsound Studios, Ypsilanti <unitdate type="inclusive" normal="1970-11-08">November 8, 1970</unitdate> Unit VII, nos. 144-145</unittitle>
-                  <physdesc>
-                    <extent>2 audiotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
                     <physfacet>reel-to-reel tapes, 7 1/2 ips, 7 in.</physfacet>
                   </physdesc>
                 </did>
@@ -13698,8 +13696,8 @@
               <did>
                 <container type="box" label="Box">72</container>
                 <unittitle>Mojo Boogie Band "Get Away" and "Go Home with You," <unitdate type="inclusive" normal="1974-11-04">November 4, 1974</unitdate> (Unit VII, no. 146)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips. 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13708,8 +13706,8 @@
               <did>
                 <container type="box" label="Box">72</container>
                 <unittitle>Mutants, various songs <unitdate type="inclusive" normal="1974-08">August 1974</unitdate> (Unit VII, no. 147)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13718,8 +13716,8 @@
               <did>
                 <container type="box" label="Box">72</container>
                 <unittitle>Jazz music, "Omnibus" <unitdate type="inclusive" normal="1972-12">December 1972</unitdate> (Unit VII, no. 148)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips; 7 in.; double track</physfacet>
                 </physdesc>
               </did>
@@ -13728,8 +13726,8 @@
               <did>
                 <container type="box" label="Box">72</container>
                 <unittitle>Radio King and His Court of Rhythm, various live, demo, and studio recordings <unitdate type="bulk" normal="1972/1975">1972-1975</unitdate> (Unit VII, no. 148-155)</unittitle>
-                <physdesc>
-                  <extent>8 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">8 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13738,8 +13736,8 @@
               <did>
                 <container type="box" label="Box">72</container>
                 <unittitle>Ramble Crowe, live WNRZ Sunday People's Concert <unitdate type="inclusive">undated</unitdate> (Unit VII, no. 156)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13748,8 +13746,8 @@
               <did>
                 <container type="box" label="Box">72</container>
                 <unittitle>Rationals live at the Grande Ballroom <unitdate type="inclusive" normal="1968-10-27" certainty="approximate">circa October 27, 1968</unitdate> (Unit VII, no. 157)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13758,8 +13756,8 @@
               <did>
                 <container type="box" label="Box">72</container>
                 <unittitle>Spikedrivers, various songs, <unitdate type="inclusive" normal="1967">summer 1967</unitdate> (Unit VII, no. 158)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in</physfacet>
                 </physdesc>
               </did>
@@ -13768,8 +13766,8 @@
               <did>
                 <container type="box" label="Box">72</container>
                 <unittitle>Tate Blues Band, live at Otis Spawn Memorial Park, Ann Arbor <unitdate type="inclusive" normal="1973-06-24">June 24, 1973</unitdate> (Unit VII, no. 159)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13778,8 +13776,8 @@
               <did>
                 <container type="box" label="Box">72</container>
                 <unittitle>Terraplane, various songs <unitdate type="inclusive" normal="1973-06-21">June 21, 1973</unitdate> (Unit VII, no. 160)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13788,8 +13786,8 @@
               <did>
                 <container type="box" label="Box">72</container>
                 <unittitle>Unicorn News, sound collage of Democratic National Convention <unitdate type="inclusive" normal="1972">1972</unitdate> (Unit VII, no. 161)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 3-3/4 ips; 7 in.; double track</physfacet>
                 </physdesc>
               </did>
@@ -13798,8 +13796,8 @@
               <did>
                 <container type="box" label="Box">72</container>
                 <unittitle>The Up, various live, demo and studio recordings, <unitdate type="bulk" normal="1969/1972">1969-1972</unitdate> (Unit VII, nos. 162-180)</unittitle>
-                <physdesc>
-                  <extent>19 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">19 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13808,8 +13806,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>The Urbations, various live, demo and studio recordings, <unitdate type="bulk" normal="1982/1984">1982-1984</unitdate> (Unit VII, no. 181-188)</unittitle>
-                <physdesc>
-                  <extent>8 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">8 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, primarily 7 /12 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13823,8 +13821,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>WABX, "History of the Detroit Underground," radio show <unitdate type="inclusive" normal="1971/1972">1971-1972</unitdate> (Unit VIII, no. 189)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13833,8 +13831,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>WBCN, Ann Arbor, "Sister's Radio Show #1," <unitdate type="inclusive" normal="1972">1972</unitdate> (Unit VIII, no. 190)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13843,8 +13841,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>WDET, Detroit, "Intro to Dizzy (Gillespie) concert," <unitdate type="inclusive" normal="1978">1978</unitdate> (Unit VIII, no. 191)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13853,8 +13851,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>WEMU, Ypsilanti, John Sinclair and Michael G. Nastos <unitdate type="inclusive" normal="1981">1981</unitdate> (Unit VIII, no. 192)</unittitle>
-                <physdesc>
-                  <extent>3 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13863,8 +13861,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>WGPR, Detroit, "Electrifying Mojo," <unitdate type="inclusive" normal="1981-11-26">November 26, 1981</unitdate> (Unit VIII, no. 194)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips, 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13873,8 +13871,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>WGPR, Detroit, "Electrifying Mojo," <unitdate type="inclusive" normal="1982">Spring 1982</unitdate> and Duke-A-Paduka on WWOZ, Orleans, <unitdate type="inclusive" normal="1982-05">May 1982</unitdate> (Unit VIII, no. 195)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips. 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13883,8 +13881,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>WJLB, Rev. Pennington on WJLB <unitdate type="inclusive" normal="1977-12-24">December 24, 1977</unitdate> (Unit VIII, no. 196)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips. 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13893,8 +13891,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>WNRZ, Mock radio show proposal, October 31, 1970. (Unit VIII, no. 197)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13903,8 +13901,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>WNRZ, Dr. John Interview <unitdate type="inclusive" normal="1972-12-12">December 12, 1972</unitdate> (Unit VIII, no. 198)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in</physfacet>
                 </physdesc>
               </did>
@@ -13913,8 +13911,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>WNRZ, "Toke Time with John Sinclair," <unitdate type="inclusive" normal="1973-03-26">March 26, 1973</unitdate> (Unit VIII, no. 199)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13923,8 +13921,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>"Weird Radio Air Checks and Debris," assembled <unitdate type="inclusive" normal="1981">1981</unitdate> (Unit VIII, no. 200)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 7 in.</physfacet>
                 </physdesc>
               </did>
@@ -13933,8 +13931,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>Bob Rudnick Radio Spots, approximately <unitdate type="inclusive" normal="1969/1970">1969-1970</unitdate> (Unit VIII, no. 201)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 15 ips., 7 in</physfacet>
                 </physdesc>
               </did>
@@ -13943,8 +13941,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>Lightnin' spot for "WNRZ Marathon," approximately <unitdate type="inclusive" normal="1970/1972">1970-1972 (Unit VIII, no. 202)</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7 in</physfacet>
                 </physdesc>
               </did>
@@ -13953,8 +13951,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>People's Communication Committee "Takin Over" spot. (Unit VIII, no. 203)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 5 in.</physfacet>
                 </physdesc>
               </did>
@@ -13963,8 +13961,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>WBCN spots (Music of Detroit, Various concerts) <unitdate type="inclusive" normal="1979-08-04">August 4, 1979</unitdate> (Unit VIII, no. 204)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 5 in.</physfacet>
                 </physdesc>
               </did>
@@ -13973,8 +13971,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>Miscellaneous spots <unitdate type="inclusive" normal="1972/1973">1972-1973</unitdate> (Unit VIII, no. 205)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips. 5 in.</physfacet>
                 </physdesc>
               </did>
@@ -13986,8 +13984,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>UMSOM spots for Concert <unitdate type="inclusive" normal="1979-12-07">December 7, 1979</unitdate> (Unit VIII, no. 206)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips. 5 in.</physfacet>
                 </physdesc>
               </did>
@@ -13996,8 +13994,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>Promo Spots (Music of Detroit and Jazz Development Workshop, Allied Artists Concert) <unitdate type="inclusive" normal="1979-08-04">August 4, 1979</unitdate> (Unit VIII, no. 207)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips., 5 in.</physfacet>
                 </physdesc>
               </did>
@@ -14006,8 +14004,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>Sample commercial spots produced by Rainbow Productions for promotional purposes and P.C.C. Michigan Boogie <unitdate type="inclusive" normal="1972/1973">1972-1973</unitdate> (Unit VIII, no. 208)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips; 7 in.; double track</physfacet>
                 </physdesc>
               </did>
@@ -14016,8 +14014,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>Two commercial spots selling the <unitdate type="inclusive" normal="1972">1972</unitdate> Ann Arbor Blues and Jazz Festival festival album, <unitdate type="inclusive" normal="1973">1973</unitdate> (Unit VIII, no. 209)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips; 4 in.; double track</physfacet>
                 </physdesc>
               </did>
@@ -14026,8 +14024,8 @@
               <did>
                 <container type="box" label="Box">73</container>
                 <unittitle>WNRZ commercial spot advertising "Part III. The Music of John Coltrane," with John Sinclair and Dexter Q; and P.C.C. newscasts and election endorsements <unitdate type="inclusive" normal="1973-02">February 1973</unitdate> (Unit VIII, no. 210)</unittitle>
-                <physdesc>
-                  <extent>1 audiotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                   <physfacet>reel-to-reel tapes, 7-1/2 ips; 7 in.; double track</physfacet>
                 </physdesc>
               </did>
@@ -14037,8 +14035,8 @@
         <c02 level="series">
           <did>
             <unittitle>Compact discs</unittitle>
-            <physdesc>
-              <extent>26 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">26 optical disks</extent>
               <physfacet>CDs</physfacet>
             </physdesc>
           </did>
@@ -14149,8 +14147,8 @@
               <did>
                 <container type="box" label="Box">73-B</container>
                 <unittitle>Various artists</unittitle>
-                <physdesc>
-                  <extent>9 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">9 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -14168,8 +14166,8 @@
             <did>
               <container type="box" label="Box">73-B</container>
               <unittitle>Ann Arbor Blues and Jazz Festival <unitdate type="inclusive" normal="1974">1974</unitdate></unittitle>
-              <physdesc>
-                <extent>3 digital audio tapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 digital audio tapes</extent>
               </physdesc>
             </did>
           </c03>
@@ -15429,8 +15427,8 @@
                   <did>
                     <container type="box" label="Box">40</container>
                     <unittitle>Madeline Fletcher</unittitle>
-                    <physdesc>
-                      <extent>2 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 sheets</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -15486,8 +15484,8 @@
                   <did>
                     <container type="box" label="Box">40</container>
                     <unittitle>Nancy Wilson</unittitle>
-                    <physdesc>
-                      <extent>3 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">3 sheets</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -15496,8 +15494,8 @@
                 <did>
                   <container type="box" label="Box">40</container>
                   <unittitle>Miscellaneous contact prints and negatives; unidentified</unittitle>
-                  <physdesc>
-                    <extent>3 sheets</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">3 sheets</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -15681,8 +15679,8 @@
                   <did>
                     <container type="box" label="Box">40</container>
                     <unittitle>Detroit <unitdate type="inclusive" normal="1973-08">8/73</unitdate></unittitle>
-                    <physdesc>
-                      <extent>3 sheets and ca. 15 negatives</extent>
+                    <physdesc altrender="part">
+                      <extent altrender="materialtype spaceoccupied">3 sheets</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -15749,8 +15747,8 @@
                   <did>
                     <container type="box" label="Box">40</container>
                     <unittitle>WDET</unittitle>
-                    <physdesc>
-                      <extent>2 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 sheets</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -16768,8 +16766,8 @@
                 <did>
                   <container type="box" label="Box">41</container>
                   <unittitle>"M" subsubseries of contact sheets</unittitle>
-                  <physdesc>
-                    <extent>19 envelopes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">19 envelopes</extent>
                   </physdesc>
                 </did>
               </c05>
@@ -16828,8 +16826,8 @@
                   <did>
                     <container type="box" label="Box">42</container>
                     <unittitle>Auto plant, unidentified</unittitle>
-                    <physdesc>
-                      <extent>4 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">4 sheets</extent>
                       <physfacet>prints only</physfacet>
                     </physdesc>
                   </did>
@@ -16861,8 +16859,8 @@
                   <did>
                     <container type="box" label="Box">42</container>
                     <unittitle>Police, G.G. 1st precinct <unitdate type="inclusive" normal="1976-09-05">09/05/1976</unitdate></unittitle>
-                    <physdesc>
-                      <extent>2 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 sheets</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -16870,8 +16868,8 @@
                   <did>
                     <container type="box" label="Box">42</container>
                     <unittitle>Police, G.G. 5th precinct <unitdate type="inclusive" normal="1976-09">9/76</unitdate></unittitle>
-                    <physdesc>
-                      <extent>2 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 sheets</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -16885,8 +16883,8 @@
                   <did>
                     <container type="box" label="Box">42</container>
                     <unittitle>Kettering High School <unitdate type="inclusive" normal="1976-09-09">09/09/1976</unitdate></unittitle>
-                    <physdesc>
-                      <extent>2 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 sheets</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -16935,8 +16933,8 @@
                   <did>
                     <container type="box" label="Box">42</container>
                     <unittitle>Teddy Pendergrass <unitdate type="inclusive" normal="1976-04">4/76</unitdate></unittitle>
-                    <physdesc>
-                      <extent>2 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 sheets</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -16956,8 +16954,8 @@
                   <did>
                     <container type="box" label="Box">42</container>
                     <unittitle>Detroit Tigers opening game <unitdate type="inclusive" normal="1976-04-14">04/14/1976</unitdate></unittitle>
-                    <physdesc>
-                      <extent>3 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">3 sheets</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -16971,8 +16969,8 @@
                   <did>
                     <container type="box" label="Box">42</container>
                     <unittitle>Rod Rodgers Dance Company <unitdate type="inclusive" normal="1976-04-29">04/29/1976</unitdate></unittitle>
-                    <physdesc>
-                      <extent>2 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 sheets</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -17051,8 +17049,8 @@
                   <did>
                     <container type="box" label="Box">42</container>
                     <unittitle>Four Tops, Roostertail</unittitle>
-                    <physdesc>
-                      <extent>3 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">3 sheets</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -17083,8 +17081,8 @@
                   <did>
                     <container type="box" label="Box">42</container>
                     <unittitle>Kenny Burrell <unitdate type="inclusive" normal="1976-07">7/76</unitdate></unittitle>
-                    <physdesc>
-                      <extent>3 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">3 sheets</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -17104,8 +17102,8 @@
                   <did>
                     <container type="box" label="Box">42</container>
                     <unittitle>Basketball game Sun/WJZZ <unitdate>undated</unitdate></unittitle>
-                    <physdesc>
-                      <extent>3 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">3 sheets</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -17125,8 +17123,8 @@
                   <did>
                     <container type="box" label="Box">42</container>
                     <unittitle>Open house <unitdate type="inclusive">undated</unitdate></unittitle>
-                    <physdesc>
-                      <extent>2 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 sheets</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -17145,8 +17143,8 @@
                   <did>
                     <container type="box" label="Box">42</container>
                     <unittitle>Unidentified</unittitle>
-                    <physdesc>
-                      <extent>2 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 sheets</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -17159,8 +17157,8 @@
                   <did>
                     <container type="box" label="Box">42</container>
                     <unittitle>Rock concerts, including Edgar Winter and Average White Band <unitdate type="inclusive">undated</unitdate></unittitle>
-                    <physdesc>
-                      <extent>7 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">7 sheets</extent>
                       <physfacet>prints only</physfacet>
                     </physdesc>
                   </did>
@@ -17180,8 +17178,8 @@
                   <did>
                     <container type="box" label="Box">42</container>
                     <unittitle>Craters <unitdate type="inclusive" normal="1972-07-04">07/04/1972</unitdate></unittitle>
-                    <physdesc>
-                      <extent>2 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 sheets</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -17189,8 +17187,8 @@
                   <did>
                     <container type="box" label="Box">42</container>
                     <unittitle>Free concert, 8th Day <unitdate type="inclusive" normal="1972-07-09">07/09/1972</unitdate></unittitle>
-                    <physdesc>
-                      <extent>3 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">3 sheets</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -17529,8 +17527,8 @@
                   <did>
                     <container type="box" label="Box">42</container>
                     <unittitle>Highland Park <unitdate type="inclusive" normal="1976-08">8/76</unitdate></unittitle>
-                    <physdesc>
-                      <extent>2 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 sheets</extent>
                     </physdesc>
                   </did>
                 </c06>
@@ -17549,8 +17547,8 @@
                   <did>
                     <container type="box" label="Box">42</container>
                     <unittitle>Unidentified</unittitle>
-                    <physdesc>
-                      <extent>2 sheets</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">2 sheets</extent>
                       <physfacet>print only</physfacet>
                     </physdesc>
                   </did>
@@ -18033,8 +18031,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18057,8 +18055,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18081,8 +18079,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18105,8 +18103,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18129,8 +18127,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18153,8 +18151,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18177,8 +18175,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18201,8 +18199,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18225,8 +18223,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18249,8 +18247,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18273,8 +18271,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18297,8 +18295,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18321,8 +18319,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18345,8 +18343,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18369,8 +18367,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18393,8 +18391,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18417,8 +18415,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18441,8 +18439,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18465,8 +18463,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18489,8 +18487,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18513,8 +18511,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18537,8 +18535,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18561,8 +18559,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18585,8 +18583,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18614,8 +18612,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18638,8 +18636,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18662,8 +18660,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18686,8 +18684,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18710,8 +18708,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18734,8 +18732,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18758,8 +18756,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18782,8 +18780,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>
@@ -18806,8 +18804,8 @@
                 <did>
                   <container type="box" label="DVD Box">9</container>
                   <unittitle>Use Copy:</unittitle>
-                  <physdesc>
-                    <extent>1 optical disks</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                     <physfacet>DVDs</physfacet>
                   </physdesc>
                 </did>

--- a/Real_Masters_all/singerjd.xml
+++ b/Real_Masters_all/singerjd.xml
@@ -2378,8 +2378,8 @@
           <c03 level="file">
             <did>
               <unittitle>PS 160 Lectures</unittitle>
-              <physdesc>
-                <extent>5 audiotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">5 audiotapes</extent>
                 <physfacet>reel-to-reel tapes; 3 3/4 ips</physfacet>
               </physdesc>
             </did>
@@ -2430,8 +2430,8 @@
             <did>
               <container type="box" label="Box">21</container>
               <unittitle>Lecture on world politics <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>1 audiotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel tapes</physfacet>
               </physdesc>
             </did>
@@ -2440,8 +2440,8 @@
             <did>
               <container type="box" label="Box">21</container>
               <unittitle>Lecture on global terrorism at the University of Michigan International Center <unitdate type="inclusive" normal="1972-10-10">October 10, 1972</unitdate> and untitled lecture at Temple University, <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>1 audiotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel tapes</physfacet>
               </physdesc>
             </did>
@@ -2450,8 +2450,8 @@
             <did>
               <container type="box" label="Box">21</container>
               <unittitle>Untitled and unidentified</unittitle>
-              <physdesc>
-                <extent>5 audiotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">5 audiotapes</extent>
                 <physfacet>reel-to-reel tapes</physfacet>
               </physdesc>
             </did>
@@ -2465,8 +2465,8 @@
             <did>
               <container type="box" label="Box">21</container>
               <unittitle>COW seminar, the University of Michigan, 2006</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-RWs</physfacet>
               </physdesc>
             </did>
@@ -2475,8 +2475,8 @@
             <did>
               <container type="box" label="Box">21</container>
               <unittitle>Honorary Degree presentation at the SUNY Commencement, 2007</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-Rs</physfacet>
               </physdesc>
             </did>
@@ -2485,8 +2485,8 @@
             <did>
               <container type="box" label="Box">21</container>
               <unittitle>Video conference with students, undated</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVD-ROMs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/sipubs.xml
+++ b/Real_Masters_all/sipubs.xml
@@ -199,8 +199,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle>Connecting People, Information &amp; Technology in More Valuable Ways <unitdate type="inclusive" normal="2005" certainty="approximate">circa 2005</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-ROMs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/sleepbdnl.xml
+++ b/Real_Masters_all/sleepbdnl.xml
@@ -61,10 +61,9 @@ Late 1960s-2015
 1990s
 </unitdate>
 </unittitle>
-      <physdesc>
-        <extent encodinganalog="300">
-2.25 linear feet (in 3 boxes) and 1 oversize folder
-</extent>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">2.25 linear feet</extent>
+        <extent altrender="carrier">(in 3 boxes)</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2016007 Bz 2
@@ -163,8 +162,8 @@ The collection is arranged into three series: Resident Files, Legal Files, and M
           <did>
             <container type="box" label="Box">1		</container>
             <unittitle>Correspondence, <unitdate type="inclusive">1993-1997</unitdate> </unittitle>
-            <physdesc>
-              <extent>11 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">11 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -172,8 +171,8 @@ The collection is arranged into three series: Resident Files, Legal Files, and M
           <did>
             <container type="box" label="Box">1		</container>
             <unittitle>Individual resident files, <unitdate type="inclusive">1994-1995</unitdate> </unittitle>
-            <physdesc>
-              <extent>100 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">100 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -181,8 +180,8 @@ The collection is arranged into three series: Resident Files, Legal Files, and M
           <did>
             <container type="box" label="Box">2	</container>
             <unittitle>Financial information,1997-1998 </unittitle>
-            <physdesc>
-              <extent>6 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">6 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -190,8 +189,8 @@ The collection is arranged into three series: Resident Files, Legal Files, and M
           <did>
             <container type="box" label="Box">2	</container>
             <unittitle>Membership information, <unitdate type="inclusive">1983-1999</unitdate> </unittitle>
-            <physdesc>
-              <extent>18 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">18 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -199,8 +198,8 @@ The collection is arranged into three series: Resident Files, Legal Files, and M
           <did>
             <container type="box" label="Box">2	</container>
             <unittitle>Photographs of properties, <unitdate type="inclusive">1996-2000</unitdate> </unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -208,8 +207,8 @@ The collection is arranged into three series: Resident Files, Legal Files, and M
           <did>
             <container type="box" label="Box">2	</container>
             <unittitle>Related cases, <unitdate type="inclusive">1971-1999</unitdate> </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -217,8 +216,8 @@ The collection is arranged into three series: Resident Files, Legal Files, and M
           <did>
             <container type="box" label="Box">2	</container>
             <unittitle>SBDNL administration files, <unitdate type="inclusive">1995-1997</unitdate> </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -252,8 +251,8 @@ The collection is arranged into three series: Resident Files, Legal Files, and M
           <did>
             <container type="box" label="Box">3		</container>
             <unittitle>Research, <unitdate type="inclusive">1997-1999</unitdate> </unittitle>
-            <physdesc>
-              <extent>9 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">9 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -275,8 +274,8 @@ The collection is arranged into three series: Resident Files, Legal Files, and M
           <did>
             <container type="box" label="Box">3		</container>
             <unittitle>Clippings, <unitdate type="inclusive">1994-1999</unitdate> </unittitle>
-            <physdesc>
-              <extent>6 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">6 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -284,8 +283,8 @@ The collection is arranged into three series: Resident Files, Legal Files, and M
           <did>
             <container type="box" label="Box">3		</container>
             <unittitle>Other media <unitdate type="inclusive">1995-1999</unitdate> </unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/sleepbdnl.xml
+++ b/Real_Masters_all/sleepbdnl.xml
@@ -1,55 +1,57 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE ead PUBLIC "+//ISBN 1-931666-00-8//DTD ead.dtd (Encoded Archival Description (EAD) Version 2002)//EN" "ead.dtd">
 <ead>
-
-<eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
-
-<eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::sleepbdnl.xml//EN" encodinganalog="Identifier">
+  <eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
+    <eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::sleepbdnl.xml//EN" encodinganalog="Identifier">
 umich-bhl-2016007</eadid>
-
-<filedesc><titlestmt><titleproper encodinganalog="Title">Finding Aid for 
+    <filedesc>
+      <titlestmt>
+        <titleproper encodinganalog="Title">Finding Aid for 
 Sleeping Bear Dunes National Lakeshore Extended Occupancy Rights Group
 
 </titleproper>
-<author encodinganalog="Creator">Collection processed and finding aid created by 
-Benjamin Bond </author></titlestmt>
-
-<publicationstmt><publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
-<date encodinganalog="Date" normal="2016">
-2016</date></publicationstmt></filedesc>
-
-<profiledesc>
-<creation>Encoded finding aid created by 
+        <author encodinganalog="Creator">Collection processed and finding aid created by 
+Benjamin Bond </author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
+        <date encodinganalog="Date" normal="2016">
+2016</date>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>Encoded finding aid created by 
 Olga Virakhovskaya 
 <date>2016</date></creation>
-
-<langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage><descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules></profiledesc>
-
-<revisiondesc><change><date>2016-01-22</date><item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item></change></revisiondesc></eadheader>
-
-<frontmatter><titlepage>
-
-<publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
-
-<titleproper>Finding aid for<lb/>
+      <langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage>
+      <descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules>
+    </profiledesc>
+    <revisiondesc>
+      <change>
+        <date>2016-01-22</date>
+        <item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item>
+      </change>
+    </revisiondesc>
+  </eadheader>
+  <frontmatter>
+    <titlepage>
+      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <titleproper>Finding aid for<lb/>
 Sleeping Bear Dunes National Lakeshore <lb/>Extended Occupancy Rights Group records
 </titleproper>
-
-<author>Finding aid created by<lb/> 
+      <author>Finding aid created by<lb/> 
 Benjamin Bond, in January, 2016
 </author>
-
-</titlepage>
-</frontmatter>
-
-<archdesc level="recordgrp" audience="external" type="inventory" relatedencoding="MARC21"><did>
-
-<origination>
-<corpname source="lcnaf" encodinganalog="110">
+    </titlepage>
+  </frontmatter>
+  <archdesc level="recordgrp" audience="external" type="inventory" relatedencoding="MARC21">
+    <did>
+      <origination>
+        <corpname source="lcnaf" encodinganalog="110">
 Sleeping Bear Dunes National Lakeshore Extended Occupancy Rights Group
-</corpname></origination>
-
-<unittitle encodinganalog="245">
+</corpname>
+      </origination>
+      <unittitle encodinganalog="245">
 Sleeping Bear Dunes National Lakeshore Extended Occupancy Rights Group records
 <unitdate type="inclusive" encodinganalog="245$f">
 Late 1960s-2015
@@ -59,138 +61,241 @@ Late 1960s-2015
 1990s
 </unitdate>
 </unittitle>
-
-<physdesc><extent encodinganalog="300">
+      <physdesc>
+        <extent encodinganalog="300">
 2.25 linear feet (in 3 boxes) and 1 oversize folder
-</extent></physdesc>
-
-<unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
+</extent>
+      </physdesc>
+      <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2016007 Bz 2
 </unitid>
-
-<langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
-
-<abstract>
+      <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
+      <abstract>
 The Sleeping Bear Dunes National Lakeshore Extended Occupancy Rights Group (SBDNL) records collected by Paul and JoAnne Wheaton. SBDNL was a group of residents of Sleeping Bear Dunes National Lakeshore who were interested in seeking to extend or modify their lease arrangements with the National Park Service. The collection consists of documents pertaining to information about the residents of Sleeping Bear and their property, legal documentation, and media and news sources regarding the issue, as well as a large number of photos. 
 </abstract>
-
-
-<repository><corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
-<extptr href="bhladd" show="embed" actuate="onload"/></repository></did>
-
-<descgrp type="admin">
-<acqinfo encodinganalog="541"><p>
+      <repository>
+        <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
+        <extptr href="bhladd" show="embed" actuate="onload"/>
+      </repository>
+    </did>
+    <descgrp type="admin">
+      <acqinfo encodinganalog="541">
+        <p>
 Donated by JoAnee Wheaton (donor no. 
 <num type="donor" encodinganalog="541$e">11272</num>) in June, 2015.  
  
-</p></acqinfo>
-
-
-
-<accruals encodinganalog="584"><p>
+</p>
+      </acqinfo>
+      <accruals encodinganalog="584">
+        <p>
 No further additions to the records are expected.
-</p></accruals><accessrestrict encodinganalog="506">
-<p>The collection is open without restriction.</p>
- </accessrestrict>
-
-
-<userestrict encodinganalog="540"><p>
-Copyright is held by the Regents of the University of Michigan.</p></userestrict>
-
-
-<prefercite encodinganalog="524"><p>[item], folder, box,
-Sleeping Bear Dunes National Lakeshore Extended Occupancy Rights Group records, Bentley Historical Library, University of Michigan.</p></prefercite>
- </descgrp>
-
-<bioghist encodinganalog="545">
-<p>The Sleeping Bear Dunes National Lakeshore is located in the northwest of the lower peninsula of Michigan in Leelanau and Benzie counties, on the coast of Lake Michigan and near Empire. Famous for its stunning vistas and historic farmland, its designation as a national lakeshore sparked a controversy between the residents of the lakeshore and the National Park Service. The national lakeshore was first proposed by Senator Philip Hart of Michigan in 1961 and the bill creating it was passed in 1970. Under the bill, any property built prior to 1964 was permitted to remain on the park grounds and expand as desired. Properties erected between 1964 and 1970, however, were condemned and their owners to be given monetary settlements.</p>
-
-<p>Facing eviction, many property owners formed a group called Sleeping Bear Dunes National Lakeshore Extended Occupancy Rights Group (SBDNL)  with the goal of acquiring either life leases on their homes or extensions on their leaseback period. The group included Ron Eckert as president, and Paul and JoAnne Wheaton as vice-president and secretary, respectively. As secretary, JoAnne collected much of the paper material generated and used by the group from its founding. Around ninety residents signed commitment forms to the group.</p>
-
-<p> Prior to the 1970 bill, it had been the precedent to extend occupancy rights to ninety nine years for lease holders whose property fell within a newly-formed national park. The Sleeping Bear Dunes Lakeshore residents were given a leaseback period of five years before their property would be destroyed. Many homeowners whose property satisfied the pre-1964 cutoff opted to leave despite their exemption, and many of these homes form the historic farmlands of the park.</p>
-
-<p>The SBDNL Extended Occupancy Rights group sought the advice and legal representation of Grand Rapids lawyers, appealed to Senator Hart and other legislatures, and made their case publically known through local media outlets. By taking their case to court, many residents, including the Wheatons, were able to extend their lease by thirty five years, ending in 2005. After this period, most of the structures were bulldozed in an attempt to preserve the natural condition of the area. </p>
-
-
-</bioghist>
-
-<arrangement encodinganalog="351">
-<p>
+</p>
+      </accruals>
+      <accessrestrict encodinganalog="506">
+        <p>The collection is open without restriction.</p>
+      </accessrestrict>
+      <userestrict encodinganalog="540">
+        <p>
+Copyright is held by the Regents of the University of Michigan.</p>
+      </userestrict>
+      <prefercite encodinganalog="524">
+        <p>[item], folder, box,
+Sleeping Bear Dunes National Lakeshore Extended Occupancy Rights Group records, Bentley Historical Library, University of Michigan.</p>
+      </prefercite>
+    </descgrp>
+    <bioghist encodinganalog="545">
+      <p>The Sleeping Bear Dunes National Lakeshore is located in the northwest of the lower peninsula of Michigan in Leelanau and Benzie counties, on the coast of Lake Michigan and near Empire. Famous for its stunning vistas and historic farmland, its designation as a national lakeshore sparked a controversy between the residents of the lakeshore and the National Park Service. The national lakeshore was first proposed by Senator Philip Hart of Michigan in 1961 and the bill creating it was passed in 1970. Under the bill, any property built prior to 1964 was permitted to remain on the park grounds and expand as desired. Properties erected between 1964 and 1970, however, were condemned and their owners to be given monetary settlements.</p>
+      <p>Facing eviction, many property owners formed a group called Sleeping Bear Dunes National Lakeshore Extended Occupancy Rights Group (SBDNL)  with the goal of acquiring either life leases on their homes or extensions on their leaseback period. The group included Ron Eckert as president, and Paul and JoAnne Wheaton as vice-president and secretary, respectively. As secretary, JoAnne collected much of the paper material generated and used by the group from its founding. Around ninety residents signed commitment forms to the group.</p>
+      <p> Prior to the 1970 bill, it had been the precedent to extend occupancy rights to ninety nine years for lease holders whose property fell within a newly-formed national park. The Sleeping Bear Dunes Lakeshore residents were given a leaseback period of five years before their property would be destroyed. Many homeowners whose property satisfied the pre-1964 cutoff opted to leave despite their exemption, and many of these homes form the historic farmlands of the park.</p>
+      <p>The SBDNL Extended Occupancy Rights group sought the advice and legal representation of Grand Rapids lawyers, appealed to Senator Hart and other legislatures, and made their case publically known through local media outlets. By taking their case to court, many residents, including the Wheatons, were able to extend their lease by thirty five years, ending in 2005. After this period, most of the structures were bulldozed in an attempt to preserve the natural condition of the area. </p>
+    </bioghist>
+    <arrangement encodinganalog="351">
+      <p>
 The collection is arranged into three series: Resident Files, Legal Files, and Media.
 </p>
-</arrangement>
-
-<scopecontent encodinganalog="520">
-<p>The Sleeping Bear Dunes National Lakeshore Extended Occupancy Rights Group Records contain the paperwork and photos accumulated by Paul and JoAnne Wheaton dating from the mid 1960's to 2015. Included are records of membership in the Extended Rights Group, legal files pertaining to court cases and legislation, and media coverage of the issue. Numerous photographs of properties destroyed by the National Park Service are present in the collection. </p></scopecontent>
-
-<controlaccess><p><extptr href="accnote" show="embed" actuate="onload"/></p><controlaccess><head>Subjects:</head>
-
-<subject source="lcsh" encodinganalog="650">Homeowners' associations--Michigan--Leelanau County.</subject>
-<subject source="lcsh" encodinganalog="650">Land use--Michigan--Leelanau County.</subject>
-<subject source="lcsh" encodinganalog="650">National parks and reserves--Michigan--Leelanau County.</subject>
-<subject source="lcsh" encodinganalog="650">Right of property--Michigan--Leelanau County.</subject>
-<geogname source="lcsh" encodinganalog="651">Sleeping Bear Dunes National Lakeshore (Mich.)</geogname>
-<corpname source="lcnaf" encodinganalog="610">Sleeping Bear Dunes National Lakeshore Extended Occupancy Rights Group.</corpname>
-<corpname source="lcnaf" encodinganalog="610">United States. National Park Service. Midwest Region.</corpname>
-
-</controlaccess>
-
-<controlaccess><head>Subjects - Visual Materials:</head>
-
-<subject source="lctgm" encodinganalog="650">Houses--Michigan--Leelanau County.</subject>
-
-</controlaccess>
-
- 
-
-<controlaccess><head>Contributors: </head>
-
-<persname source="lcnaf" encodinganalog="700">Wheaton, JoAnne.</persname>
-<persname source="lcnaf" encodinganalog="700">Wheaton, Paul.</persname>
- 
-</controlaccess>
-
-<controlaccess><head>Genre Terms:</head>
-<genreform source="aat" encodinganalog="655">Photographs.</genreform>
-</controlaccess>
-
-</controlaccess>
-
-
-<dsc type="combined">
-<c01 level="series"><did><unittitle>Resident Files</unittitle></did><scopecontent><p>The Resident Files series (1.5 linear feet) contains individual folders for each committed member of the SBDNL Extended Occupancy Rights group, background information on the topic provided by JoAnne Wheaton, the group's financial information, correspondence among members, administrative documents of their meetings, and a plethora of photographs of residencies and properties both occupied and deserted. </p></scopecontent>
-<c02 level="file"><did><container type="box" label="Box">1		</container><unittitle>Background information, <unitdate type="inclusive">2015</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1		</container><unittitle>Correspondence, <unitdate type="inclusive">1993-1997</unitdate> </unittitle> <physdesc><extent>11 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1		</container><unittitle>Individual resident files, <unitdate type="inclusive">1994-1995</unitdate> </unittitle> <physdesc><extent>100 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">2	</container><unittitle>Financial information,1997-1998 </unittitle> <physdesc><extent>6 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">2	</container><unittitle>Membership information, <unitdate type="inclusive">1983-1999</unitdate> </unittitle> <physdesc><extent>18 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">2	</container><unittitle>Photographs of properties, <unitdate type="inclusive">1996-2000</unitdate> </unittitle> <physdesc><extent>2 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">2	</container><unittitle>Related cases, <unitdate type="inclusive">1971-1999</unitdate> </unittitle> <physdesc><extent>3 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">2	</container><unittitle>SBDNL administration files, <unitdate type="inclusive">1995-1997</unitdate> </unittitle> <physdesc><extent>3 folders</extent></physdesc></did></c02></c01>
-
-
-
-<c01 level="series"><did><unittitle>Legal Files</unittitle></did><scopecontent><p>Within the Legal Files (0.5 linear feet) series will be found information on and correspondence with the attorneys involved with the case.  Pertinent legislation is supplied along with research carried out by the group on the law affecting their case. The oversize folder contains additional legal information, largely records of business with the group's lawyers. </p>
-
-</scopecontent>
-<c02 level="file"><did><container type="box" label="Box">2	</container><unittitle>Attorneys, 1984-2000(8 folders)</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">2	</container><unittitle>Correspondence, 1994-1998(5 folders)</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">2	</container><unittitle>Legislature, 1961-1997(11 folders)</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3		</container><unittitle>Research, <unitdate type="inclusive">1997-1999</unitdate> </unittitle> <physdesc><extent>9 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="folder" label="Oversize folder">1 	</container><unittitle>Miscellaneous, <unitdate type="inclusive">1979-1981</unitdate></unittitle></did></c02></c01>
-
-
-
-<c01 level="series"><did><unittitle>Media</unittitle></did><scopecontent><p>The Media series (0.25 linear feet) is majority newspaper clippings of stories about the group or the Sleeping Bear Dunes in general. Additionally, a few folders are included that relate to media contact information or involvement. </p></scopecontent>
-<c02 level="file"><did><container type="box" label="Box">3		</container><unittitle>Clippings, <unitdate type="inclusive">1994-1999</unitdate> </unittitle> <physdesc><extent>6 folders</extent></physdesc></did></c02>
-<c02 level="file"><did><container type="box" label="Box">3		</container><unittitle>Other media <unitdate type="inclusive">1995-1999</unitdate> </unittitle> <physdesc><extent>3 folders</extent></physdesc></did></c02></c01>
-      
-
-</dsc>
-<descgrp type="add"><relatedmaterial><head>Related material</head><p><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-9786" show="new" actuate="onrequest">Loren S. and Marjorie Rabe Barritt Collection</title> at the Bentley Historical Library.</p>
-</relatedmaterial></descgrp>
-</archdesc>
-
-
-
+    </arrangement>
+    <scopecontent encodinganalog="520">
+      <p>The Sleeping Bear Dunes National Lakeshore Extended Occupancy Rights Group Records contain the paperwork and photos accumulated by Paul and JoAnne Wheaton dating from the mid 1960's to 2015. Included are records of membership in the Extended Rights Group, legal files pertaining to court cases and legislation, and media coverage of the issue. Numerous photographs of properties destroyed by the National Park Service are present in the collection. </p>
+    </scopecontent>
+    <controlaccess>
+      <p>
+        <extptr href="accnote" show="embed" actuate="onload"/>
+      </p>
+      <controlaccess>
+        <head>Subjects:</head>
+        <subject source="lcsh" encodinganalog="650">Homeowners' associations--Michigan--Leelanau County.</subject>
+        <subject source="lcsh" encodinganalog="650">Land use--Michigan--Leelanau County.</subject>
+        <subject source="lcsh" encodinganalog="650">National parks and reserves--Michigan--Leelanau County.</subject>
+        <subject source="lcsh" encodinganalog="650">Right of property--Michigan--Leelanau County.</subject>
+        <geogname source="lcsh" encodinganalog="651">Sleeping Bear Dunes National Lakeshore (Mich.)</geogname>
+        <corpname source="lcnaf" encodinganalog="610">Sleeping Bear Dunes National Lakeshore Extended Occupancy Rights Group.</corpname>
+        <corpname source="lcnaf" encodinganalog="610">United States. National Park Service. Midwest Region.</corpname>
+      </controlaccess>
+      <controlaccess>
+        <head>Subjects - Visual Materials:</head>
+        <subject source="lctgm" encodinganalog="650">Houses--Michigan--Leelanau County.</subject>
+      </controlaccess>
+      <controlaccess>
+        <head>Contributors: </head>
+        <persname source="lcnaf" encodinganalog="700">Wheaton, JoAnne.</persname>
+        <persname source="lcnaf" encodinganalog="700">Wheaton, Paul.</persname>
+      </controlaccess>
+      <controlaccess>
+        <head>Genre Terms:</head>
+        <genreform source="aat" encodinganalog="655">Photographs.</genreform>
+      </controlaccess>
+    </controlaccess>
+    <dsc type="combined">
+      <c01 level="series">
+        <did>
+          <unittitle>Resident Files</unittitle>
+        </did>
+        <scopecontent>
+          <p>The Resident Files series (1.5 linear feet) contains individual folders for each committed member of the SBDNL Extended Occupancy Rights group, background information on the topic provided by JoAnne Wheaton, the group's financial information, correspondence among members, administrative documents of their meetings, and a plethora of photographs of residencies and properties both occupied and deserted. </p>
+        </scopecontent>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1		</container>
+            <unittitle>Background information, <unitdate type="inclusive">2015</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1		</container>
+            <unittitle>Correspondence, <unitdate type="inclusive">1993-1997</unitdate> </unittitle>
+            <physdesc>
+              <extent>11 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1		</container>
+            <unittitle>Individual resident files, <unitdate type="inclusive">1994-1995</unitdate> </unittitle>
+            <physdesc>
+              <extent>100 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2	</container>
+            <unittitle>Financial information,1997-1998 </unittitle>
+            <physdesc>
+              <extent>6 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2	</container>
+            <unittitle>Membership information, <unitdate type="inclusive">1983-1999</unitdate> </unittitle>
+            <physdesc>
+              <extent>18 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2	</container>
+            <unittitle>Photographs of properties, <unitdate type="inclusive">1996-2000</unitdate> </unittitle>
+            <physdesc>
+              <extent>2 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2	</container>
+            <unittitle>Related cases, <unitdate type="inclusive">1971-1999</unitdate> </unittitle>
+            <physdesc>
+              <extent>3 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2	</container>
+            <unittitle>SBDNL administration files, <unitdate type="inclusive">1995-1997</unitdate> </unittitle>
+            <physdesc>
+              <extent>3 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+      </c01>
+      <c01 level="series">
+        <did>
+          <unittitle>Legal Files</unittitle>
+        </did>
+        <scopecontent>
+          <p>Within the Legal Files (0.5 linear feet) series will be found information on and correspondence with the attorneys involved with the case.  Pertinent legislation is supplied along with research carried out by the group on the law affecting their case. The oversize folder contains additional legal information, largely records of business with the group's lawyers. </p>
+        </scopecontent>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2	</container>
+            <unittitle>Attorneys, 1984-2000(8 folders)</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2	</container>
+            <unittitle>Correspondence, 1994-1998(5 folders)</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">2	</container>
+            <unittitle>Legislature, 1961-1997(11 folders)</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3		</container>
+            <unittitle>Research, <unitdate type="inclusive">1997-1999</unitdate> </unittitle>
+            <physdesc>
+              <extent>9 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="folder" label="Oversize folder">1 	</container>
+            <unittitle>Miscellaneous, <unitdate type="inclusive">1979-1981</unitdate></unittitle>
+          </did>
+        </c02>
+      </c01>
+      <c01 level="series">
+        <did>
+          <unittitle>Media</unittitle>
+        </did>
+        <scopecontent>
+          <p>The Media series (0.25 linear feet) is majority newspaper clippings of stories about the group or the Sleeping Bear Dunes in general. Additionally, a few folders are included that relate to media contact information or involvement. </p>
+        </scopecontent>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3		</container>
+            <unittitle>Clippings, <unitdate type="inclusive">1994-1999</unitdate> </unittitle>
+            <physdesc>
+              <extent>6 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">3		</container>
+            <unittitle>Other media <unitdate type="inclusive">1995-1999</unitdate> </unittitle>
+            <physdesc>
+              <extent>3 folders</extent>
+            </physdesc>
+          </did>
+        </c02>
+      </c01>
+    </dsc>
+    <descgrp type="add">
+      <relatedmaterial>
+        <head>Related material</head>
+        <p><title href="http://quod.lib.umich.edu/cgi/f/findaid/findaid-idx?c=bhlead;idno=umich-bhl-9786" show="new" actuate="onrequest">Loren S. and Marjorie Rabe Barritt Collection</title> at the Bentley Historical Library.</p>
+      </relatedmaterial>
+    </descgrp>
+  </archdesc>
 </ead>

--- a/Real_Masters_all/snre.xml
+++ b/Real_Masters_all/snre.xml
@@ -9370,8 +9370,7 @@
                   <container type="box" label="Box">49</container>
                   <unittitle>Miscellaneous States and Unidentified</unittitle>
                   <physdesc altrender="whole">
-                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
-                    <extent>34 images</extent>
+                    <extent altrender="materialtype spaceoccupied">34 images</extent>
                     <physfacet>black and white</physfacet>
                   </physdesc>
                 </did>

--- a/Real_Masters_all/souris.xml
+++ b/Real_Masters_all/souris.xml
@@ -448,8 +448,8 @@
           <did>
             <container type="box" label="Box">33</container>
             <unittitle>CD of Talk (circa 55 minutes)</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CDs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/spencerc.xml
+++ b/Real_Masters_all/spencerc.xml
@@ -431,8 +431,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>CD-ROM Images of unveiling of historical marker <unitdate type="inclusive" normal="2004-11-06">November 6, 2004</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-ROMs</physfacet>
               </physdesc>
             </did>
@@ -456,8 +456,8 @@
               <did>
                 <container type="box" label="Box">5</container>
                 <unittitle>Interview with Spencer</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -469,8 +469,8 @@
               <did>
                 <container type="box" label="Box">5</container>
                 <unittitle>Interview with Spencer</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -482,8 +482,8 @@
               <did>
                 <container type="box" label="Box">5</container>
                 <unittitle>Dunbar High School, Class of <unitdate type="inclusive" normal="1926">1926</unitdate> 50th reunion, <unitdate type="inclusive" normal="1976">1976</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -492,8 +492,8 @@
               <did>
                 <container type="box" label="Box">5</container>
                 <unittitle>Anne Spencer home becomes historic landmark <unitdate type="inclusive" normal="1976">1976</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -507,8 +507,8 @@
               <did>
                 <container type="box" label="Box">5</container>
                 <unittitle>"An evening with Chauncey E. Spencer," <unitdate type="inclusive" normal="1996-02-08">February 8, 1996</unitdate> Smithsonian National Air and Space Museum</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                   <dimensions>90 minutes</dimensions>
                 </physdesc>
@@ -518,8 +518,8 @@
               <did>
                 <container type="box" label="Box">5</container>
                 <unittitle>"A Place in the Sky" (being the Chauncey Spencer Story)</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -528,8 +528,8 @@
               <did>
                 <container type="box" label="Box">5</container>
                 <unittitle>Aircraft Crash File (United States Air Force) <unitdate type="inclusive" normal="1943/1944">1943-1944</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -538,8 +538,8 @@
               <did>
                 <container type="box" label="Box">5</container>
                 <unittitle>"The Flying Fortress"</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                   <dimensions>20 minutes</dimensions>
                 </physdesc>
@@ -549,8 +549,8 @@
               <did>
                 <container type="box" label="Box">5</container>
                 <unittitle>"The 18th Air Force"</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -565,8 +565,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Chauncey Spencer in his home describing framed photographs on wall and relating the images to the events in his life, particularly African American airmen; portion of CS funeral service; interlude without commentary of Spencer photographs; "The 99th Pursuit Squadron"</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVDs</physfacet>
                 <dimensions>ca. 30 min.</dimensions>
               </physdesc>
@@ -576,8 +576,8 @@
             <did>
               <container type="box" label="Box">5</container>
               <unittitle>Talk by CS on his career</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>DVDs</physfacet>
                 <dimensions>88 minutes</dimensions>
               </physdesc>

--- a/Real_Masters_all/sphum.xml
+++ b/Real_Masters_all/sphum.xml
@@ -62,12 +62,12 @@
       </origination>
       <unittitle encodinganalog="245">School of Public Health (University of Michigan) records <unitdate type="inclusive" encodinganalog="245$f" normal="1909/2015">1909-2015</unitdate> <unitdate type="bulk" encodinganalog="245$g" normal="1941/2004">1941-2004</unitdate></unittitle>
       <physdesc altrender="part">
-        <extent encodinganalog="300">97 linear feet</extent>
-        <extent altrender="carrier">in 98 boxes</extent>
+        <extent altrender="materialtype spaceoccupied">8.74 GB</extent>
+        <physfacet>online</physfacet>
       </physdesc>
       <physdesc altrender="part">
-        <extent encodinganalog="300">8.74 GB</extent>
-        <physfacet>online</physfacet>
+        <extent altrender="materialtype spaceoccupied">97 linear feet</extent>
+        <extent altrender="carrier">in 98 boxes</extent>
       </physdesc>
       <abstract>Teaching and research unit of the University of Michigan. Records include dean's files, administrative records, minutes, also records of the school's program in Public Health Nursing and records of the Association of Schools of Public Health.</abstract>
       <unitid countrycode="us" repositorycode="MiU-H" encodinganalog="099" type="call number">87321 Bimu C281 2</unitid>
@@ -776,8 +776,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>Michigan Community Health Project <unitdate type="inclusive" normal="1940/1941" certainty="approximate">circa 1940-1941</unitdate></unittitle>
-              <physdesc>
-                <extent>4 reports</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 reports</extent>
               </physdesc>
             </did>
           </c03>
@@ -2087,8 +2087,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1985/1989">1985-1989</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>5 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">5 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -2098,8 +2098,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1990/1991">1990-1991</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>2 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -5811,8 +5811,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1972">1972</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>2 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
                 <odd>
@@ -5825,8 +5825,8 @@
                   <unittitle>
                     <unitdate type="inclusive" normal="1973/1976">1973-1976</unitdate>
                   </unittitle>
-                  <physdesc>
-                    <extent>2 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
                 <odd>
@@ -6789,8 +6789,8 @@
                 <did>
                   <container type="box" label="Box">89</container>
                   <unittitle>Budget Meeting <unitdate type="inclusive" normal="1990-03-09">March 9, 1990</unitdate></unittitle>
-                  <physdesc>
-                    <extent>2 folders</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">2 folders</extent>
                   </physdesc>
                 </did>
                 <accessrestrict>

--- a/Real_Masters_all/stuadcen.xml
+++ b/Real_Masters_all/stuadcen.xml
@@ -1414,8 +1414,8 @@
           <did>
             <container type="box" label="Box">6</container>
             <unittitle>"Anne -- Arbor --Kids Sarah Anthony"</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-R</physfacet>
             </physdesc>
           </did>
@@ -1449,8 +1449,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>Student Advocacy Center #1 <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1459,8 +1459,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>Student Advocacy Center #2 <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1469,8 +1469,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>A Celebration of the Life of Marcene root, Aug 24 <unitdate type="inclusive" normal="2001">2001</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1499,8 +1499,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>Project Re-Enroll <unitdate type="inclusive" normal="1998">1998</unitdate></unittitle>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
               </physdesc>
             </did>
           </c03>
@@ -1508,8 +1508,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>Board Meeting <unitdate type="inclusive" normal="2002-09-14">9/14/2002</unitdate></unittitle>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/sweum.xml
+++ b/Real_Masters_all/sweum.xml
@@ -286,8 +286,8 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Summer Engineering Exploration photographs <unitdate type="inclusive" normal="2003">2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CD-Rs</physfacet>
               </physdesc>
             </did>
@@ -301,8 +301,8 @@
             <did>
               <container type="box" label="Box">3</container>
               <unittitle>Summer Engineering Exploration <unitdate type="inclusive" normal="2000">2000</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/swmurban.xml
+++ b/Real_Masters_all/swmurban.xml
@@ -3695,8 +3695,8 @@
             <did>
               <container type="box" label="Box">23</container>
               <unittitle>Board Member Listings</unittitle>
-              <physdesc>
-                <extent>1 floppy disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
                 <physfacet>3.5"</physfacet>
               </physdesc>
             </did>
@@ -3705,8 +3705,8 @@
             <did>
               <container type="box" label="Box">23</container>
               <unittitle>NULITES</unittitle>
-              <physdesc>
-                <extent>1 floppy disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
                 <physfacet>3.5"</physfacet>
               </physdesc>
             </did>
@@ -3722,8 +3722,8 @@
             <did>
               <container type="box" label="Box">23</container>
               <unittitle>40th Anniversary</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -3732,8 +3732,8 @@
             <did>
               <container type="box" label="Box">23</container>
               <unittitle>Community Voices</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -3742,8 +3742,8 @@
             <did>
               <container type="box" label="Box">23</container>
               <unittitle>Dreams</unittitle>
-              <physdesc>
-                <extent>2 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -3752,8 +3752,8 @@
             <did>
               <container type="box" label="Box">23</container>
               <unittitle>Mid-Day Magazine <unitdate type="inclusive" normal="2006">2006</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -3762,8 +3762,8 @@
             <did>
               <container type="box" label="Box">23</container>
               <unittitle>Newsletter <unitdate type="inclusive" normal="2004">2004</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -3772,8 +3772,8 @@
             <did>
               <container type="box" label="Box">23</container>
               <unittitle>Urban League Documents <unitdate type="inclusive" normal="2004">2004</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -3793,8 +3793,8 @@
               <did>
                 <container type="box" label="Box">23</container>
                 <unittitle>Annual Report <unitdate type="inclusive" normal="2005">2005</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>DVDs</physfacet>
                 </physdesc>
               </did>
@@ -3803,8 +3803,8 @@
               <did>
                 <container type="box" label="Box">23</container>
                 <unittitle>From Vision to Impact</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>DVDs</physfacet>
                 </physdesc>
               </did>

--- a/Real_Masters_all/thompbank.xml
+++ b/Real_Masters_all/thompbank.xml
@@ -58,10 +58,8 @@ Bankole Thompson papers
 </unitdate>
  
 </unittitle>
-      <physdesc>
-        <extent encodinganalog="300">
-0.25 linear feet
-</extent>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">0.25 linear feet</extent>
       </physdesc>
       <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2016009 Aa 2

--- a/Real_Masters_all/thompbank.xml
+++ b/Real_Masters_all/thompbank.xml
@@ -1,145 +1,156 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE ead PUBLIC "+//ISBN 1-931666-00-8//DTD ead.dtd (Encoded Archival Description (EAD) Version 2002)//EN" "ead.dtd">
 <ead>
-
-<eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
-
-<eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::thompbank.xml//EN" encodinganalog="Identifier">
+  <eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core" scriptencoding="iso15924" countryencoding="iso3166-1">
+    <eadid countrycode="us" mainagencycode="MiU-H" publicid="us//::miu-h//TXT us::miu-h::thompbank.xml//EN" encodinganalog="Identifier">
 umich-bhl-2016009</eadid>
-
-<filedesc><titlestmt><titleproper encodinganalog="Title">Finding Aid for 
+    <filedesc>
+      <titlestmt>
+        <titleproper encodinganalog="Title">Finding Aid for 
 Bankole Thompson papers
 
 </titleproper>
-<author encodinganalog="Creator">Collection processed and finding aid created by 
-Ben Bond </author></titlestmt>
-
-<publicationstmt><publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
-<date encodinganalog="Date" normal="2016">
-2016</date></publicationstmt></filedesc>
-
-<profiledesc>
-<creation>Encoded finding aid created by 
+        <author encodinganalog="Creator">Collection processed and finding aid created by 
+Ben Bond </author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher encodinganalog="Publisher">Bentley Historical Library, University of Michigan</publisher>
+        <date encodinganalog="Date" normal="2016">
+2016</date>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>Encoded finding aid created by 
 Olga Virakhovskaya 
 <date>2016</date></creation>
-
-<langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage><descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules></profiledesc>
-
-<revisiondesc><change><date>2016-01-26</date><item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item></change></revisiondesc></eadheader>
-
-<frontmatter><titlepage>
-
-<publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
-
-<titleproper>Finding aid for<lb/>
+      <langusage encodinganalog="Language">The finding aid is written in  <language langcode="eng" scriptcode="Latn">English</language></langusage>
+      <descrules>Finding aid prepared using Describing Archives: A Content Standard (DACS)</descrules>
+    </profiledesc>
+    <revisiondesc>
+      <change>
+        <date>2016-01-26</date>
+        <item>Original encoding from Word 10.0 file using Word macros and Xmetal.</item>
+      </change>
+    </revisiondesc>
+  </eadheader>
+  <frontmatter>
+    <titlepage>
+      <publisher><lb/>Bentley Historical Library<lb/>University of Michigan</publisher>
+      <titleproper>Finding aid for<lb/>
 Bankole Thompson papers
 </titleproper>
-
-<author>Finding aid created by<lb/> 
+      <author>Finding aid created by<lb/> 
 Ben Bond, in January 2016
 </author>
-
-</titlepage>
-</frontmatter>
-
-<archdesc level="recordgrp" audience="external" type="inventory" relatedencoding="MARC21"><did>
-
-<origination>
-<corpname source="lcnaf" encodinganalog="110">
+    </titlepage>
+  </frontmatter>
+  <archdesc level="recordgrp" audience="external" type="inventory" relatedencoding="MARC21">
+    <did>
+      <origination>
+        <corpname source="lcnaf" encodinganalog="110">
 Thompson, Bankole
-</corpname></origination>
-
-<unittitle encodinganalog="245">
+</corpname>
+      </origination>
+      <unittitle encodinganalog="245">
 Bankole Thompson papers
 <unitdate type="inclusive" encodinganalog="245$f">
 2006-2016
 </unitdate>
  
 </unittitle>
-
-<physdesc><extent encodinganalog="300">
+      <physdesc>
+        <extent encodinganalog="300">
 0.25 linear feet
-</extent></physdesc>
-
-<unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
+</extent>
+      </physdesc>
+      <unitid encodinganalog="852$h" repositorycode="miu-h" countrycode="us" type="call number">
 2016009 Aa 2
 </unitid>
-
-<langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
-
-<abstract>
+      <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language> </langmaterial>
+      <abstract>
 Bankole Thompson is a Michigan award-winning journalist and author who served as the senior editor of the <title render="italic">Michigan Chronicle</title> newspaper in Detroit from 2006 to 2015. He is known for his coverage of the 2008 presidential election and his one-on-one interviews with Barack Obama. The collection includes a selection of Thompson's writings and speeches, two books, and biographical information.
 </abstract>
-
-
-<repository><corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
-<extptr href="bhladd" show="embed" actuate="onload"/></repository></did>
-
-<descgrp type="admin">
-<acqinfo encodinganalog="541"><p>
+      <repository>
+        <corpname encodinganalog="852"><subarea>Bentley Historical Library</subarea>, University of Michigan</corpname>
+        <extptr href="bhladd" show="embed" actuate="onload"/>
+      </repository>
+    </did>
+    <descgrp type="admin">
+      <acqinfo encodinganalog="541">
+        <p>
 Donated by Bankole Thompson (donor no. <num type="donor" encodinganalog="541$e">11429</num>), in June, 2015.
  
-</p></acqinfo>
-
-<accruals encodinganalog="584"><p>Periodic additions to the records expected.</p></accruals>
-
- <accessrestrict encodinganalog="506">
-<p>The collection is open without restriction</p>
-</accessrestrict>
-
-
-<userestrict encodinganalog="540"><p>
+</p>
+      </acqinfo>
+      <accruals encodinganalog="584">
+        <p>Periodic additions to the records expected.</p>
+      </accruals>
+      <accessrestrict encodinganalog="506">
+        <p>The collection is open without restriction</p>
+      </accessrestrict>
+      <userestrict encodinganalog="540">
+        <p>
 Copyright is held by the Regents of the University of Michigan.
-</p></userestrict>
-
-
-<prefercite encodinganalog="524"><p>[item], folder, box,
-Bankole Thompson papers, Bentley Historical Library, University of Michigan</p></prefercite>
- </descgrp>
-
-<bioghist encodinganalog="545">
-<p>Acclaimed journalist and author Bankole Thompson has been involved with several organizations and publications in his professional career. He is known as a "courageous voice on behalf of the dispossessed and disenfranchised, a shining example of journalism for the public good" (Eisenhower Foundation). His reports cover myriad issues from around the world, and specifically those facing Michigan's African-American community.</p>
-
-<p>From 2006 until 2015 Thompson served as the senior editor of the <title render="italic">Michigan Chronicle</title>, where his coverage of the 2008 presidential election and interviews with Barack Obama have earned him the praise of media mogul Tom Joyner, referring to Thompson as an "innovative editor". His reasons for leaving the <title render="italic">Michigan Chronicle</title> weren't made public, but Thompson has alluded that he was under pressure by editorial staff to resign. Currently he works with the <title render="italic">Detroit News</title> as a contributing columnist whose weekly articles will appeal to "Detroiters who are looking for diverse perspectives" (Thompson, 2015). </p>
-
-<p>Thompson is the author of a series of books on the Obama administration, including <title render="italic">Obama and Jewish Loyalty</title>, <title render="italic">Obama and Business Loyalty</title>, and <title render="italic">Obama and Black Loyalty</title>. Additionally, he makes many media appearances and speaking engagements, notably directing the Africa Faith and Justice Network lecture series at the Brookings Institute, Carnegie Endowment for International Peace and the National Press Club. </p>
-
-
-</bioghist>
-
- 
-
-<scopecontent encodinganalog="520">
-<p>The collection includes: Thompson's selected writings and speeches; a transcript from his keynote address from "2015 Unity: Journalists for Diversity Regional Media Summit"; a signed copy of volume 1 of <title render="italic">Obama and Black Loyalty</title>; a copy of <title render="italic">Bankole Thompson: Portrait of a Quintessential Journalist</title>; a flier from a 2006 Detroit Public Library Symposium; and brief biographical information. </p></scopecontent>
-
-<controlaccess><p><extptr href="accnote" show="embed" actuate="onload"/></p><controlaccess><head>Subjects:</head>
-
-<subject source="lcsh" encodinganalog="650">African American journalists--Detroit.</subject>
-<subject source="lcsh" encodinganalog="650">African American newspapers--Michigan--Detroit.</subject>
-<subject source="lcsh" encodinganalog="650">African Americans--Michigan--Detroit.</subject>
-<geogname source="lcsh" encodinganalog="651">Detroit (Mich.)</geogname>
-<subject source="lcsh" encodinganalog="650">Journalists--Michigan--Detroit.</subject>
-<persname source="lcnaf" encodinganalog="600">Obama, Barack.</persname>
-<persname source="lcnaf" encodinganalog="600">Thompson, Bankole.</persname>
- 
-
-</controlaccess>
- 
-
-</controlaccess>
-
-
-<dsc type="combined">
-<c01 level="series"><did><unittitle>Bankole Thompson papers</unittitle></did>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Articles, <unitdate type="inclusive">2016</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Biographical information</unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Books, <unitdate type="inclusive">2010</unitdate> and <unitdate type="inclusive">undated</unitdate></unittitle></did></c02>
-<c02 level="file"><did><container type="box" label="Box">1</container><unittitle>Writings, <unitdate type="inclusive">2015</unitdate> and <unitdate type="inclusive">undated</unitdate></unittitle></did></c02></c01>
-
-</dsc>
-
-</archdesc>
-
-
-
+</p>
+      </userestrict>
+      <prefercite encodinganalog="524">
+        <p>[item], folder, box,
+Bankole Thompson papers, Bentley Historical Library, University of Michigan</p>
+      </prefercite>
+    </descgrp>
+    <bioghist encodinganalog="545">
+      <p>Acclaimed journalist and author Bankole Thompson has been involved with several organizations and publications in his professional career. He is known as a "courageous voice on behalf of the dispossessed and disenfranchised, a shining example of journalism for the public good" (Eisenhower Foundation). His reports cover myriad issues from around the world, and specifically those facing Michigan's African-American community.</p>
+      <p>From 2006 until 2015 Thompson served as the senior editor of the <title render="italic">Michigan Chronicle</title>, where his coverage of the 2008 presidential election and interviews with Barack Obama have earned him the praise of media mogul Tom Joyner, referring to Thompson as an "innovative editor". His reasons for leaving the <title render="italic">Michigan Chronicle</title> weren't made public, but Thompson has alluded that he was under pressure by editorial staff to resign. Currently he works with the <title render="italic">Detroit News</title> as a contributing columnist whose weekly articles will appeal to "Detroiters who are looking for diverse perspectives" (Thompson, 2015). </p>
+      <p>Thompson is the author of a series of books on the Obama administration, including <title render="italic">Obama and Jewish Loyalty</title>, <title render="italic">Obama and Business Loyalty</title>, and <title render="italic">Obama and Black Loyalty</title>. Additionally, he makes many media appearances and speaking engagements, notably directing the Africa Faith and Justice Network lecture series at the Brookings Institute, Carnegie Endowment for International Peace and the National Press Club. </p>
+    </bioghist>
+    <scopecontent encodinganalog="520">
+      <p>The collection includes: Thompson's selected writings and speeches; a transcript from his keynote address from "2015 Unity: Journalists for Diversity Regional Media Summit"; a signed copy of volume 1 of <title render="italic">Obama and Black Loyalty</title>; a copy of <title render="italic">Bankole Thompson: Portrait of a Quintessential Journalist</title>; a flier from a 2006 Detroit Public Library Symposium; and brief biographical information. </p>
+    </scopecontent>
+    <controlaccess>
+      <p>
+        <extptr href="accnote" show="embed" actuate="onload"/>
+      </p>
+      <controlaccess>
+        <head>Subjects:</head>
+        <subject source="lcsh" encodinganalog="650">African American journalists--Detroit.</subject>
+        <subject source="lcsh" encodinganalog="650">African American newspapers--Michigan--Detroit.</subject>
+        <subject source="lcsh" encodinganalog="650">African Americans--Michigan--Detroit.</subject>
+        <geogname source="lcsh" encodinganalog="651">Detroit (Mich.)</geogname>
+        <subject source="lcsh" encodinganalog="650">Journalists--Michigan--Detroit.</subject>
+        <persname source="lcnaf" encodinganalog="600">Obama, Barack.</persname>
+        <persname source="lcnaf" encodinganalog="600">Thompson, Bankole.</persname>
+      </controlaccess>
+    </controlaccess>
+    <dsc type="combined">
+      <c01 level="series">
+        <did>
+          <unittitle>Bankole Thompson papers</unittitle>
+        </did>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Articles, <unitdate type="inclusive">2016</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Biographical information</unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Books, <unitdate type="inclusive">2010</unitdate> and <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="box" label="Box">1</container>
+            <unittitle>Writings, <unitdate type="inclusive">2015</unitdate> and <unitdate type="inclusive">undated</unitdate></unittitle>
+          </did>
+        </c02>
+      </c01>
+    </dsc>
+  </archdesc>
 </ead>

--- a/Real_Masters_all/tibbsch.xml
+++ b/Real_Masters_all/tibbsch.xml
@@ -1271,8 +1271,8 @@
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>A.K.A. Sorority Songs (45 RPM record)</unittitle>
-            <physdesc>
-              <extent>1 phonograph records</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
               <physfacet>45 rpm</physfacet>
             </physdesc>
           </did>
@@ -1281,8 +1281,8 @@
           <did>
             <container type="box" label="Box">4</container>
             <unittitle>A.K.A., Sisterhood and Service: the First Century <unitdate type="inclusive" normal="2008">2008</unitdate></unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>DVDs</physfacet>
             </physdesc>
           </did>
@@ -1295,8 +1295,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>The First Member: Ethel Hedgeman Lyle-the story of her life and the vision that led to the founding of A.K.A. sorority <unitdate type="inclusive">undated</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1305,8 +1305,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>The Legacy Revisited: We Pledge Ourselves to Remember (slide presentation) <unitdate type="inclusive" normal="1994">1994</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1315,8 +1315,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Tau Alpha Omega, A.K.A. Sorority Founder's Day 10th anniversary celebration <unitdate type="inclusive" normal="2001">2001</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -1330,8 +1330,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>62nd Boule, minutes <unitdate type="inclusive" normal="2006">2006</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1340,8 +1340,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>63rd Boule <unitdate type="inclusive" normal="2008">2008</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1350,8 +1350,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>64th Boule <unitdate type="inclusive" normal="2010">2010</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1360,8 +1360,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>65th Boule <unitdate type="inclusive" normal="2012">2012</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1370,8 +1370,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>77th Great Lakes Regional Conference <unitdate type="inclusive" normal="2008">2008</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1380,8 +1380,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Great Lakes undergraduate roundup signage committee <unitdate type="inclusive" normal="2009">2009</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1390,8 +1390,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Barbara Anne McKinzie, Supreme Basileus: the journey to supreme leadership</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1400,8 +1400,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Altha Steen, candidate for Basileus, presentation <unitdate type="inclusive" normal="2001">2001</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1410,8 +1410,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Integrating the archives into chapter operations <unitdate type="inclusive" normal="2008">2008</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1420,8 +1420,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>"Simply...the best" archives regional promotion <unitdate type="inclusive" normal="2010">2010</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1430,8 +1430,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Ivy Leaf, digital edition sample <unitdate type="inclusive" normal="2007">2007</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1440,8 +1440,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Tau Alpha Omega, unspecified event <unitdate type="inclusive" normal="2006">2006</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -1450,8 +1450,8 @@
             <did>
               <container type="box" label="Box">4</container>
               <unittitle>Tau Alpha Omega, unspecified event <unitdate type="inclusive" normal="2006">2006</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/uawford.xml
+++ b/Real_Masters_all/uawford.xml
@@ -429,8 +429,8 @@
             <did>
               <container type="box" label="Box">2</container>
               <unittitle>Psychology 430, Marie Waung</unittitle>
-              <physdesc>
-                <extent>2 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/ucouncil.xml
+++ b/Real_Masters_all/ucouncil.xml
@@ -501,8 +501,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Establishment of Campus Police, <unitdate type="inclusive" normal="1970/1974">1970-1974</unitdate></unittitle>
-            <physdesc>
-              <extent>2 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
             </physdesc>
           </did>
         </c02>
@@ -546,8 +546,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Minutes, <unitdate type="inclusive">May 1970-February 1974</unitdate></unittitle>
-            <physdesc>
-              <extent>3 folders</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 folders</extent>
             </physdesc>
           </did>
         </c02>

--- a/Real_Masters_all/ulibrary.xml
+++ b/Real_Masters_all/ulibrary.xml
@@ -83583,8 +83583,8 @@
             <did>
               <container type="box" label="Box">239</container>
               <unittitle>Fine Arts Library Shelflist (16mm) <unitdate type="inclusive" normal="1979">1979</unitdate></unittitle>
-              <physdesc>
-                <extent>3 reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 reels</extent>
               </physdesc>
             </did>
           </c03>
@@ -83592,8 +83592,8 @@
             <did>
               <container type="box" label="Box">239</container>
               <unittitle>Fine Arts Library New Accessions (16 mm) <unitdate type="inclusive" normal="1980/1982">1980-1982</unitdate></unittitle>
-              <physdesc>
-                <extent>3 reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 reels</extent>
               </physdesc>
             </did>
           </c03>
@@ -83601,8 +83601,8 @@
             <did>
               <container type="box" label="Box">239</container>
               <unittitle>Faculty Appraisal of A University Library (16 mm) <unitdate type="inclusive" normal="1961">1961</unitdate></unittitle>
-              <physdesc>
-                <extent>3 reels</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 reels</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/umercmrs.xml
+++ b/Real_Masters_all/umercmrs.xml
@@ -332,8 +332,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>ERC/RMS Patents</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-ROMs</physfacet>
             </physdesc>
           </did>
@@ -342,8 +342,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>CIRP 2nd International Conference on Reconfigurable Manufacturing <unitdate type="inclusive" normal="2003-08-20/2003-08-21">August 20-21, 2003</unitdate></unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-ROMs</physfacet>
             </physdesc>
           </did>
@@ -352,8 +352,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>ERC/RMS Reconfigurable Factory Testbed</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-ROMs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/umhsvol.xml
+++ b/Real_Masters_all/umhsvol.xml
@@ -510,8 +510,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Compact Disc (CD) Photographs</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD-Rs</physfacet>
             </physdesc>
           </did>
@@ -520,8 +520,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Digital Video Disc (DVDs)</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>DVDs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/umpresid.xml
+++ b/Real_Masters_all/umpresid.xml
@@ -70601,8 +70601,8 @@
                   <did>
                     <container type="box" label="Box">442</container>
                     <unittitle>General <unitdate type="inclusive" normal="2002">2002</unitdate>, <unitdate type="inclusive" normal="2005">2005</unitdate> (includes a CD-R containing documents related to the scholarship)</unittitle>
-                    <physdesc>
-                      <extent>1 optical disks</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                       <physfacet>CD-Rs</physfacet>
                     </physdesc>
                   </did>

--- a/Real_Masters_all/umussoc.xml
+++ b/Real_Masters_all/umussoc.xml
@@ -7071,8 +7071,8 @@
             <did>
               <container type="box" label="Box">123</container>
               <unittitle>Daniella Mercury on WEMU <unitdate type="inclusive" normal="2003-04-11">April 11, 2003</unitdate></unittitle>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
               </physdesc>
             </did>
           </c03>
@@ -7085,8 +7085,8 @@
             <did>
               <container type="box" label="Box">123</container>
               <unittitle>Franz Joseph Haydn's "The Creation," <unitdate type="inclusive" normal="2005-04-02">April 2, 2005</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -7095,8 +7095,8 @@
             <did>
               <container type="box" label="Box">123</container>
               <unittitle>St. Matthew Passion, Detroit Symphony Orchestra, UMS Choral Union, MSU Children's Choir <unitdate type="inclusive" normal="2008-03-21">March 21, 2008</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -7105,8 +7105,8 @@
             <did>
               <container type="box" label="Box">123</container>
               <unittitle>UMS Choral Union, Handel's Messiah, Ann Arbor Symphony Orchestra <unitdate type="inclusive" normal="2007-12-01">December 1, 2007</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -7115,8 +7115,8 @@
             <did>
               <container type="box" label="Box">123</container>
               <unittitle>UMS Choral Union, Three Sacred Pieces, All-Night Vigil, Op. 37, The Passing of the Year, Carmina Burana <unitdate type="inclusive" normal="2009-04-23">April 23, 2009</unitdate></unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -7139,8 +7139,8 @@
             <did>
               <container type="box" label="Box">123</container>
               <unittitle><title render="italic">Messiah</title> The University of Michigan Choral Union and the University Symphony Orchestra, <unitdate type="inclusive" normal="1978-12">December 1978</unitdate></unittitle>
-              <physdesc>
-                <extent>1 phonograph records</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
               </physdesc>
             </did>
             <odd>
@@ -7151,8 +7151,8 @@
             <did>
               <container type="box" label="Box">123</container>
               <unittitle><title render="italic">Commemorating 100 Years</title> The University of Michigan Symphony Orchestra Conducted by Yehudi Menuhin and Eugene Ormandy, <unitdate type="inclusive" normal="1979">1979</unitdate></unittitle>
-              <physdesc>
-                <extent>1 phonograph records</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
               </physdesc>
             </did>
             <odd>

--- a/Real_Masters_all/vanzoern.xml
+++ b/Real_Masters_all/vanzoern.xml
@@ -181,8 +181,8 @@
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Laura Basch <unitdate type="inclusive" normal="1993">1993</unitdate></unittitle>
-            <physdesc>
-              <extent>9 audiocassettes</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">9 audiocassettes</extent>
               <physfacet>with summaries</physfacet>
             </physdesc>
           </did>
@@ -191,8 +191,8 @@
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>John Lanham <unitdate type="inclusive" normal="2000">2000</unitdate></unittitle>
-            <physdesc>
-              <extent>3 audiocassettes</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 audiocassettes</extent>
               <physfacet>with summaries</physfacet>
             </physdesc>
           </did>
@@ -201,8 +201,8 @@
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Jay Van Zoeren interviews <unitdate type="inclusive" normal="1995/1996">1995-1996</unitdate></unittitle>
-            <physdesc>
-              <extent>7 audiocassettes</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">7 audiocassettes</extent>
             </physdesc>
           </did>
         </c02>
@@ -221,8 +221,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Tour of the Burfiend farm with George Burfiend <unitdate type="inclusive" normal="2005">2005</unitdate></unittitle>
-            <physdesc>
-              <extent>3 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">3 optical disks</extent>
               <physfacet>DVDs with summary</physfacet>
             </physdesc>
           </did>
@@ -231,8 +231,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>George Burfiend interviews <unitdate type="inclusive" normal="2006/2007">2006-2007</unitdate></unittitle>
-            <physdesc>
-              <extent>5 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">5 optical disks</extent>
               <physfacet>CDs</physfacet>
             </physdesc>
           </did>
@@ -241,8 +241,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Image and text files</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD</physfacet>
             </physdesc>
           </did>
@@ -262,8 +262,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Jack DeKorne interview</unittitle>
-            <physdesc>
-              <extent>6 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">6 optical disks</extent>
               <physfacet>audio CDs with outline</physfacet>
             </physdesc>
           </did>
@@ -272,8 +272,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Trudy Van Noord interview</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>audio CD with outline</physfacet>
             </physdesc>
           </did>
@@ -288,8 +288,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Images and text files</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD</physfacet>
             </physdesc>
           </did>
@@ -303,8 +303,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Judy Carole Fargo and Ruth Ann Doan Jones interview</unittitle>
-            <physdesc>
-              <extent>2 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
               <physfacet>audio CDs with summary</physfacet>
             </physdesc>
           </did>
@@ -319,8 +319,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Image and text files</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD</physfacet>
             </physdesc>
           </did>
@@ -346,8 +346,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Interview <unitdate type="inclusive" normal="2003">2003</unitdate></unittitle>
-            <physdesc>
-              <extent>2 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
               <physfacet>audio CDs with transcript</physfacet>
             </physdesc>
           </did>
@@ -356,8 +356,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Interviews <unitdate type="inclusive" normal="2005/2008">2005-2008</unitdate></unittitle>
-            <physdesc>
-              <extent>4 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">4 optical disks</extent>
               <physfacet>audio CDs with summary</physfacet>
             </physdesc>
           </did>
@@ -366,8 +366,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Image and text files</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD</physfacet>
             </physdesc>
           </did>
@@ -381,8 +381,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Alfred and Loraine [Lorraine?] Mason interview regarding the Charles and Hattie Olsen farm, Port Oneida, and surrounding areas</unittitle>
-            <physdesc>
-              <extent>4 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">4 optical disks</extent>
               <physfacet>audio CDs with summary</physfacet>
             </physdesc>
           </did>
@@ -397,8 +397,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Image and text files</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>CD</physfacet>
             </physdesc>
           </did>
@@ -418,8 +418,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Leonard Thoreson interview</unittitle>
-            <physdesc>
-              <extent>7 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">7 optical disks</extent>
               <physfacet>audio CDs with summary</physfacet>
             </physdesc>
           </did>
@@ -428,8 +428,8 @@
           <did>
             <container type="box" label="Box">2</container>
             <unittitle>Farm tour</unittitle>
-            <physdesc>
-              <extent>1 optical disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
               <physfacet>video DVD with summary</physfacet>
             </physdesc>
           </did>
@@ -444,8 +444,8 @@
       <c01 level="series">
         <did>
           <unittitle>Frederick and Margretha Werner Farm oral history interview and photo collection <unitdate type="inclusive" normal="2006/2007">2006-2007</unitdate></unittitle>
-          <physdesc>
-            <extent>1 optical disks</extent>
+          <physdesc altrender="whole">
+            <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
             <physfacet>CD</physfacet>
           </physdesc>
         </did>

--- a/Real_Masters_all/vietvetd.xml
+++ b/Real_Masters_all/vietvetd.xml
@@ -1376,8 +1376,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle>Activities <unitdate type="inclusive" normal="1992">1992</unitdate></unittitle>
-              <physdesc>
-                <extent>1 floppy disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
                 <physfacet>3.5"</physfacet>
               </physdesc>
             </did>
@@ -1429,8 +1429,8 @@
           <did>
             <container type="box" label="Box">7</container>
             <unittitle>Michigan personnel who died in war <unitdate type="inclusive" normal="1992">1992</unitdate></unittitle>
-            <physdesc>
-              <extent>1 floppy disks</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
               <physfacet>3.5"</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/vpminaff.xml
+++ b/Real_Masters_all/vpminaff.xml
@@ -9475,8 +9475,8 @@
           <did>
             <container type="box" label="Box">18</container>
             <unittitle>Photographs, <unitdate type="inclusive" normal="1992" certainty="approximate">circa 1992</unitdate></unittitle>
-            <physdesc>
-              <extent>6 envelopes</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">6 envelopes</extent>
               <physfacet>black and white photographs</physfacet>
             </physdesc>
           </did>

--- a/Real_Masters_all/wallm60m.xml
+++ b/Real_Masters_all/wallm60m.xml
@@ -25495,8 +25495,8 @@
               <did>
                 <container type="box" label="Box">95</container>
                 <unittitle>"The Hate That Hate Produced" (Black Muslims) <unitdate type="inclusive" normal="1959-07-23">July 23, 1959</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -25505,8 +25505,8 @@
               <did>
                 <container type="box" label="Box">95</container>
                 <unittitle><unitdate type="inclusive" normal="1986">1986</unitdate> Election Night coverage (Mike Wallace appearances)Visual</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -25515,8 +25515,8 @@
               <did>
                 <container type="box" label="Box">95</container>
                 <unittitle><title render="italic">60 Minutes</title> segment featuring floor of the House of Representatives and Representative Livingston</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -25525,8 +25525,8 @@
               <did>
                 <container type="box" label="Box">95</container>
                 <unittitle><title render="italic">20/20</title> program featuring Barbara Walters and Mike Wallace</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -25535,8 +25535,8 @@
               <did>
                 <container type="box" label="Box">95</container>
                 <unittitle>"Taking Part" <unitdate type="inclusive" normal="1989-10-25">October 25, 1989</unitdate> (20 minutes)</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -25545,8 +25545,8 @@
               <did>
                 <container type="box" label="Box">95</container>
                 <unittitle><title render="italic">60 Minutes</title> segment <title render="italic">Brown v. Koch</title>, January 24 and <unitdate type="inclusive" normal="1988-06-12">June 12, 1988</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -25555,8 +25555,8 @@
               <did>
                 <container type="box" label="Box">95</container>
                 <unittitle>Ed Murrow Excerpts</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>U-matic</physfacet>
                 </physdesc>
               </did>
@@ -25569,8 +25569,8 @@
                 <did>
                   <container type="box" label="Box">95</container>
                   <unittitle>Tobacco <unitdate type="inclusive" normal="1996-01-26">January 26, 1996</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
                   </physdesc>
                 </did>
@@ -25579,8 +25579,8 @@
                 <did>
                   <container type="box" label="Box">95</container>
                   <unittitle>Tobacco <unitdate type="inclusive" normal="1996-01-29">January 29, 1996</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
                   </physdesc>
                 </did>
@@ -25589,8 +25589,8 @@
                 <did>
                   <container type="box" label="Box">95</container>
                   <unittitle>CBS News -- <title render="italic">60 Minutes</title>, <unitdate type="inclusive" normal="1995-11-12">November 12, 1995</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
                   </physdesc>
                 </did>
@@ -25599,8 +25599,8 @@
                 <did>
                   <container type="box" label="Box">95</container>
                   <unittitle>CBS News Broadcasts, January 29, January 31, and <unitdate type="inclusive" normal="1996-02-01">February 1, 1996</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
                   </physdesc>
                 </did>
@@ -25609,8 +25609,8 @@
                 <did>
                   <container type="box" label="Box">95</container>
                   <unittitle><title render="italic">60 Minutes</title> (Off-Air Recording), <unitdate type="inclusive" normal="1996-02-04">February 4, 1996</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>U-matic</physfacet>
                   </physdesc>
                 </did>
@@ -25635,8 +25635,8 @@
               <did>
                 <container type="box" label="Box">96</container>
                 <unittitle>ASAE Boston Convention featuring speech by Donald Trump <unitdate type="inclusive" normal="1989">1989</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -25645,8 +25645,8 @@
               <did>
                 <container type="box" label="Box">96</container>
                 <unittitle>Saddam: Interview with Saddam Hussein (Jews of Baghdad, aftermath of Gulf War</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -25655,8 +25655,8 @@
               <did>
                 <container type="box" label="Box">96</container>
                 <unittitle><title render="italic">60 Minutes</title> interview with Edward Teller, <unitdate type="inclusive" normal="1988-11-13">November 13, 1988</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -25665,8 +25665,8 @@
               <did>
                 <container type="box" label="Box">96</container>
                 <unittitle>Television Academy Hall of Fame Show <unitdate type="inclusive" normal="1993-11-20">November 20, 1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -25675,8 +25675,8 @@
               <did>
                 <container type="box" label="Box">96</container>
                 <unittitle>"All about TV" (Richard Salant Tribute)</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -25691,8 +25691,8 @@
                 <did>
                   <container type="box" label="Box">96</container>
                   <unittitle>"America's Other Assassins" (1995)</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>VHS (TM)</physfacet>
                   </physdesc>
                 </did>
@@ -25701,8 +25701,8 @@
                 <did>
                   <container type="box" label="Box">96</container>
                   <unittitle>National Press Club-Don Hewitt Lunch <unitdate type="inclusive" normal="1995-10-17">October 17, 1995</unitdate></unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>VHS (TM)</physfacet>
                   </physdesc>
                 </did>
@@ -25711,8 +25711,8 @@
                 <did>
                   <container type="box" label="Box">96</container>
                   <unittitle>"Earthquakes: Living on the Edge" (1995)</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>VHS (TM)</physfacet>
                   </physdesc>
                 </did>
@@ -25721,8 +25721,8 @@
                 <did>
                   <container type="box" label="Box">96</container>
                   <unittitle>"First Ladies" (1994)</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>VHS (TM)</physfacet>
                   </physdesc>
                 </did>
@@ -25731,8 +25731,8 @@
                 <did>
                   <container type="box" label="Box">96</container>
                   <unittitle>"Persian Gulf War" (1995)</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>VHS (TM)</physfacet>
                   </physdesc>
                 </did>
@@ -25741,8 +25741,8 @@
                 <did>
                   <container type="box" label="Box">96</container>
                   <unittitle>"Uprising at Attica" (1995)</unittitle>
-                  <physdesc>
-                    <extent>1 videotapes</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                     <physfacet>VHS (TM)</physfacet>
                   </physdesc>
                 </did>
@@ -25752,8 +25752,8 @@
               <did>
                 <container type="box" label="Box">96</container>
                 <unittitle><title render="italic">Dead Blue: Surviving Depression</title> (HBO) regarding Wallace's battle with depression</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -25762,8 +25762,8 @@
               <did>
                 <container type="box" label="Box">96</container>
                 <unittitle><title render="italic">The 60 Minutes Deception: An Expose of Media Corruption</title>, <unitdate type="inclusive" normal="1997">1997</unitdate> Citizens for Honest Government (Regarding Vincent Foster's <unitdate type="inclusive" normal="1997">1997</unitdate> death)</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -25780,8 +25780,8 @@
                   <did>
                     <container type="box" label="Box">96</container>
                     <unittitle>"Blowing Smoke," <unitdate type="inclusive" normal="1996-03-24">March 24, 1996</unitdate></unittitle>
-                    <physdesc>
-                      <extent>1 videotapes</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                       <physfacet>VHS (TM)</physfacet>
                     </physdesc>
                   </did>
@@ -25790,8 +25790,8 @@
                   <did>
                     <container type="box" label="Box">96</container>
                     <unittitle>"Jeffrey Wigand, Ph.D.," <unitdate type="inclusive" normal="1996-02-04">February 4, 1996</unitdate></unittitle>
-                    <physdesc>
-                      <extent>1 videotapes</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                       <physfacet>VHS (TM)</physfacet>
                     </physdesc>
                   </did>
@@ -25800,8 +25800,8 @@
                   <did>
                     <container type="box" label="Box">96</container>
                     <unittitle>"Up in Smoke," <unitdate type="inclusive" normal="1994-03-24">March 24, 1994</unitdate></unittitle>
-                    <physdesc>
-                      <extent>1 videotapes</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                       <physfacet>VHS (TM)</physfacet>
                     </physdesc>
                   </did>
@@ -25815,8 +25815,8 @@
                   <did>
                     <container type="box" label="Box">96</container>
                     <unittitle>Regarding Jeffrey Wigand Case <unitdate type="inclusive" normal="1995-11-29">November 29, 1995</unitdate>, <unitdate type="inclusive" normal="1996-01-26">January 26, 1996</unitdate></unittitle>
-                    <physdesc>
-                      <extent>1 videotapes</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                       <physfacet>VHS (TM)</physfacet>
                     </physdesc>
                   </did>
@@ -25825,8 +25825,8 @@
                   <did>
                     <container type="box" label="Box">96</container>
                     <unittitle>Regarding Jeffrey Wigand Case, <unitdate type="inclusive" normal="1996-01-31">1996 January 31</unitdate>, <unitdate type="inclusive" normal="1996-01-27">1996 January 27 </unitdate>, <unitdate type="inclusive" normal="1996-02-01">February 1, 1996</unitdate></unittitle>
-                    <physdesc>
-                      <extent>1 videotapes</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                       <physfacet>VHS (TM)</physfacet>
                     </physdesc>
                   </did>
@@ -25841,8 +25841,8 @@
                   <did>
                     <container type="box" label="Box">96</container>
                     <unittitle>" <title render="italic">60 Minutes</title>" (regarding CBS management decision not to run tobacco piece), <unitdate type="inclusive" normal="1995-09-13">September 13, 1995</unitdate></unittitle>
-                    <physdesc>
-                      <extent>1 videotapes</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                       <physfacet>VHS (TM)</physfacet>
                     </physdesc>
                   </did>
@@ -25851,8 +25851,8 @@
                   <did>
                     <container type="box" label="Box">96</container>
                     <unittitle>Interview with <title render="italic">60 Minutes</title> Staff on success of show (also mentions tobacco tapes deposition), <unitdate type="inclusive" normal="1997-05-06">May 6, 1997</unitdate></unittitle>
-                    <physdesc>
-                      <extent>1 videotapes</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                       <physfacet>VHS (TM)</physfacet>
                     </physdesc>
                   </did>
@@ -25866,8 +25866,8 @@
                   <did>
                     <container type="box" label="Box">96</container>
                     <unittitle>Brown and Williamson's charge against CBS for the <title render="italic">Sixty Minutes</title> Tapes, <unitdate type="inclusive" normal="1996-02-15">February 15, 1996</unitdate></unittitle>
-                    <physdesc>
-                      <extent>1 videotapes</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                       <physfacet>VHS (TM)</physfacet>
                     </physdesc>
                   </did>
@@ -25881,8 +25881,8 @@
                   <did>
                     <container type="box" label="Box">96</container>
                     <unittitle>Jeffrey Wigand's History through Court Records <unitdate type="inclusive" normal="1996-01-18">January 18, 1996</unitdate></unittitle>
-                    <physdesc>
-                      <extent>1 videotapes</extent>
+                    <physdesc altrender="whole">
+                      <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                       <physfacet>VHS (TM)</physfacet>
                     </physdesc>
                   </did>
@@ -25893,8 +25893,8 @@
               <did>
                 <container type="box" label="Box">154</container>
                 <unittitle>Louis Farrakhan <unitdate type="inclusive" normal="2000-04-01">April 1, 2000</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -25903,8 +25903,8 @@
               <did>
                 <container type="box" label="Box">154</container>
                 <unittitle>Committee of 100 Headliner Journalism Award <unitdate type="inclusive" normal="2001-04-26">April 26, 2001</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -25916,8 +25916,8 @@
               <did>
                 <container type="box" label="Box">154</container>
                 <unittitle>"Insidious Killer: Chemical and Biological Weapons" (20th Century with Mike Wallace)</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -25926,8 +25926,8 @@
               <did>
                 <container type="box" label="Box">154</container>
                 <unittitle>"A Passion for Justice" (Richard LaPointe Case)</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -25936,8 +25936,8 @@
               <did>
                 <container type="box" label="Box">154</container>
                 <unittitle>Closeup U.S.A. (Arkansas Black Family) <unitdate type="inclusive" normal="1960-08">August 1960</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -25946,8 +25946,8 @@
               <did>
                 <container type="box" label="Box">154</container>
                 <unittitle>The Mike Wallace Interviews. With William O. Douglas <unitdate type="inclusive" normal="1958-05-18">May 18, 1958</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -25956,8 +25956,8 @@
               <did>
                 <container type="box" label="Box">154</container>
                 <unittitle>MW being interviewed by foreign correspondents on topic of assisted suicide and Dr. Jack Kevorkian <unitdate type="inclusive" normal="2002-05-23">May 23, 2002</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -25969,8 +25969,8 @@
                 <physdesc altrender="whole">
                   <extent altrender="materialtype spaceoccupied">2 copies</extent>
                 </physdesc>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -25982,8 +25982,8 @@
               <did>
                 <container type="box" label="Box">154</container>
                 <unittitle>60 minutes segment: KIPP (Knowledge in Power Program) <unitdate type="inclusive" normal="1999-09">September 1999</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -25992,8 +25992,8 @@
               <did>
                 <container type="box" label="Box">154</container>
                 <unittitle>60 minutes segment: Oprah (Oprah Winfrey) <unitdate type="inclusive" normal="1986-12-14">December 14, 1986</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -26002,8 +26002,8 @@
               <did>
                 <container type="box" label="Box">154</container>
                 <unittitle>Mike Wallace Interview program: Interview with Charles (?) Kelly (World War II Congressional Medal of Honor winner) <unitdate type="inclusive" normal="1950/1959" certainty="approximate">1950s</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -26012,8 +26012,8 @@
               <did>
                 <container type="box" label="Box">154</container>
                 <unittitle>Oldenburg</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -26025,8 +26025,8 @@
               <did>
                 <container type="box" label="Box">154</container>
                 <unittitle>CBS News (WCBS Channel 2) segment re Mike Wallace and his CD "The Girl She's Mine" <unitdate type="inclusive" normal="2001-02-08">February 8, 2001</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -26035,8 +26035,8 @@
               <did>
                 <container type="box" label="Box">154</container>
                 <unittitle>Mike Wallace on Charlie Rose program <unitdate type="inclusive" normal="2002-06-17">June 17, 2002</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -26045,8 +26045,8 @@
               <did>
                 <container type="box" label="Box">154</container>
                 <unittitle>The Race for Space (David L. Wolper production)</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -26055,8 +26055,8 @@
               <did>
                 <container type="box" label="Box">154</container>
                 <unittitle><title render="italic">60 Minutes</title>-25th Anniversary Special, <unitdate type="inclusive" normal="1993-11-14">November 14, 1993</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -26065,8 +26065,8 @@
               <did>
                 <container type="box" label="Box">154</container>
                 <unittitle>Magnus interview MW on case of tobacco and Brown and Williamson on the CBS Eve. News <unitdate type="inclusive" normal="1995-11-10">November 10, 1995</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -26075,8 +26075,8 @@
               <did>
                 <container type="box" label="Box">154</container>
                 <unittitle>Television in America: An Autobiography with Mike Wallace <unitdate type="inclusive" normal="2002-10-28">October 28, 2002</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -26101,8 +26101,8 @@
               <did>
                 <container type="box" label="Box">97</container>
                 <unittitle>TV 50 <unitdate type="inclusive" normal="1989">1989</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>Betacam (TM)</physfacet>
                 </physdesc>
               </did>
@@ -26111,8 +26111,8 @@
               <did>
                 <container type="box" label="Box">97</container>
                 <unittitle>CBS Evening News Segment on Jeffrey Wigand <unitdate type="inclusive" normal="1995-11-29">November 29, 1995</unitdate>, <unitdate type="inclusive" normal="1996-01-26">January 26, 1996</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>Betacam (TM)</physfacet>
                 </physdesc>
               </did>
@@ -26136,8 +26136,8 @@
               <did>
                 <container type="box" label="Box">97</container>
                 <unittitle>Ramstein Air Base, Germany <unitdate type="inclusive" normal="1982">1982</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>Betacam (TM)</physfacet>
                 </physdesc>
               </did>
@@ -26146,8 +26146,8 @@
               <did>
                 <container type="box" label="Box">97</container>
                 <unittitle>Soros Foundation <unitdate type="inclusive" normal="1989">1989</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>Betacam (TM)</physfacet>
                 </physdesc>
               </did>
@@ -26156,8 +26156,8 @@
               <did>
                 <container type="box" label="Box">97</container>
                 <unittitle>Adm. William J. Crowe Jr. interview <unitdate type="inclusive" normal="1988">1988</unitdate> or <unitdate type="inclusive" normal="1989">1989</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>Betacam (TM)</physfacet>
                 </physdesc>
               </did>
@@ -26166,8 +26166,8 @@
               <did>
                 <container type="box" label="Box">97</container>
                 <unittitle>Sandy Goodman's tapes (various segments)</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>Betacam (TM)</physfacet>
                 </physdesc>
               </did>
@@ -26176,8 +26176,8 @@
               <did>
                 <container type="box" label="Box">97</container>
                 <unittitle>Arafat interviews <unitdate type="inclusive" normal="1977">1977</unitdate>, <unitdate type="inclusive" normal="1979">1979</unitdate>, <unitdate type="inclusive" normal="1989">1989</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>Betacam (TM)</physfacet>
                 </physdesc>
               </did>
@@ -26199,8 +26199,8 @@
           <c03 level="otherlevel" otherlevel="item-main">
             <did>
               <unittitle>Mike Wallace on Information Please; Quiz Show as student at the University of Michigan, <unitdate type="inclusive">1939 February 07</unitdate></unittitle>
-              <physdesc>
-                <extent>1 audiotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel tapes, 7 inch, 7 1/2 ips</physfacet>
               </physdesc>
             </did>
@@ -26224,8 +26224,8 @@
           <c03 level="otherlevel" otherlevel="item-main">
             <did>
               <unittitle>Telephone recordings with Al Ramrus, George Weissman, Don Coe, Claude Carpenter, Olly Trayz., <unitdate type="inclusive">1957 September 07</unitdate></unittitle>
-              <physdesc>
-                <extent>1 audiotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel tapes, 7 inch, 3 3/4 ips</physfacet>
               </physdesc>
             </did>
@@ -26281,8 +26281,8 @@
           <c03 level="otherlevel" otherlevel="item-main">
             <did>
               <unittitle>The Hate that Hate Produced, <unitdate type="inclusive">[Undated]</unitdate></unittitle>
-              <physdesc>
-                <extent>1 audiotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel tapes, 7 inch, 3 3/4 ips</physfacet>
               </physdesc>
             </did>
@@ -26306,8 +26306,8 @@
           <c03 level="otherlevel" otherlevel="item-main">
             <did>
               <unittitle>Publisher China Post; Voice of Free China; Quemoy Golf Course; Talk Piece-Dan in Quemoy, <unitdate type="inclusive">[Undated]</unitdate></unittitle>
-              <physdesc>
-                <extent>1 audiotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel tapes, 7 inch, 7.5 ips</physfacet>
               </physdesc>
             </did>
@@ -26331,8 +26331,8 @@
           <c03 level="otherlevel" otherlevel="item-main">
             <did>
               <unittitle>Mike Wallace in Kenya, <unitdate type="inclusive">[Undated]</unitdate></unittitle>
-              <physdesc>
-                <extent>1 audiotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel tapes, 7 inch, 7.5 ips</physfacet>
               </physdesc>
             </did>
@@ -26356,8 +26356,8 @@
           <c03 level="otherlevel" otherlevel="item-main">
             <did>
               <unittitle>Prime Minister Nguye Cao Ky of Vietnam interview, <unitdate type="inclusive">[Undated]</unitdate></unittitle>
-              <physdesc>
-                <extent>2 audiotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 audiotapes</extent>
                 <physfacet>reel-to-reel tapes, 5 inch, 7.5 ips</physfacet>
               </physdesc>
             </did>
@@ -26397,8 +26397,8 @@
           <c03 level="otherlevel" otherlevel="item-main">
             <did>
               <unittitle>PM Cairo interview, <unitdate type="inclusive">[Undated]</unitdate></unittitle>
-              <physdesc>
-                <extent>1 audiotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiotapes</extent>
                 <physfacet>reel-to-reel tapes, 5 inch, 7.5 ips</physfacet>
               </physdesc>
             </did>
@@ -26428,8 +26428,8 @@
             <did>
               <container type="box" label="Box">153</container>
               <unittitle>Radio programs for which MW was announcer (e.g. Sky King, Green Hornet, Spike Jones Spotlight Revue)</unittitle>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
               </physdesc>
             </did>
           </c03>
@@ -26437,8 +26437,8 @@
             <did>
               <container type="box" label="Box">153</container>
               <unittitle>Mike Wallace Interviews</unittitle>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
               </physdesc>
             </did>
           </c03>
@@ -26446,8 +26446,8 @@
             <did>
               <container type="box" label="Box">153</container>
               <unittitle>PM East</unittitle>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
               </physdesc>
             </did>
           </c03>
@@ -26460,8 +26460,8 @@
             <did>
               <container type="box" label="Box">153</container>
               <unittitle>MW on the radio, appearances at conferences, program proposals, etc.)</unittitle>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
               </physdesc>
             </did>
           </c03>

--- a/Real_Masters_all/wardfam.xml
+++ b/Real_Masters_all/wardfam.xml
@@ -656,8 +656,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>Correspondence <unitdate type="inclusive" normal="1885/1896">1885-1896</unitdate></unittitle>
-                <physdesc>
-                  <extent>15 folders</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">15 folders</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1337,8 +1337,8 @@
                 <unittitle>
                   <unitdate type="inclusive" normal="1931/1937">1931-1937</unitdate>
                 </unittitle>
-                <physdesc>
-                  <extent>0.5 linear feet</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">0.5 linear feet</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1848,8 +1848,8 @@
             <did>
               <container type="box" label="Box">31</container>
               <unittitle>Kanawa and Elk River Railroad</unittitle>
-              <physdesc>
-                <extent> 2 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1857,8 +1857,8 @@
             <did>
               <container type="box" label="Box">31</container>
               <unittitle>Coit</unittitle>
-              <physdesc>
-                <extent> 7 folders</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">7 folders</extent>
               </physdesc>
             </did>
           </c03>
@@ -1956,8 +1956,8 @@
             <did>
               <container type="box" label="Box">28</container>
               <unittitle>Russia (Vladivostok harbor) <unitdate type="inclusive" normal="1920/1929" certainty="approximate">1920s</unitdate></unittitle>
-              <physdesc>
-                <extent>4 negatives</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">4 negatives</extent>
               </physdesc>
             </did>
           </c03>
@@ -2148,8 +2148,8 @@
             <container label="Drawer" type="map-case">1</container>
             <container label="Folder" type="folder">3</container>
             <unittitle>British Columbia</unittitle>
-            <physdesc>
-              <extent>5 maps</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">5 maps</extent>
             </physdesc>
           </did>
           <odd>
@@ -2161,8 +2161,8 @@
             <container label="Drawer" type="map-case">1</container>
             <container label="Folder" type="folder">3</container>
             <unittitle>West Virginia</unittitle>
-            <physdesc>
-              <extent>2 maps</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 maps</extent>
             </physdesc>
           </did>
           <odd>
@@ -2174,8 +2174,8 @@
             <container label="Drawer" type="map-case">1</container>
             <container label="Folder" type="folder">4</container>
             <unittitle>California</unittitle>
-            <physdesc>
-              <extent>19 maps</extent>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">19 maps</extent>
             </physdesc>
           </did>
           <odd>
@@ -2195,8 +2195,8 @@
                 <container label="Drawer" type="map-case">1</container>
                 <container label="Folder" type="folder">5</container>
                 <unittitle>David Ward estate land holdings <unitdate type="inclusive" normal="1914/1925">1914-1925</unitdate>, <unitdate>undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>13 maps</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">13 maps</extent>
                 </physdesc>
               </did>
               <odd>
@@ -2208,8 +2208,8 @@
                 <container label="Drawer" type="map-case">1</container>
                 <container label="Folder" type="folder">6</container>
                 <unittitle>Land ownership maps of townships <unitdate type="inclusive" normal="1882/1889">1882-1889</unitdate>, <unitdate>undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>43 maps</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">43 maps</extent>
                 </physdesc>
               </did>
               <odd>
@@ -2221,8 +2221,8 @@
                 <container label="Drawer" type="map-case">1</container>
                 <container label="Folder" type="folder">7</container>
                 <unittitle>Logging operations in Antrim and Otsego Counties <unitdate type="inclusive" normal="1886/1911">1886-1911</unitdate>, <unitdate>undated</unitdate></unittitle>
-                <physdesc>
-                  <extent>37 maps</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">37 maps</extent>
                 </physdesc>
               </did>
               <odd>
@@ -2235,8 +2235,8 @@
               <container label="Drawer" type="map-case">1</container>
               <container label="Folder" type="folder">8</container>
               <unittitle>Orchard Lake area <unitdate type="inclusive" normal="1922/1956">1922-1956</unitdate></unittitle>
-              <physdesc>
-                <extent>14 maps</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">14 maps</extent>
               </physdesc>
             </did>
             <odd>

--- a/Real_Masters_all/weinsteina.xml
+++ b/Real_Masters_all/weinsteina.xml
@@ -3132,16 +3132,16 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 1: America-More or Less</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <unittitle>Audiocassette 2: American Revolution</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <c05 level="item">
@@ -3168,16 +3168,16 @@
             <did>
               <container type="box" label="Box">11</container>
               <unittitle>Baby Jesus/Kill My Body (audiocassette)</unittitle>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
               </physdesc>
             </did>
           </c03>
           <c03 level="file">
             <did>
               <unittitle>Barnyard Boogaloo (audiocassette)</unittitle>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
               </physdesc>
             </did>
             <odd>
@@ -3210,8 +3210,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 1: Black Max. William Bolcom and Joan Morris, recorded <unitdate type="inclusive" normal="1985-02-14">February 14, 1985</unitdate> at Kerrytown Concert House, Ann Arbor, Mich.</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3219,8 +3219,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 2: Marlene Bateman (mezzo-soprano), Stephen Sulich (piano)</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3228,8 +3228,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 3: Raquel Hecker and Jocelyn Swigger, The Looking Glass Studios, New York, NY. <unitdate type="inclusive" normal="1995-04-02">April 2, 1995</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3237,8 +3237,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 4: Sharon Mabry</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3246,8 +3246,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 5: Killer Bees</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3255,8 +3255,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 6: Joan Morris</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3264,16 +3264,16 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 7: William Bolcom and Joan Morris</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <unittitle>Audiocassette 8: Cabaret Songs</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <c05 level="item">
@@ -3296,8 +3296,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 9: Cabaret Songs</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3305,8 +3305,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 10: Cabaret Songs performed by unidentified, recorded <unitdate type="inclusive" normal="1992-01">January 1992</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3324,8 +3324,8 @@
             <c04 level="file">
               <did>
                 <unittitle>Audiocassette 1:</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <c05 level="item">
@@ -3347,8 +3347,8 @@
             <c04 level="file">
               <did>
                 <unittitle>Audiocassette 2</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <c05 level="item">
@@ -3366,8 +3366,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 3: Peterson (WKCR)</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3375,8 +3375,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 4: Ballroom <unitdate type="inclusive" normal="1992-12-13">December 13, 1992</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3384,16 +3384,16 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 5: Casino Paradise</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <unittitle>Audiocassette 6: William Bolcom and Joan Morris <unitdate type="inclusive" normal="1992-06">June 1992</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <c05 level="item">
@@ -3416,16 +3416,16 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 7: Casino Paradise</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <unittitle>Audiocassette 8</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <c05 level="item">
@@ -3451,8 +3451,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 9: Commissioned by American Music Theater Festival <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3468,8 +3468,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 1: Yale <unitdate type="inclusive" normal="1966">1966</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3477,8 +3477,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 2: Dynamite-I</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3486,8 +3486,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 3: Act I Parts 1 and 2. Yale <unitdate type="inclusive" normal="1966">1966</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3495,8 +3495,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 4: Act II</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3504,8 +3504,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 5: Yale</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3513,8 +3513,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 6: Act I Parts 1 and 2</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3530,8 +3530,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 1: MT</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3539,8 +3539,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 2: David Amram/Alfred Leslie</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3556,8 +3556,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 1: Fortuna</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3565,8 +3565,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 2: "Money Matters" Paul Sperry, tenor; Musical Elements Bob Beaser, conductor</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3574,8 +3574,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 3: Circus music <unitdate type="inclusive" normal="1962">1962</unitdate> and other songs</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3591,8 +3591,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 1: Chicago <unitdate type="inclusive" normal="1977">1977</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3600,8 +3600,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 2: Street Opera</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3609,8 +3609,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 3: Street Opera, Chicago <unitdate type="inclusive" normal="1976">1976</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3626,8 +3626,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 1: Lorca's Gypsy New York</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3635,8 +3635,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 2: Lorca/Greco</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3649,8 +3649,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 1: Mahagonny Songspiel</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3658,8 +3658,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 2: MT</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3667,8 +3667,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 3: Mahagonny</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3676,8 +3676,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 4: Terrible Food; Mahagonny</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3685,8 +3685,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 5: Mahagonny #1</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3694,8 +3694,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 6: Mahagonny #2</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3703,8 +3703,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 7: Mahagonny I</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3712,8 +3712,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 8: Mahagonny II</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3721,8 +3721,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 9: Mahagonny and Little Mahagonny</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3730,8 +3730,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 10: Lost in [the] Stars</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3739,8 +3739,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 11: Mahagonny at Met; Carmen Jones</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3748,8 +3748,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 12: Mahagonny-A. W.</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3757,8 +3757,8 @@
               <did>
                 <container type="box" label="Box">11</container>
                 <unittitle>Audiocassette 13: MT</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3777,8 +3777,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>CD-ROM 1: 29 Cabaret Songs. Joan Morris (soprano) and William Bolcom (piano). Recorded live <unitdate type="inclusive" normal="2003-09-21">September 21, 2003</unitdate> at Flea Theatre NY Tribeca. Editproof for Arnold Weinstein, <unitdate type="inclusive" normal="2003-10-17">October 17, 2003</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -3787,8 +3787,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>CD-ROM 2: Blue: the Complete Cabaret Songs of William Bolcom and Arnold Weinstein. Michelle Murray (soprano) and David Murray (piano). Recorded live <unitdate type="inclusive" normal="2001-11-05">November 5, 2001</unitdate> at the Arizona State University Organ Hall</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -3797,8 +3797,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>CD-ROM 3: Cabaret Songs.</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -3807,8 +3807,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>CD-ROM 4: Cabaret Songs Complete. Joan Morris (mezzo-soprano), William Bolcom (piano). Recorded live <unitdate type="inclusive" normal="2003-09-21">September 21, 2003</unitdate> at the Flea Theater, New York City</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -3817,8 +3817,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>CD-ROM 5: Masterpieces of Cabaret: Twelve Cabaret Songs (1977-83). Jody Karin Applebaum (soprano) and Marc-Andre Hamelin (piano). Copyright <unitdate type="inclusive" normal="1992">1992</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -3827,8 +3827,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>CD-ROM 6: Music of William Bolcom: Let Evening Comel Briefly It Enters; Cabaret Songs, Books 3 and 4 for Centaur Records. Benita Valente (soprano), Cynthia Raim (piano), Joan Morris (mezzo-soprano), William Bolcom (piano), with Michael Tree (viola). Recorded <unitdate type="inclusive" normal="1998-12-18/1998-12-20">December 18-20, 1998</unitdate> at Lefrak Hall, Queens College, Flushing, New York</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -3837,8 +3837,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>CD-ROM 7: William Bolcom: Let Evening Come; Briefly It Enters; Cabaret Songs, Volumes 3 and 4. Benita Valente (soprano), Joan Morris (mezzo-soprano), William Bolcom (piano), Cynthia Raim (piano), Michael Tree (viola). Recorded <unitdate type="inclusive" normal="2001-12-18/2001-12-20" certainty="approximate">December 18-20, 2001</unitdate> at Lefrak Concert Hall, Queens College, Flushing, New York</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -3855,8 +3855,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>CD-ROM 1: American Music Theater Festival Presents Casino Paradise. Recorded at Sigma Sound Studios in Philadelphia, Penn. April 16, 1990.</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -3865,8 +3865,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>CD-ROMs 2-3: Casino Paradise: a studio production by The University of Michigan Musical Theatre Department. <unitdate type="inclusive" normal="2000-02-17/2000-02-20">February 17-20, 2000</unitdate> Ann Arbor, Mich.</unittitle>
-                <physdesc>
-                  <extent>2 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -3883,8 +3883,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 1: McTeague. Original sound recording, Lyric Opera of Chicago, 1992. Commentary by Alfred Glasser.</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3892,8 +3892,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 2: MT</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3901,8 +3901,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 3: MT</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3910,8 +3910,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 4 : McTeague</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3919,8 +3919,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 5: Act I</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3928,8 +3928,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 6: Act II</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3937,8 +3937,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 7: Act II</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3946,8 +3946,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 8: Act III</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3955,8 +3955,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 9: Act II</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3964,8 +3964,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 10: Act II</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3981,8 +3981,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 1: Metamorphoses-full production <unitdate type="inclusive" normal="1973">1973</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3990,8 +3990,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 2: A Jane L., Ltd Presentation</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -3999,8 +3999,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 3: Set You Free</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4008,8 +4008,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 4: Finale</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4017,8 +4017,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 5: Parts 1 and 2</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4026,8 +4026,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 6: Finale; Ovid; Set Me Free</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4035,8 +4035,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 7:Ovid; Million; You and Me; Ugly</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4049,8 +4049,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 1: Monkey</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4058,16 +4058,16 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 2: <unitdate type="inclusive" normal="2002-11-08">November 8, 2002</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
             <c04 level="file">
               <did>
                 <unittitle>CD-ROM 1: Monkey</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -4091,8 +4091,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>CD-ROM 2: Monkey Story</unittitle>
-                <physdesc>
-                  <extent>1 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -4124,8 +4124,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 1: My Wife</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4133,8 +4133,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 2: Bolcom and Morris</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4142,8 +4142,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 3</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <c05 level="item">
@@ -4219,8 +4219,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 1: Play of Consciousness</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4228,8 +4228,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 2: Jump Up; Play of Consciousness</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4237,8 +4237,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 3: Evil; Marching Band</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4260,8 +4260,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 1: Folk Songs, Yiddish</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4269,8 +4269,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 2: <unitdate type="inclusive" normal="1995-03-15">March 15, 1995</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <c05 level="item">
@@ -4288,8 +4288,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 3</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <c05 level="item">
@@ -4312,8 +4312,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 4</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <c05 level="item">
@@ -4331,8 +4331,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 5: Rascal 2</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4340,8 +4340,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 6: Oy Vay Duet</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4349,8 +4349,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 7: Oy Vay Love Duet</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <c05 level="item">
@@ -4373,8 +4373,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 8: Demo</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4382,8 +4382,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 9: Hank's Shlemiel Song</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4391,8 +4391,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 10: Shlemiel Songs</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <c05 level="item">
@@ -4410,8 +4410,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 11: Title Song</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <c05 level="item">
@@ -4429,8 +4429,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 12: Additions</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
               <c05 level="item">
@@ -4466,8 +4466,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 1: View from the Bridge</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4475,8 +4475,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 2: View from the Bridge</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4484,8 +4484,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 3: Arnold on NPR about "View"</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4493,8 +4493,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>CD-ROMs 1-3: Metropolitan Opera. December 12, 2002. Dennis Russell Davies (conductor)</unittitle>
-                <physdesc>
-                  <extent>3 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">3 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -4503,8 +4503,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>CD-ROMs 4-5: World premiere recording <unitdate type="inclusive" normal="1999-10/1999-11">October-November 1999</unitdate>. Lyric Opera of Chicago</unittitle>
-                <physdesc>
-                  <extent>2 optical disks</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                   <physfacet>CDs</physfacet>
                 </physdesc>
               </did>
@@ -4530,8 +4530,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 1: Schneider-Weill</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4539,8 +4539,8 @@
               <did>
                 <container type="box" label="Box">12</container>
                 <unittitle>Audiocassette 2: Wind in the Willows</unittitle>
-                <physdesc>
-                  <extent>1 audiocassettes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -4564,8 +4564,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle>Tape 1: B[o]lcom/Weinstein interview. Piano with Morris "View from the Bridge"</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -4574,8 +4574,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle>Tape 2: Work/Interviews</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -4584,8 +4584,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle>Tape 3: Interviews</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -4595,8 +4595,8 @@
             <did>
               <container type="box" label="Box">13</container>
               <unittitle>Casino Paradise, University of Michigan <unitdate type="inclusive" normal="2000-02-19">February 19, 2000</unitdate></unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -4619,8 +4619,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle>Real McTeague</unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -4629,8 +4629,8 @@
               <did>
                 <container type="box" label="Box">13</container>
                 <unittitle>University of Indiana <unitdate type="inclusive" normal="1996-02-17">February 17, 1996</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 videotapes</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                   <physfacet>VHS (TM)</physfacet>
                 </physdesc>
               </did>
@@ -4650,8 +4650,8 @@
             <did>
               <container type="box" label="Box">13</container>
               <unittitle>William Bolcom &amp; Joan Morris</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/winesher.xml
+++ b/Real_Masters_all/winesher.xml
@@ -1228,8 +1228,8 @@
               <physdesc altrender="whole">
                 <extent altrender="materialtype spaceoccupied">3 folders</extent>
               </physdesc>
-              <physdesc>
-                <extent>3 floppy disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">3 floppy disks</extent>
                 <physfacet>3.5"</physfacet>
               </physdesc>
             </did>
@@ -1458,8 +1458,8 @@
             <did>
               <container type="box" label="Box">7</container>
               <unittitle><title render="italic">Tough Minds-Tender Hearts</title>, unpublished, <unitdate type="inclusive" normal="1988">1988</unitdate></unittitle>
-              <physdesc>
-                <extent>2 floppy disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 floppy disks</extent>
                 <physfacet>3.5"</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/womglee.xml
+++ b/Real_Masters_all/womglee.xml
@@ -137,8 +137,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle><unitdate type="inclusive" normal="1994">1994</unitdate> Spring Concert</unittitle>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
               </physdesc>
             </did>
           </c03>
@@ -146,8 +146,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle><unitdate type="inclusive" normal="1995">1995</unitdate> Spring Concert</unittitle>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
               </physdesc>
             </did>
           </c03>
@@ -155,8 +155,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle><unitdate type="inclusive" normal="1995">1995</unitdate> Fall Concert</unittitle>
-              <physdesc>
-                <extent>1 audiocassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 audiocassettes</extent>
               </physdesc>
             </did>
           </c03>
@@ -169,8 +169,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle><unitdate type="inclusive" normal="2001">2001</unitdate> Fall Concert</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -179,8 +179,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> Spring Concert</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -189,8 +189,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle><unitdate type="inclusive" normal="2002">2002</unitdate> Winter Concert</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -199,8 +199,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle><unitdate type="inclusive" normal="2003">2003</unitdate> Winter Concert</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -209,8 +209,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle><unitdate type="inclusive" normal="2004">2004</unitdate> Spring Concert</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -219,8 +219,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle><unitdate type="inclusive" normal="2004">2004</unitdate> Winter Concert</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -229,8 +229,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle><unitdate type="inclusive" normal="2006">2006</unitdate> Concert at First Congregational Church, Ann Arbor, MI</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -244,8 +244,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle><unitdate type="inclusive" normal="2007">2007</unitdate> Spring photographs</unittitle>
-              <physdesc>
-                <extent>1 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 optical disks</extent>
                 <physfacet>CDs</physfacet>
               </physdesc>
             </did>
@@ -306,8 +306,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle><unitdate type="inclusive" normal="1986">1986</unitdate> Fall Concert</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -316,8 +316,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle><unitdate type="inclusive" normal="1987">1987</unitdate> Fall Concert</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -326,8 +326,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle><unitdate type="inclusive" normal="1988">1988</unitdate> Spring Concert</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -336,8 +336,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle><unitdate type="inclusive" normal="1989">1989</unitdate> Spring Concert</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>
@@ -346,8 +346,8 @@
             <did>
               <container type="box" label="Box">1</container>
               <unittitle><unitdate type="inclusive">Undated</unitdate> demo tape</unittitle>
-              <physdesc>
-                <extent>1 videotapes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 videotapes</extent>
                 <physfacet>VHS (TM)</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/wrclub.xml
+++ b/Real_Masters_all/wrclub.xml
@@ -400,8 +400,8 @@
               <unittitle>
                 <unitdate type="inclusive" normal="1979/1985">1979-1985</unitdate>
               </unittitle>
-              <physdesc>
-                <extent>1 floppy disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">1 floppy disks</extent>
                 <physfacet>5.25"</physfacet>
               </physdesc>
             </did>

--- a/Real_Masters_all/wuom.xml
+++ b/Real_Masters_all/wuom.xml
@@ -1809,8 +1809,8 @@
               <did>
                 <container type="box" label="Box">15</container>
                 <unittitle>"They Fought Alone"</unittitle>
-                <physdesc>
-                  <extent>1 binder</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 volumes</extent>
                 </physdesc>
               </did>
             </c04>
@@ -1940,8 +1940,8 @@
             <did>
               <container type="box" label="Box">16</container>
               <unittitle>Kennedy, John F., at Michigan Union <unitdate type="inclusive" normal="1960-10-13/1960-10-14">October 13-14, 1960</unitdate></unittitle>
-              <physdesc>
-                <extent>2 cassettes</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 audiocassettes</extent>
               </physdesc>
               <unitid>[R147A-R148A]</unitid>
             </did>
@@ -2400,8 +2400,8 @@
             <c04 level="file">
               <did>
                 <unittitle>"Tales of the Valiant" broadcast <unitdate type="inclusive" normal="1955-10/1955-12">October-December 1955</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 reels</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 reels</extent>
                 </physdesc>
               </did>
               <odd>
@@ -3613,8 +3613,8 @@
             <c04 level="file">
               <did>
                 <unittitle>"Hello, Alumni" [report/interview/documentary] / T. Hawley Tapping, host</unittitle>
-                <physdesc>
-                  <extent>13 reels</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">13 reels</extent>
                 </physdesc>
               </did>
               <c05 level="otherlevel" otherlevel="item-main">
@@ -3925,8 +3925,8 @@
             <c04 level="file">
               <did>
                 <unittitle>"I Open the Door" [readings of children's literature] / Virginia Michalak, reader, 1964.</unittitle>
-                <physdesc>
-                  <extent>2 reels</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 reels</extent>
                 </physdesc>
               </did>
               <odd>
@@ -3959,8 +3959,8 @@
             <c04 level="file">
               <did>
                 <unittitle>"Record Collector" [music anthology] / Warren Good, host</unittitle>
-                <physdesc>
-                  <extent>1 reels</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 reels</extent>
                 </physdesc>
               </did>
               <odd>
@@ -4515,8 +4515,8 @@
               <c05>
                 <did>
                   <unittitle>Afro-American: A Survey History [pilot course, Afro-American Studies Program] / Harold Cruse, et al., broadcast <unitdate type="inclusive" normal="1969">Fall 1969</unitdate></unittitle>
-                  <physdesc>
-                    <extent>12 reels</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">12 reels</extent>
                   </physdesc>
                 </did>
                 <c06 level="otherlevel" otherlevel="item-main">
@@ -5556,8 +5556,8 @@
               <did>
                 <container type="box" label="Box">21</container>
                 <unittitle>Anniversary and Dedication Programs </unittitle>
-                <physdesc>
-                  <extent>2 reels</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 reels</extent>
                 </physdesc>
                 <unitid>[R151B-152B]</unitid>
               </did>
@@ -5576,8 +5576,8 @@
               <did>
                 <container type="box" label="Box">22</container>
                 <unittitle>Tenth Anniversary Program, recorded <unitdate type="inclusive" normal="1958-07-03">July 3, 1958</unitdate></unittitle>
-                <physdesc>
-                  <extent>2 reels</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">2 reels</extent>
                 </physdesc>
                 <unitid>R154B-R155B</unitid>
               </did>
@@ -5973,8 +5973,8 @@
             <c04 level="file">
               <did>
                 <unittitle>Symposium, 1973-1975</unittitle>
-                <physdesc>
-                  <extent>9 reels</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">9 reels</extent>
                 </physdesc>
               </did>
               <odd>
@@ -8951,8 +8951,8 @@
             <c04 level="file">
               <did>
                 <unittitle>"Festival of Song" <unitdate type="inclusive" normal="1959/1971">1959/60-1970/71</unitdate></unittitle>
-                <physdesc>
-                  <extent>7 sound discs</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">7 phonograph records</extent>
                   <physfacet>12 in., 33 1/3 rpm</physfacet>
                 </physdesc>
                 <unitid>[D2-D8]</unitid>
@@ -8961,8 +8961,8 @@
                 <did>
                   <container type="box" label="Box">31</container>
                   <unittitle>Theme Music for Down Story Book Lane</unittitle>
-                  <physdesc>
-                    <extent>1 sound discs</extent>
+                  <physdesc altrender="whole">
+                    <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                     <physfacet>12 in., 33 1/3 rpm</physfacet>
                   </physdesc>
                   <unitid>[D9]</unitid>
@@ -8981,8 +8981,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>[Acceptance Speech, Baird Carillon Dedication] / Charles Baird; [Nationally broadcast greetings to University of Michigan Alumni Clubs / T. Hawley Tapping, recorded <unitdate type="inclusive" normal="1937">1937</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 sound discs</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>aluminum acetate; 10 in., 78 rpm</physfacet>
                 </physdesc>
                 <unitid>[D10]</unitid>
@@ -9003,8 +9003,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>[Addresses for] 110th Birthday Party of University of Michigan / Alexander G. Ruthven, Clair Hughes, recorded <unitdate type="inclusive" normal="1947-01-16">January 16, 1947</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 sound discs</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>aluminum acetate, inside start; 12 in., 33 1/3 rpm</physfacet>
                 </physdesc>
                 <unitid>[D12]</unitid>
@@ -9017,8 +9017,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>[Comments on University of Michigan 100th Anniversary] / Arthur L. Cross; To the Dallas Alumni <unitdate type="inclusive" normal="1938-01-20">January 20, 1938</unitdate> / T. Hawley Tapping, recorded <unitdate type="inclusive" normal="1938">1938</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 sound discs</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>aluminum acetate; 8 in., 33 1/3 rpm</physfacet>
                 </physdesc>
                 <unitid>[D13]</unitid>
@@ -9053,8 +9053,8 @@
               <did>
                 <container type="box" label="Box">31</container>
                 <unittitle>Rose Bowl Greetings / Fritz Crisler; 111th Anniversary greetings / Alexander G. Ruthven, [T. Hawley] Tapping, recorded <unitdate type="inclusive" normal="1948">1948</unitdate></unittitle>
-                <physdesc>
-                  <extent>1 sound discs</extent>
+                <physdesc altrender="whole">
+                  <extent altrender="materialtype spaceoccupied">1 phonograph records</extent>
                   <physfacet>aluminum acetate; 10 in. 33 1/3 rpm</physfacet>
                 </physdesc>
                 <unitid>[D16]</unitid>

--- a/Real_Masters_all/ymcadet.xml
+++ b/Real_Masters_all/ymcadet.xml
@@ -1095,8 +1095,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>Downtown Family YMCA/Boll Family YMCA beam signing/topping off <unitdate type="inclusive" normal="2004">2004</unitdate></unittitle>
-              <physdesc>
-                <extent>2 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">2 optical disks</extent>
                 <physfacet>CD-ROMs</physfacet>
               </physdesc>
             </did>
@@ -1105,8 +1105,8 @@
             <did>
               <container type="box" label="Box">6</container>
               <unittitle>Legacy golf classic <unitdate type="inclusive" normal="2003">2003</unitdate></unittitle>
-              <physdesc>
-                <extent>5 optical disks</extent>
+              <physdesc altrender="whole">
+                <extent altrender="materialtype spaceoccupied">5 optical disks</extent>
                 <physfacet>CD-ROMs</physfacet>
               </physdesc>
             </did>


### PR DESCRIPTION
The extent splitter should now account for pre-existing physfacets, dimensions, and carriers. Also it is now skipping any extents that already have an _altrender_ attribute.
