### PR TITLE
um dearborn and flint

### DIFF
--- a/Real_Masters_all/aswad.xml
+++ b/Real_Masters_all/aswad.xml
@@ -104,6 +104,9 @@
           <did>
             <container type="box" label="Box">1</container>
             <unittitle>Arab Culture and Religion <unitdate type="inclusive" normal="1962/1993">1962-1993</unitdate></unittitle>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">2 folders</extent>
+            </physdesc>
           </did>
         </c02>
         <c02 level="file">

--- a/Real_Masters_all/lesliedale.xml
+++ b/Real_Masters_all/lesliedale.xml
@@ -139,7 +139,6 @@
           </did>
           <c03 level="file">
             <did>
-              <container type="box" label="Box">1</container>
               <unittitle>Ann Arbor High School Football 50 Year Reunion</unittitle>
             </did>
             <c04 level="file">
@@ -279,6 +278,12 @@
                 </dao>
               </did>
             </c04>
+          </c03>
+          <c03 level="file">
+            <did>
+              <container type="box" label="Box">1</container>
+              <unittitle>Columns from Ann Arbor magazines and newspapers, <unitdate type="inclusive" normal="1999/2008">1999-2008</unitdate></unittitle>
+            </did>
           </c03>
         </c02>
         <c02 level="subseries">


### PR DESCRIPTION
Okay, remember what I said earlier about agents with '--' subdivided subjects? I was slightly wrong.

We have at least two agents that have a double dash for which what comes after the double dash is actually part of the agent's name.

University of Michigan--Dearborn [http://id.loc.gov/authorities/names/n79069136]
University of Michigan--Flint [http://id.loc.gov/authorities/names/n79128281]

We even have:

University of Michigan--Dearborn. Department of History.

Which is an agent containing BOTH kinds of subdivisions. Not sure how that ought to be split up.

@walkerdb -- any ideas how this could be handled in the agent mapping script? Mapping just make these hard coded exceptions?
